### PR TITLE
feat(FinancialConnections): Pass client_secret on calls to pollAccountNumbers

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
@@ -108,7 +108,12 @@ internal class SaveAccountToLink @Inject constructor(
                 maxNumberOfRetries = 20,
             ),
             retryCondition = { it.shouldRetry },
-            block = { accountsRepository.pollAccountNumbers(linkedAccountIds) },
+            block = {
+                accountsRepository.pollAccountNumbers(
+                    clientSecret = configuration.financialConnectionsSessionClientSecret,
+                    linkedAccounts = linkedAccountIds,
+                )
+            },
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
@@ -65,7 +65,10 @@ internal interface FinancialConnectionsAccountsRepository {
         consentAcquired: Boolean?
     ): ShareNetworkedAccountsResponse
 
-    suspend fun pollAccountNumbers(linkedAccounts: Set<String>)
+    suspend fun pollAccountNumbers(
+        clientSecret: String,
+        linkedAccounts: Set<String>,
+    )
 
     companion object {
         operator fun invoke(
@@ -213,7 +216,10 @@ private class FinancialConnectionsAccountsRepositoryImpl(
         }
     }
 
-    override suspend fun pollAccountNumbers(linkedAccounts: Set<String>) {
+    override suspend fun pollAccountNumbers(
+        clientSecret: String,
+        linkedAccounts: Set<String>,
+    ) {
         val accounts = linkedAccounts.mapIndexed { index, account ->
             "${NetworkConstants.PARAM_LINKED_ACCOUNTS}[$index]" to account
         }.toMap()
@@ -221,7 +227,7 @@ private class FinancialConnectionsAccountsRepositoryImpl(
         val request = apiRequestFactory.createGet(
             url = pollAccountsNumbersUrl,
             options = provideApiRequestOptions(useConsumerPublishableKey = false),
-            params = accounts,
+            params = accounts + (PARAMS_CLIENT_SECRET to clientSecret),
         )
 
         requestExecutor.execute(request)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
@@ -33,11 +33,15 @@ internal class SaveAccountToLinkTest {
     @Test
     fun `Polls account numbers if requested to do so`() = runTest(testDispatcher) {
         val polledAccountIds = mutableSetOf<String>()
+        var polledClientSecret: String? = null
 
         val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val accountsRepository = mockAccountsRepository(
-            onPollAccountNumbers = polledAccountIds::addAll,
+            onPollAccountNumbers = { clientSecret, linkedAccounts ->
+                polledClientSecret = clientSecret
+                polledAccountIds.addAll(linkedAccounts)
+            },
         )
 
         val saveAccountToLink = makeSaveAccountToLink(accountsRepository = accountsRepository)
@@ -50,6 +54,7 @@ internal class SaveAccountToLinkTest {
             shouldPollAccountNumbers = true,
         )
 
+        assertThat(polledClientSecret).isEqualTo(ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET)
         assertThat(polledAccountIds).containsExactly("linked_id_1", "linked_id_2")
     }
 
@@ -60,7 +65,9 @@ internal class SaveAccountToLinkTest {
         val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val accountsRepository = mockAccountsRepository(
-            onPollAccountNumbers = polledAccountIds::addAll,
+            onPollAccountNumbers = { _, linkedAccounts ->
+                polledAccountIds.addAll(linkedAccounts)
+            },
         )
 
         val saveAccountToLink = makeSaveAccountToLink(accountsRepository = accountsRepository)
@@ -87,7 +94,7 @@ internal class SaveAccountToLinkTest {
         )
 
         val accountsRepository = mockAccountsRepository(
-            onPollAccountNumbers = { error("This is failing") },
+            onPollAccountNumbers = { _, _ -> error("This is failing") },
         )
 
         val saveAccountToLink = makeSaveAccountToLink(
@@ -113,7 +120,7 @@ internal class SaveAccountToLinkTest {
         val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
 
         val accountsRepository = mockAccountsRepository(
-            onPollAccountNumbers = { error("This is failing") },
+            onPollAccountNumbers = { _, _ -> error("This is failing") },
         )
 
         val successRepository = SuccessContentRepository(SavedStateHandle())
@@ -262,12 +269,15 @@ internal class SaveAccountToLinkTest {
     }
 
     private fun mockAccountsRepository(
-        onPollAccountNumbers: (Set<String>) -> Unit = {},
+        onPollAccountNumbers: (String, Set<String>) -> Unit = { _, _ -> },
     ): FinancialConnectionsAccountsRepository {
         return object : AbsFinancialConnectionsAccountsRepository() {
 
-            override suspend fun pollAccountNumbers(linkedAccounts: Set<String>) {
-                onPollAccountNumbers(linkedAccounts)
+            override suspend fun pollAccountNumbers(
+                clientSecret: String,
+                linkedAccounts: Set<String>,
+            ) {
+                onPollAccountNumbers(clientSecret, linkedAccounts)
             }
         }
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsAccountsRepository.kt
@@ -58,7 +58,10 @@ internal abstract class AbsFinancialConnectionsAccountsRepository : FinancialCon
         TODO("Not yet implemented")
     }
 
-    override suspend fun pollAccountNumbers(linkedAccounts: Set<String>) {
+    override suspend fun pollAccountNumbers(
+        clientSecret: String,
+        linkedAccounts: Set<String>,
+    ) {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Summary
Passes the `client_secret` parameter on calls to `/v1/link_account_sessions/poll_account_numbers`. This parameter is currently optional but it really shouldn't be.  All other APIs in the FC client here use the `client_secret` param. 

## Motivation
Having `client_secret` available on the backend helps us a lot with flagging, metrics, and logging. It's also our means of access control and it's weird we don't require it just on this API. I'll eventually want to make it required and kick old SDK versions over to webview.

## Testing
Added a new unit test.

## Changelog
Entirely internal and doesn't change any user facing behavior, so I don't think this needs a changelog entry.