### PR TITLE
Fix AppCompat theme crash in Connect WebView JS alert dialogs

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -441,7 +441,10 @@ internal class StripeConnectWebView private constructor(
                 ?: view.context.getString(android.R.string.cancel).takeIf { isConfirm }
 
             // Prepare and show the dialog.
-            AlertDialog.Builder(view.context)
+            // Use the two-arg Builder to enforce an AppCompat theme. On some devices/OEM WebView
+            // implementations, view.context may not carry AppCompat theme attributes, which causes
+            // AppCompatDelegateImpl.createSubDecor to throw an IllegalStateException.
+            AlertDialog.Builder(view.context, androidx.appcompat.R.style.Theme_AppCompat_Light_Dialog_Alert)
                 .setCancelable(true)
                 .setOnCancelListener {
                     didConfirm = false


### PR DESCRIPTION
# Summary
Use the two-arg `AlertDialog.Builder` constructor with an explicit `Theme_AppCompat_Light_Dialog_Alert` theme in `StripeConnectWebChromeClient.handleJsAlert`, so the dialog no longer depends on `view.context` carrying AppCompat theme attributes.

# Motivation
On some devices/OEM WebView implementations, the WebView's context (e.g. `MutableContextWrapper`, OEM wrappers) doesn't carry AppCompat theme attributes. When a JS alert or confirm is triggered, `AlertDialog.Builder(view.context)` causes `AppCompatDelegateImpl.createSubDecor` to throw `IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity`, crashing the app during Connect account onboarding.

Fixes https://github.com/stripe/stripe-android/issues/12914
Jira: https://jira.corp.stripe.com/browse/RUN_MXMOBILE-16125

# Testing
- [ ] Modified tests

# Changelog
- [Fixed] Fixed crash in Connect embedded components when a JS alert/confirm dialog is triggered on devices where the WebView context lacks AppCompat theme attributes.