### PR TITLE
Add new StripeCardScan analytics events

### DIFF
--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/FakeDurationProvider.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/FakeDurationProvider.kt
@@ -16,6 +16,11 @@ internal class FakeDurationProvider(
         _callsTurbine.add(Call.Start(key, reset))
     }
 
+    override fun elapsed(key: DurationProvider.Key): Duration {
+        _callsTurbine.add(Call.Elapsed(key))
+        return duration
+    }
+
     override fun end(key: DurationProvider.Key): Duration {
         _callsTurbine.add(Call.End(key))
         return duration
@@ -29,6 +34,8 @@ internal class FakeDurationProvider(
         val key: DurationProvider.Key
 
         data class Start(override val key: DurationProvider.Key, val reset: Boolean) : Call
+
+        data class Elapsed(override val key: DurationProvider.Key) : Call
 
         data class End(override val key: DurationProvider.Key) : Call
     }

--- a/payments-core/src/test/java/com/stripe/android/analytics/FakeDurationProvider.kt
+++ b/payments-core/src/test/java/com/stripe/android/analytics/FakeDurationProvider.kt
@@ -13,6 +13,11 @@ internal class FakeDurationProvider(
         calls.add(Call.Start(key, reset))
     }
 
+    override fun elapsed(key: DurationProvider.Key): Duration {
+        calls.add(Call.Elapsed(key))
+        return duration
+    }
+
     override fun end(key: DurationProvider.Key): Duration {
         calls.add(Call.End(key))
         return duration
@@ -24,6 +29,8 @@ internal class FakeDurationProvider(
         val key: DurationProvider.Key
 
         data class Start(override val key: DurationProvider.Key, val reset: Boolean) : Call
+
+        data class Elapsed(override val key: DurationProvider.Key) : Call
 
         data class End(override val key: DurationProvider.Key) : Call
     }

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
@@ -166,6 +166,10 @@ internal class DefaultCaptchaEventsReporterTest {
                 startCalled = true
             }
 
+            override fun elapsed(key: DurationProvider.Key): Duration? {
+                throw NotImplementedError("this function should not be called")
+            }
+
             override fun end(key: DurationProvider.Key): Duration? {
                 throw NotImplementedError("this function should not be called")
             }

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
@@ -84,6 +84,10 @@ class DefaultLinkEventsReporterTest {
             // Do nothing.
         }
 
+        override fun elapsed(key: DurationProvider.Key): Duration? {
+            return Duration.ZERO
+        }
+
         override fun end(key: DurationProvider.Key): Duration? {
             return Duration.ZERO
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1411,6 +1411,10 @@ class DefaultEventReporterTest {
             assertThat(call.reset).isEqualTo(reset)
         }
 
+        override fun elapsed(key: DurationProvider.Key): Duration? {
+            return null
+        }
+
         override fun end(key: DurationProvider.Key): Duration {
             val call = endCalls.pop()
             assertThat(call.key).isEqualTo(key)

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeDurationProvider.kt
@@ -13,6 +13,11 @@ internal class FakeDurationProvider(
         calls.add(Call.Start(key, reset))
     }
 
+    override fun elapsed(key: DurationProvider.Key): Duration {
+        calls.add(Call.Elapsed(key))
+        return duration
+    }
+
     override fun end(key: DurationProvider.Key): Duration {
         calls.add(Call.End(key))
         return duration
@@ -24,6 +29,8 @@ internal class FakeDurationProvider(
         val key: DurationProvider.Key
 
         data class Start(override val key: DurationProvider.Key, val reset: Boolean) : Call
+
+        data class Elapsed(override val key: DurationProvider.Key) : Call
 
         data class End(override val key: DurationProvider.Key) : Call
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -9,7 +9,7 @@ import kotlin.time.DurationUnit
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface DurationProvider {
     fun start(key: Key, reset: Boolean = true)
-    fun elapsed(key: Key): Duration? = null
+    fun elapsed(key: Key): Duration?
     fun end(key: Key): Duration?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -9,6 +9,7 @@ import kotlin.time.DurationUnit
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface DurationProvider {
     fun start(key: Key, reset: Boolean = true)
+    fun elapsed(key: Key): Duration? = null
     fun end(key: Key): Duration?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -42,10 +43,14 @@ class DefaultDurationProvider private constructor() : DurationProvider {
         }
     }
 
+    override fun elapsed(key: DurationProvider.Key): Duration? {
+        val startTime = store[key] ?: return null
+        return (SystemClock.uptimeMillis() - startTime).milliseconds
+    }
+
     override fun end(key: DurationProvider.Key): Duration? {
         val startTime = store.remove(key) ?: return null
-        val duration = SystemClock.uptimeMillis() - startTime
-        return duration.milliseconds
+        return (SystemClock.uptimeMillis() - startTime).milliseconds
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -24,6 +24,7 @@ import com.stripe.android.stripecardscan.R
 import com.stripe.android.stripecardscan.camera.getScanCameraAdapter
 import com.stripe.android.stripecardscan.cardscan.exception.UnknownScanException
 import com.stripe.android.stripecardscan.cardscan.result.MainLoopAggregator
+import com.stripe.android.stripecardscan.payment.ml.CardOcr
 import com.stripe.android.stripecardscan.cardscan.result.MainLoopState
 import com.stripe.android.stripecardscan.databinding.StripeActivityCardscanBinding
 import com.stripe.android.stripecardscan.di.DaggerCardScanComponent
@@ -174,6 +175,29 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             override suspend fun onInterimResult(
                 result: MainLoopAggregator.InterimResult
             ) = launch(Dispatchers.Main) {
+                // Milestone events are called on every matching frame; the reporter
+                // handles deduplication so each event is only emitted once per session.
+                when (result.analyzerResult.source) {
+                    CardOcr.Source.MlKit -> {
+                        if (result.analyzerResult.pan != null) {
+                            cardScanEventsReporter.scanMlKitFoundPan()
+                        }
+                        if (result.analyzerResult.expiryMonth != null && result.analyzerResult.expiryYear != null) {
+                            cardScanEventsReporter.scanMlKitFoundExp()
+                        }
+                    }
+                    CardOcr.Source.Darknite -> {
+                        if (result.analyzerResult.pan != null) {
+                            cardScanEventsReporter.scanDarkniteFoundPan()
+                        }
+                    }
+                    CardOcr.Source.Unknown -> Unit
+                }
+
+                if (result.state.hasModelDisagreement) {
+                    cardScanEventsReporter.scanModelsDisagree()
+                }
+
                 when (result.state) {
                     is MainLoopState.Initial -> changeScanState(CardScanState.NotFound)
                     is MainLoopState.OcrFound,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -24,11 +24,11 @@ import com.stripe.android.stripecardscan.R
 import com.stripe.android.stripecardscan.camera.getScanCameraAdapter
 import com.stripe.android.stripecardscan.cardscan.exception.UnknownScanException
 import com.stripe.android.stripecardscan.cardscan.result.MainLoopAggregator
-import com.stripe.android.stripecardscan.payment.ml.CardOcr
 import com.stripe.android.stripecardscan.cardscan.result.MainLoopState
 import com.stripe.android.stripecardscan.databinding.StripeActivityCardscanBinding
 import com.stripe.android.stripecardscan.di.DaggerCardScanComponent
 import com.stripe.android.stripecardscan.payment.card.ScannedCard
+import com.stripe.android.stripecardscan.payment.ml.CardOcr
 import com.stripe.android.stripecardscan.scanui.CancellationReason
 import com.stripe.android.stripecardscan.scanui.ScanActivity
 import com.stripe.android.stripecardscan.scanui.ScanResultListener

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanEventsReporter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanEventsReporter.kt
@@ -10,4 +10,12 @@ internal interface CardScanEventsReporter {
     fun scanFailed(error: Throwable?)
 
     fun scanCancelled(reason: CancellationReason)
+
+    fun scanMlKitFoundPan()
+
+    fun scanMlKitFoundExp()
+
+    fun scanDarkniteFoundPan()
+
+    fun scanModelsDisagree()
 }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.stripecardscan.cardscan
 
-import android.os.SystemClock
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -9,7 +8,6 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.stripecardscan.scanui.CancellationReason
 import javax.inject.Inject
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
 
 internal class DefaultCardScanEventsReporter @Inject constructor(
@@ -18,9 +16,6 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
     private val durationProvider: DurationProvider,
     private val cardScanConfiguration: CardScanConfiguration
 ) : CardScanEventsReporter {
-    // Tracked separately from DurationProvider because milestone events need elapsed time
-    // mid-scan, but DurationProvider only returns duration on end().
-    private var scanStartedAtMillis: Long? = null
     private var hasLoggedMlKitFoundPan = false
     private var hasLoggedMlKitFoundExp = false
     private var hasLoggedDarkniteFoundPan = false
@@ -28,7 +23,6 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
 
     override fun scanStarted() {
         clearSessionState()
-        scanStartedAtMillis = SystemClock.uptimeMillis()
         durationProvider.start(DurationProvider.Key.CardScan)
         fireEvent(
             eventName = "cardscan_scan_started"
@@ -128,28 +122,23 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
         eventName: String,
         onLogged: () -> Unit,
     ) {
-        if (!shouldLog || scanStartedAtMillis == null) {
+        val elapsed = durationProvider.elapsed(DurationProvider.Key.CardScan)
+        if (!shouldLog || elapsed == null) {
             return
         }
 
         onLogged()
         fireEvent(
             eventName = eventName,
-            additionalParams = durationInSecondsFromStart(elapsedDurationFromStart())
+            additionalParams = durationInSecondsFromStart(elapsed)
         )
     }
 
     private fun clearSessionState() {
-        scanStartedAtMillis = null
         hasLoggedMlKitFoundPan = false
         hasLoggedMlKitFoundExp = false
         hasLoggedDarkniteFoundPan = false
         hasLoggedModelsDisagree = false
-    }
-
-    private fun elapsedDurationFromStart(): Duration? {
-        val startTime = scanStartedAtMillis ?: return null
-        return (SystemClock.uptimeMillis() - startTime).milliseconds
     }
 
     private fun durationInSecondsFromStart(duration: Duration?): Map<String, Float> {

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.stripecardscan.cardscan
 
+import androidx.annotation.MainThread
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -10,6 +11,7 @@ import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
+@MainThread
 internal class DefaultCardScanEventsReporter @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
@@ -9,8 +9,8 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.stripecardscan.scanui.CancellationReason
 import javax.inject.Inject
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
 
 internal class DefaultCardScanEventsReporter @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporter.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.stripecardscan.cardscan
 
+import android.os.SystemClock
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -9,6 +10,7 @@ import com.stripe.android.stripecardscan.scanui.CancellationReason
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class DefaultCardScanEventsReporter @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
@@ -16,7 +18,17 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
     private val durationProvider: DurationProvider,
     private val cardScanConfiguration: CardScanConfiguration
 ) : CardScanEventsReporter {
+    // Tracked separately from DurationProvider because milestone events need elapsed time
+    // mid-scan, but DurationProvider only returns duration on end().
+    private var scanStartedAtMillis: Long? = null
+    private var hasLoggedMlKitFoundPan = false
+    private var hasLoggedMlKitFoundExp = false
+    private var hasLoggedDarkniteFoundPan = false
+    private var hasLoggedModelsDisagree = false
+
     override fun scanStarted() {
+        clearSessionState()
+        scanStartedAtMillis = SystemClock.uptimeMillis()
         durationProvider.start(DurationProvider.Key.CardScan)
         fireEvent(
             eventName = "cardscan_scan_started"
@@ -29,6 +41,7 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
             eventName = "cardscan_success",
             additionalParams = durationInSecondsFromStart(duration)
         )
+        clearSessionState()
     }
 
     override fun scanFailed(error: Throwable?) {
@@ -40,6 +53,7 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
             eventName = "cardscan_failed",
             additionalParams = durationInSecondsFromStart(duration) + params
         )
+        clearSessionState()
     }
 
     override fun scanCancelled(reason: CancellationReason) {
@@ -50,6 +64,43 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
                 "cancellation_reason" to reason.analyticsReason()
             )
         )
+        clearSessionState()
+    }
+
+    override fun scanMlKitFoundPan() {
+        fireMilestoneEvent(
+            shouldLog = !hasLoggedMlKitFoundPan,
+            eventName = "cardscan_mlkit_found_pan",
+        ) {
+            hasLoggedMlKitFoundPan = true
+        }
+    }
+
+    override fun scanMlKitFoundExp() {
+        fireMilestoneEvent(
+            shouldLog = !hasLoggedMlKitFoundExp,
+            eventName = "cardscan_mlkit_found_exp",
+        ) {
+            hasLoggedMlKitFoundExp = true
+        }
+    }
+
+    override fun scanDarkniteFoundPan() {
+        fireMilestoneEvent(
+            shouldLog = !hasLoggedDarkniteFoundPan,
+            eventName = "cardscan_darknite_found_pan",
+        ) {
+            hasLoggedDarkniteFoundPan = true
+        }
+    }
+
+    override fun scanModelsDisagree() {
+        fireMilestoneEvent(
+            shouldLog = !hasLoggedModelsDisagree,
+            eventName = "cardscan_models_disagree",
+        ) {
+            hasLoggedModelsDisagree = true
+        }
     }
 
     private fun fireEvent(
@@ -70,6 +121,35 @@ internal class DefaultCardScanEventsReporter @Inject constructor(
                 additionalParams = additionalParams + baseParams
             )
         )
+    }
+
+    private fun fireMilestoneEvent(
+        shouldLog: Boolean,
+        eventName: String,
+        onLogged: () -> Unit,
+    ) {
+        if (!shouldLog || scanStartedAtMillis == null) {
+            return
+        }
+
+        onLogged()
+        fireEvent(
+            eventName = eventName,
+            additionalParams = durationInSecondsFromStart(elapsedDurationFromStart())
+        )
+    }
+
+    private fun clearSessionState() {
+        scanStartedAtMillis = null
+        hasLoggedMlKitFoundPan = false
+        hasLoggedMlKitFoundExp = false
+        hasLoggedDarkniteFoundPan = false
+        hasLoggedModelsDisagree = false
+    }
+
+    private fun elapsedDurationFromStart(): Duration? {
+        val startTime = scanStartedAtMillis ?: return null
+        return (SystemClock.uptimeMillis() - startTime).milliseconds
     }
 
     private fun durationInSecondsFromStart(duration: Duration?): Map<String, Float> {

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/result/MainLoopState.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/result/MainLoopState.kt
@@ -10,6 +10,7 @@ internal sealed class MainLoopState(
     timeSource: TimeSource,
     protected val enableExpiryWait: Boolean = false,
 ) : MachineState(timeSource) {
+    open val hasModelDisagreement: Boolean = false
 
     companion object {
         /**
@@ -33,6 +34,11 @@ internal sealed class MainLoopState(
          * when expiry detection is enabled.
          */
         val EXPIRY_WAIT_DURATION = 1.seconds
+
+        /**
+         * Both OCR models need repeated evidence before we report that they disagree.
+         */
+        const val MODEL_DISAGREEMENT_THRESHOLD = 2
     }
 
     internal abstract suspend fun consumeTransition(
@@ -54,6 +60,7 @@ internal sealed class MainLoopState(
                 pan = transition.pan,
                 expiryMonth = transition.expiryMonth,
                 expiryYear = transition.expiryYear,
+                source = transition.source,
             )
         }
     }
@@ -64,9 +71,13 @@ internal sealed class MainLoopState(
         pan: String,
         expiryMonth: Int? = null,
         expiryYear: Int? = null,
+        source: CardOcr.Source = CardOcr.Source.Unknown,
     ) : MainLoopState(timeSource, enableExpiryWait) {
 
         private val panCounter = ItemCounter(pan)
+        private val panCountersBySource = mutableMapOf<CardOcr.Source, ItemCounter<String>>().apply {
+            source.takeIf { it != CardOcr.Source.Unknown }?.let { put(it, ItemCounter(pan)) }
+        }
         private val expiryCounter = ItemCounter(
             if (expiryMonth != null && expiryYear != null) {
                 CardOcr.Expiry(month = expiryMonth, year = expiryYear)
@@ -81,12 +92,23 @@ internal sealed class MainLoopState(
         private val mostLikelyExpiry: CardOcr.Expiry?
             get() = expiryCounter.getHighestCountItemOrNull()?.item
 
+        override val hasModelDisagreement: Boolean
+            get() = topPanFor(CardOcr.Source.MlKit)?.let { mlKitTopPan ->
+                topPanFor(CardOcr.Source.Darknite)?.let { darkniteTopPan ->
+                    mlKitTopPan != darkniteTopPan
+                }
+            } ?: false
+
         private var lastCardVisible = TimeSource.Monotonic.markNow()
 
         private fun highestOcrCount() = panCounter.getHighestCountItem().count
         private fun isOcrSatisfied() = highestOcrCount() >= DESIRED_OCR_AGREEMENT
         private fun isTimedOut() = reachedStateAt.elapsedNow() > OCR_SEARCH_DURATION
         private fun isNoCardVisible() = lastCardVisible.elapsedNow() > NO_CARD_VISIBLE_DURATION
+        private fun topPanFor(source: CardOcr.Source): String? {
+            val topItem = panCountersBySource[source]?.getHighestCountItemOrNull() ?: return null
+            return topItem.item.takeIf { topItem.count >= MODEL_DISAGREEMENT_THRESHOLD }
+        }
 
         override suspend fun consumeTransition(
             transition: CardOcr.Prediction
@@ -94,6 +116,9 @@ internal sealed class MainLoopState(
             val transitionPan = transition.pan
             if (!transitionPan.isNullOrEmpty()) {
                 panCounter.countItem(transitionPan)
+                transition.source.takeIf { it != CardOcr.Source.Unknown }?.let { source ->
+                    panCountersBySource.getOrPut(source) { ItemCounter() }.countItem(transitionPan)
+                }
                 lastCardVisible = TimeSource.Monotonic.markNow()
             }
 
@@ -110,6 +135,7 @@ internal sealed class MainLoopState(
                             timeSource = timeSource,
                             enableExpiryWait = enableExpiryWait,
                             pan = mostLikelyPan,
+                            hasModelDisagreement = hasModelDisagreement,
                         )
                     } else {
                         Finished(
@@ -117,6 +143,7 @@ internal sealed class MainLoopState(
                             pan = mostLikelyPan,
                             expiryMonth = mostLikelyExpiry?.month,
                             expiryYear = mostLikelyExpiry?.year,
+                            hasModelDisagreement = hasModelDisagreement,
                         )
                     }
                 isTimedOut() ->
@@ -125,6 +152,7 @@ internal sealed class MainLoopState(
                         pan = mostLikelyPan,
                         expiryMonth = mostLikelyExpiry?.month,
                         expiryYear = mostLikelyExpiry?.year,
+                        hasModelDisagreement = hasModelDisagreement,
                     )
                 isNoCardVisible() ->
                     Initial(timeSource, enableExpiryWait)
@@ -137,6 +165,7 @@ internal sealed class MainLoopState(
         timeSource: TimeSource,
         enableExpiryWait: Boolean = false,
         private val pan: String,
+        override val hasModelDisagreement: Boolean = false,
     ) : MainLoopState(timeSource, enableExpiryWait) {
 
         private val expiryCounter = ItemCounter<CardOcr.Expiry>(null)
@@ -161,6 +190,7 @@ internal sealed class MainLoopState(
                     pan = pan,
                     expiryMonth = mostLikelyExpiry?.month,
                     expiryYear = mostLikelyExpiry?.year,
+                    hasModelDisagreement = hasModelDisagreement,
                 )
             } else {
                 this
@@ -173,6 +203,7 @@ internal sealed class MainLoopState(
         val pan: String,
         val expiryMonth: Int? = null,
         val expiryYear: Int? = null,
+        override val hasModelDisagreement: Boolean = false,
     ) : MainLoopState(timeSource) {
         override suspend fun consumeTransition(
             transition: CardOcr.Prediction

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/CardOcr.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/CardOcr.kt
@@ -15,6 +15,11 @@ private const val IMAGE_STD = 128.5f
  * Shared input/output types and preprocessing for card OCR analyzers.
  */
 internal object CardOcr {
+    enum class Source {
+        Unknown,
+        MlKit,
+        Darknite
+    }
 
     data class Input(val ssdOcrImage: MLImage, val cardBitmap: Bitmap)
 
@@ -39,6 +44,7 @@ internal object CardOcr {
         val pan: String?,
         val expiryMonth: Int? = null,
         val expiryYear: Int? = null,
+        val source: Source = Source.Unknown,
     ) {
 
         /**

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/MLKitTextRecognizer.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/MLKitTextRecognizer.kt
@@ -52,9 +52,10 @@ internal class MLKitTextRecognizer internal constructor(
                 pan = pan,
                 expiryMonth = expiry?.month,
                 expiryYear = expiry?.year,
+                source = CardOcr.Source.MlKit,
             )
         } catch (e: Exception) {
-            CardOcr.Prediction(pan = null)
+            CardOcr.Prediction(pan = null, source = CardOcr.Source.MlKit)
         }
     }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
@@ -133,9 +133,15 @@ internal class SSDOcr private constructor(interpreter: InterpreterWrapper) :
 
         val predictedNumber = detectedBoxes.map { it.label }.joinToString("")
         return if (isValidPan(predictedNumber)) {
-            CardOcr.Prediction(predictedNumber)
+            CardOcr.Prediction(
+                pan = predictedNumber,
+                source = CardOcr.Source.Darknite,
+            )
         } else {
-            CardOcr.Prediction(null)
+            CardOcr.Prediction(
+                pan = null,
+                source = CardOcr.Source.Darknite,
+            )
         }
     }
 

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.stripecardscan.cardscan
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
+import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.stripecardscan.scanui.CancellationReason
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import org.junit.Test
@@ -198,6 +199,9 @@ internal class DefaultCardScanEventsReporterTest {
         testBlock: (DefaultCardScanEventsReporter, FakeAnalyticsRequestExecutor) -> Unit
     ) {
         val analyticsRequestExecutor = FakeAnalyticsRequestExecutor()
+        val durationProvider = DefaultDurationProvider.instance
+        // Clear any leftover state from prior tests sharing the singleton.
+        durationProvider.end(DurationProvider.Key.CardScan)
         val eventsReporter = DefaultCardScanEventsReporter(
             analyticsRequestExecutor = analyticsRequestExecutor,
             analyticsRequestFactory = AnalyticsRequestFactory(
@@ -208,7 +212,7 @@ internal class DefaultCardScanEventsReporterTest {
                 networkTypeProvider = { "" },
                 pluginTypeProvider = { null }
             ),
-            durationProvider = DefaultDurationProvider.instance,
+            durationProvider = durationProvider,
             cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID)
         )
 

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -111,6 +111,84 @@ internal class DefaultCardScanEventsReporterTest {
                 .isEqualTo("user_cannot_scan")
         }
 
+    @Test
+    fun testMlKitFoundPanSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+        defaultCardScanEventsReporter.scanStarted()
+        ShadowSystemClock.advanceBy(2, TimeUnit.SECONDS)
+
+        defaultCardScanEventsReporter.scanMlKitFoundPan()
+        defaultCardScanEventsReporter.scanMlKitFoundPan()
+
+        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+
+        assertThat(loggedRequests).hasSize(2)
+        val loggedParams = loggedRequests.last().params
+        assertThat(loggedParams["event"]).isEqualTo("cardscan_mlkit_found_pan")
+        assertThat(loggedParams["duration"]).isEqualTo(2f)
+        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+    }
+
+    @Test
+    fun testMlKitFoundExpSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+        defaultCardScanEventsReporter.scanStarted()
+        ShadowSystemClock.advanceBy(3, TimeUnit.SECONDS)
+
+        defaultCardScanEventsReporter.scanMlKitFoundExp()
+        defaultCardScanEventsReporter.scanMlKitFoundExp()
+
+        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+
+        assertThat(loggedRequests).hasSize(2)
+        val loggedParams = loggedRequests.last().params
+        assertThat(loggedParams["event"]).isEqualTo("cardscan_mlkit_found_exp")
+        assertThat(loggedParams["duration"]).isEqualTo(3f)
+        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+    }
+
+    @Test
+    fun testDarkniteFoundPanSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+        defaultCardScanEventsReporter.scanStarted()
+        ShadowSystemClock.advanceBy(4, TimeUnit.SECONDS)
+
+        defaultCardScanEventsReporter.scanDarkniteFoundPan()
+        defaultCardScanEventsReporter.scanDarkniteFoundPan()
+
+        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+
+        assertThat(loggedRequests).hasSize(2)
+        val loggedParams = loggedRequests.last().params
+        assertThat(loggedParams["event"]).isEqualTo("cardscan_darknite_found_pan")
+        assertThat(loggedParams["duration"]).isEqualTo(4f)
+        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+    }
+
+    @Test
+    fun testModelsDisagreeSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+        defaultCardScanEventsReporter.scanStarted()
+        ShadowSystemClock.advanceBy(5, TimeUnit.SECONDS)
+
+        defaultCardScanEventsReporter.scanModelsDisagree()
+        defaultCardScanEventsReporter.scanModelsDisagree()
+
+        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+
+        assertThat(loggedRequests).hasSize(2)
+        val loggedParams = loggedRequests.last().params
+        assertThat(loggedParams["event"]).isEqualTo("cardscan_models_disagree")
+        assertThat(loggedParams["duration"]).isEqualTo(5f)
+        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+    }
+
+    @Test
+    fun testMilestonesDoNotEmitWithoutActiveSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+        defaultCardScanEventsReporter.scanMlKitFoundPan()
+        defaultCardScanEventsReporter.scanMlKitFoundExp()
+        defaultCardScanEventsReporter.scanDarkniteFoundPan()
+        defaultCardScanEventsReporter.scanModelsDisagree()
+
+        assertThat(fakeAnalyticsRequestExecutor.getExecutedRequests()).isEmpty()
+    }
+
     private fun runScenario(
         testBlock: (DefaultCardScanEventsReporter, FakeAnalyticsRequestExecutor) -> Unit
     ) {

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -112,7 +112,8 @@ internal class DefaultCardScanEventsReporterTest {
         }
 
     @Test
-    fun testMlKitFoundPanSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+    fun testMlKitFoundPanSentOncePerSession() =
+        runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
         defaultCardScanEventsReporter.scanStarted()
         ShadowSystemClock.advanceBy(2, TimeUnit.SECONDS)
 
@@ -129,7 +130,8 @@ internal class DefaultCardScanEventsReporterTest {
     }
 
     @Test
-    fun testMlKitFoundExpSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+    fun testMlKitFoundExpSentOncePerSession() =
+        runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
         defaultCardScanEventsReporter.scanStarted()
         ShadowSystemClock.advanceBy(3, TimeUnit.SECONDS)
 
@@ -146,7 +148,8 @@ internal class DefaultCardScanEventsReporterTest {
     }
 
     @Test
-    fun testDarkniteFoundPanSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+    fun testDarkniteFoundPanSentOncePerSession() =
+        runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
         defaultCardScanEventsReporter.scanStarted()
         ShadowSystemClock.advanceBy(4, TimeUnit.SECONDS)
 
@@ -163,7 +166,8 @@ internal class DefaultCardScanEventsReporterTest {
     }
 
     @Test
-    fun testModelsDisagreeSentOncePerSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+    fun testModelsDisagreeSentOncePerSession() =
+        runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
         defaultCardScanEventsReporter.scanStarted()
         ShadowSystemClock.advanceBy(5, TimeUnit.SECONDS)
 
@@ -180,7 +184,8 @@ internal class DefaultCardScanEventsReporterTest {
     }
 
     @Test
-    fun testMilestonesDoNotEmitWithoutActiveSession() = runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
+    fun testMilestonesDoNotEmitWithoutActiveSession() =
+        runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
         defaultCardScanEventsReporter.scanMlKitFoundPan()
         defaultCardScanEventsReporter.scanMlKitFoundExp()
         defaultCardScanEventsReporter.scanDarkniteFoundPan()

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/FakeCardScansEventReporter.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/FakeCardScansEventReporter.kt
@@ -8,6 +8,10 @@ class FakeCardScansEventReporter private constructor() : CardScanEventsReporter 
     private val scanSucceededTurbine = Turbine<Unit>()
     private val scanFailedTurbine = Turbine<Throwable?>()
     private val scanCancelledTurbine = Turbine<Unit>()
+    private val scanMlKitFoundPanTurbine = Turbine<Unit>()
+    private val scanMlKitFoundExpTurbine = Turbine<Unit>()
+    private val scanDarkniteFoundPanTurbine = Turbine<Unit>()
+    private val scanModelsDisagreeTurbine = Turbine<Unit>()
 
     override fun scanStarted() {
         scanStartedTurbine.add(Unit)
@@ -25,11 +29,31 @@ class FakeCardScansEventReporter private constructor() : CardScanEventsReporter 
         scanCancelledTurbine.add(Unit)
     }
 
+    override fun scanMlKitFoundPan() {
+        scanMlKitFoundPanTurbine.add(Unit)
+    }
+
+    override fun scanMlKitFoundExp() {
+        scanMlKitFoundExpTurbine.add(Unit)
+    }
+
+    override fun scanDarkniteFoundPan() {
+        scanDarkniteFoundPanTurbine.add(Unit)
+    }
+
+    override fun scanModelsDisagree() {
+        scanModelsDisagreeTurbine.add(Unit)
+    }
+
     private fun ensureAllEventsConsumed() {
         scanStartedTurbine.ensureAllEventsConsumed()
         scanSucceededTurbine.ensureAllEventsConsumed()
         scanFailedTurbine.ensureAllEventsConsumed()
         scanCancelledTurbine.ensureAllEventsConsumed()
+        scanMlKitFoundPanTurbine.ensureAllEventsConsumed()
+        scanMlKitFoundExpTurbine.ensureAllEventsConsumed()
+        scanDarkniteFoundPanTurbine.ensureAllEventsConsumed()
+        scanModelsDisagreeTurbine.ensureAllEventsConsumed()
     }
 
     class Scenario(
@@ -49,6 +73,22 @@ class FakeCardScansEventReporter private constructor() : CardScanEventsReporter 
 
         suspend fun awaitScanCancelled() {
             return eventsReporter.scanCancelledTurbine.awaitItem()
+        }
+
+        suspend fun awaitMlKitFoundPan() {
+            return eventsReporter.scanMlKitFoundPanTurbine.awaitItem()
+        }
+
+        suspend fun awaitMlKitFoundExp() {
+            return eventsReporter.scanMlKitFoundExpTurbine.awaitItem()
+        }
+
+        suspend fun awaitDarkniteFoundPan() {
+            return eventsReporter.scanDarkniteFoundPanTurbine.awaitItem()
+        }
+
+        suspend fun awaitModelsDisagree() {
+            return eventsReporter.scanModelsDisagreeTurbine.awaitItem()
         }
     }
 

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/result/MainLoopStateTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/result/MainLoopStateTest.kt
@@ -305,4 +305,134 @@ class MainLoopStateTest {
         // Should go directly to Finished, not ExpiryWait
         assertThat(state).isInstanceOf(MainLoopState.Finished::class.java)
     }
+
+    @Test
+    fun `Prediction source defaults to Unknown`() {
+        assertThat(CardOcr.Prediction(pan = "4242424242424242").source).isEqualTo(CardOcr.Source.Unknown)
+    }
+
+    @Test
+    fun `OcrFound does not report disagreement when only one model is active`() = runTest {
+        var state: MainLoopState = MainLoopState.Initial(timeSource)
+
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+
+        assertThat(state.hasModelDisagreement).isFalse()
+    }
+
+    @Test
+    fun `OcrFound does not report disagreement when model leaders agree`() = runTest {
+        var state: MainLoopState = MainLoopState.Initial(timeSource)
+
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.Darknite,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.Darknite,
+            )
+        )
+
+        assertThat(state.hasModelDisagreement).isFalse()
+    }
+
+    @Test
+    fun `OcrFound reports disagreement when models repeatedly favor different PANs`() = runTest {
+        var state: MainLoopState = MainLoopState.Initial(timeSource)
+
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "5555555555554444",
+                source = CardOcr.Source.Darknite,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "5555555555554444",
+                source = CardOcr.Source.Darknite,
+            )
+        )
+
+        assertThat(state).isInstanceOf(MainLoopState.OcrFound::class.java)
+        assertThat(state.hasModelDisagreement).isTrue()
+    }
+
+    @Test
+    fun `Finished preserves disagreement flag when reached after disagreement`() = runTest {
+        var state: MainLoopState = MainLoopState.Initial(timeSource)
+
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "5555555555554444",
+                source = CardOcr.Source.Darknite,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "5555555555554444",
+                source = CardOcr.Source.Darknite,
+            )
+        )
+        state = state.consumeTransition(
+            CardOcr.Prediction(
+                pan = "4242424242424242",
+                source = CardOcr.Source.MlKit,
+            )
+        )
+
+        assertThat(state).isInstanceOf(MainLoopState.Finished::class.java)
+        assertThat(state.hasModelDisagreement).isTrue()
+        assertThat((state as MainLoopState.Finished).pan).isEqualTo("4242424242424242")
+    }
 }


### PR DESCRIPTION
# Summary

Adds new analytics events for the new card scanner:


Event | Description
-- | --
cardscan_mlkit_found_pan | Sent the first time during a scanning session the MLKit model finds a valid PAN. (includes duration)
cardscan_mlkit_found_exp | Sent the first time during a scanning session that the MLKit model finds a valid expiration date. (includes duration)
cardscan_darknite_found_pan | Sent the first time during a scanning session when the Bouncer (Darknite) model finds a valid PAN. (includes duration)
cardscan_models_disagree | Sent once during a scanning session when both models find multiple frames with a different, but valid, PAN. The PAN with the highest number of "votes" will win. (includes duration)

Also added a new `elapsed` function to DurationProvider to sample the current duration for these intermediate events without ending the DurationProvider.

# Motivation
Tracking success rate for the new scanner.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
N/A