### PR TITLE
Add config and promotion to ManageContract for embedded payment.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -1,0 +1,234 @@
+package com.stripe.android.paymentelement.embedded
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.common.spms.DefaultLinkFormElementFactory
+import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
+import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
+import com.stripe.android.common.spms.LinkFormElementFactory
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
+import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
+import com.stripe.android.common.taptoadd.DefaultTapToAddHelper
+import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.common.taptoadd.TapToAddMode
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.core.utils.RealUserFacingLogger
+import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.form.DefaultFormActivityRegistrar
+import com.stripe.android.paymentelement.embedded.form.DefaultFormActivityStateHelper
+import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
+import com.stripe.android.paymentelement.embedded.form.FormActivityRegistrar
+import com.stripe.android.paymentelement.embedded.form.FormActivityStateHelper
+import com.stripe.android.paymentelement.embedded.form.FormActivitySubcomponent
+import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
+import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
+import com.stripe.android.paymentelement.embedded.manage.DefaultEmbeddedManageScreenInteractorFactory
+import com.stripe.android.paymentelement.embedded.manage.DefaultEmbeddedUpdateScreenInteractorFactory
+import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInteractorFactory
+import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
+import com.stripe.android.paymentelement.embedded.manage.InitialManageScreenFactory
+import com.stripe.android.paymentelement.embedded.manage.ManageNavigator
+import com.stripe.android.paymentelement.embedded.manage.ManageSavedPaymentMethodMutatorFactory
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultPrefsRepository
+import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.verticalmode.DefaultSavedPaymentMethodConfirmInteractor
+import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import com.stripe.android.uicore.image.DefaultStripeImageLoader
+import com.stripe.android.uicore.image.StripeImageLoader
+import com.stripe.android.uicore.utils.stateFlowOf
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Singleton
+
+@Module(
+    subcomponents = [
+        FormActivitySubcomponent::class,
+    ]
+)
+internal interface EmbeddedActivityModule {
+    @Binds
+    fun bindsEmbeddedManageScreenInteractorFactory(
+        factory: DefaultEmbeddedManageScreenInteractorFactory
+    ): EmbeddedManageScreenInteractorFactory
+
+    @Binds
+    fun bindsEmbeddedUpdateScreenInteractorFactory(
+        factory: DefaultEmbeddedUpdateScreenInteractorFactory
+    ): EmbeddedUpdateScreenInteractorFactory
+
+    @Binds
+    fun bindsCardAccountRangeRepositoryFactory(
+        defaultCardAccountRangeRepositoryFactory: DefaultCardAccountRangeRepositoryFactory
+    ): CardAccountRangeRepository.Factory
+
+    @Binds
+    fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
+
+    @Binds
+    fun bindsFormActivityStateHelper(helper: DefaultFormActivityStateHelper): FormActivityStateHelper
+
+    @Binds
+    fun bindsPrefsRepositoryFactory(factory: DefaultPrefsRepository.Factory): PrefsRepository.Factory
+
+    @Binds
+    fun bindsTapToAddHelperFactory(factory: DefaultTapToAddHelper.Factory): TapToAddHelper.Factory
+
+    @Binds
+    fun bindsSavedPaymentMethodLinkFormHelper(
+        helper: DefaultSavedPaymentMethodLinkFormHelper
+    ): SavedPaymentMethodLinkFormHelper
+
+    @Binds
+    fun bindsLinkInlineSignupAvailability(
+        impl: DefaultLinkInlineSignupAvailability,
+    ): LinkInlineSignupAvailability
+
+    @Suppress("TooManyFunctions")
+    companion object {
+        @Provides
+        fun providesContext(application: Application): Context {
+            return application
+        }
+
+        @Provides
+        @Singleton
+        @ViewModelScope
+        fun provideViewModelScope(): CoroutineScope {
+            return CoroutineScope(Dispatchers.Main)
+        }
+
+        @Provides
+        @Singleton
+        fun provideManageNavigator(
+            initialManageScreenFactory: InitialManageScreenFactory,
+            @ViewModelScope viewModelScope: CoroutineScope,
+            eventReporter: EventReporter,
+        ): ManageNavigator {
+            return ManageNavigator(
+                coroutineScope = viewModelScope,
+                eventReporter = eventReporter,
+                initialScreen = initialManageScreenFactory.createInitialScreen(),
+            )
+        }
+
+        @Provides
+        @Singleton
+        fun provideSavedPaymentMethodMutator(
+            factory: ManageSavedPaymentMethodMutatorFactory
+        ): SavedPaymentMethodMutator {
+            return factory.createSavedPaymentMethodMutator()
+        }
+
+        @Provides
+        @Singleton
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
+
+        @Provides
+        @Singleton
+        fun provideFormInteractor(
+            interactorFactory: EmbeddedFormInteractorFactory
+        ): DefaultVerticalModeFormInteractor = interactorFactory.create()
+
+        @Provides
+        @Singleton
+        fun provideConfirmationHandler(
+            confirmationHandlerFactory: ConfirmationHandler.Factory,
+            @ViewModelScope coroutineScope: CoroutineScope,
+        ): ConfirmationHandler {
+            return confirmationHandlerFactory.create(coroutineScope)
+        }
+
+        @Provides
+        @Singleton
+        fun providesTapToAddHelper(
+            @ViewModelScope coroutineScope: CoroutineScope,
+            configuration: EmbeddedPaymentElement.Configuration,
+            tapToAddHelperFactory: TapToAddHelper.Factory,
+            embeddedSelectionHolder: EmbeddedSelectionHolder,
+            customerStateHolder: CustomerStateHolder,
+            paymentMethodMetadata: PaymentMethodMetadata,
+        ): TapToAddHelper {
+            return tapToAddHelperFactory.create(
+                coroutineScope = coroutineScope,
+                tapToAddMode = when (configuration.formSheetAction) {
+                    EmbeddedPaymentElement.FormSheetAction.Continue -> TapToAddMode.Continue
+                    EmbeddedPaymentElement.FormSheetAction.Confirm -> TapToAddMode.Complete
+                },
+                updateSelection = embeddedSelectionHolder::set,
+                customerStateHolder = customerStateHolder,
+                linkSignupMode = stateFlowOf(paymentMethodMetadata.linkState?.signupMode),
+            )
+        }
+
+        @Provides
+        @Singleton
+        fun provideOnClickOverrideDelegate(): OnClickOverrideDelegate = OnClickDelegateOverrideImpl()
+
+        @Provides
+        @Singleton
+        fun providesFormActivityConfirmationHandlerRegistrar(
+            confirmationHandler: ConfirmationHandler,
+            tapToAddHelper: TapToAddHelper,
+        ): FormActivityRegistrar {
+            return DefaultFormActivityRegistrar(confirmationHandler, tapToAddHelper)
+        }
+
+        @Provides
+        @Singleton
+        fun provideStripeImageLoader(context: Context): StripeImageLoader {
+            return DefaultStripeImageLoader(context)
+        }
+
+        @Provides
+        fun providePaymentMethodMetadataFlow(
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): StateFlow<PaymentMethodMetadata?> {
+            return stateFlowOf(paymentMethodMetadata)
+        }
+
+        @Provides
+        fun providesTapToAddLinkFormElementFactory(): LinkFormElementFactory {
+            return DefaultLinkFormElementFactory
+        }
+
+        @Provides
+        fun provideSavedPaymentMethodConfirmInteractorFactory(
+            @ViewModelScope coroutineScope: CoroutineScope,
+            paymentMethodMetadata: PaymentMethodMetadata,
+            savedPaymentMethodLinkFormHelper: SavedPaymentMethodLinkFormHelper,
+        ): SavedPaymentMethodConfirmInteractor.Factory {
+            return DefaultSavedPaymentMethodConfirmInteractor.Factory(
+                paymentMethodMetadata = paymentMethodMetadata,
+                savedPaymentMethodLinkFormHelper = savedPaymentMethodLinkFormHelper,
+                coroutineScope = coroutineScope,
+            )
+        }
+
+        @Provides
+        fun providesPaymentMethodMessagePromotionHelper(
+            promotion: PaymentMethodMessagePromotion?
+        ): PaymentMethodMessagePromotionsHelper = PrefetchedPaymentMethodMessagePromotionsHelper(
+            listOfNotNull(promotion)
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -40,6 +40,7 @@ internal interface EmbeddedSheetLauncher {
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
         selection: PaymentSelection?,
+        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
     )
 }
 
@@ -150,11 +151,18 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
         selection: PaymentSelection?,
+        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
     ) {
         val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
         if (checkoutSession != null) {
             CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
             CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
+        }
+        if (embeddedConfirmationState == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+            )
+            return
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
@@ -163,6 +171,11 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             customerState = customerState,
             selection = selection,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+            selectedPaymentMethodCode = selection?.paymentMethodType ?: "",
+            hasSavedPaymentMethods = customerState.paymentMethods.isNotEmpty(),
+            statusBarColor = statusBarColor,
+            configuration = embeddedConfirmationState.configuration,
+            promotion = null,
         )
         manageActivityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -230,6 +230,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = confirmationStateHolder.state,
                 )
             },
             transitionToFormScreen = { code ->
@@ -306,6 +307,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = confirmationStateHolder.state,
                 )
             },
             isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -1,69 +1,39 @@
 package com.stripe.android.paymentelement.embedded.form
 
 import android.app.Application
