### PR TITLE
Add PMM Promotions analytics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -538,6 +538,26 @@ internal class DefaultEventReporter @Inject internal constructor(
         }
     }
 
+    override fun onPaymentMethodMessagePromotionsFetched() {
+        durationProvider.start(DurationProvider.Key.PaymentMethodMessaging)
+        fireEvent(
+            PaymentSheetEvent.PaymentMethodMessaging.Fetched()
+        )
+    }
+
+    override fun onPaymentMethodMessagePromotionsIncomplete() {
+        val duration = durationProvider.end(DurationProvider.Key.PaymentMethodMessaging)
+        fireEvent(
+            PaymentSheetEvent.PaymentMethodMessaging.Incomplete(duration)
+        )
+    }
+//
+//    override fun onPaymentMethodMessageLearnMoreClicked(paymentMethod: PaymentMethodCode) {
+//        fireEvent(
+//            PaymentSheetEvent.PaymentMethodMessaging.LearnMoreClicked(paymentMethod)
+//        )
+//    }
+
     private fun defaultParams(paymentMethodMetadata: PaymentMethodMetadata?): Map<String, Any> {
         return paymentMethodMetadata?.analyticsMetadata?.paramsMap ?: emptyMap()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -551,12 +551,6 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.PaymentMethodMessaging.Incomplete(duration)
         )
     }
-//
-//    override fun onPaymentMethodMessageLearnMoreClicked(paymentMethod: PaymentMethodCode) {
-//        fireEvent(
-//            PaymentSheetEvent.PaymentMethodMessaging.LearnMoreClicked(paymentMethod)
-//        )
-//    }
 
     private fun defaultParams(paymentMethodMetadata: PaymentMethodMetadata?): Map<String, Any> {
         return paymentMethodMetadata?.analyticsMetadata?.paramsMap ?: emptyMap()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -268,6 +268,16 @@ internal interface EventReporter : CardScanEventsReporter {
      */
     fun onShopPayWebViewCancelled(didReceiveECEClick: Boolean)
 
+    /**
+     * Promotions fetched from PMM API.
+     */
+    fun onPaymentMethodMessagePromotionsFetched()
+
+    /**
+     * Promotions request is not completed when attempting to display promotions.
+     */
+    fun onPaymentMethodMessagePromotionsIncomplete()
+
     enum class Mode(val code: String) {
         Complete("complete"),
         Custom("custom"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -552,6 +552,18 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         }
     }
 
+    sealed class PaymentMethodMessaging : PaymentSheetEvent() {
+
+        class Fetched : PaymentMethodMessaging() {
+            override val eventName: String = "payment_method_messaging_fetched"
+        }
+
+        class Incomplete(val duration: Duration?) : PaymentMethodMessaging() {
+            override val eventName: String = "payment_method_messaging_incomplete"
+            override val params: Map<String, Any?> = duration.mapOfDurationInSeconds()
+        }
+    }
+
     internal companion object {
         private fun analyticsValue(
             paymentSelection: PaymentSelection?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodMessagePromotionList
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.amount
 import com.stripe.android.paymentsheet.model.currency
 import dagger.Binds
@@ -38,11 +39,13 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
     private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val workContext: CoroutineContext,
+    private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
     private var promotionsDeferred: Deferred<Result<PaymentMethodMessagePromotionList>>? = null
 
     override fun fetchPromotionsAsync(intent: StripeIntent) {
         if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
+            eventReporter.onPaymentMethodMessagePromotionsFetched()
             promotionsDeferred?.cancel()
             promotionsDeferred = null
             promotionsDeferred = viewModelScope.async(workContext) {
@@ -62,8 +65,13 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
 
     override fun getPromotionIfAvailableForCode(code: PaymentMethodCode): PaymentMethodMessagePromotion? {
         return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
-            promotionsDeferred?.takeIf { it.isCompleted }?.getCompleted()?.getOrNull()?.promotions?.find {
-                it.paymentMethodType.lowercase() == code
+            if (promotionsDeferred?.isCompleted == true) {
+                promotionsDeferred?.getCompleted()?.getOrNull()?.promotions?.find {
+                    it.paymentMethodType.lowercase() == code
+                }
+            } else {
+                eventReporter.onPaymentMethodMessagePromotionsIncomplete()
+                null
             }
         } else {
             null
@@ -72,7 +80,12 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
 
     override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
         return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
-            promotionsDeferred?.takeIf { it.isCompleted }?.getCompleted()?.getOrNull()?.promotions
+            if (promotionsDeferred?.isCompleted == true) {
+                promotionsDeferred?.getCompleted()?.getOrNull()?.promotions
+            } else {
+                eventReporter.onPaymentMethodMessagePromotionsIncomplete()
+                null
+            }
         } else {
             null
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -94,6 +94,14 @@ internal class FakeEventReporter : EventReporter {
     val tapToAddAttemptWithUnsupportedDeviceCalls: ReceiveTurbine<Unit> =
         _tapToAddAttemptWithUnsupportedDeviceCalls
 
+    private val _pmmPromotionsFetched = Turbine<Unit>()
+    val pmmPromotionsFetched: ReceiveTurbine<Unit> =
+        _pmmPromotionsFetched
+
+    private val _pmmPromotionsIncomplete = Turbine<Unit>()
+    val pmmPromotionsIncomplete: ReceiveTurbine<Unit> =
+        _pmmPromotionsIncomplete
+
     fun validate() {
         _paymentFailureCalls.ensureAllEventsConsumed()
         _paymentSuccessCalls.ensureAllEventsConsumed()
@@ -119,6 +127,8 @@ internal class FakeEventReporter : EventReporter {
         _tapToAddConfirmCalls.ensureAllEventsConsumed()
         _failedToAddCardWithTapToAddCalls.ensureAllEventsConsumed()
         _tapToAddAttemptWithUnsupportedDeviceCalls.ensureAllEventsConsumed()
+        _pmmPromotionsFetched.ensureAllEventsConsumed()
+        _pmmPromotionsIncomplete.ensureAllEventsConsumed()
     }
 
     override fun onInit() {
@@ -269,6 +279,14 @@ internal class FakeEventReporter : EventReporter {
     }
 
     override fun onShopPayWebViewCancelled(didReceiveECEClick: Boolean) {
+    }
+
+    override fun onPaymentMethodMessagePromotionsFetched() {
+        _pmmPromotionsFetched.add(Unit)
+    }
+
+    override fun onPaymentMethodMessagePromotionsIncomplete() {
+        _pmmPromotionsIncomplete.add(Unit)
     }
 
     override fun onCardScanStarted(implementation: String) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -10,9 +10,11 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodMessagePromotionList
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.repositories.DefaultPaymentMethodMessagePromotionsHelper
 import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.Locale
@@ -32,6 +34,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true,
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        assertThat(eventReporter.pmmPromotionsFetched.awaitItem()).isNotNull()
         val request = fakeRepository.calls.awaitItem()
         assertThat(request.amount).isEqualTo(1099)
         assertThat(request.currency).isEqualTo("usd")
@@ -44,15 +47,28 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertThat(eventReporter.pmmPromotionsFetched.awaitItem()).isNotNull()
+        val result = helper.getPromotionIfAvailableForCode("afterpay_clearpay")
+        assertThat(result).isEqualTo(AFTERPAY_PROMOTION)
+    }
+
+    @Test
+    fun `onPaymentMethodMessagePromotionsIncomplete event sent when request still in progress `() = runScenario(
+        featureFlagEnabled = true
+    ) {
+        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
         val result = helper.getPromotionIfAvailableForCode("afterpay_clearpay")
         assertThat(result).isNull()
+        assertThat(eventReporter.pmmPromotionsFetched.awaitItem()).isNotNull()
+        assertThat(eventReporter.pmmPromotionsIncomplete.awaitItem()).isNotNull()
     }
 
     private fun runScenario(
         featureFlagEnabled: Boolean = false,
         repositoryResult: Result<PaymentMethodMessagePromotionList> = Result.success(
             PaymentMethodMessagePromotionList(
-            listOf(AFTERPAY_PROMOTION)
+                listOf(AFTERPAY_PROMOTION)
             )
         ),
         block: suspend Scenario.() -> Unit,
@@ -61,6 +77,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
         val fakeRepository = FakePromotionsStripeRepository(repositoryResult)
         val testDispatcher = StandardTestDispatcher(testScheduler)
+        val eventReporter = FakeEventReporter()
 
         val helper = DefaultPaymentMethodMessagePromotionsHelper(
             stripeRepository = fakeRepository,
@@ -69,17 +86,24 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
             },
             viewModelScope = this,
             workContext = testDispatcher,
+            eventReporter = eventReporter
         )
 
         Scenario(
             helper = helper,
             fakeRepository = fakeRepository,
+            dispatcher = testDispatcher,
+            eventReporter = eventReporter
         ).block()
+
+        eventReporter.validate()
     }
 
     private data class Scenario(
         val helper: DefaultPaymentMethodMessagePromotionsHelper,
         val fakeRepository: FakePromotionsStripeRepository,
+        val dispatcher: TestDispatcher,
+        val eventReporter: FakeEventReporter
     )
 
     private class FakePromotionsStripeRepository(

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -25,7 +25,8 @@ interface DurationProvider {
         PrepareAttestation,
         Attest,
         IntentConfirmationChallenge,
-        IntentConfirmationChallengeWebViewLoaded
+        IntentConfirmationChallengeWebViewLoaded,
+        PaymentMethodMessaging
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add analytics for PMM promotions being fetch and if API request has not completed by the time MPE tries to display the promotion

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
