### PR TITLE
Validate that Tap to Add cannot be used with billing details configuration

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -80,6 +80,7 @@ import com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlayg
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.ConfirmationTokenSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedTwoStepSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.EnableTapToAddSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
@@ -179,8 +180,11 @@ internal class PaymentSheetPlaygroundActivity :
                     .externalPaymentMethodConfirmHandler(this)
                     .confirmCustomPaymentMethodCallback(this)
                     .analyticEventCallback(viewModel::analyticCallback)
-                    .createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
                     .also {
+                        if (playgroundState?.snapshot[EnableTapToAddSettingsDefinition] == true) {
+                            it.createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
+                        }
+
                         if (playgroundState?.snapshot[ConfirmationTokenSettingsDefinition] == true) {
                             it.createIntentCallback(viewModel::createIntentWithConfirmationTokenCallback)
                         } else {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -53,6 +53,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.ConfirmationT
 import com.stripe.android.paymentsheet.example.playground.settings.DropdownSetting
 import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedRowSelectionBehaviorSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedViewDisplaysMandateSettingDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.EnableTapToAddSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
@@ -115,7 +116,11 @@ internal class EmbeddedPlaygroundActivity :
             .confirmCustomPaymentMethodCallback(this)
             .externalPaymentMethodConfirmHandler(this)
             .analyticEventCallback(this)
-            .createCardPresentSetupIntentCallback(this)
+            .also {
+                if (playgroundState.snapshot[EnableTapToAddSettingsDefinition]) {
+                    it.createCardPresentSetupIntentCallback(this)
+                }
+            }
             .rowSelectionBehavior(
                 playgroundSettings[EmbeddedRowSelectionBehaviorSettingsDefinition].value.rowSelectionBehavior
             )

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.LinkController
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -58,6 +59,7 @@ internal data class CommonConfiguration(
         checkoutSessionValidate(initializationMode)
         externalPaymentMethodsValidate(isLiveMode)
         confirmationTokenValidate(isLiveMode, callbackIdentifier)
+        tapToAddValidate(callbackIdentifier)
 
         customer?.accessType?.let { customerAccessType ->
             customerAccessTypeValidate(customerAccessType)
@@ -137,6 +139,21 @@ internal data class CommonConfiguration(
         ) {
             throw IllegalArgumentException(
                 "createIntentWithConfirmationTokenCallback must be used with CustomerSession."
+            )
+        }
+    }
+
+    // These exception messages are not localized as they are not intended to be displayed to a user.
+    @OptIn(TapToAddPreview::class)
+    private fun tapToAddValidate(
+        @PaymentElementCallbackIdentifier callbackIdentifier: String
+    ) {
+        if (
+            PaymentElementCallbackReferences[callbackIdentifier]?.createCardPresentSetupIntentCallback != null &&
+            billingDetailsCollectionConfiguration.collectsAnything
+        ) {
+            throw IllegalArgumentException(
+                "Tap to Add does not support collecting any billing details!"
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -153,7 +153,9 @@ internal data class CommonConfiguration(
             billingDetailsCollectionConfiguration.collectsAnything
         ) {
             throw IllegalArgumentException(
-                "Tap to Add does not support collecting any billing details!"
+                "Tap to Add does not supporting collecting billing fields with " +
+                    "BillingDetailsCollectionConfiguration. To use Tap to Add, set all " +
+                    "BillingDetailsCollectionConfiguration config options to 'Automatic'."
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -518,7 +518,9 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         assertFailsWith<IllegalArgumentException>(
-            "Tap to Add does not support collecting any billing details!",
+            "Tap to Add does not supporting collecting billing fields with " +
+                "BillingDetailsCollectionConfiguration. To use Tap to Add, set all " +
+                "BillingDetailsCollectionConfiguration config options to 'Automatic'."
         ) {
             configCollectingBilling.validate(
                 initializationMode = DEFAULT_INITIALIZATION_MODE,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.toArgb
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -494,6 +495,60 @@ class PaymentSheetConfigurationKtxTest {
                 callbackIdentifier = ""
             )
         }
+    }
+
+    @OptIn(TapToAddPreview::class)
+    @Test
+    fun `'validate' should fail when Tap to Add callback is set and billing details collection collects anything`() {
+        val callbackIdentifier = "tap_to_add_common_configuration_test"
+
+        PaymentElementCallbackReferences[callbackIdentifier] = PaymentElementCallbacks.Builder()
+            .createCardPresentSetupIntentCallback {
+                error("Should not be called")
+            }
+            .build()
+
+        val configCollectingBilling = configuration.newBuilder()
+            .billingDetailsCollectionConfiguration(
+                PaymentSheet.BillingDetailsCollectionConfiguration(
+                    name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                )
+            )
+            .build()
+            .asCommonConfiguration()
+
+        assertFailsWith<IllegalArgumentException>(
+            "Tap to Add does not support collecting any billing details!",
+        ) {
+            configCollectingBilling.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                isLiveMode = false,
+                callbackIdentifier = callbackIdentifier,
+            )
+        }
+    }
+
+    @OptIn(TapToAddPreview::class)
+    @Test
+    fun `'validate' should succeed when Tap to Add callback is set and billing details collection collects nothing`() {
+        val callbackIdentifier = "tap_to_add_common_configuration_test"
+
+        PaymentElementCallbackReferences[callbackIdentifier] = PaymentElementCallbacks.Builder()
+            .createCardPresentSetupIntentCallback {
+                error("Should not be called")
+            }
+            .build()
+
+        val configNotCollectingBilling = configuration.newBuilder()
+            .billingDetailsCollectionConfiguration(PaymentSheet.BillingDetailsCollectionConfiguration())
+            .build()
+            .asCommonConfiguration()
+
+        configNotCollectingBilling.validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
+            isLiveMode = false,
+            callbackIdentifier = callbackIdentifier,
+        )
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
Validate that Tap to Add cannot be used with billing details configuration

# Motivation
Ensure merchants are aware of this limitation and prevent PMs from being created without expected billing details.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified