### PR TITLE
Rename ManageActivity to EmbeddedSheetActivity for clarity.

### DIFF
--- a/paymentsheet/src/main/AndroidManifest.xml
+++ b/paymentsheet/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
             android:name="com.stripe.android.paymentelement.embedded.form.FormActivity"
             android:theme="@style/StripePaymentSheetDefaultTheme" />
         <activity
-            android:name="com.stripe.android.paymentelement.embedded.manage.ManageActivity"
+            android:name="com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity"
             android:theme="@style/StripePaymentSheetDefaultTheme" />
         <activity
             android:name="com.stripe.android.common.taptoadd.TapToAddActivity"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -33,10 +33,10 @@ import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentelement.embedded.manage.DefaultEmbeddedManageScreenInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.DefaultEmbeddedUpdateScreenInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInteractorFactory
-import com.stripe.android.paymentelement.embedded.manage.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.InitialManageScreenFactory
 import com.stripe.android.paymentelement.embedded.manage.ManageSavedPaymentMethodMutatorFactory
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -15,8 +15,8 @@ import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateA
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.FormContract
 import com.stripe.android.paymentelement.embedded.form.FormResult
-import com.stripe.android.paymentelement.embedded.manage.ManageContract
-import com.stripe.android.paymentelement.embedded.manage.ManageResult
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetResult
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -63,7 +63,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     formActivityLauncher.unregister()
-                    manageActivityLauncher.unregister()
+                    sheetActivityLauncher.unregister()
                     super.onDestroy(owner)
                 }
             }
@@ -93,13 +93,14 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             }
         }
 
