### PR TITLE
Redact sensitive query params in network error messages

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/exception/APIConnectionException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/APIConnectionException.kt
@@ -2,6 +2,7 @@ package com.stripe.android.core.exception
 
 import androidx.annotation.RestrictTo
 import java.io.IOException
+import java.net.URLDecoder
 
 /**
  * An [Exception] that represents a failure to connect to Stripe's API.
@@ -17,12 +18,28 @@ class APIConnectionException(
     override fun analyticsValue(): String = "connectionError"
 
     companion object {
+        private val SENSITIVE_PARAM_NAMES = setOf(
+            "key",
+            "client_secret",
+            "ephemeral_key",
+            "legacy_customer_ephemeral_key",
+        )
+
+        private val SENSITIVE_VALUE_PREFIXES = listOf(
+            "ek_live_", "ek_test_",
+            "pk_live_", "pk_test_",
+            "sk_live_", "sk_test_",
+            "uk_live_", "uk_test_",
+            "rk_live_", "rk_test_",
+        )
+
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @JvmSynthetic
         fun create(e: IOException, url: String? = null): APIConnectionException {
+            val sanitizedUrl = url?.let(Companion::redactUrl)
             val displayUrl = listOfNotNull(
                 "Stripe",
-                "($url)".takeUnless { url.isNullOrBlank() }
+                "($sanitizedUrl)".takeUnless { sanitizedUrl.isNullOrBlank() }
             ).joinToString(" ")
             return APIConnectionException(
                 "IOException during API request to $displayUrl: ${e.message}. " +
@@ -32,6 +49,38 @@ class APIConnectionException(
                     "or let us know at support@stripe.com.",
                 e
             )
+        }
+
+        private fun redactUrl(url: String): String {
+            val queryIndex = url.indexOf('?')
+            if (queryIndex < 0 || queryIndex == url.lastIndex) return url
+
+            val baseUrl = url.substring(0, queryIndex)
+            val queryString = url.substring(queryIndex + 1)
+
+            val redactedParams = queryString.split("&").joinToString("&") { param ->
+                val eqIndex = param.indexOf('=')
+                if (eqIndex < 0) return@joinToString param
+                val name = decodeComponent(param.substring(0, eqIndex))
+                val value = decodeComponent(param.substring(eqIndex + 1))
+                val redacted = if (shouldRedactParam(name, value)) "**REDACTED**" else value
+                "$name=$redacted"
+            }
+
+            return "$baseUrl?$redactedParams"
+        }
+
+        private fun decodeComponent(encoded: String): String {
+            return try {
+                URLDecoder.decode(encoded, "UTF-8")
+            } catch (_: IllegalArgumentException) {
+                encoded
+            }
+        }
+
+        private fun shouldRedactParam(name: String, value: String): Boolean {
+            if (name in SENSITIVE_PARAM_NAMES) return true
+            return SENSITIVE_VALUE_PREFIXES.any { value.startsWith(it) }
         }
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -105,6 +105,10 @@ data class ApiRequest internal constructor(
         val idempotencyKey: String? = null
     ) : Parcelable {
 
+        override fun toString(): String {
+            return "Options(apiKey=***)"
+        }
+
         val apiKeyIsUserKey: Boolean
             get() = apiKey.startsWith("uk_")
 

--- a/stripe-core/src/test/java/com/stripe/android/core/exception/APIConnectionExceptionTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/exception/APIConnectionExceptionTest.kt
@@ -15,10 +15,7 @@ class APIConnectionExceptionTest {
         assertEquals(
             "IOException during API request to Stripe " +
                 "(https://api.stripe.com/v1/payment_methods): Could not connect. " +
-                "Please check your internet connection and try again. " +
-                "If this problem persists, you should check Stripe's service " +
-                "status at https://status.stripe.com/, " +
-                "or let us know at support@stripe.com.",
+                BOILERPLATE_SUFFIX,
             ex.message
         )
     }
@@ -30,11 +27,82 @@ class APIConnectionExceptionTest {
         )
         assertEquals(
             "IOException during API request to Stripe: Could not connect. " +
-                "Please check your internet connection and try again. " +
-                "If this problem persists, you should check Stripe's service " +
-                "status at https://status.stripe.com/, " +
-                "or let us know at support@stripe.com.",
+                BOILERPLATE_SUFFIX,
             ex.message
         )
+    }
+
+    @Test
+    fun testCreateWithUrlRedactsSensitiveQueryParams() {
+        val ex = APIConnectionException.create(
+            IOException("Unable to resolve host"),
+            "https://api.stripe.com/v1/elements/sessions?" +
+                "legacy_customer_ephemeral_key=ek_live_secret123&" +
+                "type=deferred_intent&locale=en-US&" +
+                "mobile_session_id=fc2e200b-581a-4f24-93b6-990912a337db"
+        )
+        assertEquals(
+            "IOException during API request to Stripe " +
+                "(https://api.stripe.com/v1/elements/sessions?" +
+                "legacy_customer_ephemeral_key=**REDACTED**&" +
+                "type=deferred_intent&locale=en-US&" +
+                "mobile_session_id=fc2e200b-581a-4f24-93b6-990912a337db): " +
+                "Unable to resolve host. " +
+                BOILERPLATE_SUFFIX,
+            ex.message
+        )
+    }
+
+    @Test
+    fun testCreateRedactsValuesThatLookLikeStripeKeys() {
+        val ex = APIConnectionException.create(
+            IOException("fail"),
+            "https://api.stripe.com/v1/foo?key=pk_live_abc123&other=safe_value"
+        )
+        assertEquals(
+            "IOException during API request to Stripe " +
+                "(https://api.stripe.com/v1/foo?" +
+                "key=**REDACTED**&other=safe_value): fail. " +
+                BOILERPLATE_SUFFIX,
+            ex.message
+        )
+    }
+
+    @Test
+    fun testCreateRedactsClientSecret() {
+        val ex = APIConnectionException.create(
+            IOException("fail"),
+            "https://api.stripe.com/v1/foo?client_secret=pi_secret_value&mode=payment"
+        )
+        assertEquals(
+            "IOException during API request to Stripe " +
+                "(https://api.stripe.com/v1/foo?" +
+                "client_secret=**REDACTED**&mode=payment): fail. " +
+                BOILERPLATE_SUFFIX,
+            ex.message
+        )
+    }
+
+    @Test
+    fun testCreateRedactsUrlEncodedParamNames() {
+        val ex = APIConnectionException.create(
+            IOException("fail"),
+            "https://api.stripe.com/v1/foo?client%5Fsecret=some_value&mode=payment"
+        )
+        assertEquals(
+            "IOException during API request to Stripe " +
+                "(https://api.stripe.com/v1/foo?" +
+                "client_secret=**REDACTED**&mode=payment): fail. " +
+                BOILERPLATE_SUFFIX,
+            ex.message
+        )
+    }
+
+    private companion object {
+        private const val BOILERPLATE_SUFFIX =
+            "Please check your internet connection and try again. " +
+                "If this problem persists, you should check Stripe's service " +
+                "status at https://status.stripe.com/, " +
+                "or let us know at support@stripe.com."
     }
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/ApiRequestTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/ApiRequestTest.kt
@@ -6,6 +6,7 @@ import org.robolectric.RobolectricTestRunner
 import java.io.ByteArrayOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -92,6 +93,14 @@ internal class ApiRequestTest {
             mapOf("param" to "123")
         ).url
         assertEquals(url, "sources?param=123")
+    }
+
+    @Test
+    fun optionsToStringDoesNotExposeApiKey() {
+        val options = ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+        val str = options.toString()
+        assertFalse(str.contains(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY))
+        assertFalse(str.contains("pk_test"))
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
When network requests fail (e.g. DNS resolution failure), `APIConnectionException` includes the full request URL in its error message. For GET requests, the URL contains query parameters that can include sensitive values like ephemeral keys (`ek_live_...`) and client secrets. These leak into device logs, crash reports, and any third-party logging integrations merchants may have.

This PR selectively redacts sensitive query parameter values while preserving non-sensitive debugging context (session IDs, locale, request type, etc.).

**Before:**
```
IOException during API request to Stripe (https://api.stripe.com/v1/elements/sessions?legacy_customer_ephemeral_key=ek_live_ABC123&type=deferred_intent&mobile_session_id=fc2e200b): Unable to resolve host...
```

**After:**
```
IOException during API request to Stripe (https://api.stripe.com/v1/elements/sessions?legacy_customer_ephemeral_key=**REDACTED**&type=deferred_intent&mobile_session_id=fc2e200b): Unable to resolve host...
```

### Changes
- **`APIConnectionException.kt`** — `create()` now redacts sensitive query params by name (`client_secret`, `key`, `ephemeral_key`, `legacy_customer_ephemeral_key`) and by value prefix (`ek_live_`, `pk_live_`, `sk_live_`, etc.)
- **`ApiRequest.Options`** — Added `toString()` override to prevent the data class auto-generated `toString()` from exposing the API key
- Added tests for both

## Motivation
RUN_MOBILESDK-5316

## Testing
Unit tests added covering:
- Sensitive query param values are redacted
- Non-sensitive params (session ID, locale, type) are preserved
- Values matching Stripe key patterns are caught regardless of param name
- `ApiRequest.Options.toString()` does not expose the API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)