### PR TITLE
Update Afterpay/Clearpay BNPL branding to "Buy Now, Pay Later"

### DIFF
--- a/payments-ui-core/res/values-en-rGB/strings.xml
+++ b/payments-ui-core/res/values-en-rGB/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
-  <string name="stripe_afterpay_clearpay_marketing"><![CDATA[Buy now or pay later with <img/>]]></string>
+  <string name="stripe_afterpay_clearpay_marketing"><![CDATA[Buy Now, Pay Later with <img/>]]></string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="stripe_afterpay_clearpay_message"><![CDATA[Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>]]></string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
-  <string name="stripe_afterpay_clearpay_marketing"><![CDATA[Buy now or pay later with <img/>]]></string>
+  <string name="stripe_afterpay_clearpay_marketing"><![CDATA[Buy Now, Pay Later with <img/>]]></string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="stripe_afterpay_clearpay_message"><![CDATA[Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>]]></string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
@@ -28,7 +28,7 @@ class AfterpayClearpayHeaderElementTest {
 
         assertThat(
             element.getLabel(ApplicationProvider.getApplicationContext<Application>().resources)
-        ).isEqualTo("Buy now or pay later with <img/> <b>ⓘ</b>")
+        ).isEqualTo("Buy Now, Pay Later with <img/> <b>ⓘ</b>")
     }
 
     @Test

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -7,7 +7,7 @@
   <!-- Text for a button that, when tapped, displays another screen where the customer can add a new payment method -->
   <string name="stripe_add_payment_method">Add a payment method</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->
-  <string name="stripe_afterpay_subtitle">Buy now or pay later with Afterpay</string>
+  <string name="stripe_afterpay_subtitle">Buy Now, Pay Later with Afterpay</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="stripe_bank_account_ending_in">Bank account ending in %s</string>
   <!-- Concise description of a saved bank account. E.g. 'Bank account ···· 4242' -->
@@ -17,9 +17,9 @@
   <!-- Text for alert message when user needs to confirm payment in their banking app -->
   <string name="stripe_blik_confirm_payment">Confirm the payment in your bank\'s app within %s to complete the purchase.</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->
-  <string name="stripe_cashapp_afterpay_subtitle">Buy now or pay later with Cash App Afterpay</string>
+  <string name="stripe_cashapp_afterpay_subtitle">Buy Now, Pay Later with Cash App Afterpay</string>
   <!-- This shows the message on Buy Now Pay Later LPM, clearpay. -->
-  <string name="stripe_clearpay_subtitle">Buy now or pay later with Clearpay</string>
+  <string name="stripe_clearpay_subtitle">Buy Now, Pay Later with Clearpay</string>
   <!-- Used as the title for prompting the user if they want to close the sheet -->
   <string name="stripe_confirm_close_form_body">Your payment information will not be saved.</string>
   <!-- Used as the title for prompting the user if they want to close the sheet -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -7,7 +7,7 @@
   <!-- Text for a button that, when tapped, displays another screen where the customer can add a new payment method -->
   <string name="stripe_add_payment_method">Add a payment method</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->
-  <string name="stripe_afterpay_subtitle">Buy now or pay later with Afterpay</string>
+  <string name="stripe_afterpay_subtitle">Buy Now, Pay Later with Afterpay</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="stripe_bank_account_ending_in">Bank account ending in %s</string>
   <!-- Concise description of a saved bank account. E.g. 'Bank account ···· 4242' -->
@@ -17,9 +17,9 @@
   <!-- Text for alert message when user needs to confirm payment in their banking app -->
   <string name="stripe_blik_confirm_payment">Confirm the payment in your bank\'s app within %s to complete the purchase.</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay. -->
-  <string name="stripe_cashapp_afterpay_subtitle">Buy now or pay later with Cash App Afterpay</string>
+  <string name="stripe_cashapp_afterpay_subtitle">Buy Now, Pay Later with Cash App Afterpay</string>
   <!-- This shows the message on Buy Now Pay Later LPM, clearpay. -->
-  <string name="stripe_clearpay_subtitle">Buy now or pay later with Clearpay</string>
+  <string name="stripe_clearpay_subtitle">Buy Now, Pay Later with Clearpay</string>
   <!-- Used as the title for prompting the user if they want to close the sheet -->
   <string name="stripe_confirm_close_form_body">Your payment information will not be saved.</string>
   <!-- Used as the title for prompting the user if they want to close the sheet -->


### PR DESCRIPTION
## Summary
- Update "Buy now or pay later" → "Buy Now, Pay Later" across all Afterpay/Clearpay/Cash App Afterpay English strings to match branding guidelines
- Fix `AfterpayClearpayHeaderElementTest` to expect the updated string

## Motivation
Afterpay/Clearpay branding requires "Buy Now, Pay Later" (capitalized, comma-separated) instead of "Buy now or pay later". See RUN_MOBILESDK-5307.

Supersedes #12885. Aligned with iOS PR stripe/stripe-ios#6331.

## Changes
**English strings updated** (in both `values/` and `values-en-rGB/`):
- `stripe_afterpay_clearpay_marketing`: "Buy Now, Pay Later with \<img/>" (`payments-ui-core`)
- `stripe_afterpay_subtitle`: "Buy Now, Pay Later with Afterpay" (`paymentsheet`)
- `stripe_cashapp_afterpay_subtitle`: "Buy Now, Pay Later with Cash App Afterpay" (`paymentsheet`)
- `stripe_clearpay_subtitle`: "Buy Now, Pay Later with Clearpay" (`paymentsheet`)

**Translations**: Not modified — translations are managed via Lokalize and will be updated in the next translation sync. The iOS PR takes a different approach (removing translations to fall back to English), but on Android the standard process is to let Lokalize handle it.

## Testing
- [x] `AfterpayClearpayHeaderElementTest` — updated assertion and verified passing
- [x] `AfterpayClearpayDefinitionTest` — verified passing (uses resource resolution, not hardcoded strings)

## Changelog
- [Changed] Updated Afterpay/Clearpay subtitle text from "Buy now or pay later" to "Buy Now, Pay Later" to match branding guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)