### PR TITLE
Fix PaymentSheet displaying raw API error messages to end users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][12950](https://github.com/stripe/stripe-android/pull/12950) Fixed an issue where raw API error messages (e.g. `invalid_request_error`) were displayed to end users instead of a generic fallback message. Only `card_error` messages are now shown directly.
+
 ## 23.5.0 - 2026-04-20
 * [REMOVED][12871](https://github.com/stripe/stripe-android/pull/12871) Removed UPI support across the SDK.
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
@@ -17,8 +17,10 @@ internal fun Throwable?.stripeErrorMessage(context: Context): String {
     (this as? LocalStripeException)?.displayMessage?.let {
         return it
     }
-    (this as? StripeException)?.stripeError?.message?.let {
-        return it
+    (this as? StripeException)?.stripeError?.let { error ->
+        if (error.type == "card_error") {
+            error.message?.let { return it }
+        }
     }
     return context.getString(R.string.stripe_something_went_wrong)
 }
@@ -31,8 +33,10 @@ internal fun Throwable.stripeErrorMessage(): ResolvableString {
     (this as? LocalStripeException)?.displayMessage?.let {
         return it.resolvableString
     }
-    (this as? StripeException)?.stripeError?.message?.let {
-        return it.resolvableString
+    (this as? StripeException)?.stripeError?.let { error ->
+        if (error.type == "card_error") {
+            error.message?.let { return it.resolvableString }
+        }
     }
     this.getTerminalErrorMessage()?.let {
         return it

--- a/paymentsheet/src/test/java/com/stripe/android/common/exception/StripeErrorMessageTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/exception/StripeErrorMessageTest.kt
@@ -37,9 +37,19 @@ internal class StripeErrorMessageTest {
     }
 
     @Test
-    fun testStripeExceptionWithStripeErrorMessage() {
-        assertThatStripeErrorMessage(CardException(StripeError(message = "From the server")))
-            .isEqualTo("From the server")
+    fun testCardErrorTypeShowsRawMessage() {
+        assertThatStripeErrorMessage(
+            CardException(StripeError(type = "card_error", message = "Your card was declined."))
+        ).isEqualTo("Your card was declined.")
+    }
+
+    @Test
+    fun testNonCardErrorTypeShowsGenericMessage() {
+        assertThatStripeErrorMessage(
+            InvalidRequestException(
+                stripeError = StripeError(type = "invalid_request_error", message = "Developer message")
+            )
+        ).isEqualTo("Something went wrong")
     }
 
     @Test
@@ -67,9 +77,19 @@ internal class StripeErrorMessageTest {
     }
 
     @Test
-    fun testStripeExceptionWithStripeErrorMessageWithResolvableString() {
-        assertThatResolvableStripeErrorMessage(CardException(StripeError(message = "From the server")))
-            .isEqualTo("From the server".resolvableString)
+    fun testCardErrorTypeShowsRawMessageWithResolvableString() {
+        assertThatResolvableStripeErrorMessage(
+            CardException(StripeError(type = "card_error", message = "Your card was declined."))
+        ).isEqualTo("Your card was declined.".resolvableString)
+    }
+
+    @Test
+    fun testNonCardErrorTypeShowsGenericMessageWithResolvableString() {
+        assertThatResolvableStripeErrorMessage(
+            InvalidRequestException(
+                stripeError = StripeError(type = "invalid_request_error", message = "Developer message")
+            )
+        ).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -290,25 +290,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `attachPaymentMethod fails with default message when the payment method couldn't be attached`() = runTest {
-        val adapter = createAdapter(
-            customerRepository = FakeCustomerRepository(
-                onAttachPaymentMethod = {
-                    Result.failure(
-                        APIException(
-                            message = "could not attach payment method",
-                        )
-                    )
-                }
-            )
-        )
-        val result = adapter.attachPaymentMethod("pm_1234")
-        assertThat(result.failureOrNull()?.displayMessage)
-            .isEqualTo("Something went wrong")
-    }
-
-    @Test
-    fun `attachPaymentMethod fails with generic message for non-card API error`() = runTest {
+    fun `attachPaymentMethod fails with generic message when the payment method couldn't be attached`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onAttachPaymentMethod = {
@@ -342,25 +324,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `detachPaymentMethod fails with default message when the payment method couldn't be detached`() = runTest {
-        val adapter = createAdapter(
-            customerRepository = FakeCustomerRepository(
-                onDetachPaymentMethod = {
-                    Result.failure(
-                        APIException(
-                            message = "could not detach payment method",
-                        )
-                    )
-                }
-            )
-        )
-        val result = adapter.detachPaymentMethod("pm_1234")
-        assertThat(result.failureOrNull()?.displayMessage)
-            .isEqualTo("Something went wrong")
-    }
-
-    @Test
-    fun `detachPaymentMethod fails with generic message for non-card API error`() = runTest {
+    fun `detachPaymentMethod fails with generic message when the payment method couldn't be detached`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onDetachPaymentMethod = {
@@ -397,28 +361,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `updatePaymentMethod fails with default message when the payment method couldn't be updated`() = runTest {
-        val adapter = createAdapter(
-            customerRepository = FakeCustomerRepository(
-                onUpdatePaymentMethod = {
-                    Result.failure(
-                        APIException(
-                            message = "could not update payment method",
-                        )
-                    )
-                }
-            )
-        )
-        val result = adapter.updatePaymentMethod(
-            paymentMethodId = "pm_1234",
-            params = PaymentMethodUpdateParams.createCard()
-        )
-        assertThat(result.failureOrNull()?.displayMessage)
-            .isEqualTo("Something went wrong")
-    }
-
-    @Test
-    fun `updatePaymentMethod fails with generic message for non-card API error`() = runTest {
+    fun `updatePaymentMethod fails with generic message when the payment method couldn't be updated`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onUpdatePaymentMethod = {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -308,7 +308,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `attachPaymentMethod fails with Stripe message when the payment method couldn't be attached`() = runTest {
+    fun `attachPaymentMethod fails with generic message for non-card API error`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onAttachPaymentMethod = {
@@ -323,7 +323,7 @@ class CustomerAdapterTest {
         )
         val result = adapter.attachPaymentMethod("pm_1234")
         assertThat(result.failureOrNull()?.displayMessage)
-            .isEqualTo("Unable to attach payment method")
+            .isEqualTo("Something went wrong")
     }
 
     @Test
@@ -360,7 +360,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `detachPaymentMethod fails with Stripe message when the payment method couldn't be detached`() = runTest {
+    fun `detachPaymentMethod fails with generic message for non-card API error`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onDetachPaymentMethod = {
@@ -375,7 +375,7 @@ class CustomerAdapterTest {
         )
         val result = adapter.detachPaymentMethod("pm_1234")
         assertThat(result.failureOrNull()?.displayMessage)
-            .isEqualTo("Unable to detach payment method")
+            .isEqualTo("Something went wrong")
     }
 
     @Test
@@ -418,7 +418,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `updatePaymentMethod fails with Stripe message when the payment method couldn't be updated`() = runTest {
+    fun `updatePaymentMethod fails with generic message for non-card API error`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onUpdatePaymentMethod = {
@@ -436,7 +436,7 @@ class CustomerAdapterTest {
             params = PaymentMethodUpdateParams.createCard()
         )
         assertThat(result.failureOrNull()?.displayMessage)
-            .isEqualTo("Unable to update payment method")
+            .isEqualTo("Something went wrong")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Only expose raw `stripeError.message` to end users for `card_error` type errors
- All non-card error types (e.g. `invalid_request_error`, `api_error`) now fall through to the generic localized "Something went wrong" message
- Previously, developer-facing messages like "This Connect account cannot currently make live charges. The `requirements.disabled_reason` property on the account will provide information about why..." were shown directly to consumers

## Motivation
Per [Stripe API docs](https://stripe.com/docs/api/errors#errors-message): _"For card errors, these messages can be shown to your users."_ Only `card_error` type should expose its raw message. This matches the behavior of `StripeErrorMapping.kt` which already gates on `type == "card_error"`.

## Testing
- Updated unit tests to verify card errors show raw messages and non-card errors show generic fallback
- Added new test cases for `InvalidRequestException` with a message (the actual bug scenario)
- Updated `CustomerAdapterTest` expectations for non-card API errors

## Changelog
* [FIXED][12950](https://github.com/stripe/stripe-android/pull/12950) Fixed an issue where raw API error messages (e.g. `invalid_request_error`) were displayed to end users instead of a generic fallback message. Only `card_error` messages are now shown directly.

Fixes [RUN_MOBILESDK-5334](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5334)