### PR TITLE
Add has_card_art analytics to PaymentSheet and CustomerSheet events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -57,6 +57,7 @@ import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.analytics.hasCardArt
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -1168,7 +1169,8 @@ internal class CustomerSheetViewModel(
         type?.let {
             eventReporter.onConfirmPaymentMethodSucceeded(
                 type = type,
-                syncDefaultEnabled = syncDefaultEnabled
+                syncDefaultEnabled = syncDefaultEnabled,
+                hasCardArt = paymentSelection.hasCardArt(),
             )
         }
         _result.tryEmit(
@@ -1188,7 +1190,8 @@ internal class CustomerSheetViewModel(
         type?.let {
             eventReporter.onConfirmPaymentMethodFailed(
                 type = type,
-                syncDefaultEnabled = syncDefaultEnabled
+                syncDefaultEnabled = syncDefaultEnabled,
+                hasCardArt = paymentSelection.hasCardArt(),
             )
         }
         logger.error(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -85,10 +85,12 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
     class ConfirmPaymentMethodSucceeded(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     ) : CustomerSheetEvent() {
         override val additionalParams: Map<String, Any?> = buildMap {
             put(FIELD_PAYMENT_METHOD_TYPE, type)
             syncDefaultEnabled?.let { put(FIELD_SYNC_DEFAULT_ENABLED, it) }
+            put(FIELD_HAS_CARD_ART, hasCardArt)
         }
         override val eventName: String = CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_SUCCEEDED
     }
@@ -96,10 +98,12 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
     class ConfirmPaymentMethodFailed(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     ) : CustomerSheetEvent() {
         override val additionalParams: Map<String, Any?> = buildMap {
             put(FIELD_PAYMENT_METHOD_TYPE, type)
             syncDefaultEnabled?.let { put(FIELD_SYNC_DEFAULT_ENABLED, it) }
+            put(FIELD_HAS_CARD_ART, hasCardArt)
         }
         override val eventName: String = CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_FAILED
     }
@@ -416,6 +420,7 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         const val FIELD_ERROR_MESSAGE = "error_message"
         const val FIELD_PAYMENT_METHOD_TYPE = "payment_method_type"
         const val FIELD_SYNC_DEFAULT_ENABLED = "sync_default_enabled"
+        const val FIELD_HAS_CARD_ART = "has_card_art"
         const val FIELD_OPEN_CARD_SCAN_AUTOMATICALLY_ENABLED = "open_card_scan_automatically_enabled"
         const val FIELD_SELECTED_LPM = "selected_lpm"
         const val FIELD_CARD_BRAND_ACCEPTANCE = "card_brand_acceptance"

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
@@ -48,6 +48,7 @@ internal interface CustomerSheetEventReporter {
     fun onConfirmPaymentMethodSucceeded(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     )
 
     /**
@@ -56,6 +57,7 @@ internal interface CustomerSheetEventReporter {
     fun onConfirmPaymentMethodFailed(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     )
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
@@ -70,11 +70,13 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
     override fun onConfirmPaymentMethodSucceeded(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     ) {
         fireEvent(
             CustomerSheetEvent.ConfirmPaymentMethodSucceeded(
                 type = type,
                 syncDefaultEnabled = syncDefaultEnabled,
+                hasCardArt = hasCardArt,
             )
         )
     }
@@ -82,11 +84,13 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
     override fun onConfirmPaymentMethodFailed(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     ) {
         fireEvent(
             CustomerSheetEvent.ConfirmPaymentMethodFailed(
                 type = type,
                 syncDefaultEnabled = syncDefaultEnabled,
+                hasCardArt = hasCardArt,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -232,6 +232,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 duration = duration,
                 selectedLpm = paymentSelection.code(),
                 linkContext = paymentSelection.linkContext(),
+                hasCardArt = paymentSelection.hasCardArt(),
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -127,6 +127,9 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     ) : PaymentSheetEvent() {
         override val eventName: String =
             formatEventName(mode, "paymentoption_${analyticsValue(paymentSelection)}_select")
+        override val params: Map<String, Any?> = mapOf(
+            FIELD_HAS_CARD_ART to paymentSelection.hasCardArt(),
+        )
     }
 
     class ShowPaymentOptionForm(
@@ -174,12 +177,14 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         duration: Duration?,
         selectedLpm: String?,
         linkContext: String?,
+        hasCardArt: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_confirm_button_tapped"
         override val params: Map<String, Any?> = mapOf(
             FIELD_DURATION to duration?.asSeconds,
             FIELD_SELECTED_LPM to selectedLpm,
             FIELD_LINK_CONTEXT to linkContext,
+            FIELD_HAS_CARD_ART to hasCardArt,
         ).filterNotNullValues()
     }
 
@@ -215,6 +220,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             }
             put(FIELD_SELECTED_LPM, paymentSelection.code())
             put(FIELD_IS_SAVED_PAYMENT_METHOD, paymentSelection.isSaved)
+            put(FIELD_HAS_CARD_ART, paymentSelection.hasCardArt())
             paymentSelection.linkContext()?.let { linkContext ->
                 put(FIELD_LINK_CONTEXT, linkContext)
             }
@@ -620,6 +626,13 @@ internal fun PaymentSelection.code(): String {
         is PaymentSelection.Saved -> paymentMethod.type?.code ?: "saved"
         is PaymentSelection.ExternalPaymentMethod -> type
         is PaymentSelection.CustomPaymentMethod -> id
+    }
+}
+
+internal fun PaymentSelection?.hasCardArt(): Boolean {
+    return when (this) {
+        is PaymentSelection.Saved -> paymentMethod.card?.cardArt?.artImage?.url != null
+        else -> false
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.C
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_UPDATE_PAYMENT_METHOD
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.CS_UPDATE_PAYMENT_METHOD_FAILED
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.FIELD_ERROR_MESSAGE
+import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.FIELD_HAS_CARD_ART
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.FIELD_HAS_DEFAULT_PAYMENT_METHOD
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.FIELD_PAYMENT_METHOD_TYPE
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent.Companion.FIELD_SELECTED_LPM
@@ -200,12 +201,14 @@ class CustomerSheetEventReporterTest {
     fun `onConfirmPaymentMethodSucceeded should fire analytics request with expected event value`() {
         eventReporter.onConfirmPaymentMethodSucceeded(
             type = PaymentMethod.Type.Card.code,
-            syncDefaultEnabled = null
+            syncDefaultEnabled = null,
+            hasCardArt = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_SUCCEEDED &&
-                    req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code
+                    req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code &&
+                    req.params[FIELD_HAS_CARD_ART] == false
             }
         )
     }
@@ -214,7 +217,8 @@ class CustomerSheetEventReporterTest {
     fun `onConfirmPaymentMethodSucceeded with syncDefaultEnabled should fire analytics request with expected value`() {
         eventReporter.onConfirmPaymentMethodSucceeded(
             type = PaymentMethod.Type.Card.code,
-            syncDefaultEnabled = true
+            syncDefaultEnabled = true,
+            hasCardArt = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -226,15 +230,33 @@ class CustomerSheetEventReporterTest {
     }
 
     @Test
+    fun `onConfirmPaymentMethodSucceeded with card art should fire analytics request with has_card_art true`() {
+        eventReporter.onConfirmPaymentMethodSucceeded(
+            type = PaymentMethod.Type.Card.code,
+            syncDefaultEnabled = null,
+            hasCardArt = true,
+        )
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_SUCCEEDED &&
+                    req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code &&
+                    req.params[FIELD_HAS_CARD_ART] == true
+            }
+        )
+    }
+
+    @Test
     fun `onConfirmPaymentMethodFailed should fire analytics request with expected event value`() {
         eventReporter.onConfirmPaymentMethodFailed(
             type = PaymentMethod.Type.Card.code,
-            syncDefaultEnabled = null
+            syncDefaultEnabled = null,
+            hasCardArt = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_FAILED &&
-                    req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code
+                    req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code &&
+                    req.params[FIELD_HAS_CARD_ART] == false
             }
         )
     }
@@ -243,13 +265,30 @@ class CustomerSheetEventReporterTest {
     fun `onConfirmPaymentMethodFailed with syncDefaultEnabled should fire analytics request with expected value`() {
         eventReporter.onConfirmPaymentMethodFailed(
             type = PaymentMethod.Type.Card.code,
-            syncDefaultEnabled = true
+            syncDefaultEnabled = true,
+            hasCardArt = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_FAILED &&
                     req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code &&
                     req.params[FIELD_SYNC_DEFAULT_ENABLED] == true
+            }
+        )
+    }
+
+    @Test
+    fun `onConfirmPaymentMethodFailed with card art should fire analytics request with has_card_art true`() {
+        eventReporter.onConfirmPaymentMethodFailed(
+            type = PaymentMethod.Type.Card.code,
+            syncDefaultEnabled = null,
+            hasCardArt = true,
+        )
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == CS_SELECT_PAYMENT_METHOD_CONFIRMED_SAVED_PM_FAILED &&
+                    req.params[FIELD_PAYMENT_METHOD_TYPE] == PaymentMethod.Type.Card.code &&
+                    req.params[FIELD_HAS_CARD_ART] == true
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1374,7 +1374,7 @@ class CustomerSheetViewModelTest {
         viewModel.viewState.test {
             viewModel.handleViewAction(CustomerSheetViewAction.OnItemSelected(PaymentSelection.GooglePay))
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            verify(eventReporter).onConfirmPaymentMethodSucceeded(eq("google_pay"), eq(false))
+            verify(eventReporter).onConfirmPaymentMethodSucceeded(eq("google_pay"), eq(false), eq(false))
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1400,7 +1400,7 @@ class CustomerSheetViewModelTest {
         viewModel.viewState.test {
             viewModel.handleViewAction(CustomerSheetViewAction.OnItemSelected(PaymentSelection.GooglePay))
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            verify(eventReporter).onConfirmPaymentMethodFailed(eq("google_pay"), eq(false))
+            verify(eventReporter).onConfirmPaymentMethodFailed(eq("google_pay"), eq(false), eq(false))
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1423,7 +1423,7 @@ class CustomerSheetViewModelTest {
                 )
             )
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            verify(eventReporter).onConfirmPaymentMethodSucceeded(eq("card"), eq(false))
+            verify(eventReporter).onConfirmPaymentMethodSucceeded(eq("card"), eq(false), eq(false))
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1450,7 +1450,7 @@ class CustomerSheetViewModelTest {
                 )
             )
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            verify(eventReporter).onConfirmPaymentMethodSucceeded(eq("card"), eq(true))
+            verify(eventReporter).onConfirmPaymentMethodSucceeded(eq("card"), eq(true), eq(false))
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1486,7 +1486,7 @@ class CustomerSheetViewModelTest {
                 )
             )
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            verify(eventReporter).onConfirmPaymentMethodFailed(eq("card"), eq(true))
+            verify(eventReporter).onConfirmPaymentMethodFailed(eq("card"), eq(true), eq(false))
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1517,7 +1517,7 @@ class CustomerSheetViewModelTest {
                 )
             )
             viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-            verify(eventReporter).onConfirmPaymentMethodFailed(eq("card"), eq(false))
+            verify(eventReporter).onConfirmPaymentMethodFailed(eq("card"), eq(false), eq(false))
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/analytics/CustomerSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/analytics/CustomerSheetEventTest.kt
@@ -180,6 +180,48 @@ class CustomerSheetEventTest {
     }
 
     @Test
+    fun `ConfirmPaymentMethodSucceeded event should include has_card_art false`() {
+        val event = CustomerSheetEvent.ConfirmPaymentMethodSucceeded(
+            type = "card",
+            syncDefaultEnabled = null,
+            hasCardArt = false,
+        )
+        assertThat(event.eventName).isEqualTo("cs_select_payment_method_screen_confirmed_savedpm_success")
+        assertThat(event.additionalParams["has_card_art"]).isEqualTo(false)
+    }
+
+    @Test
+    fun `ConfirmPaymentMethodSucceeded event should include has_card_art true`() {
+        val event = CustomerSheetEvent.ConfirmPaymentMethodSucceeded(
+            type = "card",
+            syncDefaultEnabled = null,
+            hasCardArt = true,
+        )
+        assertThat(event.additionalParams["has_card_art"]).isEqualTo(true)
+    }
+
+    @Test
+    fun `ConfirmPaymentMethodFailed event should include has_card_art false`() {
+        val event = CustomerSheetEvent.ConfirmPaymentMethodFailed(
+            type = "card",
+            syncDefaultEnabled = null,
+            hasCardArt = false,
+        )
+        assertThat(event.eventName).isEqualTo("cs_select_payment_method_screen_confirmed_savedpm_failure")
+        assertThat(event.additionalParams["has_card_art"]).isEqualTo(false)
+    }
+
+    @Test
+    fun `ConfirmPaymentMethodFailed event should include has_card_art true`() {
+        val event = CustomerSheetEvent.ConfirmPaymentMethodFailed(
+            type = "card",
+            syncDefaultEnabled = null,
+            hasCardArt = true,
+        )
+        assertThat(event.additionalParams["has_card_art"]).isEqualTo(true)
+    }
+
+    @Test
     fun `LoadSucceeded event should have correct event name`() {
         val event = CustomerSheetEvent.LoadSucceeded(createCustomerSheetSession())
         assertThat(event.eventName).isEqualTo("cs_load_succeeded")

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -924,11 +924,13 @@ private class FakeCustomerSheetEventReporter : CustomerSheetEventReporter {
     override fun onConfirmPaymentMethodSucceeded(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     ) = Unit
 
     override fun onConfirmPaymentMethodFailed(
         type: String,
         syncDefaultEnabled: Boolean?,
+        hasCardArt: Boolean,
     ) = Unit
 
     override fun onEditTapped() = Unit

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -353,6 +353,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("event", "mc_confirm_button_tapped")
         assertThat(request.params).containsEntry("duration", 3.0f)
         assertThat(request.params).containsEntry("selected_lpm", "google_pay")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 
@@ -1030,6 +1031,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("event", "mc_complete_payment_googlepay_success")
         assertThat(request.params).containsEntry("duration", 10.0f)
         assertThat(request.params).doesNotContainKey("deferred_intent_confirmation_type")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 
@@ -1053,6 +1055,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("event", "mc_complete_payment_googlepay_success")
         assertThat(request.params).containsEntry("duration", 8.0f)
         assertThat(request.params).containsEntry("deferred_intent_confirmation_type", "client")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 
@@ -1120,6 +1123,7 @@ class DefaultEventReporterTest {
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_paymentoption_savedpm_select")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 
@@ -1139,6 +1143,7 @@ class DefaultEventReporterTest {
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_paymentoption_link_select")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 
@@ -1156,7 +1161,36 @@ class DefaultEventReporterTest {
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_paymentoption_newpm_select")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
+    }
+
+    @Test
+    fun `onSelectPaymentOption fires event with card art`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        val savedWithCardArt = PaymentSelection.Saved(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                    cardArt = PaymentMethod.Card.CardArt(
+                        artImage = PaymentMethod.Card.CardArt.ArtImage(
+                            format = "png",
+                            url = "https://example.com/card-art.png",
+                        ),
+                        programName = "Test Program",
+                    ),
+                ),
+            )
+        )
+
+        eventReporter.onSelectPaymentOption(savedWithCardArt)
+
+        val analyticEvent = analyticsEventTurbine.awaitItem()
+        assertThat(analyticEvent).isEqualTo(AnalyticEvent.SelectedSavedPaymentMethod("card"))
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_complete_paymentoption_savedpm_select")
+        assertThat(request.params).containsEntry("has_card_art", true)
     }
 
     @Test
@@ -1183,6 +1217,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("duration", 6.0f)
         assertThat(request.params).containsEntry("error_message", "java.lang.RuntimeException")
         assertThat(request.params).containsEntry("selected_lpm", "google_pay")
+        assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds additional card art metrics around confirmation and selecting saved pms


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Analytics

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
