### PR TITLE
async download for lokalise strings

### DIFF
--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -64,7 +64,8 @@ do
                   --export-sort "a_z" \
                   --directory-prefix . \
                   --original-filenames=false \
-                  --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
+                  --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml" \
+                  --async
     fi
 
     # Need to download english separately because their strings are not marked final (this is what we uploaded)
@@ -78,7 +79,8 @@ do
           --export-sort "a_z" \
           --directory-prefix . \
           --original-filenames=false \
-          --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml"
+          --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml" \
+          --async
 
     #There is a command line switch that might be better than this, see: --language-mapping
     if [ "$FETCH_ALL_LANGUAGES" = true ]; then


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
async download for lokalise strings

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5274

```
API request error 413 Project too big for sync export. Please use our async export endpoint instead. (/files/async-download)
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
