### PR TITLE
Add PMM Promotion to PaymentMethodRowButton

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PaymentMethodMessageHeaderUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PaymentMethodMessageHeaderUI.kt
@@ -1,14 +1,21 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
+import com.stripe.android.model.PaymentMethodMessagePromotion
 
 @Composable
 internal fun PaymentMethodMessageHeaderUI(element: PaymentMethodMessageHeaderElement) {
-    val promotion = element.promotion
+    PaymentMethodMessagePromotionText(element.promotion)
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun PaymentMethodMessagePromotionText(promotion: PaymentMethodMessagePromotion) {
     val message = buildAnnotatedString {
         append(promotion.message.maybeAddPeriod())
         withLink(

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2314,10 +2314,10 @@ public final class com/stripe/android/paymentsheet/verticalmode/ComposableSingle
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/verticalmode/ComposableSingletons$PaymentMethodRowButtonKt;
 	public fun <init> ()V
 	public final fun getLambda$-1179981339$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1423392141$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-228724754$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-775164684$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$1616606426$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1795895082$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1972223339$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/stripe/android/paymentsheet/verticalmode/ComposableSingletons$SavedPaymentMethodConfirmUIKt {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -104,7 +104,7 @@ internal data class SupportedPaymentMethod(
     fun asDisplayablePaymentMethod(
         customerSavedPaymentMethods: List<PaymentMethod>,
         incentive: PaymentMethodIncentive?,
-        promotionProvider: (() -> PaymentMethodMessagePromotion?)?,
+        promotionProvider: (() -> PaymentMethodMessagePromotion?)? = null,
         onClick: () -> Unit,
     ): DisplayablePaymentMethod {
         fun isTypeAndHasCustomerSavedPaymentMethodsOfType(type: PaymentMethod.Type): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.ui.IconHelper
@@ -103,6 +104,7 @@ internal data class SupportedPaymentMethod(
     fun asDisplayablePaymentMethod(
         customerSavedPaymentMethods: List<PaymentMethod>,
         incentive: PaymentMethodIncentive?,
+        promotionProvider: (() -> PaymentMethodMessagePromotion?)?,
         onClick: () -> Unit,
     ): DisplayablePaymentMethod {
         fun isTypeAndHasCustomerSavedPaymentMethodsOfType(type: PaymentMethod.Type): Boolean {
@@ -127,6 +129,7 @@ internal data class SupportedPaymentMethod(
             iconRequiresTinting = iconRequiresTinting,
             subtitle = subtitle,
             promoBadge = incentive?.displayText,
+            promotionProvider = promotionProvider,
             onClick = onClick,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodMessagePromotionList
@@ -116,6 +117,14 @@ internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessage
     override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
         return null
     }
+}
+
+internal object PromotionSupportedPaymentMethods {
+    val supportedPaymentMethods = setOf(
+        PaymentMethod.Type.Klarna.code,
+        PaymentMethod.Type.Affirm.code,
+        PaymentMethod.Type.AfterpayClearpay.code
+    )
 }
 
 @Module

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/DisplayablePaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/DisplayablePaymentMethod.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.ui.IconHelper
 
 internal data class DisplayablePaymentMethod(
@@ -17,6 +18,7 @@ internal data class DisplayablePaymentMethod(
     val iconRequiresTinting: Boolean,
     val subtitle: ResolvableString? = null,
     val promoBadge: String? = null,
+    val promotionProvider: (() -> PaymentMethodMessagePromotion?)? = null,
     val onClick: () -> Unit,
     @DrawableRes private val outlinedIconResource: Int? = null,
 ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButton.kt
@@ -64,7 +64,7 @@ internal fun NewPaymentMethodRowButton(
     modifier: Modifier = Modifier,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
     appearance: Embedded = Embedded(Embedded.RowStyle.FloatingButton.default),
-    promotionProvider: (() -> PaymentMethodMessagePromotion?)?
+    promotionProvider: (() -> PaymentMethodMessagePromotion?)? = null
 ) {
     PaymentMethodRowButton(
         isEnabled = isEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.ui.PaymentMethodIcon
 import com.stripe.android.paymentsheet.verticalmode.UIConstants.iconHeight
@@ -44,6 +45,7 @@ internal fun NewPaymentMethodRowButton(
         modifier = modifier.testTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_${displayablePaymentMethod.code}"),
         appearance = appearance,
         trailingContent = trailingContent,
+        promotionProvider = displayablePaymentMethod.promotionProvider
     )
 }
 
@@ -61,7 +63,8 @@ internal fun NewPaymentMethodRowButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
-    appearance: Embedded = Embedded(Embedded.RowStyle.FloatingButton.default)
+    appearance: Embedded = Embedded(Embedded.RowStyle.FloatingButton.default),
+    promotionProvider: (() -> PaymentMethodMessagePromotion?)?
 ) {
     PaymentMethodRowButton(
         isEnabled = isEnabled,
@@ -84,5 +87,6 @@ internal fun NewPaymentMethodRowButton(
         modifier = modifier,
         appearance = appearance,
         trailingContent = trailingContent,
+        promotionProvider = promotionProvider,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import android.content.res.Configuration
-import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -389,7 +389,7 @@ private fun TitleContent(
     appearance: Appearance.Embedded,
 ) {
     val titleColor = appearance.style.getTitleTextColor()
-    Column(Modifier.animateContentSize()) {
+    Column {
         Text(
             text = title,
             style = appearance.titleFont?.toTextStyle()
@@ -414,7 +414,7 @@ private fun TitleContent(
             }
         } else {
             val promotion = promotionProvider()
-            if (isSelected) {
+            AnimatedVisibility(isSelected) {
                 if (promotion != null) {
                     PaymentMethodMessagePromotionText(promotion)
                 } else if (subtitle != null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import android.content.res.Configuration
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -33,11 +34,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle
@@ -66,6 +72,7 @@ internal fun PaymentMethodRowButton(
     contentDescription: String? = null,
     modifier: Modifier = Modifier,
     appearance: Appearance.Embedded = Appearance.Embedded(RowStyle.FloatingButton.default),
+    promotionProvider: (() -> PaymentMethodMessagePromotion?)?,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
     val defaultPadding = if (subtitle != null) {
@@ -102,6 +109,8 @@ internal fun PaymentMethodRowButton(
                 iconContent = iconContent,
                 title = title,
                 subtitle = subtitle,
+                promotionProvider = promotionProvider,
+                isSelected = isSelected,
                 contentDescription = contentDescription,
                 appearance = appearance,
                 modifier = if (appearance.style.shouldAddModifierWeight()) {
@@ -338,6 +347,8 @@ private fun RowButtonInnerContent(
     iconContent: @Composable RowScope.() -> Unit,
     title: String,
     subtitle: String?,
+    promotionProvider: (() -> PaymentMethodMessagePromotion?)?,
+    isSelected: Boolean,
     contentDescription: String? = null,
     appearance: Appearance.Embedded,
     modifier: Modifier = Modifier
@@ -353,7 +364,9 @@ private fun RowButtonInnerContent(
         TitleContent(
             title = title,
             subtitle = subtitle,
+            promotionSupplier = promotionProvider,
             isEnabled = isEnabled,
+            isSelected = isSelected,
             contentDescription = contentDescription,
             appearance = appearance
         )
@@ -372,12 +385,14 @@ private fun RowButtonInnerContent(
 private fun TitleContent(
     title: String,
     subtitle: String?,
+    promotionSupplier: (() -> PaymentMethodMessagePromotion?)?,
     isEnabled: Boolean,
+    isSelected: Boolean,
     contentDescription: String?,
     appearance: Appearance.Embedded,
 ) {
     val titleColor = appearance.style.getTitleTextColor()
-    Column {
+    Column(Modifier.animateContentSize()) {
         Text(
             text = title,
             style = appearance.titleFont?.toTextStyle()
@@ -392,14 +407,60 @@ private fun TitleContent(
             }
         )
 
-        if (subtitle != null) {
-            val subtitleTextColor = appearance.style.getSubtitleTextColor()
-            Text(
-                text = subtitle,
-                style = appearance.subtitleFont?.toTextStyle()
-                    ?: MaterialTheme.typography.caption.copy(fontWeight = FontWeight.Normal),
-                color = if (isEnabled) subtitleTextColor else subtitleTextColor.copy(alpha = 0.6f),
+        if (promotionSupplier == null) {
+            if (subtitle != null) {
+                Subtitle(
+                    appearance = appearance,
+                    subtitle = subtitle,
+                    isEnabled = isEnabled
+                )
+            }
+        } else {
+            val promotion = promotionSupplier()
+            if (isSelected) {
+                if (promotion != null) {
+                    Text(buildPaymentMethodMessage(promotion))
+                } else if (subtitle != null) {
+                    // Fallback to subtitle on click if promotion wasn't fetched successfully
+                    Subtitle(
+                        appearance = appearance,
+                        subtitle = subtitle,
+                        isEnabled = isEnabled
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(AppearanceAPIAdditionsPreview::class)
+@Composable
+private fun Subtitle(
+    appearance: Appearance.Embedded,
+    subtitle: String?,
+    isEnabled: Boolean
+) {
+    if (subtitle != null) {
+        val subtitleTextColor = appearance.style.getSubtitleTextColor()
+        Text(
+            text = subtitle,
+            style = appearance.subtitleFont?.toTextStyle()
+                ?: MaterialTheme.typography.caption.copy(fontWeight = FontWeight.Normal),
+            color = if (isEnabled) subtitleTextColor else subtitleTextColor.copy(alpha = 0.6f),
+        )
+    }
+}
+
+private fun buildPaymentMethodMessage(promotion: PaymentMethodMessagePromotion): AnnotatedString {
+    return buildAnnotatedString {
+        append(promotion.message)
+        append(". ")
+        withLink(
+            LinkAnnotation.Url(
+                url = promotion.learnMore.url
             )
+        ) {
+            append(promotion.learnMore.message)
         }
     }
 }
@@ -433,6 +494,7 @@ private fun ButtonPreview() {
                 promoText = null,
                 onClick = {},
                 appearance = Appearance.Embedded.default,
+                promotionProvider = { null },
                 trailingContent = {
                     Text("Edit")
                 }
@@ -458,6 +520,7 @@ private fun ButtonPreview() {
                 promoText = null,
                 onClick = {},
                 appearance = Appearance.Embedded.default,
+                promotionProvider = { null },
                 trailingContent = {
                     Text("Edit")
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
@@ -34,12 +34,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -52,6 +48,7 @@ import com.stripe.android.paymentsheet.ui.DefaultPaymentMethodLabel
 import com.stripe.android.paymentsheet.ui.PaymentMethodIcon
 import com.stripe.android.paymentsheet.ui.PromoBadge
 import com.stripe.android.paymentsheet.verticalmode.UIConstants.iconWidth
+import com.stripe.android.ui.core.elements.PaymentMethodMessagePromotionText
 import com.stripe.android.uicore.DefaultStripeTheme
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
@@ -364,7 +361,7 @@ private fun RowButtonInnerContent(
         TitleContent(
             title = title,
             subtitle = subtitle,
-            promotionSupplier = promotionProvider,
+            promotionProvider = promotionProvider,
             isEnabled = isEnabled,
             isSelected = isSelected,
             contentDescription = contentDescription,
@@ -385,7 +382,7 @@ private fun RowButtonInnerContent(
 private fun TitleContent(
     title: String,
     subtitle: String?,
-    promotionSupplier: (() -> PaymentMethodMessagePromotion?)?,
+    promotionProvider: (() -> PaymentMethodMessagePromotion?)?,
     isEnabled: Boolean,
     isSelected: Boolean,
     contentDescription: String?,
@@ -407,7 +404,7 @@ private fun TitleContent(
             }
         )
 
-        if (promotionSupplier == null) {
+        if (promotionProvider == null) {
             if (subtitle != null) {
                 Subtitle(
                     appearance = appearance,
@@ -416,10 +413,10 @@ private fun TitleContent(
                 )
             }
         } else {
-            val promotion = promotionSupplier()
+            val promotion = promotionProvider()
             if (isSelected) {
                 if (promotion != null) {
-                    Text(buildPaymentMethodMessage(promotion))
+                    PaymentMethodMessagePromotionText(promotion)
                 } else if (subtitle != null) {
                     // Fallback to subtitle on click if promotion wasn't fetched successfully
                     Subtitle(
@@ -448,20 +445,6 @@ private fun Subtitle(
                 ?: MaterialTheme.typography.caption.copy(fontWeight = FontWeight.Normal),
             color = if (isEnabled) subtitleTextColor else subtitleTextColor.copy(alpha = 0.6f),
         )
-    }
-}
-
-private fun buildPaymentMethodMessage(promotion: PaymentMethodMessagePromotion): AnnotatedString {
-    return buildAnnotatedString {
-        append(promotion.message)
-        append(". ")
-        withLink(
-            LinkAnnotation.Url(
-                url = promotion.learnMore.url
-            )
-        ) {
-            append(promotion.learnMore.message)
-        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -4,11 +4,13 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -372,7 +374,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     ): List<DisplayablePaymentMethod> {
         val lpms = supportedPaymentMethods.map { supportedPaymentMethod ->
             val paymentMethodIncentive = incentive?.takeIfMatches(supportedPaymentMethod.code)
-            supportedPaymentMethod.asDisplayablePaymentMethod(paymentMethods, paymentMethodIncentive) {
+            supportedPaymentMethod.asDisplayablePaymentMethod(
+                customerSavedPaymentMethods = paymentMethods,
+                incentive = paymentMethodIncentive,
+                promotionProvider = getPromotionProvider(supportedPaymentMethod.code)
+            ) {
                 handleViewAction(ViewAction.PaymentMethodSelected(supportedPaymentMethod.code))
             }
         }
@@ -651,5 +657,13 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
         is PaymentSelection.New.USBankAccount -> label
         else -> null
+    }
+
+    private fun getPromotionProvider(code: PaymentMethodCode): (() -> PaymentMethodMessagePromotion?)? {
+        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
+            { paymentMethodMessagePromotionsHelper?.getPromotionIfAvailableForCode(code) }
+        } else {
+            null
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.repositories.PromotionSupportedPaymentMethods
 import com.stripe.android.paymentsheet.state.WalletLocation
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
@@ -660,7 +661,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     }
 
     private fun getPromotionProvider(code: PaymentMethodCode): (() -> PaymentMethodMessagePromotion?)? {
-        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
+        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled &&
+            PromotionSupportedPaymentMethods.supportedPaymentMethods.contains(code)
+        ) {
             { paymentMethodMessagePromotionsHelper?.getPromotionIfAvailableForCode(code) }
         } else {
             null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -84,7 +84,8 @@ internal fun SavedPaymentMethodRowButton(
         contentDescription = contentDescription,
         trailingContent = trailingContent,
         appearance = appearance,
-        shouldShowDefaultBadge = displayableSavedPaymentMethod.shouldShowDefaultBadge
+        shouldShowDefaultBadge = displayableSavedPaymentMethod.shouldShowDefaultBadge,
+        promotionProvider = { null }
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -85,7 +85,7 @@ internal fun SavedPaymentMethodRowButton(
         trailingContent = trailingContent,
         appearance = appearance,
         shouldShowDefaultBadge = displayableSavedPaymentMethod.shouldShowDefaultBadge,
-        promotionProvider = { null }
+        promotionProvider = null
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
@@ -3,11 +3,12 @@ package com.stripe.android.utils
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 
-class FakePaymentMethodMessagePromotionsHelper(
+internal class FakePaymentMethodMessagePromotionsHelper(
     private val promotions: List<PaymentMethodMessagePromotion>? = null
 ) : PaymentMethodMessagePromotionsHelper {
     private val _calls = Turbine<Unit>()
@@ -29,5 +30,41 @@ class FakePaymentMethodMessagePromotionsHelper(
 
     fun validate() {
         calls.ensureAllEventsConsumed()
+    }
+
+    internal object Factory {
+        fun create(
+            promotions: List<PaymentMethodMessagePromotion>? = Companion.promotions
+        ): PaymentMethodMessagePromotionsHelper {
+            return FakePaymentMethodMessagePromotionsHelper(promotions)
+        }
+    }
+
+    internal companion object {
+        val klarnaPromotion = PaymentMethodMessagePromotion(
+            paymentMethodType = "KLARNA",
+            message = "This is a message",
+            learnMore = PaymentMethodMessageLearnMore(
+                message = "Click me",
+                url = "https://www.test.com"
+            )
+        )
+        val affirmPromotion = PaymentMethodMessagePromotion(
+            paymentMethodType = "AFFIRM",
+            message = "This is a message",
+            learnMore = PaymentMethodMessageLearnMore(
+                message = "Click me",
+                url = "https://www.test.com"
+            )
+        )
+        val afterpayPromotion = PaymentMethodMessagePromotion(
+            paymentMethodType = "AFTERPAY_CLEARPAY",
+            message = "This is a message",
+            learnMore = PaymentMethodMessageLearnMore(
+                message = "Click me",
+                url = "https://www.test.com"
+            )
+        )
+        val promotions = listOf(klarnaPromotion, affirmPromotion, afterpayPromotion)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -27,6 +28,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.verticalmode.CurrencyOption
@@ -37,6 +39,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -1682,6 +1685,50 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         }
     }
 
+    @Test
+    fun `Passes promotion provider to supported bnpls`() {
+        FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            )
+        )
+        runScenario(
+            promotionsHelper = FakePaymentMethodMessagePromotionsHelper.Factory.create(),
+            paymentMethodMetadata = metadata
+        ) {
+            interactor.state.test {
+                val paymentMethods = awaitItem().displayablePaymentMethods
+                val promotionProvider = paymentMethods.first { it.code == "klarna" }.promotionProvider
+                assertThat(promotionProvider).isNotNull()
+                assertThat(promotionProvider?.invoke()).isEqualTo(
+                    FakePaymentMethodMessagePromotionsHelper.klarnaPromotion
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Does not pass promotion provider to unsupported PMs`() {
+        FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna")
+            )
+        )
+        runScenario(
+            promotionsHelper = FakePaymentMethodMessagePromotionsHelper.Factory.create(),
+            paymentMethodMetadata = metadata
+        ) {
+            interactor.state.test {
+                val paymentMethods = awaitItem().displayablePaymentMethods
+                val paymentMethod = paymentMethods.first { it.code == "card" }
+                assertThat(paymentMethod).isNotNull()
+                assertThat(paymentMethod.promotionProvider).isNull()
+            }
+        }
+    }
+
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private val linkAndGooglePayWalletState = WalletsState(
@@ -1739,6 +1786,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         initialWalletsState: WalletsState? = null,
         displaysMandatesInFormScreen: Boolean = false,
         initialCurrencySelectorOptions: CurrencySelectorOptions? = null,
+        promotionsHelper: PaymentMethodMessagePromotionsHelper? = null,
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -1811,7 +1859,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             onCurrencySelected = { currencyOption ->
                 onCurrencySelectedTurbine.add(currencyOption)
             },
-            paymentMethodMessagePromotionsHelper = null
+            paymentMethodMessagePromotionsHelper = promotionsHelper
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
@@ -8,15 +8,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
@@ -26,6 +31,7 @@ import com.stripe.android.paymentsheet.ViewActionRecorder
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.Selection
 import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
@@ -110,6 +116,110 @@ internal class PaymentMethodLayoutUITest(
             composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_card").performClick()
             assertThat(onClickCalled).isTrue()
             assertThat(viewActionRecorder.viewActions).isEmpty()
+        }
+    }
+
+    @Test
+    fun clickingOnBnpL_with_promotion_shows_promotion() {
+        FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "affirm")
+            )
+        )
+        var onClickCalled = false
+        runScenario(
+            initialState = createState(
+                displayablePaymentMethods = listOf(
+                    AffirmDefinition.uiDefinitionFactory(metadata).supportedPaymentMethod(
+                        metadata = metadata,
+                        definition = AffirmDefinition,
+                        sharedDataSpecs = emptyList()
+                    )!!
+                        .asDisplayablePaymentMethod(
+                            customerSavedPaymentMethods = emptyList(),
+                            incentive = null,
+                            onClick = { onClickCalled = true },
+                            promotionProvider = { FakePaymentMethodMessagePromotionsHelper.affirmPromotion }
+                        ),
+                ),
+                displayedSavedPaymentMethod = null,
+            )
+        ) {
+            assertThat(onClickCalled).isFalse()
+            composeRule.onNodeWithText("This is a message", substring = true).isNotDisplayed()
+            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_affirm").performClick()
+            assertThat(onClickCalled).isTrue()
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+            composeRule.onNodeWithText("This is a message", substring = true).isDisplayed()
+        }
+    }
+
+    @Test
+    fun clickingOnBnpL_falls_back_to_subtitle_if_promotion_not_available() {
+        FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "affirm")
+            )
+        )
+        var onClickCalled = false
+        runScenario(
+            initialState = createState(
+                displayablePaymentMethods = listOf(
+                    AffirmDefinition.uiDefinitionFactory(metadata).supportedPaymentMethod(
+                        metadata = metadata,
+                        definition = AffirmDefinition,
+                        sharedDataSpecs = emptyList()
+                    )!!
+                        .asDisplayablePaymentMethod(
+                            customerSavedPaymentMethods = emptyList(),
+                            incentive = null,
+                            onClick = { onClickCalled = true },
+                            promotionProvider = { null }
+                        ),
+                ),
+                displayedSavedPaymentMethod = null,
+            )
+        ) {
+            assertThat(onClickCalled).isFalse()
+            composeRule.onNodeWithText("Pay over time with Affirm").isNotDisplayed()
+            composeRule.onNodeWithTag(TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON + "_affirm").performClick()
+            assertThat(onClickCalled).isTrue()
+            assertThat(viewActionRecorder.viewActions).isEmpty()
+            composeRule.onNodeWithText("Pay over time with Affirm").isDisplayed()
+        }
+    }
+
+    @Test
+    fun displays_subtitle_if_promotion_provider_is_null() {
+        FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "affirm")
+            )
+        )
+        var onClickCalled = false
+        runScenario(
+            initialState = createState(
+                displayablePaymentMethods = listOf(
+                    AffirmDefinition.uiDefinitionFactory(metadata).supportedPaymentMethod(
+                        metadata = metadata,
+                        definition = AffirmDefinition,
+                        sharedDataSpecs = emptyList()
+                    )!!
+                        .asDisplayablePaymentMethod(
+                            customerSavedPaymentMethods = emptyList(),
+                            incentive = null,
+                            onClick = { onClickCalled = true },
+                            promotionProvider = null
+                        ),
+                ),
+                displayedSavedPaymentMethod = null,
+            )
+        ) {
+            assertThat(onClickCalled).isFalse()
+            composeRule.onNodeWithText("Pay over time with Affirm").isDisplayed()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButtonScreenshotTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButtonScreenshotTestUtils.kt
@@ -50,7 +50,8 @@ internal fun testPaymentMethodRowButton(
             onClick = {},
             trailingContent = trailingContent,
             shouldShowDefaultBadge = shouldShowDefaultBadge,
-            appearance = appearance
+            appearance = appearance,
+            promotionProvider = null
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add `promotionProvider` to `DisplayablePaymentMethod`
- Supply provider for supported PMs when constructing displayable PMs in PaymentMethodVerticalLayoutInteractor
- Display promotion in PaymentMethodRowButton if provider is not null and isSelected if no forms are required, else display subtitle

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- https://docs.google.com/document/d/1pi9vehSvFpT80lgEYwBmE_NCcDE5nPTnRrhBrYqlzUQ/edit?tab=t.0
- Provider pattern used as PMM promotions fetch has spotty latency, so we want to wait til the last possible moment before checking if API request has completed and there are promotions available


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

https://github.com/user-attachments/assets/08e67c5b-6840-46c3-814e-f2cbe35c66bf




# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