-    private val manageActivityLauncher: ActivityResultLauncher<ManageContract.Args> =
-        activityResultCaller.registerForActivityResult(ManageContract) { result ->
+    private val sheetActivityLauncher: ActivityResultLauncher<EmbeddedSheetContract.Args> =
+        activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
             sheetStateHolder.sheetIsOpen = false
             when (result) {
-                is ManageResult.Error -> Unit
-                is ManageResult.Complete -> {
-                    customerStateHolder.setCustomerState(result.customerState)
+                is EmbeddedSheetResult.Error -> Unit
+                is EmbeddedSheetResult.Cancelled -> Unit
+                is EmbeddedSheetResult.Complete -> {
+                    result.customerState?.let { customerStateHolder.setCustomerState(it) }
                     selectionHolder.set(result.selection)
                     if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
                         rowSelectionImmediateActionHandler.invoke()
@@ -166,17 +167,17 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val args = ManageContract.Args(
-            paymentMethodMetadata = paymentMethodMetadata,
-            customerState = customerState,
-            selection = selection,
-            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+        val args = EmbeddedSheetContract.Args(
             selectedPaymentMethodCode = selection?.paymentMethodType ?: "",
+            paymentMethodMetadata = paymentMethodMetadata,
             hasSavedPaymentMethods = customerState.paymentMethods.isNotEmpty(),
-            statusBarColor = statusBarColor,
             configuration = embeddedConfirmationState.configuration,
+            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+            statusBarColor = statusBarColor,
+            selection = selection,
+            customerState = customerState,
             promotion = null,
         )
-        manageActivityLauncher.launch(args)
+        sheetActivityLauncher.launch(args)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.manage
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.manage
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.manage
 
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.manage
+package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
@@ -145,7 +145,7 @@ internal class EmbeddedNavigator private constructor(
             @Composable
             override fun Content() {
                 Column {
-                    UpdatePaymentMethodUI(interactor = interactor, modifier = Modifier)
+                    UpdatePaymentMethodUI(interactor = interactor, modifier = Modifier.Companion)
                     PaymentSheetContentPadding(subtractingExtraPadding = 16.dp)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -1,5 +1,6 @@
-package com.stripe.android.paymentelement.embedded.manage
+package com.stripe.android.paymentelement.embedded.sheet
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
@@ -37,30 +38,29 @@ import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
 import javax.inject.Inject
 
-internal class ManageActivity : AppCompatActivity() {
-    private val args: ManageContract.Args? by lazy {
-        ManageContract.Args.fromIntent(intent)
+internal class EmbeddedSheetActivity : AppCompatActivity() {
+    private val args: EmbeddedSheetContract.Args? by lazy {
+        EmbeddedSheetContract.Args.fromIntent(intent)
     }
 
-    private val viewModel: ManageViewModel by viewModels {
-        ManageViewModel.Factory {
+    private val viewModel: EmbeddedSheetViewModel by viewModels {
+        EmbeddedSheetViewModel.Factory {
             requireNotNull(args)
         }
     }
 
     @Inject
+    lateinit var eventReporter: EventReporter
+
+    @Inject
     lateinit var customerStateHolder: CustomerStateHolder
 
     @Inject
-    lateinit var manageNavigator: EmbeddedNavigator
+    lateinit var embeddedNavigator: EmbeddedNavigator
 
     @Inject
     lateinit var selectionHolder: EmbeddedSelectionHolder
 
-    @Inject
-    lateinit var eventReporter: EventReporter
-
-    @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -70,40 +70,45 @@ internal class ManageActivity : AppCompatActivity() {
         }
 
         renderEdgeToEdge()
-
         viewModel.component.inject(this)
 
         onBackPressedDispatcher.addCallback {
-            if (!manageNavigator.screen.value.isPerformingNetworkOperation()) {
-                manageNavigator.performAction(EmbeddedNavigator.Action.Back)
+            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation()) {
+                embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
             }
         }
 
         setContent {
             StripeTheme {
-                val screen by manageNavigator.screen.collectAsState()
-                val bottomSheetState = rememberStripeBottomSheetState(
-                    confirmValueChange = { !screen.isPerformingNetworkOperation() }
-                )
-                ElementsBottomSheetLayout(
-                    state = bottomSheetState,
-                    onDismissed = {
-                        setManageResult(false)
+                SheetContent()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    @Composable
+    private fun SheetContent() {
+        val screen by embeddedNavigator.screen.collectAsState()
+        val bottomSheetState = rememberStripeBottomSheetState(
+            confirmValueChange = { !screen.isPerformingNetworkOperation() }
+        )
+        ElementsBottomSheetLayout(
+            state = bottomSheetState,
+            onDismissed = {
+                setEmbeddedResult(shouldInvokeSelectionCallback = false)
+                finish()
+            }
+        ) {
+            var hasResult by remember { mutableStateOf(false) }
+            if (!hasResult) {
+                Box(modifier = Modifier.padding(bottom = 20.dp)) {
+                    ScreenContent(embeddedNavigator, screen)
+                }
+                LaunchedEffect(Unit) {
+                    embeddedNavigator.result.collect { result ->
+                        hasResult = true
+                        setEmbeddedResult(shouldInvokeSelectionCallback = result == true)
                         finish()
-                    }
-                ) {
-                    var hasResult by remember { mutableStateOf(false) }
-                    if (!hasResult) {
-                        Box(modifier = Modifier.padding(bottom = 20.dp)) {
-                            ScreenContent(manageNavigator, screen)
-                        }
-                        LaunchedEffect(screen) {
-                            manageNavigator.result.collect { result ->
-                                setManageResult(result == true)
-                                finish()
-                                hasResult = true
-                            }
-                        }
                     }
                 }
             }
@@ -127,7 +132,7 @@ internal class ManageActivity : AppCompatActivity() {
                     state = topBarState,
                     canNavigateBack = navigator.canGoBack,
                     isEnabled = true,
-                    handleBackPressed = { manageNavigator.performAction(EmbeddedNavigator.Action.Back) },
+                    handleBackPressed = { embeddedNavigator.performAction(EmbeddedNavigator.Action.Back) },
                 )
             },
             content = {
@@ -171,15 +176,16 @@ internal class ManageActivity : AppCompatActivity() {
         }
     }
 
-    private fun setManageResult(shouldInvokeSelectionCallback: Boolean) {
-        val result = ManageResult.Complete(
-            customerState = requireNotNull(customerStateHolder.customer.value),
+    private fun setEmbeddedResult(shouldInvokeSelectionCallback: Boolean) {
+        val result = EmbeddedSheetResult.Complete(
             selection = selectionHolder.selection.value,
-            shouldInvokeSelectionCallback = shouldInvokeSelectionCallback
+            hasBeenConfirmed = false,
+            customerState = customerStateHolder.customer.value,
+            shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
         )
         setResult(
-            RESULT_OK,
-            ManageResult.toIntent(intent, result)
+            Activity.RESULT_OK,
+            EmbeddedSheetResult.toIntent(intent, result)
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.manage
+package com.stripe.android.paymentelement.embedded.sheet
 
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
@@ -32,27 +32,29 @@ import javax.inject.Singleton
     ],
 )
 @Singleton
-internal interface ManageComponent {
-    val viewModel: ManageViewModel
-    val customerStateHolder: CustomerStateHolder
+internal interface EmbeddedSheetComponent {
+    val viewModel: EmbeddedSheetViewModel
     val selectionHolder: EmbeddedSelectionHolder
-    fun inject(activity: ManageActivity)
+    val customerStateHolder: CustomerStateHolder
+
+    fun inject(activity: EmbeddedSheetActivity)
 
     @Component.Factory
     interface Factory {
         fun build(
-            @BindsInstance savedStateHandle: SavedStateHandle,
             @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
-            @BindsInstance application: Application,
-            @BindsInstance @PaymentElementCallbackIdentifier
-            paymentElementCallbackIdentifier: String,
             @BindsInstance selectedPaymentMethodCode: PaymentMethodCode,
             @BindsInstance hasSavedPaymentMethods: Boolean,
             @BindsInstance
             @Named(STATUS_BAR_COLOR)
             statusBarColor: Int?,
             @BindsInstance configuration: EmbeddedPaymentElement.Configuration,
+            @BindsInstance
+            @PaymentElementCallbackIdentifier
+            paymentElementCallbackIdentifier: String,
+            @BindsInstance application: Application,
+            @BindsInstance savedStateHandle: SavedStateHandle,
             @BindsInstance promotion: PaymentMethodMessagePromotion?,
-        ): ManageComponent
+        ): EmbeddedSheetComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.manage
+package com.stripe.android.paymentelement.embedded.sheet
 
 import android.content.Context
 import android.content.Intent
@@ -13,57 +13,62 @@ import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
-internal sealed interface ManageResult : Parcelable {
+internal sealed interface EmbeddedSheetResult : Parcelable {
 
     @Parcelize
     data class Complete(
-        val customerState: CustomerState,
         val selection: PaymentSelection?,
-        val shouldInvokeSelectionCallback: Boolean
-    ) : ManageResult
+        val hasBeenConfirmed: Boolean,
+        val customerState: CustomerState?,
+        val shouldInvokeSelectionCallback: Boolean,
+    ) : EmbeddedSheetResult
 
     @Parcelize
-    object Error : ManageResult
+    data class Cancelled(
+        val customerState: CustomerState?,
+    ) : EmbeddedSheetResult
+
+    @Parcelize
+    data object Error : EmbeddedSheetResult
 
     companion object {
         internal const val EXTRA_RESULT = ActivityStarter.Result.EXTRA
 
-        fun toIntent(intent: Intent, result: ManageResult): Intent {
+        fun toIntent(intent: Intent, result: EmbeddedSheetResult): Intent {
             return intent.putExtra(EXTRA_RESULT, result)
         }
 
-        fun fromIntent(intent: Intent?): ManageResult {
+        fun fromIntent(intent: Intent?): EmbeddedSheetResult {
             val result = intent?.extras?.let { bundle ->
-                BundleCompat.getParcelable(bundle, EXTRA_RESULT, ManageResult::class.java)
+                BundleCompat.getParcelable(bundle, EXTRA_RESULT, EmbeddedSheetResult::class.java)
             }
-
             return result ?: Error
         }
     }
 }
 
-internal object ManageContract : ActivityResultContract<ManageContract.Args, ManageResult>() {
+internal object EmbeddedSheetContract : ActivityResultContract<EmbeddedSheetContract.Args, EmbeddedSheetResult>() {
     internal const val EXTRA_ARGS: String = "extra_activity_args"
 
     override fun createIntent(context: Context, input: Args): Intent {
-        return Intent(context, ManageActivity::class.java)
+        return Intent(context, EmbeddedSheetActivity::class.java)
             .putExtra(EXTRA_ARGS, input)
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): ManageResult {
-        return ManageResult.fromIntent(intent)
+    override fun parseResult(resultCode: Int, intent: Intent?): EmbeddedSheetResult {
+        return EmbeddedSheetResult.fromIntent(intent)
     }
 
     @Parcelize
     internal data class Args(
-        val paymentMethodMetadata: PaymentMethodMetadata,
-        val customerState: CustomerState,
-        val selection: PaymentSelection?,
-        val paymentElementCallbackIdentifier: String,
         val selectedPaymentMethodCode: String,
+        val paymentMethodMetadata: PaymentMethodMetadata,
         val hasSavedPaymentMethods: Boolean,
-        val statusBarColor: Int?,
         val configuration: EmbeddedPaymentElement.Configuration,
+        val paymentElementCallbackIdentifier: String,
+        val statusBarColor: Int?,
+        val selection: PaymentSelection?,
+        val customerState: CustomerState?,
         val promotion: PaymentMethodMessagePromotion?,
     ) : Parcelable {
         companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.manage
+package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -10,8 +10,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import javax.inject.Inject
 
-internal class ManageViewModel @Inject constructor(
-    val component: ManageComponent,
+internal class EmbeddedSheetViewModel @Inject constructor(
+    val component: EmbeddedSheetComponent,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
 ) : ViewModel() {
     override fun onCleared() {
@@ -19,23 +19,20 @@ internal class ManageViewModel @Inject constructor(
     }
 
     class Factory(
-        private val argsSupplier: () -> ManageContract.Args,
+        private val argsSupplier: () -> EmbeddedSheetContract.Args,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-            val savedStateHandle = extras.createSavedStateHandle()
-
             val args = argsSupplier()
-
-            val component = DaggerManageComponent.factory().build(
-                savedStateHandle = savedStateHandle,
-                paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
+            val component = DaggerEmbeddedSheetComponent.factory().build(
                 paymentMethodMetadata = args.paymentMethodMetadata,
-                application = extras.requireApplication(),
                 selectedPaymentMethodCode = args.selectedPaymentMethodCode,
                 hasSavedPaymentMethods = args.hasSavedPaymentMethods,
                 statusBarColor = args.statusBarColor,
                 configuration = args.configuration,
+                paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
+                application = extras.requireApplication(),
+                savedStateHandle = extras.createSavedStateHandle(),
                 promotion = args.promotion,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -26,8 +26,8 @@ import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImm
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.FormContract
 import com.stripe.android.paymentelement.embedded.form.FormResult
-import com.stripe.android.paymentelement.embedded.manage.ManageContract
-import com.stripe.android.paymentelement.embedded.manage.ManageResult
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetResult
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -355,15 +355,15 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val state = EmbeddedConfirmationStateFixtures.defaultState()
-        val expectedArgs = ManageContract.Args(
-            paymentMethodMetadata = paymentMethodMetadata,
-            customerState = customerState,
-            selection = PaymentSelection.GooglePay,
-            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
+        val expectedArgs = EmbeddedSheetContract.Args(
             selectedPaymentMethodCode = "google_pay",
+            paymentMethodMetadata = paymentMethodMetadata,
             hasSavedPaymentMethods = customerState.paymentMethods.isNotEmpty(),
-            statusBarColor = null,
             configuration = state.configuration,
+            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
+            statusBarColor = null,
+            selection = PaymentSelection.GooglePay,
+            customerState = customerState,
             promotion = null,
         )
 
@@ -384,17 +384,18 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     @Test
-    fun `manageActivityLauncher callback updates state on complete result`() = testScenario {
+    fun `manageSheetLauncher callback updates state on complete result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        val result = ManageResult.Complete(
+        val result = EmbeddedSheetResult.Complete(
             customerState = customerState,
             selection = selection,
+            hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
         )
 
-        val callback = manageRegisterCall.callback.asCallbackFor<ManageResult>()
+        val callback = manageRegisterCall.callback.asCallbackFor<EmbeddedSheetResult>()
         callback.onActivityResult(result)
 
         assertThat(customerStateHolder.customer.value).isEqualTo(customerState)
@@ -403,49 +404,51 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     @Test
-    fun `manageActivityLauncher callback invokes rowSelectionCallback when flag set`() {
+    fun `manageSheetLauncher callback invokes rowSelectionCallback when flag set`() {
         testScenario(
             shouldRowSelectionBeInvoked = true
         ) {
             sheetStateHolder.sheetIsOpen = true
             val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-            val result = ManageResult.Complete(
+            val result = EmbeddedSheetResult.Complete(
                 customerState = customerState,
                 selection = selection,
+                hasBeenConfirmed = false,
                 shouldInvokeSelectionCallback = true,
             )
 
-            val callback = manageRegisterCall.callback.asCallbackFor<ManageResult>()
+            val callback = manageRegisterCall.callback.asCallbackFor<EmbeddedSheetResult>()
             callback.onActivityResult(result)
         }
     }
 
     @Test
-    fun `manageActivityLauncher callback doesn't invokes rowSelectionCallback when flag not set`() {
+    fun `manageSheetLauncher callback doesn't invokes rowSelectionCallback when flag not set`() {
         testScenario(
             shouldRowSelectionBeInvoked = false
         ) {
             sheetStateHolder.sheetIsOpen = true
             val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-            val result = ManageResult.Complete(
+            val result = EmbeddedSheetResult.Complete(
                 customerState = customerState,
                 selection = selection,
+                hasBeenConfirmed = false,
                 shouldInvokeSelectionCallback = false,
             )
 
-            val callback = manageRegisterCall.callback.asCallbackFor<ManageResult>()
+            val callback = manageRegisterCall.callback.asCallbackFor<EmbeddedSheetResult>()
             callback.onActivityResult(result)
         }
     }
 
     @Test
-    fun `manageActivityLauncher callback does not update state on non-complete result`() = testScenario {
+    fun `manageSheetLauncher callback does not update state on error result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         customerStateHolder.setCustomerState(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
-        val result = ManageResult.Error
-        val callback = manageRegisterCall.callback.asCallbackFor<ManageResult>()
+        val result = EmbeddedSheetResult.Error
+        val callback = manageRegisterCall.callback.asCallbackFor<EmbeddedSheetResult>()
 
         callback.onActivityResult(result)
 
@@ -455,14 +458,14 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     @Test
-    fun `manageActivityLauncher callback does not invoke rowSelectionCallback on non-complete result`() {
+    fun `manageSheetLauncher callback does not invoke rowSelectionCallback on error result`() {
         testScenario(
             shouldRowSelectionBeInvoked = false
         ) {
             sheetStateHolder.sheetIsOpen = true
             customerStateHolder.setCustomerState(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
-            val result = ManageResult.Error
-            val callback = manageRegisterCall.callback.asCallbackFor<ManageResult>()
+            val result = EmbeddedSheetResult.Error
+            val callback = manageRegisterCall.callback.asCallbackFor<EmbeddedSheetResult>()
 
             callback.onActivityResult(result)
         }
@@ -585,7 +588,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             assertThat(manageRegisterCall).isNotNull()
 
             assertThat(formRegisterCall.contract).isInstanceOf<FormContract>()
-            assertThat(manageRegisterCall.contract).isInstanceOf<ManageContract>()
+            assertThat(manageRegisterCall.contract).isInstanceOf<EmbeddedSheetContract>()
 
             Scenario(
                 testScope = testScope,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
@@ -28,7 +28,7 @@ import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.manage.ManageActivity
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -44,7 +44,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 internal class FormActivityTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
-    private val composeTestRule = createAndroidComposeRule<ManageActivity>()
+    private val composeTestRule = createAndroidComposeRule<EmbeddedSheetActivity>()
     private val networkRule = NetworkRule()
 
     private val formPage = FormPage(composeTestRule)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.manage
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.ui.FakeUpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactoryTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.manage
+package com.stripe.android.paymentelement.embedded.sheet
 
 import android.app.Application
 import android.os.Bundle
@@ -45,9 +45,9 @@ import java.util.concurrent.CountDownLatch
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
-internal class ManageActivityTest {
+internal class EmbeddedSheetActivityTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
-    private val composeTestRule = createAndroidComposeRule<ManageActivity>()
+    private val composeTestRule = createAndroidComposeRule<EmbeddedSheetActivity>()
     private val networkRule = NetworkRule()
 
     private val managePage = ManagePage(composeTestRule)
@@ -72,12 +72,12 @@ internal class ManageActivityTest {
     @Test
     fun `when launched without args should finish with error result`() {
         ActivityScenario.launchActivityForResult(
-            ManageActivity::class.java,
+            EmbeddedSheetActivity::class.java,
             Bundle.EMPTY
         ).use { activityScenario ->
             assertThat(activityScenario.state).isEqualTo(Lifecycle.State.DESTROYED)
-            val result = ManageContract.parseResult(0, activityScenario.result.resultData)
-            assertThat(result).isInstanceOf(ManageResult.Error::class.java)
+            val result = EmbeddedSheetContract.parseResult(0, activityScenario.result.resultData)
+            assertThat(result).isInstanceOf(EmbeddedSheetResult.Error::class.java)
         }
     }
 
@@ -245,21 +245,21 @@ internal class ManageActivityTest {
         selection: PaymentSelection? = null,
         block: Scenario.() -> Unit,
     ) {
-        ActivityScenario.launchActivityForResult<ManageActivity>(
-            ManageContract.createIntent(
+        ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
+            EmbeddedSheetContract.createIntent(
                 context = applicationContext,
-                input = ManageContract.Args(
+                input = EmbeddedSheetContract.Args(
+                    selectedPaymentMethodCode = selection?.paymentMethodType ?: "",
                     paymentMethodMetadata = paymentMethodMetadata,
+                    hasSavedPaymentMethods = paymentMethods.isNotEmpty(),
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+                        .build(),
+                    paymentElementCallbackIdentifier = "EmbeddedSheetActivityTestCallbackIdentifier",
+                    statusBarColor = null,
+                    selection = selection,
                     customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                         paymentMethods = paymentMethods,
                     ),
-                    selection = selection,
-                    paymentElementCallbackIdentifier = "ManageActivityTestCallbackIdentifier",
-                    selectedPaymentMethodCode = selection?.paymentMethodType ?: "",
-                    hasSavedPaymentMethods = paymentMethods.isNotEmpty(),
-                    statusBarColor = null,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
-                        .build(),
                     promotion = null,
                 ),
             )
@@ -280,17 +280,18 @@ internal class ManageActivityTest {
     }
 
     private class Scenario(
-        val activityScenario: ActivityScenario<ManageActivity>,
+        val activityScenario: ActivityScenario<EmbeddedSheetActivity>,
     ) {
         fun assertCompletedResultSelection(paymentMethodId: String?) {
-            val result = ManageContract.parseResult(0, activityScenario.result.resultData)
-            assertThat(((result as ManageResult.Complete).selection as PaymentSelection.Saved?)?.paymentMethod?.id)
+            val result = EmbeddedSheetContract.parseResult(0, activityScenario.result.resultData)
+            val savedSelection = (result as EmbeddedSheetResult.Complete).selection as PaymentSelection.Saved?
+            assertThat(savedSelection?.paymentMethod?.id)
                 .isEqualTo(paymentMethodId)
         }
 
         fun completedResultPaymentMethods(): List<PaymentMethod> {
-            val result = ManageContract.parseResult(0, activityScenario.result.resultData)
-            return (result as ManageResult.Complete).customerState.paymentMethods
+            val result = EmbeddedSheetContract.parseResult(0, activityScenario.result.resultData)
+            return (result as EmbeddedSheetResult.Complete).customerState!!.paymentMethods
         }
     }
 }


### PR DESCRIPTION
# Summary
Renamed `ManageActivity` and related classes to `EmbeddedSheetActivity` to better reflect their purpose as a general embedded sheet container, not just for managing payment methods.

# Motivation
The previous naming was misleading as these components handle more than just "managing" payment methods - they serve as a general embedded sheet container for various payment-related actions. The new naming makes the code's purpose clearer and more maintainable.

# Testing
- [x] Modified tests
- [x] Manually verified