-import android.content.Context
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.cards.CardAccountRangeRepository
-import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.common.di.ApplicationIdModule
-import com.stripe.android.common.spms.DefaultLinkFormElementFactory
-import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
-import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
-import com.stripe.android.common.spms.LinkFormElementFactory
-import com.stripe.android.common.spms.LinkInlineSignupAvailability
-import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
-import com.stripe.android.common.taptoadd.DefaultTapToAddHelper
-import com.stripe.android.common.taptoadd.TapToAddHelper
-import com.stripe.android.common.taptoadd.TapToAddMode
-import com.stripe.android.core.injection.ViewModelScope
-import com.stripe.android.core.utils.RealUserFacingLogger
-import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
-import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityModule
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultPrefsRepository
-import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.verticalmode.DefaultSavedPaymentMethodConfirmInteractor
-import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
-import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
-import com.stripe.android.uicore.image.DefaultStripeImageLoader
-import com.stripe.android.uicore.image.StripeImageLoader
-import com.stripe.android.uicore.utils.stateFlowOf
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
-import dagger.Provides
 import dagger.Subcomponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Component(
     modules = [
-        ApplicationIdModule::class,
+        EmbeddedActivityModule::class,
         EmbeddedCommonModule::class,
-        FormActivityViewModelModule::class,
+        ApplicationIdModule::class,
         ExtendedPaymentElementConfirmationModule::class,
         GooglePayLauncherModule::class,
-        EmbeddedLinkExtrasModule::class
+        EmbeddedLinkExtrasModule::class,
     ]
 )
 @Singleton
@@ -88,151 +58,8 @@ internal interface FormActivityViewModelComponent {
             paymentElementCallbackIdentifier: String,
             @BindsInstance application: Application,
             @BindsInstance savedStateHandle: SavedStateHandle,
-            @BindsInstance promotion: PaymentMethodMessagePromotion?
+            @BindsInstance promotion: PaymentMethodMessagePromotion?,
         ): FormActivityViewModelComponent
-    }
-}
-
-@Module(
-    subcomponents = [
-        FormActivitySubcomponent::class
-    ]
-)
-internal interface FormActivityViewModelModule {
-    @Binds
-    fun bindsCardAccountRangeRepositoryFactory(
-        defaultCardAccountRangeRepositoryFactory: DefaultCardAccountRangeRepositoryFactory
-    ): CardAccountRangeRepository.Factory
-
-    @Binds
-    fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
-
-    @Binds
-    fun bindsFormActivityStateHelper(helper: DefaultFormActivityStateHelper): FormActivityStateHelper
-
-    @Binds
-    fun bindsPrefsRepositoryFactory(factory: DefaultPrefsRepository.Factory): PrefsRepository.Factory
-
-    @Binds
-    fun bindsTapToAddHelperFactory(factory: DefaultTapToAddHelper.Factory): TapToAddHelper.Factory
-
-    @Binds
-    fun bindsSavedPaymentMethodLinkFormHelper(
-        helper: DefaultSavedPaymentMethodLinkFormHelper
-    ): SavedPaymentMethodLinkFormHelper
-
-    @Binds
-    fun bindsLinkInlineSignupAvailability(
-        impl: DefaultLinkInlineSignupAvailability,
-    ): LinkInlineSignupAvailability
-
-    @Suppress("TooManyFunctions")
-    companion object {
-        @Provides
-        fun providesContext(application: Application): Context {
-            return application
-        }
-
-        @Provides
-        @Singleton
-        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
-            return LinkAccountHolder(savedStateHandle)
-        }
-
-        @Provides
-        @Singleton
-        @ViewModelScope
-        fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
-        }
-
-        @Provides
-        @Singleton
-        fun provideFormInteractor(
-            interactorFactory: EmbeddedFormInteractorFactory
-        ): DefaultVerticalModeFormInteractor = interactorFactory.create()
-
-        @Provides
-        @Singleton
-        fun provideConfirmationHandler(
-            confirmationHandlerFactory: ConfirmationHandler.Factory,
-            @ViewModelScope coroutineScope: CoroutineScope,
-        ): ConfirmationHandler {
-            return confirmationHandlerFactory.create(coroutineScope)
-        }
-
-        @Provides
-        @Singleton
-        fun providesTapToAddHelper(
-            @ViewModelScope coroutineScope: CoroutineScope,
-            configuration: EmbeddedPaymentElement.Configuration,
-            tapToAddHelperFactory: TapToAddHelper.Factory,
-            embeddedSelectionHolder: EmbeddedSelectionHolder,
-            customerStateHolder: CustomerStateHolder,
-            paymentMethodMetadata: PaymentMethodMetadata,
-        ): TapToAddHelper {
-            return tapToAddHelperFactory.create(
-                coroutineScope = coroutineScope,
-                tapToAddMode = when (configuration.formSheetAction) {
-                    EmbeddedPaymentElement.FormSheetAction.Continue -> TapToAddMode.Continue
-                    EmbeddedPaymentElement.FormSheetAction.Confirm -> TapToAddMode.Complete
-                },
-                updateSelection = embeddedSelectionHolder::set,
-                customerStateHolder = customerStateHolder,
-                linkSignupMode = stateFlowOf(paymentMethodMetadata.linkState?.signupMode),
-            )
-        }
-
-        @Provides
-        @Singleton
-        fun provideOnClickOverrideDelegate(): OnClickOverrideDelegate = OnClickDelegateOverrideImpl()
-
-        @Provides
-        @Singleton
-        fun providesFormActivityConfirmationHandlerRegistrar(
-            confirmationHandler: ConfirmationHandler,
-            tapToAddHelper: TapToAddHelper,
-        ): FormActivityRegistrar {
-            return DefaultFormActivityRegistrar(confirmationHandler, tapToAddHelper)
-        }
-
-        @Provides
-        @Singleton
-        fun provideStripeImageLoader(context: Context): StripeImageLoader {
-            return DefaultStripeImageLoader(context)
-        }
-
-        @Provides
-        fun providePaymentMethodMetadataFlow(
-            paymentMethodMetadata: PaymentMethodMetadata
-        ): StateFlow<PaymentMethodMetadata?> {
-            return stateFlowOf(paymentMethodMetadata)
-        }
-
-        @Provides
-        fun providesTapToAddLinkFormElementFactory(): LinkFormElementFactory {
-            return DefaultLinkFormElementFactory
-        }
-
-        @Provides
-        fun provideSavedPaymentMethodConfirmInteractorFactory(
-            @ViewModelScope coroutineScope: CoroutineScope,
-            paymentMethodMetadata: PaymentMethodMetadata,
-            savedPaymentMethodLinkFormHelper: SavedPaymentMethodLinkFormHelper,
-        ): SavedPaymentMethodConfirmInteractor.Factory {
-            return DefaultSavedPaymentMethodConfirmInteractor.Factory(
-                paymentMethodMetadata = paymentMethodMetadata,
-                savedPaymentMethodLinkFormHelper = savedPaymentMethodLinkFormHelper,
-                coroutineScope = coroutineScope,
-            )
-        }
-
-        @Provides
-        fun providesPaymentMethodMessagePromotionHelper(
-            promotion: PaymentMethodMessagePromotion?
-        ): PaymentMethodMessagePromotionsHelper = PrefetchedPaymentMethodMessagePromotionsHelper(
-            listOfNotNull(promotion)
-        )
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageComponent.kt
@@ -1,32 +1,34 @@
 package com.stripe.android.paymentelement.embedded.manage
 
-import android.content.Context
+import android.app.Application
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.core.injection.ViewModelScope
-import com.stripe.android.core.utils.RealUserFacingLogger
-import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.common.di.ApplicationIdModule
+import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityModule
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
+import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
-import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.uicore.utils.stateFlowOf
-import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
-import dagger.Module
-import dagger.Provides
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Component(
     modules = [
-        ManageModule::class,
+        EmbeddedActivityModule::class,
         EmbeddedCommonModule::class,
+        ApplicationIdModule::class,
+        ExtendedPaymentElementConfirmationModule::class,
+        GooglePayLauncherModule::class,
+        EmbeddedLinkExtrasModule::class,
     ],
 )
 @Singleton
@@ -41,65 +43,16 @@ internal interface ManageComponent {
         fun build(
             @BindsInstance savedStateHandle: SavedStateHandle,
             @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
-            @BindsInstance context: Context,
+            @BindsInstance application: Application,
             @BindsInstance @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,
+            @BindsInstance selectedPaymentMethodCode: PaymentMethodCode,
+            @BindsInstance hasSavedPaymentMethods: Boolean,
+            @BindsInstance
+            @Named(STATUS_BAR_COLOR)
+            statusBarColor: Int?,
+            @BindsInstance configuration: EmbeddedPaymentElement.Configuration,
+            @BindsInstance promotion: PaymentMethodMessagePromotion?,
         ): ManageComponent
-    }
-}
-
-@Module
-internal interface ManageModule {
-    @Binds
-    fun bindsEmbeddedManageScreenInteractorFactory(
-        factory: DefaultEmbeddedManageScreenInteractorFactory
-    ): EmbeddedManageScreenInteractorFactory
-
-    @Binds
-    fun bindsEmbeddedUpdateScreenInteractorFactory(
-        factory: DefaultEmbeddedUpdateScreenInteractorFactory
-    ): EmbeddedUpdateScreenInteractorFactory
-
-    @Binds
-    fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
-
-    companion object {
-        @Provides
-        @Singleton
-        fun provideManageNavigator(
-            initialManageScreenFactory: InitialManageScreenFactory,
-            @ViewModelScope viewModelScope: CoroutineScope,
-            eventReporter: EventReporter,
-        ): ManageNavigator {
-            return ManageNavigator(
-                coroutineScope = viewModelScope,
-                eventReporter = eventReporter,
-                initialScreen = initialManageScreenFactory.createInitialScreen(),
-            )
-        }
-
-        @Provides
-        @Singleton
-        fun provideSavedPaymentMethodMutator(
-            factory: ManageSavedPaymentMethodMutatorFactory
-        ): SavedPaymentMethodMutator {
-            return factory.createSavedPaymentMethodMutator()
-        }
-
-        @Provides
-        fun providePaymentMethodMetadata(
-            paymentMethodMetadata: PaymentMethodMetadata
-        ): StateFlow<PaymentMethodMetadata> {
-            return stateFlowOf(
-                paymentMethodMetadata
-            )
-        }
-
-        @Provides
-        @Singleton
-        @ViewModelScope
-        fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
-        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageContract.kt
@@ -6,6 +6,8 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.view.ActivityStarter
@@ -58,6 +60,11 @@ internal object ManageContract : ActivityResultContract<ManageContract.Args, Man
         val customerState: CustomerState,
         val selection: PaymentSelection?,
         val paymentElementCallbackIdentifier: String,
+        val selectedPaymentMethodCode: String,
+        val hasSavedPaymentMethods: Boolean,
+        val statusBarColor: Int?,
+        val configuration: EmbeddedPaymentElement.Configuration,
+        val promotion: PaymentMethodMessagePromotion?,
     ) : Parcelable {
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageViewModel.kt
@@ -31,7 +31,12 @@ internal class ManageViewModel @Inject constructor(
                 savedStateHandle = savedStateHandle,
                 paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                 paymentMethodMetadata = args.paymentMethodMetadata,
-                context = extras.requireApplication(),
+                application = extras.requireApplication(),
+                selectedPaymentMethodCode = args.selectedPaymentMethodCode,
+                hasSavedPaymentMethods = args.hasSavedPaymentMethods,
+                statusBarColor = args.statusBarColor,
+                configuration = args.configuration,
+                promotion = args.promotion,
             )
 
             component.customerStateHolder.setCustomerState(args.customerState)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedSheetLauncher.kt
@@ -22,7 +22,8 @@ internal class FakeEmbeddedSheetLauncher : EmbeddedSheetLauncher {
     override fun launchManage(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
-        selection: PaymentSelection?
+        selection: PaymentSelection?,
+        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
     ) {
         error("Not expected.")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -354,14 +354,20 @@ internal class DefaultEmbeddedSheetLauncherTest {
     fun `launchManage launches activity with correct parameters`() = testScenario {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+        val state = EmbeddedConfirmationStateFixtures.defaultState()
         val expectedArgs = ManageContract.Args(
-            paymentMethodMetadata,
-            customerState,
-            PaymentSelection.GooglePay,
-            "EmbeddedFormTestIdentifier"
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerState = customerState,
+            selection = PaymentSelection.GooglePay,
+            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
+            selectedPaymentMethodCode = "google_pay",
+            hasSavedPaymentMethods = customerState.paymentMethods.isNotEmpty(),
+            statusBarColor = null,
+            configuration = state.configuration,
+            promotion = null,
         )
 
-        sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay)
+        sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay, state)
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
 
         assertThat(launchCall).isEqualTo(expectedArgs)
@@ -372,8 +378,9 @@ internal class DefaultEmbeddedSheetLauncherTest {
     fun `launchManage is not launched again when the sheet is already open`() = testScenario {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+        val state = EmbeddedConfirmationStateFixtures.defaultState()
         sheetStateHolder.sheetIsOpen = true
-        sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay)
+        sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay, state)
     }
 
     @Test
@@ -505,8 +512,9 @@ internal class DefaultEmbeddedSheetLauncherTest {
             ),
         )
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+        val state = EmbeddedConfirmationStateFixtures.defaultState(paymentMethodMetadata)
         val error = runCatching {
-            sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay)
+            sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay, state)
         }.exceptionOrNull()
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
         assertThat(error).hasMessageThat()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/ManageActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/ManageActivityTest.kt
@@ -23,8 +23,10 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.RetryRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -253,6 +255,12 @@ internal class ManageActivityTest {
                     ),
                     selection = selection,
                     paymentElementCallbackIdentifier = "ManageActivityTestCallbackIdentifier",
+                    selectedPaymentMethodCode = selection?.paymentMethodType ?: "",
+                    hasSavedPaymentMethods = paymentMethods.isNotEmpty(),
+                    statusBarColor = null,
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+                        .build(),
+                    promotion = null,
                 ),
             )
         ).use { scenario ->


### PR DESCRIPTION
# Summary
Added configuration and promotion support to the ManageContract for embedded payment element, enabling these properties to be passed through the manage screen launch flow.

# Motivation
The manage screen for embedded payment elements needs access to the configuration and promotion data to properly display and handle payment method management. This change ensures these properties are available throughout the manage flow by adding them to ManageContract.Args and updating the related components.

# Testing
- [x] Modified tests
- [ ] Added tests
- [ ] Manually verified