### PR TITLE
Remove adaptive pricing currency selector from payment sheet.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
@@ -1,14 +1,13 @@
 package com.stripe.android.paymentsheet
 
 import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.compose.ui.test.hasText
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutInit
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.checkouttesting.createPaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
@@ -175,53 +174,6 @@ internal class PaymentSheetCheckoutSessionTest {
                 configuration = defaultConfiguration,
             )
         }
-    }
-
-    @Test
-    fun testAdaptivePricingShowsCorrectPageBasedOnNumberOfLPMsAvailable() = runPaymentSheetTest(
-        networkRule = networkRule,
-        resultCallback = ::assertCompleted,
-    ) { testContext ->
-        networkRule.checkoutInit { response ->
-            response.testBodyFromFile("checkout-session-adaptive-pricing-default.json")
-        }
-
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val checkout = Checkout.configure(
-            context = context,
-            checkoutSessionClientSecret = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example",
-        ).getOrThrow()
-
-        testContext.presentPaymentSheet {
-            presentWithCheckout(
-                checkout = checkout,
-                configuration = defaultConfiguration.newBuilder()
-                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build(),
-            )
-        }
-
-        verticalModePage.waitUntilVisible()
-
-        networkRule.checkoutUpdate { response ->
-            response.testBodyFromFile("checkout-session-adaptive-pricing-integration-currency.json")
-        }
-        currencySelector.assertCurrencyOptionIsSelected("EUR")
-        currencySelector.clickCurrencyOption("USD")
-
-        formPage.waitUntilVisible()
-        currencySelector.assertCurrencyOptionIsSelected("USD")
-        formPage.fillOutCardDetails()
-
-        networkRule.createPaymentMethod()
-
-        networkRule.checkoutConfirm(
-            bodyPart("expected_amount", "5099"),
-        ) { response ->
-            response.testBodyFromFile("checkout-session-confirm.json")
-        }
-
-        page.clickPrimaryButton()
     }
 
     // region allow_redisplay tests

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -270,9 +270,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             },
             invokeRowSelectionCallback = ::invokeRowSelectionCallback,
             displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
-            onCurrencySelected = {
-                throw IllegalStateException("onCurrencySelected not supported.")
-            },
             onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
                 eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
                     visiblePaymentMethods = visiblePaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -50,7 +50,6 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -61,7 +60,6 @@ import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.DefaultSelectSavedPaymentMethodsInteractor
 import com.stripe.android.paymentsheet.utils.asGooglePayButtonType
 import com.stripe.android.paymentsheet.utils.toConfirmationError
-import com.stripe.android.paymentsheet.verticalmode.CheckoutCurrencyUpdater
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
@@ -101,7 +99,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     mode: EventReporter.Mode,
     customerStateHolderFactory: CustomerStateHolder.Factory,
     @ViewModelScope customViewModelScope: CoroutineScope,
