### PR TITLE
Restrict Link with Tap to Add using feature flag

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -324,7 +324,11 @@ internal class TapToAddTest {
                 ResponseReplacement(
                     original = "PAYMENT_METHOD_TYPES",
                     new = "\"card\", \"cashapp\""
-                )
+                ),
+                ResponseReplacement(
+                    original = "LINK_ENABLED_STATE",
+                    new = "false"
+                ),
             )
         )
     }
@@ -336,7 +340,11 @@ internal class TapToAddTest {
                 ResponseReplacement(
                     original = "PAYMENT_METHOD_TYPES",
                     new = "\"card\", \"cashapp\", \"link\""
-                )
+                ),
+                ResponseReplacement(
+                    original = "LINK_ENABLED_STATE",
+                    new = "true"
+                ),
             )
         )
     }

--- a/paymentsheet/src/androidTest/resources/elements-sessions-tta.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-tta.json
@@ -5,7 +5,8 @@
   "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
   "ordered_payment_method_types_and_wallets": [PAYMENT_METHOD_TYPES],
   "flags": {
-    "elements_mobile_android_tap_to_add_enabled": true
+    "elements_mobile_android_tap_to_add_enabled": true,
+    "elements_mobile_link_inline_signup_with_saved_pm_enabled": LINK_ENABLED_STATE
   },
   "link_settings": {
     "link_funding_sources": ["CARD"],

--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/LinkInlineSignupAvailability.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/LinkInlineSignupAvailability.kt
@@ -20,11 +20,10 @@ internal class DefaultLinkInlineSignupAvailability @Inject constructor(
     override fun availability(): LinkInlineSignupAvailability.Result {
         val linkState = paymentMethodMetadata.linkState
 
-        return when (linkState?.signupMode) {
+        return when (linkState?.signupModeResult?.availableForSavedPaymentMethods) {
+            true -> LinkInlineSignupAvailability.Result.Available(configuration = linkState.configuration)
+            false,
             null -> LinkInlineSignupAvailability.Result.Unavailable
-            else -> LinkInlineSignupAvailability.Result.Available(
-                configuration = linkState.configuration,
-            )
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -86,6 +86,9 @@ internal data class ElementsSession(
     val isTapToAddEnabled: Boolean
         get() = flags[Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED] == true
 
+    val isLinkInlineSignupWithSavedPaymentMethodsEnabled: Boolean
+        get() = flags[Flag.ELEMENTS_MOBILE_LINK_INLINE_SIGNUP_WITH_SAVED_PM_ENABLED] == true
+
     val isStripeCardScanAllowed: Boolean
         get() = flags[Flag.ELEMENTS_MOBILE_ALLOW_STRIPECARDSCAN] == true
 
@@ -231,6 +234,9 @@ internal data class ElementsSession(
         ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION("elements_mobile_attest_on_intent_confirmation"),
         ELEMENTS_MOBILE_CARD_FUND_FILTERING("elements_mobile_card_funding_filtering"),
         ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED("elements_mobile_android_tap_to_add_enabled"),
+        ELEMENTS_MOBILE_LINK_INLINE_SIGNUP_WITH_SAVED_PM_ENABLED(
+            "elements_mobile_link_inline_signup_with_saved_pm_enabled"
+        ),
         ELEMENTS_MOBILE_ALLOW_STRIPECARDSCAN("elements_mobile_allow_stripecardscan"),
         ELEMENTS_MOBILE_CARDSCAN_USE_MLKIT("elements_mobile_cardscan_use_mlkit"),
         ELEMENTS_MOBILE_CARDSCAN_DISABLE_SSDOCR("elements_mobile_cardscan_disable_ssdocr"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -42,21 +42,27 @@ internal interface CreateLinkState {
 
 internal sealed interface LinkSignupModeResult : Parcelable {
     val mode: LinkSignupMode?
+    val availableForSavedPaymentMethods: Boolean
     val disabledReasons: List<LinkSignupDisabledReason>?
 
     @Parcelize
     data object AlreadyRegistered : LinkSignupModeResult {
         override val mode: LinkSignupMode? get() = null
+        override val availableForSavedPaymentMethods: Boolean get() = false
         override val disabledReasons: List<LinkSignupDisabledReason>? get() = null
     }
 
     @Parcelize
-    data class Enabled(override val mode: LinkSignupMode) : LinkSignupModeResult {
+    data class Enabled(
+        override val mode: LinkSignupMode,
+        override val availableForSavedPaymentMethods: Boolean,
+    ) : LinkSignupModeResult {
         override val disabledReasons: List<LinkSignupDisabledReason>? get() = null
     }
 
     @Parcelize
     data class Disabled(override val disabledReasons: List<LinkSignupDisabledReason>) : LinkSignupModeResult {
+        override val availableForSavedPaymentMethods: Boolean get() = false
         override val mode: LinkSignupMode? get() = null
     }
 }
@@ -196,7 +202,10 @@ internal class DefaultCreateLinkState @Inject constructor(
             else ->
                 LinkSignupMode.InsteadOfSaveForFutureUse
         }
-        return LinkSignupModeResult.Enabled(signupMode)
+        return LinkSignupModeResult.Enabled(
+            mode = signupMode,
+            availableForSavedPaymentMethods = elementsSession.isLinkInlineSignupWithSavedPaymentMethodsEnabled
+        )
     }
 
     // Create LinkConfiguration without validating whether Link should be enabled at all.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
@@ -28,7 +28,7 @@ internal data class LinkState(
         loginState = loginState,
         signupModeResult = when {
             signupMode != null ->
-                LinkSignupModeResult.Enabled(signupMode)
+                LinkSignupModeResult.Enabled(signupMode, false)
             loginState != LoginState.LoggedOut ->
                 LinkSignupModeResult.AlreadyRegistered
             else ->

--- a/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultLinkInlineSignupAvailabilityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultLinkInlineSignupAvailabilityTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.state.LinkSignupModeResult
 import com.stripe.android.paymentsheet.state.LinkState
 import org.junit.Test
 
@@ -33,11 +34,32 @@ internal class DefaultLinkInlineSignupAvailabilityTest {
     }
 
     @Test
-    fun `availability is Available when signup mode is present`() {
+    fun `availability is Unavailable when not available for saved payment methods`() {
         val linkState = LinkState(
             configuration = TestFactory.LINK_CONFIGURATION,
             loginState = LinkState.LoginState.LoggedOut,
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            signupModeResult = LinkSignupModeResult.Enabled(
+                mode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                availableForSavedPaymentMethods = false,
+            ),
+        )
+
+        val metadata = PaymentMethodMetadataFactory.create(linkState = linkState)
+        val availability = DefaultLinkInlineSignupAvailability(metadata)
+
+        assertThat(availability.availability())
+            .isEqualTo(LinkInlineSignupAvailability.Result.Unavailable)
+    }
+
+    @Test
+    fun `availability is Available when available for saved payment methods`() {
+        val linkState = LinkState(
+            configuration = TestFactory.LINK_CONFIGURATION,
+            loginState = LinkState.LoginState.LoggedOut,
+            signupModeResult = LinkSignupModeResult.Enabled(
+                mode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                availableForSavedPaymentMethods = true,
+            ),
         )
         val metadata = PaymentMethodMetadataFactory.create(linkState = linkState)
         val availability = DefaultLinkInlineSignupAvailability(metadata)

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.LinkSignupModeResult
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -131,7 +132,10 @@ class TapToAddActivityTest {
                     )
                 ),
                 loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                signupModeResult = LinkSignupModeResult.Enabled(
+                    mode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                    availableForSavedPaymentMethods = true,
+                ),
             )
         )
     ) {
@@ -261,7 +265,10 @@ class TapToAddActivityTest {
                     )
                 ),
                 loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                signupModeResult = LinkSignupModeResult.Enabled(
+                    mode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                    availableForSavedPaymentMethods = true,
+                ),
             )
         )
     ) {
@@ -392,7 +399,10 @@ class TapToAddActivityTest {
                     )
                 ),
                 loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                signupModeResult = LinkSignupModeResult.Enabled(
+                    mode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                    availableForSavedPaymentMethods = true,
+                ),
             )
         )
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -196,6 +196,40 @@ class ElementsSessionTest {
     }
 
     @Test
+    fun `isLinkInlineSignupWithSavedPaymentMethodsEnabled returns true when flag is enabled`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = mapOf(
+                ElementsSession.Flag.ELEMENTS_MOBILE_LINK_INLINE_SIGNUP_WITH_SAVED_PM_ENABLED to true
+            )
+        )
+
+        assertThat(session.isLinkInlineSignupWithSavedPaymentMethodsEnabled).isTrue()
+    }
+
+    @Test
+    fun `isLinkInlineSignupWithSavedPaymentMethodsEnabled returns false when flag is disabled`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = mapOf(
+                ElementsSession.Flag.ELEMENTS_MOBILE_LINK_INLINE_SIGNUP_WITH_SAVED_PM_ENABLED to false
+            )
+        )
+
+        assertThat(session.isLinkInlineSignupWithSavedPaymentMethodsEnabled).isFalse()
+    }
+
+    @Test
+    fun `isLinkInlineSignupWithSavedPaymentMethodsEnabled returns false when flag is missing`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = emptyMap()
+        )
+
+        assertThat(session.isLinkInlineSignupWithSavedPaymentMethodsEnabled).isFalse()
+    }
+
+    @Test
     fun `ELEMENTS_MOBILE_ALLOW_STRIPECARDSCAN flag has correct value`() {
         assertThat(ElementsSession.Flag.ELEMENTS_MOBILE_ALLOW_STRIPECARDSCAN.flagValue)
             .isEqualTo("elements_mobile_allow_stripecardscan")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -897,7 +897,8 @@ class DefaultAnalyticsMetadataFactoryTest {
 
     private fun createLinkState(
         signupModeResult: LinkSignupModeResult = LinkSignupModeResult.Enabled(
-            LinkSignupMode.InsteadOfSaveForFutureUse
+            LinkSignupMode.InsteadOfSaveForFutureUse,
+            availableForSavedPaymentMethods = true,
         )
     ): LinkState {
         return LinkState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.state
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.isInstanceOf
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
@@ -42,6 +43,46 @@ internal class DefaultCreateLinkStateTest {
             enableCardFundFiltering = false,
             expectedFundingTypes = PaymentSheet.CardFundingType.entries
         )
+    }
+
+    @Test
+    fun `isLinkInlineSignupWithSavedPaymentMethodsEnabled is false by default`() =
+        testLinkInlineSignupWithSavedPaymentMethodsEnabledFlag(
+            flags = emptyMap(),
+            isLinkInlineSignupAvailableForSavedPaymentMethods = false,
+        )
+
+    @Test
+    fun `isLinkInlineSignupWithSavedPaymentMethodsEnabled matches elements session flag`() =
+        testLinkInlineSignupWithSavedPaymentMethodsEnabledFlag(
+            flags = mapOf(
+                ElementsSession.Flag.ELEMENTS_MOBILE_LINK_INLINE_SIGNUP_WITH_SAVED_PM_ENABLED to true
+            ),
+            isLinkInlineSignupAvailableForSavedPaymentMethods = true,
+        )
+
+    private fun testLinkInlineSignupWithSavedPaymentMethodsEnabledFlag(
+        flags: Map<ElementsSession.Flag, Boolean>,
+        isLinkInlineSignupAvailableForSavedPaymentMethods: Boolean
+    ) = runTest {
+        val createLinkState = createLinkStateFactory()
+        val configuration = PaymentSheetFixtures.CONFIG_MINIMUM.asCommonConfiguration()
+        val elementsSession = createElementsSession(flags)
+
+        val linkStateResult = createLinkState(
+            elementsSession = elementsSession,
+            configuration = configuration,
+            initializationMode = PAYMENT_INTENT_INIT_MODE,
+            customerMetadata = null,
+            clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+        )
+
+        assertThat(linkStateResult).isInstanceOf<LinkState>()
+
+        val linkState = linkStateResult as LinkState
+
+        assertThat(linkState.signupModeResult.availableForSavedPaymentMethods)
+            .isEqualTo(isLinkInlineSignupAvailableForSavedPaymentMethods)
     }
 
     @OptIn(CardFundingFilteringPrivatePreview::class)


### PR DESCRIPTION
# Summary
Restrict Link with Tap to Add using feature flag

# Motivation
Allows for enabling & disabling Link while keeping Tap to Add active. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified