### PR TITLE
Add PMM Forms to Embedded

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
@@ -29,6 +30,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         eventReporter: EventReporter,
         tapToAddHelper: TapToAddHelper? = null,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
         selectionUpdater: (PaymentSelection?) -> Unit,
     ): FormHelper {
         val automaticallyLaunchedCardScanFormDataHelper = if (selectedPaymentMethodCode.isNotBlank()) {
@@ -71,7 +73,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             autocompleteAddressInteractorFactory = null,
             automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
             tapToAddHelper = tapToAddHelper,
-            paymentMethodMessagePromotionsHelper = null
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
@@ -32,6 +33,7 @@ internal interface EmbeddedSheetLauncher {
         hasSavedPaymentMethods: Boolean,
         embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
         customerState: CustomerState?,
+        promotion: PaymentMethodMessagePromotion?,
     )
 
     fun launchManage(
@@ -110,7 +112,8 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         hasSavedPaymentMethods: Boolean,
         embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
-        customerState: CustomerState?
+        customerState: CustomerState?,
+        promotion: PaymentMethodMessagePromotion?,
     ) {
         val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
         if (checkoutSession != null) {
@@ -138,6 +141,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             statusBarColor = statusBarColor,
             paymentSelection = currentSelection,
             customerState = customerState,
+            promotion = promotion
         )
         formActivityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -202,6 +202,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             },
             // Not important for determining formType so set to default value
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
         )
         val savedPaymentMethodMutator = createSavedPaymentMethodMutator(
             coroutineScope = coroutineScope,
@@ -240,6 +241,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                     },
                     embeddedConfirmationState = confirmationStateHolder.state,
                     customerState = customerStateHolder.customer.value,
+                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(code)
                 )
             },
             paymentMethods = customerStateHolder.paymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
@@ -158,6 +158,7 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
             eventReporter = eventReporter,
             // Not important for determining formType so use default value
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            paymentMethodMessagePromotionsHelper = null,
         ) {}
         val newFormType = newFormHelper.formTypeForCode(previousSelection.paymentMethodType)
         if (newFormType != FormHelper.FormType.UserInteractionRequired) {
@@ -170,6 +171,7 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
                 eventReporter = eventReporter,
                 // Not important for determining formType so use default value
                 setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+                paymentMethodMessagePromotionsHelper = null
             ) {}
             val previousFormElements = previousFormHelper.formElementsForCode(previousSelection.paymentMethodType)
             val newFormElements = newFormHelper.formElementsForCode(previousSelection.paymentMethodType)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -11,6 +11,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Compan
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
@@ -30,6 +31,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
     private val formActivityStateHelper: FormActivityStateHelper,
     private val tapToAddHelper: TapToAddHelper,
     private val eventReporter: EventReporter,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
 ) {
     fun create(): DefaultVerticalModeFormInteractor {
         val formHelper = embeddedFormHelperFactory.create(
@@ -40,6 +42,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             tapToAddHelper = tapToAddHelper,
             // If no saved payment methods, then first saved payment method is automatically set as default
             setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
         )
 
         val usBankAccountFormArguments = USBankAccountFormArguments.createForEmbedded(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
@@ -33,6 +33,7 @@ internal class FormActivityViewModel @Inject constructor(
                 application = extras.requireApplication(),
                 paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                 savedStateHandle = extras.createSavedStateHandle(),
+                promotion = args.promotion,
             )
 
             component.selectionHolder.set(args.paymentSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -24,6 +24,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -35,6 +36,8 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.verticalmode.DefaultSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
@@ -85,6 +88,7 @@ internal interface FormActivityViewModelComponent {
             paymentElementCallbackIdentifier: String,
             @BindsInstance application: Application,
             @BindsInstance savedStateHandle: SavedStateHandle,
+            @BindsInstance promotion: PaymentMethodMessagePromotion?
         ): FormActivityViewModelComponent
     }
 }
@@ -222,6 +226,13 @@ internal interface FormActivityViewModelModule {
                 coroutineScope = coroutineScope,
             )
         }
+
+        @Provides
+        fun providesPaymentMethodMessagePromotionHelper(
+            promotion: PaymentMethodMessagePromotion?
+        ): PaymentMethodMessagePromotionsHelper = PrefetchedPaymentMethodMessagePromotionsHelper(
+            listOfNotNull(promotion)
+        )
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
@@ -66,6 +67,7 @@ internal object FormContract : ActivityResultContract<FormContract.Args, FormRes
         val statusBarColor: Int?,
         val paymentSelection: PaymentSelection?,
         val customerState: CustomerState?,
+        val promotion: PaymentMethodMessagePromotion?
     ) : Parcelable {
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedSheetLauncher.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.embedded
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -13,6 +14,7 @@ internal class FakeEmbeddedSheetLauncher : EmbeddedSheetLauncher {
         hasSavedPaymentMethods: Boolean,
         embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
         customerState: CustomerState?,
+        promotion: PaymentMethodMessagePromotion?,
     ) {
         error("Not expected.")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -15,6 +15,8 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodMessageLearnMore
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -67,6 +69,14 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val state = EmbeddedConfirmationStateFixtures.defaultState()
         val customerState = createCustomerState()
+        val promotion = PaymentMethodMessagePromotion(
+            paymentMethodType = "KLARNA",
+            message = "Message",
+            learnMore = PaymentMethodMessageLearnMore(
+                message = "Message",
+                url = "https://www.test.com"
+            )
+        )
         val expectedArgs = FormContract.Args(
             selectedPaymentMethodCode = code,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -76,11 +86,12 @@ internal class DefaultEmbeddedSheetLauncherTest {
             statusBarColor = null,
             paymentSelection = null,
             customerState = customerState,
+            promotion = promotion
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
         assertThat(selectionHolder.temporarySelection.value).isNull()
-        sheetLauncher.launchForm(code, paymentMethodMetadata, false, state, customerState)
+        sheetLauncher.launchForm(code, paymentMethodMetadata, false, state, customerState, promotion)
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
@@ -99,6 +110,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             false,
             state,
             createCustomerState(),
+            null,
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as FormContract.Args
         assertThat(launchCall.paymentSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
@@ -117,6 +129,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             false,
             state,
             createCustomerState(),
+            null,
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as FormContract.Args
         assertThat(launchCall.paymentSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
@@ -134,6 +147,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             false,
             state,
             createCustomerState(),
+            null,
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as FormContract.Args
         assertThat(launchCall.paymentSelection).isNull()
@@ -151,6 +165,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             false,
             state,
             createCustomerState(),
+            null,
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as FormContract.Args
         assertThat(launchCall.paymentSelection).isNull()
@@ -167,6 +182,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             false,
             null,
             createCustomerState(),
+            null,
         )
         val loggedErrors = errorReporter.getLoggedErrors()
         assertThat(loggedErrors.size).isEqualTo(1)
@@ -188,6 +204,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             false,
             state,
             createCustomerState(),
+            null,
         )
     }
 
@@ -462,7 +479,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         )
         val state = EmbeddedConfirmationStateFixtures.defaultState()
         val error = runCatching {
-            sheetLauncher.launchForm("card", paymentMethodMetadata, false, state, createCustomerState())
+            sheetLauncher.launchForm("card", paymentMethodMetadata, false, state, createCustomerState(), null)
         }.exceptionOrNull()
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
         assertThat(error).hasMessageThat()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import kotlinx.coroutines.test.TestScope
@@ -140,6 +141,7 @@ internal class FormActivityScreenShotTest {
             formActivityStateHelper = stateHolder,
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
         ).create()
 
         stateHolder.updateConfirmationState(confirmationState)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
@@ -155,6 +155,7 @@ internal class FormActivityTest {
                     paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
                     paymentSelection = null,
                     customerState = createCustomerState(paymentMethods = emptyList()),
+                    promotion = null
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -299,7 +300,8 @@ internal class DefaultVerticalModeFormInteractorTest {
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
             formActivityStateHelper = stateHolder,
             tapToAddHelper = FakeTapToAddHelper.noOp(),
-            eventReporter = eventReporter
+            eventReporter = eventReporter,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
         ).create()
 
         val formElements = setAsDefaultInteractor.state.value.formUiElements
@@ -349,7 +351,8 @@ internal class DefaultVerticalModeFormInteractorTest {
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
             formActivityStateHelper = stateHolder,
             tapToAddHelper = FakeTapToAddHelper.noOp(),
-            eventReporter = eventReporter
+            eventReporter = eventReporter,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
         ).create()
         block(setAsDefaultInteractor.state.value.formUiElements)
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add PaymentMethodMessagePromotion to FormContract.Args
- BindInstance of passed promotion and use to provide PrefetchedPaymentMethodMessagePromotionHelper

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
FormActivity has a different scope that PaymentElementLoader, meaning that a different instance of DefaultPaymentMethodMessagePromotionsHelper would be injected by default. This implementation allows the prefetched promotions to be used for FormActivity


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

https://github.com/user-attachments/assets/175bb923-e062-4975-b723-68eedc6b58f5




# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