-    private val checkoutCurrencyUpdater: CheckoutCurrencyUpdater,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
 ) : BaseSheetViewModel(
     config = args.config,
@@ -116,15 +113,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
 ) {
-
-    internal var latestCheckoutSessionResponse: CheckoutSessionResponse?
-        get() = savedStateHandle[LATEST_CHECKOUT_SESSION_RESPONSE]
-            ?: (args.initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
-                ?.checkoutSessionResponse
-        set(value) {
-            savedStateHandle[LATEST_CHECKOUT_SESSION_RESPONSE] = value
-        }
-
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,
         currentScreenFlow = navigationHandler.currentScreen,
@@ -392,36 +380,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         viewState.value =
             PaymentSheetViewState.Reset(userErrorMessage?.let { PaymentSheetViewState.UserErrorMessage(it) })
         savedStateHandle[SAVE_PROCESSING] = false
-    }
-
-    internal fun updateCurrency(currencyCode: String) {
-        val checkoutSession = args.initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession
-            ?: return
-
-        savedStateHandle[SAVE_PROCESSING] = true
-
-        viewModelScope.launch {
-            checkoutCurrencyUpdater.updateCurrency(
-                instancesKey = checkoutSession.instancesKey,
-                sessionId = checkoutSession.checkoutSessionResponse.id,
-                currencyCode = currencyCode,
-                config = args.config,
-                initializedViaCompose = args.initializedViaCompose,
-            ).fold(
-                onSuccess = { currencyUpdateResult ->
-                    latestCheckoutSessionResponse = currencyUpdateResult.checkoutSessionResponse
-
-                    customerStateHolder.setCustomerState(currencyUpdateResult.loaderState.customer)
-                    updateSelection(currencyUpdateResult.loaderState.paymentSelection)
-                    setPaymentMethodMetadata(currencyUpdateResult.loaderState.paymentMethodMetadata)
-                    navigateToInitialScreens(currencyUpdateResult.loaderState.paymentMethodMetadata)
-                    resetViewState()
-                },
-                onFailure = { error ->
-                    resetViewState(error.stripeErrorMessage())
-                },
-            )
-        }
     }
 
     private fun initializeNavigationStateIfNeeded(
@@ -825,7 +783,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private companion object {
         const val IN_PROGRESS_SELECTION = "IN_PROGRESS_PAYMENT_SELECTION"
-        const val LATEST_CHECKOUT_SESSION_RESPONSE = "latest_checkout_session_response"
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -66,8 +66,6 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.TapToAddAvailabilityFactory
-import com.stripe.android.paymentsheet.verticalmode.CheckoutCurrencyUpdater
-import com.stripe.android.paymentsheet.verticalmode.DefaultCheckoutCurrencyUpdater
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -185,9 +183,6 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsTapToAddHelperFactory(factory: DefaultTapToAddHelper.Factory): TapToAddHelper.Factory
-
-    @Binds
-    abstract fun bindsCheckoutCurrencyUpdater(impl: DefaultCheckoutCurrencyUpdater): CheckoutCurrencyUpdater
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.FormHelper.FormType
-import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -54,7 +53,6 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     fun handleViewAction(viewAction: ViewAction)
 
     data class State(
-        val currencySelectorOptions: CurrencySelectorOptions?,
         val displayablePaymentMethods: List<DisplayablePaymentMethod>,
         val isProcessing: Boolean,
         val selection: Selection?,
@@ -82,7 +80,6 @@ internal interface PaymentMethodVerticalLayoutInteractor {
         data class SavedPaymentMethodSelected(val savedPaymentMethod: PaymentMethod) : ViewAction
         data class UpdatePaymentMethodVisibility(val itemCode: String, val coordinates: LayoutCoordinates) : ViewAction
         data object CancelPaymentMethodVisibilityTracking : ViewAction
-        data class CurrencySelected(val currencyOption: CurrencyOption) : ViewAction
     }
 
     enum class SavedPaymentMethodAction {
@@ -116,8 +113,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val invokeRowSelectionCallback: (() -> Unit)? = null,
     private val displaysMandatesInFormScreen: Boolean,
     private val onInitiallyDisplayedPaymentMethodVisibilitySnapshot: (List<String>, List<String>) -> Unit,
-    private val currencySelectorOptions: CurrencySelectorOptions? = null,
-    private val onCurrencySelected: (CurrencyOption) -> Unit,
     dispatcher: CoroutineContext = Dispatchers.Default,
     mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
@@ -138,11 +133,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             )
             val isCurrentScreen = viewModel.navigationHandler.currentScreen.mapAsStateFlow {
                 it is PaymentSheetScreen.VerticalMode
-            }
-            val currencySelectorOptions = (viewModel as? PaymentSheetViewModel)?.let { psViewModel ->
-                psViewModel.latestCheckoutSessionResponse
-                    ?.adaptivePricingInfo
-                    ?.let { CurrencySelectorOptionsFactory.create(it) }
             }
             return DefaultPaymentMethodVerticalLayoutInteractor(
                 paymentMethodMetadata = paymentMethodMetadata,
@@ -205,10 +195,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                         walletsState = viewModel.walletsState.value,
                         isVerticalLayout = true,
                     )
-                },
-                currencySelectorOptions = currencySelectorOptions,
-                onCurrencySelected = { currencyOption ->
-                    (viewModel as? PaymentSheetViewModel)?.updateCurrency(currencyOption.code)
                 },
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             ).also { interactor ->
@@ -317,7 +303,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
             availableSavedPaymentMethodAction = action,
             mandate = getMandate(temporarySelectionCode, mostRecentSelection),
-            currencySelectorOptions = currencySelectorOptions,
         )
     }
 
@@ -586,9 +571,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             }
             is ViewAction.CancelPaymentMethodVisibilityTracking -> {
                 cancelPaymentMethodVisibilityTracking()
-            }
-            is ViewAction.CurrencySelected -> {
-                onCurrencySelected(viewAction.currencyOption)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -65,7 +65,6 @@ internal fun PaymentMethodVerticalLayoutUI(
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
         selection = state.selection,
         isEnabled = !state.isProcessing,
-        currencySelectorOptions = state.currencySelectorOptions,
         onViewMorePaymentMethods = {
             interactor.handleViewAction(
                 PaymentMethodVerticalLayoutInteractor.ViewAction.TransitionToManageSavedPaymentMethods
@@ -95,9 +94,6 @@ internal fun PaymentMethodVerticalLayoutUI(
                 PaymentMethodVerticalLayoutInteractor.ViewAction.CancelPaymentMethodVisibilityTracking
             )
         },
-        onCurrencySelected = {
-            interactor.handleViewAction(PaymentMethodVerticalLayoutInteractor.ViewAction.CurrencySelected(it))
-        },
         modifier = modifier
             .testTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT)
     )
@@ -117,8 +113,6 @@ internal fun PaymentMethodVerticalLayoutUI(
     onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     imageLoader: StripeImageLoader,
     modifier: Modifier = Modifier,
-    currencySelectorOptions: CurrencySelectorOptions? = null,
-    onCurrencySelected: (CurrencyOption) -> Unit = {},
     updatePaymentMethodVisibility: (String, LayoutCoordinates) -> Unit = { _, _ -> },
     cancelPaymentMethodVisibilityTracking: () -> Unit = {},
 ) {
@@ -130,15 +124,6 @@ internal fun PaymentMethodVerticalLayoutUI(
     DisposableEffect(paymentMethodCodes) { onDispose { cancelPaymentMethodVisibilityTracking.invoke() } }
 
     Column(modifier = modifier) {
-        if (currencySelectorOptions != null) {
-            CurrencySelectorToggle(
-                options = currencySelectorOptions,
-                onCurrencySelected = onCurrencySelected,
-                isEnabled = isEnabled,
-            )
-            Spacer(Modifier.size(16.dp))
-        }
-
         val textStyle = MaterialTheme.typography.subtitle1
         val textColor = MaterialTheme.stripeColors.onComponent
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -41,7 +41,6 @@ internal interface VerticalModeFormInteractor {
         val formArguments: FormArguments,
         private val formElements: List<FormElement>,
         val headerInformation: FormHeaderInformation?,
-        val currencySelectorOptions: CurrencySelectorOptions? = null,
     ) {
         val formUiElements = formElements.onEach { element ->
             element.onValidationStateChanged(isValidating)
@@ -51,7 +50,6 @@ internal interface VerticalModeFormInteractor {
     sealed interface ViewAction {
         data object FieldInteraction : ViewAction
         data class FormFieldValuesChanged(val formValues: FormFieldValues?) : ViewAction
-        data class CurrencySelected(val currencyOption: CurrencyOption) : ViewAction
     }
 }
 
@@ -69,8 +67,6 @@ internal class DefaultVerticalModeFormInteractor(
     paymentMethodIncentive: StateFlow<PaymentMethodIncentive?>,
     private val coroutineScope: CoroutineScope,
     private val uiContext: CoroutineContext,
-    private val currencySelectorOptions: CurrencySelectorOptions? = null,
-    private val onCurrencySelected: (CurrencyOption) -> Unit = {},
 ) : VerticalModeFormInteractor {
     private val isValidating = MutableStateFlow(false)
 
@@ -89,7 +85,6 @@ internal class DefaultVerticalModeFormInteractor(
             headerInformation = headerInformation?.copy(
                 promoBadge = paymentMethodIncentive?.takeIfMatches(selectedPaymentMethodCode)?.displayText,
             ),
-            currencySelectorOptions = currencySelectorOptions,
         )
     }
 
@@ -111,9 +106,6 @@ internal class DefaultVerticalModeFormInteractor(
             is VerticalModeFormInteractor.ViewAction.FormFieldValuesChanged -> {
                 onFormFieldValuesChanged(viewAction.formValues, selectedPaymentMethodCode)
             }
-            is VerticalModeFormInteractor.ViewAction.CurrencySelected -> {
-                onCurrencySelected(viewAction.currencyOption)
-            }
         }
     }
 
@@ -128,8 +120,6 @@ internal class DefaultVerticalModeFormInteractor(
             paymentMethodMetadata: PaymentMethodMetadata,
             customerStateHolder: CustomerStateHolder,
             bankFormInteractor: BankFormInteractor,
-            currencySelectorOptions: CurrencySelectorOptions? = null,
-            onCurrencySelected: (CurrencyOption) -> Unit = {},
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
         ): VerticalModeFormInteractor {
             val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -164,8 +154,6 @@ internal class DefaultVerticalModeFormInteractor(
                 validationRequested = viewModel.validationRequested,
                 coroutineScope = coroutineScope,
                 uiContext = Dispatchers.Main,
-                currencySelectorOptions = currencySelectorOptions,
-                onCurrencySelected = onCurrencySelected,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.verticalmode
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
@@ -47,20 +46,6 @@ internal fun VerticalModeFormUI(
     Column(modifier) {
         val headerInformation = state.headerInformation
         val enabled = !state.isProcessing
-        val currencySelectorOptions = state.currencySelectorOptions
-        if (currencySelectorOptions != null) {
-            CurrencySelectorToggle(
-                options = currencySelectorOptions,
-                onCurrencySelected = { currencyOption ->
-                    interactor.handleViewAction(
-                        VerticalModeFormInteractor.ViewAction.CurrencySelected(currencyOption)
-                    )
-                },
-                isEnabled = enabled,
-                modifier = Modifier.padding(horizontalPadding),
-            )
-            Spacer(Modifier.size(16.dp))
-        }
         if (headerInformation != null && shouldShowHeader(state.selectedPaymentMethodCode, showsWalletHeader)) {
             VerticalModeFormHeaderUI(isEnabled = enabled, formHeaderInformation = headerInformation)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -4,7 +4,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
-import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
@@ -21,10 +20,6 @@ internal object VerticalModeInitialScreenFactory {
         val bankFormInteractor = BankFormInteractor.create(viewModel)
 
         if (supportedPaymentMethodTypes.size == 1 && customerStateHolder.paymentMethods.value.isEmpty()) {
-            val currencySelectorOptions = (viewModel as? PaymentSheetViewModel)
-                ?.latestCheckoutSessionResponse
-                ?.adaptivePricingInfo
-                ?.let { CurrencySelectorOptionsFactory.create(it) }
             return listOf(
                 PaymentSheetScreen.VerticalModeForm(
                     interactor = DefaultVerticalModeFormInteractor.create(
@@ -33,10 +28,6 @@ internal object VerticalModeInitialScreenFactory {
                         paymentMethodMetadata = paymentMethodMetadata,
                         customerStateHolder = customerStateHolder,
                         bankFormInteractor = bankFormInteractor,
-                        currencySelectorOptions = currencySelectorOptions,
-                        onCurrencySelected = { currencyOption ->
-                            (viewModel as? PaymentSheetViewModel)?.updateCurrency(currencyOption.code)
-                        },
                         paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
                     ),
                     showsWalletHeader = paymentMethodMetadata.availableWallets.isNotEmpty(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Cvc
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
-import com.stripe.android.paymentsheet.verticalmode.FakeCheckoutCurrencyUpdater
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
@@ -218,7 +217,6 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-                checkoutCurrencyUpdater = FakeCheckoutCurrencyUpdater(),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -98,7 +98,6 @@ import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.ui.UPDATE_PM_REMOVE_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.verticalmode.FakeCheckoutCurrencyUpdater
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.createComposeCleanupRule
@@ -1338,7 +1337,6 @@ internal class PaymentSheetActivityTest {
                 tapToAddHelperFactory = FakeTapToAddHelper.Factory.noOp(),
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
-                checkoutCurrencyUpdater = FakeCheckoutCurrencyUpdater(),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -98,7 +98,6 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSaved
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
@@ -114,8 +113,6 @@ import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.cardParamsUpdateAction
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.paymentsheet.utils.prefillCreate
-import com.stripe.android.paymentsheet.verticalmode.CheckoutCurrencyUpdater
-import com.stripe.android.paymentsheet.verticalmode.FakeCheckoutCurrencyUpdater
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -3430,100 +3427,6 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
-    @Test
-    fun `updateCurrency - success updates latest response and resets view state without error`() = runTest {
-        val initialResponse = CheckoutSessionResponseFactory.create()
-        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            initializationMode = InitializationMode.CheckoutSession(
-                instancesKey = "test_key",
-                checkoutSessionResponse = initialResponse,
-            )
-        )
-
-        val updatedResponse = CheckoutSessionResponseFactory.create(id = "cs_updated")
-        val loaderState = FakePaymentElementLoader(
-            stripeIntent = PAYMENT_INTENT,
-            customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = PAYMENT_METHODS),
-        ).load(
-            initializationMode = InitializationMode.CheckoutSession("test_key", updatedResponse),
-            integrationConfiguration = PaymentElementLoader.Configuration.PaymentSheet(args.config),
-            metadata = PaymentElementLoader.Metadata(initializedViaCompose = false),
-        ).getOrThrow()
-
-        val fakeUpdater = FakeCheckoutCurrencyUpdater(
-            result = Result.success(
-                CheckoutCurrencyUpdater.CurrencyUpdateResult(
-                    checkoutSessionResponse = updatedResponse,
-                    loaderState = loaderState,
-                )
-            )
-        )
-
-        val viewModel = createViewModel(
-            args = args,
-            checkoutCurrencyUpdater = fakeUpdater,
-        )
-
-        viewModel.updateCurrency("eur")
-
-        assertThat(viewModel.latestCheckoutSessionResponse).isEqualTo(updatedResponse)
-        assertThat(viewModel.viewState.value).isEqualTo(PaymentSheetViewState.Reset(null))
-
-        assertThat(fakeUpdater.calls.awaitItem()).isEqualTo(
-            FakeCheckoutCurrencyUpdater.UpdateCurrencyCall(
-                instancesKey = "test_key",
-                sessionId = initialResponse.id,
-                currencyCode = "eur",
-                config = args.config,
-                initializedViaCompose = false,
-            )
-        )
-        fakeUpdater.ensureAllEventsConsumed()
-    }
-
-    @Test
-    fun `updateCurrency - failure shows error via view state`() = runTest {
-        val initialResponse = CheckoutSessionResponseFactory.create()
-        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            initializationMode = InitializationMode.CheckoutSession(
-                instancesKey = "test_key",
-                checkoutSessionResponse = initialResponse,
-            )
-        )
-
-        val fakeUpdater = FakeCheckoutCurrencyUpdater(
-            result = Result.failure(RuntimeException("Currency update failed")),
-        )
-
-        val viewModel = createViewModel(
-            args = args,
-            checkoutCurrencyUpdater = fakeUpdater,
-        )
-
-        viewModel.updateCurrency("eur")
-
-        val viewState = viewModel.viewState.value as? PaymentSheetViewState.Reset
-        assertThat(viewState?.errorMessage).isNotNull()
-
-        assertThat(fakeUpdater.calls.awaitItem().currencyCode).isEqualTo("eur")
-        fakeUpdater.ensureAllEventsConsumed()
-    }
-
-    @Test
-    fun `updateCurrency - no-op when not a checkout session`() = runTest {
-        val fakeUpdater = FakeCheckoutCurrencyUpdater()
-
-        // Default args use PaymentIntent initialization, not CheckoutSession
-        val viewModel = createViewModel(
-            checkoutCurrencyUpdater = fakeUpdater,
-        )
-
-        viewModel.updateCurrency("eur")
-
-        // No call should be made to the updater
-        fakeUpdater.ensureAllEventsConsumed()
-    }
-
     private fun testConfirmationStateRestorationAfterPaymentSuccess(
         loadStateBeforePaymentResult: Boolean
     ) = confirmationTest(
@@ -3674,7 +3577,6 @@ internal class PaymentSheetViewModelTest {
         confirmationHandlerFactory: ConfirmationHandler.Factory? = null,
         tapToAddHelperFactory: TapToAddHelper.Factory = FakeTapToAddHelper.Factory.noOp(),
         customerStateHolder: CustomerStateHolder? = null,
-        checkoutCurrencyUpdater: CheckoutCurrencyUpdater = FakeCheckoutCurrencyUpdater(),
     ): PaymentSheetViewModel {
         return TestViewModelFactory.create(
             linkConfigurationCoordinator = linkConfigurationCoordinator,
@@ -3715,7 +3617,6 @@ internal class PaymentSheetViewModelTest {
                     }
                 },
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-                checkoutCurrencyUpdater = checkoutCurrencyUpdater,
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -31,8 +31,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsState
-import com.stripe.android.paymentsheet.verticalmode.CurrencyOption
-import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -996,15 +994,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun handleViewAction_CurrencySelected_callsOnCurrencySelected() {
-        val currencyOption = CurrencyOption(code = "EUR", displayableText = "€9.50")
-        runScenario {
-            interactor.handleViewAction(ViewAction.CurrencySelected(currencyOption))
-            assertThat(onCurrencySelectedTurbine.awaitItem()).isEqualTo(currencyOption)
-        }
-    }
-
-    @Test
     fun handleViewAction_OnManageOneSavedPaymentMethod_transitionsToUpdateScreen_whenFeatureEnabled() {
         runScenario {
             val paymentMethod = PaymentMethodFixtures.displayableCard()
@@ -1670,22 +1659,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `state includes currencySelectorOptions when provided`() {
-        val options = CurrencySelectorOptions(
-            first = CurrencyOption(code = "USD", displayableText = "$10.00"),
-            second = CurrencyOption(code = "EUR", displayableText = "€9.50"),
-            selectedCode = "USD",
-        )
-        runScenario(
-            initialCurrencySelectorOptions = options,
-        ) {
-            interactor.state.test {
-                assertThat(awaitItem().currencySelectorOptions).isEqualTo(options)
-            }
-        }
-    }
-
-    @Test
     fun `Passes promotion provider to supported bnpls`() {
         FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
         val metadata = PaymentMethodMetadataFactory.create(
@@ -1785,7 +1758,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         invokeRowSelectionCallback: (() -> Unit)? = null,
         initialWalletsState: WalletsState? = null,
         displaysMandatesInFormScreen: Boolean = false,
-        initialCurrencySelectorOptions: CurrencySelectorOptions? = null,
         promotionsHelper: PaymentMethodMessagePromotionsHelper? = null,
         testBlock: suspend TestParams.() -> Unit
     ) {
@@ -1808,7 +1780,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         val reportFormShownTurbine = Turbine<PaymentMethodCode>()
         val onFormFieldValuesChangedTurbine = Turbine<Pair<FormFieldValues, String>>()
         val visibilitySnapshotTurbine = Turbine<Pair<List<String>, List<String>>>()
-        val onCurrencySelectedTurbine = Turbine<CurrencyOption>()
 
         val interactor = DefaultPaymentMethodVerticalLayoutInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
@@ -1855,10 +1826,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                     Pair(visibleItems, hiddenItems)
                 )
             },
-            currencySelectorOptions = initialCurrencySelectorOptions,
-            onCurrencySelected = { currencyOption ->
-                onCurrencySelectedTurbine.add(currencyOption)
-            },
             paymentMethodMessagePromotionsHelper = promotionsHelper
         )
 
@@ -1881,7 +1848,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             reportFormShownTurbine = reportFormShownTurbine,
             onFormFieldValuesChangedTurbine = onFormFieldValuesChangedTurbine,
             visibilitySnapshotTurbine = visibilitySnapshotTurbine,
-            onCurrencySelectedTurbine = onCurrencySelectedTurbine,
         ).apply {
             testScope.runTest {
                 testBlock()
@@ -1909,7 +1875,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         val reportFormShownTurbine: ReceiveTurbine<PaymentMethodCode>,
         val onFormFieldValuesChangedTurbine: ReceiveTurbine<Pair<FormFieldValues, String>>,
         val visibilitySnapshotTurbine: ReceiveTurbine<Pair<List<String>, List<String>>>,
-        val onCurrencySelectedTurbine: ReceiveTurbine<CurrencyOption>,
     ) {
         fun ensureAllEventsConsumed() {
             updateSelectionTurbine.ensureAllEventsConsumed()
@@ -1920,7 +1885,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             reportFormShownTurbine.ensureAllEventsConsumed()
             onFormFieldValuesChangedTurbine.ensureAllEventsConsumed()
             visibilitySnapshotTurbine.ensureAllEventsConsumed()
-            onCurrencySelectedTurbine.ensureAllEventsConsumed()
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -218,37 +218,6 @@ internal class DefaultVerticalModeFormInteractorTest {
     }
 
     @Test
-    fun `state includes currencySelectorOptions when provided`() {
-        val options = CurrencySelectorOptions(
-            first = CurrencyOption(code = "USD", displayableText = "$10.00"),
-            second = CurrencyOption(code = "EUR", displayableText = "€9.00"),
-            selectedCode = "USD",
-        )
-        runScenario(
-            selectedPaymentMethodCode = "card",
-            currencySelectorOptions = options,
-        ) {
-            assertThat(interactor.state.value.currencySelectorOptions).isEqualTo(options)
-        }
-    }
-
-    @Test
-    fun `state has null currencySelectorOptions by default`() {
-        runScenario(selectedPaymentMethodCode = "card") {
-            assertThat(interactor.state.value.currencySelectorOptions).isNull()
-        }
-    }
-
-    @Test
-    fun `handleViewAction CurrencySelected calls onCurrencySelected`() {
-        val option = CurrencyOption(code = "EUR", displayableText = "€9.00")
-        runScenario(selectedPaymentMethodCode = "card") {
-            interactor.handleViewAction(ViewAction.CurrencySelected(option))
-            assertThat(onCurrencySelectedTurbine.awaitItem()).isEqualTo(option)
-        }
-    }
-
-    @Test
     fun `do not automaticallyLaunchCardScan when card form and with paymentSelection`() {
         testAutomaticallyLaunchCardScan(
             selectedPaymentMethodCode = "card",
@@ -360,7 +329,6 @@ internal class DefaultVerticalModeFormInteractorTest {
     private fun runScenario(
         selectedPaymentMethodCode: String,
         formElements: List<FormElement> = emptyList(),
-        currencySelectorOptions: CurrencySelectorOptions? = null,
         testBlock: suspend TestParams.() -> Unit,
     ) {
         val formArguments = mock<FormArguments>()
@@ -370,7 +338,6 @@ internal class DefaultVerticalModeFormInteractorTest {
 
         val onFormFieldValuesChangedTurbine = Turbine<Pair<FormFieldValues?, String>>()
         val reportFieldInteractionTurbine = Turbine<String>()
-        val onCurrencySelectedTurbine = Turbine<CurrencyOption>()
 
         val interactor = DefaultVerticalModeFormInteractor(
             selectedPaymentMethodCode = selectedPaymentMethodCode,
@@ -390,8 +357,6 @@ internal class DefaultVerticalModeFormInteractorTest {
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             paymentMethodIncentive = stateFlowOf(null),
             uiContext = UnconfinedTestDispatcher(),
-            currencySelectorOptions = currencySelectorOptions,
-            onCurrencySelected = { onCurrencySelectedTurbine.add(it) },
         )
 
         TestParams(
@@ -400,7 +365,6 @@ internal class DefaultVerticalModeFormInteractorTest {
             validationRequestedSource = validationRequested,
             onFormFieldValuesChangedTurbine = onFormFieldValuesChangedTurbine,
             reportFieldInteractionTurbine = reportFieldInteractionTurbine,
-            onCurrencySelectedTurbine = onCurrencySelectedTurbine,
         ).apply {
             runTest {
                 testBlock()
@@ -410,7 +374,6 @@ internal class DefaultVerticalModeFormInteractorTest {
         verifyNoMoreInteractions(formArguments, usBankAccountArguments)
         onFormFieldValuesChangedTurbine.ensureAllEventsConsumed()
         reportFieldInteractionTurbine.ensureAllEventsConsumed()
-        onCurrencySelectedTurbine.ensureAllEventsConsumed()
     }
 
     private class TestParams(
@@ -419,6 +382,5 @@ internal class DefaultVerticalModeFormInteractorTest {
         val validationRequestedSource: MutableSharedFlow<Unit>,
         val onFormFieldValuesChangedTurbine: ReceiveTurbine<Pair<FormFieldValues?, String>>,
         val reportFieldInteractionTurbine: ReceiveTurbine<String>,
-        val onCurrencySelectedTurbine: ReceiveTurbine<CurrencyOption>,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
@@ -18,7 +18,6 @@ internal class FakePaymentMethodVerticalLayoutInteractor(
             initialShowsWalletsHeader: Boolean = true,
             selection: PaymentMethodVerticalLayoutInteractor.Selection? = null,
             mandate: ResolvableString? = null,
-            currencySelectorOptions: CurrencySelectorOptions? = null,
             viewActionRecorder: ViewActionRecorder<PaymentMethodVerticalLayoutInteractor.ViewAction> =
                 ViewActionRecorder()
         ): FakePaymentMethodVerticalLayoutInteractor {
@@ -38,7 +37,6 @@ internal class FakePaymentMethodVerticalLayoutInteractor(
                 availableSavedPaymentMethodAction =
                 PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
                 mandate = mandate,
-                currencySelectorOptions = currencySelectorOptions,
             )
             return FakePaymentMethodVerticalLayoutInteractor(
                 initialState = initialState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -29,7 +29,6 @@ internal class FakeVerticalModeFormInteractor private constructor(
             metadata: PaymentMethodMetadata,
             isProcessing: Boolean = false,
             isValidating: Boolean = false,
-            currencySelectorOptions: CurrencySelectorOptions? = null,
         ): VerticalModeFormInteractor {
             val formArguments = FormArgumentsFactory.create(
                 paymentMethodCode = paymentMethodCode,
@@ -58,7 +57,6 @@ internal class FakeVerticalModeFormInteractor private constructor(
                         code = paymentMethodCode,
                         customerHasSavedPaymentMethods = false,
                     ),
-                    currencySelectorOptions = currencySelectorOptions,
                 ),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
@@ -32,7 +32,6 @@ import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutI
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.Selection
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
-import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -347,56 +346,6 @@ internal class PaymentMethodLayoutUITest(
         }
     }
 
-    @Test
-    fun currencySelector_visibleWhenOptionsProvided() {
-        // Currency selector is only rendered in PaymentMethodVerticalLayoutUI, not embedded layout.
-        assumeTrue(paymentMethodsTag == TEST_TAG_NEW_PAYMENT_METHOD_VERTICAL_LAYOUT_UI)
-        runScenario(
-            initialState = createState(
-                currencySelectorOptions = CurrencySelectorOptions(
-                    first = CurrencyOption(code = "USD", displayableText = "$10.00"),
-                    second = CurrencyOption(code = "EUR", displayableText = "€9.50"),
-                    selectedCode = "USD",
-                ),
-            ),
-        ) {
-            composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertExists()
-        }
-    }
-
-    @Test
-    fun currencySelector_notVisibleWhenOptionsNull() {
-        // Currency selector is only rendered in PaymentMethodVerticalLayoutUI, not embedded layout.
-        assumeTrue(paymentMethodsTag == TEST_TAG_NEW_PAYMENT_METHOD_VERTICAL_LAYOUT_UI)
-        runScenario(
-            initialState = createState(currencySelectorOptions = null),
-        ) {
-            composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertDoesNotExist()
-        }
-    }
-
-    @Test
-    fun currencySelector_clickingOption_dispatchesCurrencySelectedViewAction() {
-        // Currency selector is only rendered in PaymentMethodVerticalLayoutUI, not embedded layout.
-        assumeTrue(paymentMethodsTag == TEST_TAG_NEW_PAYMENT_METHOD_VERTICAL_LAYOUT_UI)
-        val eurOption = CurrencyOption(code = "EUR", displayableText = "€9.50")
-        runScenario(
-            initialState = createState(
-                currencySelectorOptions = CurrencySelectorOptions(
-                    first = CurrencyOption(code = "USD", displayableText = "$10.00"),
-                    second = eurOption,
-                    selectedCode = "USD",
-                ),
-            ),
-        ) {
-            composeRule.onNodeWithTag("$TEST_TAG_CURRENCY_OPTION_PREFIX${eurOption.code}").performClick()
-            viewActionRecorder.consume(
-                PaymentMethodVerticalLayoutInteractor.ViewAction.CurrencySelected(eurOption)
-            )
-            assertThat(viewActionRecorder.viewActions).isEmpty()
-        }
-    }
-
     private fun runScenario(
         initialState: PaymentMethodVerticalLayoutInteractor.State,
         block: Scenario.() -> Unit
@@ -474,7 +423,6 @@ internal class PaymentMethodLayoutUITest(
             displayedSavedPaymentMethod: DisplayableSavedPaymentMethod? = PaymentMethodFixtures.displayableCard(),
             availableSavedPaymentMethodAction: SavedPaymentMethodAction = SavedPaymentMethodAction.MANAGE_ALL,
             mandate: ResolvableString? = null,
-            currencySelectorOptions: CurrencySelectorOptions? = null,
         ): PaymentMethodVerticalLayoutInteractor.State = PaymentMethodVerticalLayoutInteractor.State(
             displayablePaymentMethods = displayablePaymentMethods,
             isProcessing = isProcessing,
@@ -482,7 +430,6 @@ internal class PaymentMethodLayoutUITest(
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
             availableSavedPaymentMethodAction = availableSavedPaymentMethodAction,
             mandate = mandate,
-            currencySelectorOptions = currencySelectorOptions,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import com.google.common.truth.Truth.assertThat
@@ -128,37 +127,9 @@ internal class VerticalModeFormUITest {
     }
 
     @Test
-    fun `currencySelector visible when options provided`() {
-        val options = CurrencySelectorOptions(
-            first = CurrencyOption(code = "USD", displayableText = "$10.00"),
-            second = CurrencyOption(code = "EUR", displayableText = "€9.00"),
-            selectedCode = "USD",
-        )
-        runScenario(createCardState(customerHasSavedPaymentMethods = false).copy(currencySelectorOptions = options)) {
-            composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertExists()
-        }
-    }
-
-    @Test
     fun `currencySelector not visible when options null`() {
         runScenario(createCardState(customerHasSavedPaymentMethods = false)) {
             composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertDoesNotExist()
-        }
-    }
-
-    @Test
-    fun `clicking currency option dispatches CurrencySelected`() {
-        val eurOption = CurrencyOption(code = "EUR", displayableText = "€9.00")
-        val options = CurrencySelectorOptions(
-            first = CurrencyOption(code = "USD", displayableText = "$10.00"),
-            second = eurOption,
-            selectedCode = "USD",
-        )
-        runScenario(createCardState(customerHasSavedPaymentMethods = false).copy(currencySelectorOptions = options)) {
-            viewActionRecorder.consume(VerticalModeFormInteractor.ViewAction.FormFieldValuesChanged(null))
-            composeRule.onNodeWithTag("$TEST_TAG_CURRENCY_OPTION_PREFIX${eurOption.code}").performClick()
-            viewActionRecorder.consume(VerticalModeFormInteractor.ViewAction.CurrencySelected(eurOption))
-            assertThat(viewActionRecorder.viewActions).isEmpty()
         }
     }
 


### PR DESCRIPTION
# Summary
Removed the adaptive pricing currency selector functionality from the payment sheet, including all related UI components, interactors, and test code.

# Motivation
The adaptive pricing currency selector feature is being removed from the payment sheet. This includes removing the CurrencySelector UI component, the CheckoutCurrencyUpdater logic, and all associated code paths that handled currency selection and updates.

# Testing
- [x] Modified tests
- [x] Manually verified

# Changelog
[Removed] - Removed adaptive pricing currency selector from PaymentSheet.