### PR TITLE
Add cancellation emulator tests for Tap to Add

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/FormPage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/FormPage.kt
@@ -59,7 +59,7 @@ class FormPage(
         composeTestRule.waitUntil {
             composeTestRule
                 .onAllNodes(hasTestTag(FORM_ELEMENT_TEST_TAG))
-                .fetchSemanticsNodes()
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }
     }

--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/PaymentElementPageConstants.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/PaymentElementPageConstants.kt
@@ -1,0 +1,3 @@
+package com.stripe.paymentelementtestpages
+
+const val DEFAULT_PE_PAGE_UI_TIMEOUT = 5000L

--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/VerticalModePage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/VerticalModePage.kt
@@ -41,7 +41,7 @@ class VerticalModePage(
     }
 
     fun waitUntilMissing() {
-        composeTestRule.waitUntil(UI_TIMEOUT) {
+        composeTestRule.waitUntil(DEFAULT_PE_PAGE_UI_TIMEOUT) {
             composeTestRule
                 .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
@@ -139,7 +139,7 @@ class VerticalModePage(
     }
 
     fun clickNewPaymentMethodButton(paymentMethodCode: PaymentMethodCode) {
-        composeTestRule.waitUntil(timeoutMillis = UI_TIMEOUT) {
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_PE_PAGE_UI_TIMEOUT) {
             composeTestRule
                 .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT))
                 .fetchSemanticsNodes()
@@ -159,9 +159,5 @@ class VerticalModePage(
 
         composeTestRule.onNode(hasTestTag(testTag))
             .performClick()
-    }
-
-    private companion object {
-        const val UI_TIMEOUT = 5000L
     }
 }

--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/VerticalModePage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/VerticalModePage.kt
@@ -40,6 +40,15 @@ class VerticalModePage(
         }
     }
 
+    fun waitUntilMissing() {
+        composeTestRule.waitUntil(UI_TIMEOUT) {
+            composeTestRule
+                .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty()
+        }
+    }
+
     fun clickOnNewLpm(paymentMethodCode: PaymentMethodCode) {
         composeTestRule.onNode(hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$paymentMethodCode"))
             .performScrollTo()
@@ -130,7 +139,7 @@ class VerticalModePage(
     }
 
     fun clickNewPaymentMethodButton(paymentMethodCode: PaymentMethodCode) {
-        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+        composeTestRule.waitUntil(timeoutMillis = UI_TIMEOUT) {
             composeTestRule
                 .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT))
                 .fetchSemanticsNodes()
@@ -150,5 +159,9 @@ class VerticalModePage(
 
         composeTestRule.onNode(hasTestTag(testTag))
             .performClick()
+    }
+
+    private companion object {
+        const val UI_TIMEOUT = 5000L
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -52,12 +52,16 @@ internal class EmbeddedFormPage(
         return composeTestRule.onNode(hasText(label))
     }
 
+    fun isVisible(): Boolean {
+        return composeTestRule
+            .onAllNodes(hasTestTag(FORM_ELEMENT_TEST_TAG))
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .isNotEmpty()
+    }
+
     fun waitUntilVisible() {
         composeTestRule.waitUntil {
-            composeTestRule
-                .onAllNodes(hasTestTag(FORM_ELEMENT_TEST_TAG))
-                .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                .isNotEmpty()
+            isVisible()
         }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.PaymentSheet as StripePaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetPage
 import com.stripe.android.paymentsheet.utils.FlowControllerTestRunnerContext
 import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
+import com.stripe.paymentelementtestpages.DEFAULT_PE_PAGE_UI_TIMEOUT
 
 internal sealed class TapToAddIntegrationTestRunnerContext(
     protected val composeTestRule: ComposeTestRule,
@@ -76,7 +77,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             }
 
             override suspend fun confirm() {
-                // No-op
+                throw IllegalStateException("Should confirm from Tap to Add flow!")
             }
 
             override fun markTestSucceeded() {
@@ -146,7 +147,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
                 .performScrollTo()
                 .performClick()
 
-            composeTestRule.waitUntil(5_000) {
+            composeTestRule.waitUntil(DEFAULT_PE_PAGE_UI_TIMEOUT) {
                 !hasPrimaryButton()
             }
 
@@ -188,22 +189,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             composeTestRule: ComposeTestRule,
             context: EmbeddedPaymentElementTestRunnerContext
         ) : Embedded(composeTestRule, context)  {
-            private var confirmingFromForm: Boolean = false
-
             override val formSheetAction = EmbeddedPaymentElement.FormSheetAction.Confirm
-
-            override fun clickPrimaryButton() {
-                if (hasPrimaryButton()) {
-                    confirmingFromForm = true
-                    super.clickPrimaryButton()
-                }
-            }
-
-            override suspend fun confirm() {
-                if (!confirmingFromForm) {
-                    super.confirm()
-                }
-            }
 
             override fun markTestSucceeded() {
                 context.markTestSucceeded()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -1,11 +1,16 @@
 package com.stripe.android.paymentelement.taptoadd
 
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
+import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet as StripePaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetPage
@@ -33,6 +38,10 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
 
     abstract suspend fun confirm()
 
+    abstract fun clickPrimaryButton()
+
+    abstract fun markTestSucceeded()
+
     sealed class Sheet(
         composeTestRule: ComposeTestRule,
     ) : TapToAddIntegrationTestRunnerContext(composeTestRule) {
@@ -49,6 +58,10 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             paymentSheetPage.waitForCardForm()
         }
 
+        final override fun clickPrimaryButton() {
+            paymentSheetPage.clickPrimaryButton()
+        }
+
         class PaymentSheet(
             composeTestRule: ComposeTestRule,
             private val context: PaymentSheetTestRunnerContext,
@@ -63,7 +76,11 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             }
 
             override suspend fun confirm() {
-                throw IllegalStateException("Should confirm from Tap to Add flow!")
+                // No-op
+            }
+
+            override fun markTestSucceeded() {
+                context.markTestSucceeded()
             }
         }
 
@@ -93,6 +110,10 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
 
                 context.flowController.confirm()
             }
+
+            override fun markTestSucceeded() {
+                context.markTestSucceeded()
+            }
         }
     }
 
@@ -120,9 +141,36 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             )
         }
 
+        override fun clickPrimaryButton() {
+            composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+                .performScrollTo()
+                .performClick()
+
+            composeTestRule.waitUntil(5_000) {
+                !hasPrimaryButton()
+            }
+
+            composeTestRule.waitForIdle()
+        }
+
         final override fun openCardForm() {
             embeddedContentPage.clickOnLpm("card")
             embeddedFormPage.waitUntilVisible()
+        }
+
+        override suspend fun confirm() {
+            val paymentOption = context.paymentOptionTurbine.awaitItem()
+
+            assertThat(paymentOption?.label).isEqualTo("···· 4242")
+            assertThat(paymentOption?.paymentMethodType).isEqualTo("card")
+
+            context.confirm()
+        }
+
+        protected fun hasPrimaryButton(): Boolean {
+            return composeTestRule.onAllNodesWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
         }
 
         class Continue(
@@ -131,13 +179,8 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
         ) : Embedded(composeTestRule, context) {
             override val formSheetAction = EmbeddedPaymentElement.FormSheetAction.Continue
 
-            override suspend fun confirm() {
-                val paymentOption = context.paymentOptionTurbine.awaitItem()
-
-                assertThat(paymentOption?.label).isEqualTo("···· 4242")
-                assertThat(paymentOption?.paymentMethodType).isEqualTo("card")
-
-                context.confirm()
+            override fun markTestSucceeded() {
+                context.markTestSucceeded()
             }
         }
 
@@ -145,10 +188,25 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             composeTestRule: ComposeTestRule,
             context: EmbeddedPaymentElementTestRunnerContext
         ) : Embedded(composeTestRule, context)  {
+            private var confirmingFromForm: Boolean = false
+
             override val formSheetAction = EmbeddedPaymentElement.FormSheetAction.Confirm
 
+            override fun clickPrimaryButton() {
+                if (hasPrimaryButton()) {
+                    confirmingFromForm = true
+                    super.clickPrimaryButton()
+                }
+            }
+
             override suspend fun confirm() {
-                throw IllegalStateException("Should confirm from Tap to Add flow!")
+                if (!confirmingFromForm) {
+                    super.confirm()
+                }
+            }
+
+            override fun markTestSucceeded() {
+                context.markTestSucceeded()
             }
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationType.kt
@@ -34,4 +34,10 @@ internal sealed interface TapToAddIntegrationType {
             }
         }
     }
+
+    object Provider : TestParameterValuesProvider() {
+        override fun provideValues(context: Context?): List<TapToAddIntegrationType> {
+            return Complete.entries + Continue.entries
+        }
+    }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -4,8 +4,10 @@ import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -17,32 +19,47 @@ import com.stripe.android.tta.testing.TapToAddCardAddedPage
 import com.stripe.android.tta.testing.TapToAddCardCollectionTestHelper
 import com.stripe.android.tta.testing.TapToAddConfirmationPage
 import com.stripe.android.tta.testing.TapToAddLinkTestHelper
+import com.stripe.android.tta.testing.TapToAddSavedPaymentMethodPage
+import com.stripe.android.tta.testing.TerminalTestDelegate
+import com.stripe.paymentelementtestpages.FormPage
+import com.stripe.paymentelementtestpages.VerticalModePage
+import com.stripe.stripeterminal.external.models.TerminalErrorCode
+import com.stripe.stripeterminal.external.models.TerminalException
+import okhttp3.mockwebserver.MockResponse
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(TapToAddPreview::class)
 @RunWith(TestParameterInjector::class)
 internal class TapToAddTest {
+    // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure
+    // it happens, but it's okay if it takes a bit to happen.
+    private val networkRule = NetworkRule(validationTimeout = 5.seconds)
+
     val terminalWrapperTestRule = TerminalWrapperTestRule(enabled = true)
 
     @get:Rule
     val testRules: TestRules = TestRules.create(
+        networkRule = networkRule,
         terminalTestRule = terminalWrapperTestRule,
     ) {
         around(FeatureFlagTestRule(FeatureFlags.enableTapToAdd, true))
     }
 
     private val composeTestRule = testRules.compose
-    private val networkRule = testRules.networkRule
 
     private val cardCollectionTestHelper = TapToAddCardCollectionTestHelper(networkRule) {
         terminalWrapperTestRule.delegate
     }
 
+    private val paymentElementFormPage = FormPage(composeTestRule)
+    private val verticalModePage = VerticalModePage(composeTestRule)
     private val linkHelper = TapToAddLinkTestHelper(composeTestRule, networkRule)
     private val cardAddedPage = TapToAddCardAddedPage(composeTestRule, linkHelper)
     private val confirmationPage = TapToAddConfirmationPage(composeTestRule)
+    private val savedPaymentMethodPage = TapToAddSavedPaymentMethodPage(composeTestRule, linkHelper)
     private val tapToAddCardFormPage = TapToAddCardFormPage(composeTestRule)
 
     @Test
@@ -64,7 +81,7 @@ internal class TapToAddTest {
         }
     ) {
         networkRule.elementsSession { response ->
-            response.testBodyFromFile("elements-sessions-tta.json")
+            response.defaultElementsSessions()
         }
 
         cardCollectionTestHelper.enqueueSuccessfulTapToCollectFlow()
@@ -101,7 +118,7 @@ internal class TapToAddTest {
         }
     ) {
         networkRule.elementsSession { response ->
-            response.testBodyFromFile("elements-sessions-tta.json")
+            response.defaultElementsSessions()
         }
 
         cardCollectionTestHelper.enqueueSuccessfulTapToCollectFlow()
@@ -120,6 +137,153 @@ internal class TapToAddTest {
         confirm()
     }
 
+    @Test
+    fun canceledDuringCardCollection(
+        @TestParameter(valuesProvider = TapToAddIntegrationType.Provider::class)
+        integrationType: TapToAddIntegrationType
+    ) = runTapToAddIntegrationTest(
+        integrationType = integrationType,
+        composeTestRule = composeTestRule,
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            throw IllegalStateException("Create intent callback should not be called!")
+        },
+        createCardPresentCallback = {
+            CreateIntentResult.Success("seti_123_secret_123")
+        },
+        resultCallback = {
+            throw IllegalStateException("Result callback should not be called!")
+        }
+    ) {
+        networkRule.elementsSession { response ->
+            response.defaultElementsSessions()
+        }
+
+        terminalWrapperTestRule.delegate.setScenario(
+            TerminalTestDelegate.Scenario(
+                collectSetupIntentPaymentMethodResult = TerminalTestDelegate.SetupIntentResult.Failure(
+                    exception = TerminalException(
+                        errorCode = TerminalErrorCode.CANCELED,
+                        errorMessage = "Canceled!"
+                    )
+                )
+            )
+        )
+
+        launchFlow()
+        openCardForm()
+
+        tapToAddCardFormPage.clickOnTapToAdd()
+
+        paymentElementFormPage.waitUntilVisible()
+
+        markTestSucceeded()
+    }
+
+    @Test
+    fun successAfterCancelAfterCardCollectedWithCompleteMode(
+        @TestParameter(valuesProvider = TapToAddIntegrationType.Complete.Provider::class)
+        integrationType: TapToAddIntegrationType.Complete,
+    ) = runTapToAddIntegrationTest(
+        integrationType = integrationType,
+        composeTestRule = composeTestRule,
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_123_secret_123")
+        },
+        createCardPresentCallback = {
+            CreateIntentResult.Success("seti_123_secret_123")
+        },
+        resultCallback = {
+            assertThat(it).isInstanceOf(TapToAddTestResult.Completed::class.java)
+        }
+    ) {
+        networkRule.elementsSession { response ->
+            response.defaultElementsSessions()
+        }
+
+        cardCollectionTestHelper.enqueueSuccessfulTapToCollectFlow()
+
+        launchFlow()
+        openCardForm()
+
+        tapToAddCardFormPage.clickOnTapToAdd()
+
+        confirmationPage.assertPrimaryButton()
+        confirmationPage.clickCloseButton()
+        confirmationPage.waitUntilMissing()
+
+        enqueueConfirmRequests()
+
+        verticalModePage.assertHasSelectedSavedPaymentMethod(paymentMethodId = "pm_2")
+
+        clickPrimaryButton()
+
+        verticalModePage.waitUntilMissing()
+
+        confirm()
+    }
+
+    @Test
+    fun successAfterCancelAfterCardCollectedWithLink(
+        @TestParameter(valuesProvider = TapToAddIntegrationType.Provider::class)
+        integrationType: TapToAddIntegrationType
+    ) = runTapToAddIntegrationTest(
+        integrationType = integrationType,
+        composeTestRule = composeTestRule,
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_123_secret_123")
+        },
+        createCardPresentCallback = {
+            CreateIntentResult.Success("seti_123_secret_123")
+        },
+        resultCallback = {
+            assertThat(it).isInstanceOf(TapToAddTestResult.Completed::class.java)
+        }
+    ) {
+        networkRule.elementsSession { response ->
+            response.elementsSessionTtaWithLink()
+        }
+
+        enqueueRetrieveCustomerRequest()
+
+        val info = cardCollectionTestHelper.enqueueSuccessfulTapToCollectFlow()
+
+        linkHelper.enqueueLookup()
+
+        launchFlow()
+        openCardForm()
+
+        tapToAddCardFormPage.clickOnTapToAdd()
+
+        cardAddedPage.assertShown(withLink = true)
+        cardAddedPage.clickCloseButton()
+        cardAddedPage.waitUntilMissing()
+
+        savedPaymentMethodPage.assertShown()
+        savedPaymentMethodPage.fillLink()
+
+        linkHelper.enqueueSignup(withName = false)
+        linkHelper.enqueueCreatePaymentDetailsFromPaymentMethod(info.cardPaymentMethod.id)
+        enqueueConfirmRequests()
+        enqueueLinkLogout(integrationType)
+
+        clickPrimaryButton()
+        savedPaymentMethodPage.waitUntilMissing()
+
+        confirm()
+    }
+
+    private fun enqueueRetrieveCustomerRequest() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/customers/cus_123"),
+        ) { response ->
+            response.testBodyFromFile("tta-customer-get-success.json")
+        }
+    }
+
     private fun enqueueConfirmRequests() {
         networkRule.enqueue(
             method("GET"),
@@ -134,5 +298,43 @@ internal class TapToAddTest {
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
+    }
+
+    private fun enqueueLinkLogout(integrationType: TapToAddIntegrationType) {
+        if (
+            integrationType == TapToAddIntegrationType.Complete.PaymentSheet ||
+            integrationType == TapToAddIntegrationType.Continue.FlowController
+        ) {
+            networkRule.enqueue(
+                method("POST"),
+                path("/v1/consumers/sessions/log_out"),
+            ) { response ->
+                response.testBodyFromFile("consumer-session-logout-success.json")
+            }
+        }
+    }
+
+    private fun MockResponse.defaultElementsSessions() {
+        testBodyFromFile(
+            "elements-sessions-tta.json",
+            replacements = listOf(
+                ResponseReplacement(
+                    original = "PAYMENT_METHOD_TYPES",
+                    new = "\"card\", \"cashapp\""
+                )
+            )
+        )
+    }
+
+    private fun MockResponse.elementsSessionTtaWithLink() {
+        testBodyFromFile(
+            "elements-sessions-tta.json",
+            replacements = listOf(
+                ResponseReplacement(
+                    original = "PAYMENT_METHOD_TYPES",
+                    new = "\"card\", \"cashapp\", \"link\""
+                )
+            )
+        )
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -217,11 +217,12 @@ internal class TapToAddTest {
 
         verticalModePage.assertHasSelectedSavedPaymentMethod(paymentMethodId = "pm_2")
 
-        clickPrimaryButton()
+        when (integrationType) {
+            TapToAddIntegrationType.Complete.PaymentSheet -> clickPrimaryButton()
+            TapToAddIntegrationType.Complete.Embedded -> confirm()
+        }
 
         verticalModePage.waitUntilMissing()
-
-        confirm()
     }
 
     @Test
@@ -272,7 +273,9 @@ internal class TapToAddTest {
         clickPrimaryButton()
         savedPaymentMethodPage.waitUntilMissing()
 
-        confirm()
+        if (integrationType !is TapToAddIntegrationType.Complete) {
+            confirm()
+        }
     }
 
     private fun enqueueRetrieveCustomerRequest() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -424,6 +424,15 @@ internal class PaymentSheetPage(
         }
     }
 
+    fun waitUntilMissing() {
+        composeTestRule.waitUntil(5000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty()
+        }
+    }
+
     fun clickOnLpm(code: String, forVerticalMode: Boolean = false) {
         composeTestRule.waitForIdle()
         waitUntilVisible()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.testing.RetryRule
+import com.stripe.android.testing.ShampooRule
 import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.testing.RetryRule
-import com.stripe.android.testing.ShampooRule
 import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule

--- a/paymentsheet/src/androidTest/resources/elements-sessions-tta.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-tta.json
@@ -3,12 +3,13 @@
   "merchant_country": "US",
   "merchant_currency": "usd",
   "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
-  "ordered_payment_method_types_and_wallets": [
-    "card",
-    "cashapp"
-  ],
+  "ordered_payment_method_types_and_wallets": [PAYMENT_METHOD_TYPES],
   "flags": {
     "elements_mobile_android_tap_to_add_enabled": true
+  },
+  "link_settings": {
+    "link_funding_sources": ["CARD"],
+    "link_mobile_disable_default_opt_in": true
   },
   "customer": {
     "payment_methods": [],
@@ -38,10 +39,7 @@
   "payment_method_preference": {
     "object": "payment_method_preference",
     "country_code": "US",
-    "ordered_payment_method_types": [
-      "card",
-      "cashapp"
-    ],
+    "ordered_payment_method_types": [PAYMENT_METHOD_TYPES],
     "payment_intent": {
       "id": "pi_example",
       "object": "payment_intent",
@@ -69,10 +67,7 @@
           "verification_method": "automatic"
         }
       },
-      "payment_method_types": [
-        "card",
-        "cashapp"
-      ],
+      "payment_method_types": [PAYMENT_METHOD_TYPES],
       "processing": null,
       "receipt_email": null,
       "setup_future_usage": null,

--- a/paymentsheet/src/androidTest/resources/tta-customer-get-success.json
+++ b/paymentsheet/src/androidTest/resources/tta-customer-get-success.json
@@ -1,0 +1,10 @@
+{
+  "id": "cus_123",
+  "object": "customer",
+  "created": 1739227546,
+  "default_source": null,
+  "description": null,
+  "email": null,
+  "livemode": false,
+  "shipping": null
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
@@ -44,6 +45,7 @@ internal fun ColumnScope.TapToAddCardAddedScreen(
         with(state.primaryButton) {
             this?.run {
                 PrimaryButton(
+                    modifier = Modifier.testTag(TAP_TO_ADD_CARD_ADDED_PRIMARY_BUTTON),
                     label = label.resolve(),
                     locked = false,
                     enabled = enabled,
@@ -57,6 +59,9 @@ internal fun ColumnScope.TapToAddCardAddedScreen(
         Spacer(Modifier.size(10.dp))
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TAP_TO_ADD_CARD_ADDED_PRIMARY_BUTTON = "TAP_TO_ADD_CARD_ADDED_PRIMARY_BUTTON"
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val TAP_TO_ADD_CARD_ADDED_SHOWN_DELAY = 2500L

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.taptoadd.ui
 
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
@@ -10,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -62,6 +64,7 @@ internal fun ColumnScope.TapToAddConfirmationScreen(
 
         with(state.primaryButton) {
             PrimaryButton(
+                modifier = Modifier.testTag(TAP_TO_ADD_CONFIRMATION_PRIMARY_BUTTON),
                 label = label.resolve(),
                 locked = locked,
                 enabled = enabled,
@@ -81,3 +84,6 @@ internal fun ColumnScope.TapToAddConfirmationScreen(
         Spacer(Modifier.size(10.dp))
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TAP_TO_ADD_CONFIRMATION_PRIMARY_BUTTON = "TAP_TO_ADD_CONFIRMATION_PRIMARY_BUTTON"

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_CARD_ADDED_PRIMARY_BUTTON
 import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_CARD_ADDED_SHOWN_DELAY
 
 class TapToAddCardAddedPage(
@@ -62,7 +63,7 @@ class TapToAddCardAddedPage(
     }
 
     fun waitUntilMissing() {
-        composeTestRule.waitUntilLayoutWithPrimaryButtonMissing()
+        composeTestRule.waitUntilLayoutWithPrimaryButtonMissing(TAP_TO_ADD_CARD_ADDED_PRIMARY_BUTTON)
     }
 
     private fun assertHasCardAddedText() {

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddConfirmationPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddConfirmationPage.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_CONFIRMATION_PRIMARY_BUTTON
 
 class TapToAddConfirmationPage(
     private val composeTestRule: ComposeTestRule,
@@ -45,7 +46,7 @@ class TapToAddConfirmationPage(
     }
 
     fun waitUntilMissing() {
-        composeTestRule.waitUntilLayoutWithPrimaryButtonMissing()
+        composeTestRule.waitUntilLayoutWithPrimaryButtonMissing(TAP_TO_ADD_CONFIRMATION_PRIMARY_BUTTON)
     }
 
     fun clickCloseButton() {

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddHelpers.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddHelpers.kt
@@ -3,11 +3,12 @@ package com.stripe.android.tta.testing
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_LAYOUT_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 
-internal fun ComposeTestRule.waitUntilLayoutWithPrimaryButtonMissing() {
+internal fun ComposeTestRule.waitUntilLayoutWithPrimaryButtonMissing(
+    buttonTestTag: String,
+) {
     waitUntil(DEFAULT_UI_TIMEOUT) {
-        onAllNodesWithTag(PRIMARY_BUTTON_TEST_TAG)
+        onAllNodesWithTag(buttonTestTag)
             .fetchSemanticsNodes(atLeastOneRootRequired = false)
             .isEmpty()
     }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddLinkTestHelper.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddLinkTestHelper.kt
@@ -28,13 +28,17 @@ class TapToAddLinkTestHelper(
         }
     }
 
-    fun enqueueSignup() {
+    fun enqueueSignup(withName: Boolean = true) {
+        val nameMatchers = arrayOf(bodyPart("legal_name", urlEncode(NAME))).takeIf {
+            withName
+        } ?: emptyArray()
+
         networkRule.enqueue(
             method("POST"),
             path("/v1/consumers/accounts/sign_up"),
             bodyPart("email_address", urlEncode(EMAIL)),
             bodyPart("phone_number", urlEncode(PHONE)),
-            bodyPart("legal_name", urlEncode(NAME)),
+            *nameMatchers,
         ) { response ->
             response.testBodyFromFile("consumer-accounts-signup-success.json")
         }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddSavedPaymentMethodPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddSavedPaymentMethodPage.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.tta.testing
+
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+
+class TapToAddSavedPaymentMethodPage(
+    private val composeTestRule: ComposeTestRule,
+    val linkHelper: TapToAddLinkTestHelper,
+) {
+    fun assertShown() {
+        assertHasAddedCardText()
+        linkHelper.checkbox().assertExists()
+    }
+
+    fun waitUntilMissing() {
+        composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT) {
+            composeTestRule.waitForIdle()
+            composeTestRule.onAllNodes(hasText(TITLE))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty()
+        }
+    }
+
+    fun fillLink() {
+        linkHelper.checkbox().click()
+        linkHelper.fillEmail()
+        linkHelper.fillPhone()
+    }
+
+    private fun assertHasAddedCardText() {
+        val matcher = hasText(TITLE)
+
+        composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT) {
+            composeTestRule.onAllNodes(matcher)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .size == 1
+        }
+
+        composeTestRule.onNode(matcher).isDisplayed()
+    }
+
+    private companion object {
+        const val TITLE = "Added card"
+    }
+}


### PR DESCRIPTION
# Summary
Add cancellation emulator tests for Tap to Add that test the following cancellation cases:
- Cancelling into the card form if user cancelled during tap flow
- Cancelling into `Added card` screen if user added a card but didn't click `Confirm`/`Continue` and has Link input
- Cancelling into vertical layout screen if user added a card but didn't click `Confirm`/`Continue` without Link input

# Motivation
Ensures cancellation cases are tested E2E.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified