### PR TITLE
Update SDK Integration Support link to Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🤔 SDK Integration Support
-    url: https://support.stripe.com/ 
-    about: If you're having general trouble with your Stripe integration, please reach out to support
+    url: https://stripe.com/go/developer-chat
+    about: If you're having general trouble with your Stripe integration, please reach out to us on Discord


### PR DESCRIPTION
## Summary
- Updates the "SDK Integration Support" contact link in our GitHub issue template from `https://support.stripe.com/` to `https://stripe.com/go/developer-chat` (Discord)

## Motivation
Direct integration support questions to our Discord community for faster help.

## Testing
N/A — config-only change.