### PR TITLE
Fix issues with re-starting deploy script

### DIFF
--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -14,14 +14,16 @@ def create_github_release
     execute_or_fail("git checkout #{@deploy_branch}")
     execute_or_fail("git pull")
 
-    tag_release
+    release_body = release_description
+    tag_pushed = false
 
     begin
+        tag_pushed = tag_release
         release_response = octokit_client.create_release(
           "stripe/stripe-android",
           "v#{@version}",
           name: "stripe-android v#{@version}",
-          body: release_description,
+          body: release_body,
           draft: @is_dry_run
         )
 
@@ -35,8 +37,10 @@ def create_github_release
             rputs "Since this is a dry run, you should see the release as a draft. It will be missing a tag + source code attachments."
             wait_for_user
         end
-    rescue
-        delete_release_tag
+    rescue StandardError => e
+        rputs "Failed to create GitHub release for #{tag_name}: #{e.class}: #{e.message}"
+        cleanup_failed_release_tag(tag_pushed: tag_pushed)
+        raise
     end
 end
 
@@ -64,11 +68,26 @@ private def tag_release
     # There's no way to create a "draft" tag, so we skip pushing tags if this is a dry run.
     if(!@is_dry_run)
         execute_or_fail("git push origin #{tag_name}")
+        return true
     end
+
+    false
 end
 
 private def delete_release_tag
     execute("git tag -d #{tag_name}")
+end
+
+private def cleanup_failed_release_tag(tag_pushed:)
+    delete_release_tag
+
+    return unless tag_pushed
+
+    begin
+        execute_or_fail("git push origin --delete #{tag_name}")
+    rescue StandardError => cleanup_error
+        rputs "Failed to delete remote tag #{tag_name} after release failure: #{cleanup_error.class}: #{cleanup_error.message}"
+    end
 end
 
 private def release_description

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -14,8 +14,9 @@ def create_github_release
     execute_or_fail("git checkout #{@deploy_branch}")
     execute_or_fail("git pull")
 
+    tag_release
+
     begin
-        tag_pushed = tag_release
         release_response = octokit_client.create_release(
           "stripe/stripe-android",
           "v#{@version}",
@@ -65,10 +66,7 @@ private def tag_release
     # There's no way to create a "draft" tag, so we skip pushing tags if this is a dry run.
     if(!@is_dry_run)
         execute_or_fail("git push origin #{tag_name}")
-        return true
     end
-
-    false
 end
 
 private def delete_release_tag

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -14,16 +14,13 @@ def create_github_release
     execute_or_fail("git checkout #{@deploy_branch}")
     execute_or_fail("git pull")
 
-    release_body = release_description
-    tag_pushed = false
-
     begin
         tag_pushed = tag_release
         release_response = octokit_client.create_release(
           "stripe/stripe-android",
           "v#{@version}",
           name: "stripe-android v#{@version}",
-          body: release_body,
+          body: release_description,
           draft: @is_dry_run
         )
 
@@ -39,7 +36,7 @@ def create_github_release
         end
     rescue StandardError => e
         rputs "Failed to create GitHub release for #{tag_name}: #{e.class}: #{e.message}"
-        cleanup_failed_release_tag(tag_pushed: tag_pushed)
+        delete_release_tag
         raise
     end
 end
@@ -76,18 +73,6 @@ end
 
 private def delete_release_tag
     execute("git tag -d #{tag_name}")
-end
-
-private def cleanup_failed_release_tag(tag_pushed:)
-    delete_release_tag
-
-    return unless tag_pushed
-
-    begin
-        execute_or_fail("git push origin --delete #{tag_name}")
-    rescue StandardError => cleanup_error
-        rputs "Failed to delete remote tag #{tag_name} after release failure: #{cleanup_error.class}: #{cleanup_error.message}"
-    end
 end
 
 private def release_description

--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -33,7 +33,7 @@ def execute_steps(steps, step_index)
       step_index += 1
     end
   rescue Exception => e
-    rputs "Restart with --continue-from #{step_index} to re-run from this step."
+    rputs "Restart with --continue-from #{step_index} --version #{@version} to re-run from this step."
     raise
   end
 end


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Fix issues with re-starting deploy script

- When you restart the script, you need to pass the version explicitly. Otherwise it will infer that this is a patch release which may or may not be correct
- The github release step should fail more loudly

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Issues with releasing 23.5.0

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

