### PR TITLE
Pass `merchantName` during Terminal connection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
@@ -108,7 +108,11 @@ internal class DefaultTapToAddCollectionHandler(
             )
         }
 
-        connectionManager.connect()
+        connectionManager.connect(
+            config = TapToAddConnectionManager.ConnectionConfig(
+                merchantDisplayName = metadata.merchantName,
+            ),
+        )
 
         val callback = try {
             createCardPresentSetupIntentCallbackRetriever.waitForCallback()

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -41,9 +41,15 @@ internal interface TapToAddConnectionManager {
 
     /**
      * Connects to the NFC reader. Successful completion of this function indicates a successful connection while
-     * an interruption will result from a connection failure
+     * an interruption will result from a connection failure.
+     *
+     * @param config attributes required for connecting to the NFC reader.
      */
-    suspend fun connect()
+    suspend fun connect(config: ConnectionConfig)
+
+    data class ConnectionConfig(
+        val merchantDisplayName: String?
+    )
 
     companion object {
         fun create(
@@ -117,7 +123,7 @@ internal class DefaultTapToAddConnectionManager(
         }
     }
 
-    override suspend fun connect() = withContext(workContext) {
+    override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) = withContext(workContext) {
         runCatching {
             if (!isSupported) {
                 throw IllegalStateException("Tap to Add is not supported by this device!")
@@ -141,7 +147,7 @@ internal class DefaultTapToAddConnectionManager(
             val discoverReadersResult = discoverReaders()
 
             if (discoverReadersResult is DiscoverCallResult.CollectedReaders) {
-                connectReader(discoverReadersResult.readers)
+                connectReader(discoverReadersResult.readers, config)
             }
         }.fold(
             onSuccess = {
@@ -225,7 +231,10 @@ internal class DefaultTapToAddConnectionManager(
         }
     }
 
-    private suspend fun connectReader(readers: List<Reader>) = suspendCancellableCoroutine { continuation ->
+    private suspend fun connectReader(
+        readers: List<Reader>,
+        config: TapToAddConnectionManager.ConnectionConfig,
+    ) = suspendCancellableCoroutine { continuation ->
         val reader = readers.firstOrNull() ?: run {
             val exception = IllegalStateException("No reader found!")
 
@@ -244,6 +253,7 @@ internal class DefaultTapToAddConnectionManager(
             config = ConnectionConfiguration.TapToPayConnectionConfiguration(
                 useCase = TapUseCase.Verify(),
                 autoReconnectOnUnexpectedDisconnect = true,
+                merchantDisplayName = config.merchantDisplayName,
                 tapToPayReaderListener = this@DefaultTapToAddConnectionManager,
             ),
             connectionCallback = object : ReaderCallback {
@@ -310,7 +320,7 @@ internal class DefaultTapToAddConnectionManager(
 internal class UnsupportedTapToAddConnectionManager : TapToAddConnectionManager {
     override val isSupported: Boolean = false
 
-    override suspend fun connect() {
+    override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         // No-op
     }
 }
@@ -320,12 +330,12 @@ internal class TapToAddRetriableConnectionManager(
     private val fatalErrorChecker: TapToAddFatalErrorChecker,
     private val retryDelaySupplier: RetryDelaySupplier,
 ) : TapToAddConnectionManager by tapToAddConnectionManager {
-    override suspend fun connect() {
+    override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         var retriesRemaining = MAX_RETRIES
 
         while (true) {
             runCatching {
-                tapToAddConnectionManager.connect()
+                tapToAddConnectionManager.connect(config)
             }.fold(
                 onSuccess = {
                     break

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -265,7 +265,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         )
 
         eventReporter.onLoadStarted(metadata.initializedViaCompose)
-        tapToAddConnectionStarter.start()
+        tapToAddConnectionStarter.start(configuration)
 
         val isGooglePaySupportedOnDevice = async {
             isGooglePaySupportedOnDevice()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarter.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.state
 
+import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.taptoadd.TapToAddConnectionManager
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
@@ -13,7 +14,7 @@ import kotlin.coroutines.CoroutineContext
 internal interface TapToAddConnectionStarter {
     val isSupported: Boolean
 
-    fun start()
+    fun start(config: CommonConfiguration)
 }
 
 internal class DefaultTapToAddConnectionStarter @Inject constructor(
@@ -24,10 +25,14 @@ internal class DefaultTapToAddConnectionStarter @Inject constructor(
     override val isSupported: Boolean
         get() = tapToAddConnectionManager.isSupported
 
-    override fun start() {
+    override fun start(config: CommonConfiguration) {
         viewModelScope.launch(coroutineContext) {
             runCatching {
-                tapToAddConnectionManager.connect()
+                tapToAddConnectionManager.connect(
+                    config = TapToAddConnectionManager.ConnectionConfig(
+                        merchantDisplayName = config.merchantDisplayName,
+                    )
+                )
             }
         }
     }
@@ -36,7 +41,8 @@ internal class DefaultTapToAddConnectionStarter @Inject constructor(
 internal class NoOpTapToAddConnectionStarter @Inject constructor() : TapToAddConnectionStarter {
     override val isSupported: Boolean = false
 
-    override fun start() {
+    @Suppress("UNUSED_PARAMETER")
+    override fun start(config: CommonConfiguration) {
         // No-op
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -62,6 +62,9 @@ class DefaultTapToAddConnectionManagerTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val lifecycleOwner = TestLifecycleOwner()
 
+    private val testConnectionConfig =
+        TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
+
     @Test
     fun `init initializes terminal when not already initialized`() = test(
         isInitialized = false,
@@ -157,7 +160,7 @@ class DefaultTapToAddConnectionManagerTest {
         }
     ) {
         assertFailsWith<IllegalStateException> {
-            manager.connect()
+            manager.connect(testConnectionConfig)
         }
 
         verify(terminalInstance, never()).discoverReaders(any(), any(), any())
@@ -170,7 +173,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockReaderCall(Reader())
         }
     ) {
-        manager.connect()
+        manager.connect(testConnectionConfig)
 
         verify(terminalInstance, never()).discoverReaders(any(), any(), any())
     }
@@ -183,7 +186,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockDiscoverCall()
         }
     ) {
-        val connectionJob = testScope.async { manager.connect() }
+        val connectionJob = testScope.async { manager.connect(testConnectionConfig) }
 
         verify(terminalInstance).discoverReaders(
             any<DiscoveryConfiguration.TapToPayDiscoveryConfiguration>(),
@@ -214,7 +217,7 @@ class DefaultTapToAddConnectionManagerTest {
             )
         }
     ) {
-        val connectionJob = testScope.async { manager.connect() }
+        val connectionJob = testScope.async { manager.connect(testConnectionConfig) }
 
         verify(terminalInstance).discoverReaders(
             any<DiscoveryConfiguration.TapToPayDiscoveryConfiguration>(),
@@ -240,10 +243,10 @@ class DefaultTapToAddConnectionManagerTest {
         }
     ) {
         val jobs = arrayOf(
-            testScope.async { manager.connect() },
-            testScope.async { manager.connect() },
-            testScope.async { manager.connect() },
-            testScope.async { manager.connect() }
+            testScope.async { manager.connect(testConnectionConfig) },
+            testScope.async { manager.connect(testConnectionConfig) },
+            testScope.async { manager.connect(testConnectionConfig) },
+            testScope.async { manager.connect(testConnectionConfig) }
         )
 
         verify(terminalInstance, times(1)).discoverReaders(
@@ -269,7 +272,7 @@ class DefaultTapToAddConnectionManagerTest {
             }
         ) {
             assertFailsWith<SecurityException> {
-                manager.connect()
+                manager.connect(testConnectionConfig)
             }
 
             verify(terminalInstance).discoverReaders(
@@ -301,7 +304,7 @@ class DefaultTapToAddConnectionManagerTest {
                 )
             }
         ) {
-            val connectionJob = testScope.async { manager.connect() }
+            val connectionJob = testScope.async { manager.connect(testConnectionConfig) }
 
             val listenerCaptor = argumentCaptor<DiscoveryListener>()
 
@@ -320,7 +323,8 @@ class DefaultTapToAddConnectionManagerTest {
                 argWhere { config ->
                     config is ConnectionConfiguration.TapToPayConnectionConfiguration &&
                         config.autoReconnectOnUnexpectedDisconnect &&
-                        config.tapToPayReaderListener == manager
+                        config.tapToPayReaderListener == manager &&
+                        config.merchantDisplayName == testConnectionConfig.merchantDisplayName
                 },
                 any<ReaderCallback>(),
             )
@@ -343,7 +347,7 @@ class DefaultTapToAddConnectionManagerTest {
     ) {
        val connectionResult = testScope.async {
             assertFailsWith<IllegalStateException> {
-                manager.connect()
+                manager.connect(testConnectionConfig)
             }
         }
 
@@ -380,7 +384,7 @@ class DefaultTapToAddConnectionManagerTest {
             )
         }
     ) {
-        val connectionJob = testScope.async { manager.connect() }
+        val connectionJob = testScope.async { manager.connect(testConnectionConfig) }
 
         val callbackCaptor = argumentCaptor<Callback>()
 
@@ -413,7 +417,7 @@ class DefaultTapToAddConnectionManagerTest {
         }
     ) {
         val connectionResult = testScope.async {
-            assertFailsWith<TerminalException> { manager.connect() }
+            assertFailsWith<TerminalException> { manager.connect(testConnectionConfig) }
         }
 
         val callbackCaptor = argumentCaptor<Callback>()
@@ -454,7 +458,7 @@ class DefaultTapToAddConnectionManagerTest {
                 )
             }
         ) {
-            val connectionResult = testScope.async { manager.connect() }
+            val connectionResult = testScope.async { manager.connect(testConnectionConfig) }
 
             val reader = Reader()
 
@@ -484,7 +488,7 @@ class DefaultTapToAddConnectionManagerTest {
             }
         ) {
             val connectionResult = testScope.async {
-                assertFailsWith<TerminalException> { manager.connect() }
+                assertFailsWith<TerminalException> { manager.connect(testConnectionConfig) }
             }
 
             val reader = Reader()
@@ -523,7 +527,7 @@ class DefaultTapToAddConnectionManagerTest {
                 mockDiscoverCall()
             }
         ) {
-            val connectionResult = testScope.async { manager.connect() }
+            val connectionResult = testScope.async { manager.connect(testConnectionConfig) }
 
             whenever(terminalInstance.connectedReader).thenReturn(connectedReader)
 
@@ -557,7 +561,7 @@ class DefaultTapToAddConnectionManagerTest {
                 )
             }
         ) {
-            val job = testScope.async { manager.connect() }
+            val job = testScope.async { manager.connect(testConnectionConfig) }
 
             whenever(terminalInstance.connectedReader).thenReturn(connectedReader)
 
@@ -586,7 +590,7 @@ class DefaultTapToAddConnectionManagerTest {
                 )
             }
         ) {
-            val job = testScope.async { manager.connect() }
+            val job = testScope.async { manager.connect(testConnectionConfig) }
 
             val reader = Reader()
 
@@ -614,7 +618,7 @@ class DefaultTapToAddConnectionManagerTest {
         ) {
             val job = testScope.async {
                 assertFailsWith<TerminalException> {
-                    manager.connect()
+                    manager.connect(testConnectionConfig)
                 }
             }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
@@ -9,16 +9,20 @@ internal class FakeTapToAddConnectionManager private constructor(
 ) : TapToAddConnectionManager {
     private val queuedConnectResults = connectResults.toMutableList()
 
-    val connectCalls = Turbine<Unit>()
+    val connectCalls = Turbine<ConnectCall>()
 
-    override suspend fun connect() {
-        connectCalls.add(Unit)
+    override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
+        connectCalls.add(ConnectCall(config))
 
         queuedConnectResults.removeFirst().getOrThrow()
     }
 
+    data class ConnectCall(
+        val config: TapToAddConnectionManager.ConnectionConfig,
+    )
+
     class Scenario(
-        val connectCalls: ReceiveTurbine<Unit>,
+        val connectCalls: ReceiveTurbine<ConnectCall>,
         val tapToAddConnectionManager: TapToAddConnectionManager
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentelement.confirmation.intent.CallbackNotFoundExc
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeErrorReporter
@@ -800,7 +801,10 @@ class TapToAddCollectionHandlerTest {
             }
 
             if (hasConnectCall) {
-                assertThat(managerScenario.connectCalls.awaitItem()).isNotNull()
+                val connectCall = managerScenario.connectCalls.awaitItem()
+
+                assertThat(connectCall.config.merchantDisplayName)
+                    .isEqualTo(PaymentSheetFixtures.MERCHANT_DISPLAY_NAME)
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddRetriableConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddRetriableConnectionManagerTest.kt
@@ -10,6 +10,9 @@ import kotlin.test.assertFailsWith
 import kotlin.time.Duration
 
 internal class TapToAddRetriableConnectionManagerTest {
+    private val testConnectionConfig =
+        TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
+
     @Test
     fun `isSupported is true when inner manager's isSupported is true`() = runScenario(isSupported = true) {
         assertThat(retryConnectionManager.isSupported).isTrue()
@@ -24,9 +27,9 @@ internal class TapToAddRetriableConnectionManagerTest {
     fun `connect succeeds on first try and calls delegate once`() = runScenario(
         queuedConnectResults = listOf(Result.success(Unit))
     ) {
-        retryConnectionManager.connect()
+        retryConnectionManager.connect(testConnectionConfig)
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isEqualTo(testConnectionConfig)
     }
 
     @Test
@@ -36,16 +39,16 @@ internal class TapToAddRetriableConnectionManagerTest {
             Result.success(Unit)
         )
     ) {
-        retryConnectionManager.connect()
+        retryConnectionManager.connect(testConnectionConfig)
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isEqualTo(testConnectionConfig)
 
         val delayCall = getRetryDelayCalls.awaitItem()
 
         assertThat(delayCall.maxRetries).isEqualTo(3)
         assertThat(delayCall.remainingRetries).isEqualTo(3)
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isEqualTo(testConnectionConfig)
     }
 
     @Test
@@ -56,11 +59,11 @@ internal class TapToAddRetriableConnectionManagerTest {
         fatalErrorChecker = FakeTapToAddFatalErrorChecker(isFatal = true),
     ) {
         val error = assertFailsWith<IllegalStateException> {
-            retryConnectionManager.connect()
+            retryConnectionManager.connect(testConnectionConfig)
         }
 
         assertThat(error.message).isEqualTo("Fatal!")
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isEqualTo(testConnectionConfig)
         getRetryDelayCalls.expectNoEvents()
     }
 
@@ -73,10 +76,10 @@ internal class TapToAddRetriableConnectionManagerTest {
         ),
         fatalErrorChecker = FakeTapToAddFatalErrorChecker(isFatal = false),
     ) {
-        assertThat(retryConnectionManager.connect()).isNotNull()
+        retryConnectionManager.connect(testConnectionConfig)
 
         repeat(3) {
-            assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+            assertThat(innerManagerConnectCalls.awaitItem().config).isEqualTo(testConnectionConfig)
         }
 
         repeat(2) {
@@ -94,33 +97,33 @@ internal class TapToAddRetriableConnectionManagerTest {
         )
     ) {
         val error = assertFailsWith<IllegalStateException> {
-            retryConnectionManager.connect()
+            retryConnectionManager.connect(testConnectionConfig)
         }
 
         assertThat(error.message).isEqualTo("Failed!")
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isEqualTo(testConnectionConfig)
 
         val firstDelayCall = getRetryDelayCalls.awaitItem()
 
         assertThat(firstDelayCall.maxRetries).isEqualTo(3)
         assertThat(firstDelayCall.remainingRetries).isEqualTo(3)
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isNotNull()
 
         val secondDelayCall = getRetryDelayCalls.awaitItem()
 
         assertThat(secondDelayCall.maxRetries).isEqualTo(3)
         assertThat(secondDelayCall.remainingRetries).isEqualTo(2)
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isNotNull()
 
         val thirdDelayCall = getRetryDelayCalls.awaitItem()
 
         assertThat(thirdDelayCall.maxRetries).isEqualTo(3)
         assertThat(thirdDelayCall.remainingRetries).isEqualTo(1)
 
-        assertThat(innerManagerConnectCalls.awaitItem()).isNotNull()
+        assertThat(innerManagerConnectCalls.awaitItem().config).isNotNull()
     }
 
     private fun runScenario(
@@ -153,7 +156,7 @@ internal class TapToAddRetriableConnectionManagerTest {
 
     private class Scenario(
         val retryConnectionManager: TapToAddConnectionManager,
-        val innerManagerConnectCalls: ReceiveTurbine<Unit>,
+        val innerManagerConnectCalls: ReceiveTurbine<FakeTapToAddConnectionManager.ConnectCall>,
         val getRetryDelayCalls: ReceiveTurbine<FakeRetryDelaySupplier.GetDelayCall>,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -560,17 +560,21 @@ internal class DefaultPaymentElementLoaderTest {
                     tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = true),
                 )
 
+                val config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+
                 val result = loader.load(
                     initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                         clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value
                     ),
-                    paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+                    paymentSheetConfiguration = config,
                     metadata = PaymentElementLoader.Metadata(
                         initializedViaCompose = false,
                     ),
                 ).getOrThrow()
 
-                assertThat(startCalls.awaitItem()).isNotNull()
+                assertThat(startCalls.awaitItem()).isEqualTo(
+                    FakeTapToAddConnectionStarter.StartCall(config = config.asCommonConfiguration())
+                )
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isTrue()
 
@@ -603,17 +607,21 @@ internal class DefaultPaymentElementLoaderTest {
                     elementsSessionRepository = elementsSessionRepository,
                 )
 
+                val config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+
                 val result = loader.load(
                     initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                         clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value
                     ),
-                    paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+                    paymentSheetConfiguration = config,
                     metadata = PaymentElementLoader.Metadata(
                         initializedViaCompose = false,
                     ),
                 ).getOrThrow()
 
-                assertThat(startCalls.awaitItem()).isNotNull()
+                assertThat(startCalls.awaitItem()).isEqualTo(
+                    FakeTapToAddConnectionStarter.StartCall(config = config.asCommonConfiguration())
+                )
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isFalse()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -2,23 +2,28 @@ package com.stripe.android.paymentsheet.state
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
     override val isSupported: Boolean = false,
-    val startCalls: Turbine<Unit> = Turbine(),
 ) : TapToAddConnectionStarter {
+    private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun start() {
-        startCalls.add(Unit)
+    override fun start(config: CommonConfiguration) {
+        startCalls.add(StartCall(config))
     }
 
     fun ensureAllEventsConsumed() {
         startCalls.ensureAllEventsConsumed()
     }
 
+    data class StartCall(
+        val config: CommonConfiguration
+    )
+
     class Scenario(
         val connectionStarter: TapToAddConnectionStarter,
-        val startCalls: ReceiveTurbine<Unit>,
+        val startCalls: ReceiveTurbine<StartCall>,
     )
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.common.taptoadd.FakeTapToAddConnectionManager
+import com.stripe.android.common.taptoadd.TapToAddConnectionManager
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -35,7 +38,7 @@ internal class TapToAddConnectionStarterTest {
     }
 
     @Test
-    fun `start calls manager connect`() = runTest(testDispatcher) {
+    fun `start calls manager connect with merchant display name from configuration`() = runTest(testDispatcher) {
         val manager = FakeTapToAddConnectionManager.noOp(isSupported = true)
         val starter = DefaultTapToAddConnectionStarter(
             tapToAddConnectionManager = manager,
@@ -43,10 +46,20 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        starter.start()
-        testDispatcher.scheduler.advanceUntilIdle()
+        val commonConfiguration = CommonConfigurationFactory.create(
+            merchantDisplayName = "Books & Things",
+        )
 
-        assertThat(manager.connectCalls.awaitItem()).isNotNull()
+        starter.start(commonConfiguration)
+        advanceUntilIdle()
+
+        assertThat(manager.connectCalls.awaitItem()).isEqualTo(
+            FakeTapToAddConnectionManager.ConnectCall(
+                config = TapToAddConnectionManager.ConnectionConfig(
+                    merchantDisplayName = "Books & Things",
+                ),
+            )
+        )
         manager.connectCalls.ensureAllEventsConsumed()
     }
 }


### PR DESCRIPTION
# Summary
Pass `merchantName` during Terminal connection so that it can be used to properly display legal text with the merchant's display name.

# Motivation
Legal requirement

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified