### PR TITLE
Add currency selector support to Checkout API.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -167,6 +167,7 @@ private fun CheckoutScreen(
     Box {
         PlaygroundTheme(
             content = {
+                checkout.CurrencySelectorContent()
                 LineItemsSection(checkoutSession, updateLineItemQuantity)
                 ShippingAddressSection(
                     lastAddressDetails = lastAddressDetails,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -3,16 +3,23 @@ package com.stripe.android.checkout
 import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import com.stripe.android.checkout.Checkout.Companion.configure
 import com.stripe.android.checkout.Checkout.Companion.createWithState
 import com.stripe.android.checkout.injection.CheckoutComponent
 import com.stripe.android.checkout.injection.DaggerCheckoutComponent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorToggle
+import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.parcelize.Parcelize
@@ -263,6 +270,10 @@ class Checkout private constructor(
         )
     }
 
+    internal suspend fun updateCurrency(currency: String) = withInternalState { sessionId ->
+        component.checkoutSessionRepository.updateCurrency(sessionId, currency)
+    }
+
     internal fun markIntegrationLaunched() {
         internalState = internalState.copy(integrationLaunched = true)
     }
@@ -305,5 +316,20 @@ class Checkout private constructor(
             _isLoading.value = false
             result
         }
+    }
+
+    @Composable
+    fun CurrencySelectorContent() {
+        val scope = rememberCoroutineScope()
+        val isLoading by isLoading.collectAsState()
+        val checkoutSession by checkoutSession.collectAsState()
+        val currencySelectorOptions = checkoutSession.currencySelectorOptions ?: return
+        CurrencySelectorToggle(
+            options = currencySelectorOptions,
+            onCurrencySelected = { currencyOption ->
+                scope.launch(Dispatchers.Main.immediate) { updateCurrency(currencyOption.code) }
+            },
+            isEnabled = !isLoading,
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -3,6 +3,8 @@ package com.stripe.android.checkout
 import androidx.annotation.RestrictTo
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
+import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptionsFactory
 import dev.drewhamilton.poko.Poko
 
 @Poko
@@ -14,6 +16,7 @@ class CheckoutSession internal constructor(
     val totalSummary: TotalSummary?,
     val lineItems: List<LineItem>,
     val shippingOptions: List<ShippingRate>,
+    internal val currencySelectorOptions: CurrencySelectorOptions?,
 ) {
 
     @Poko
@@ -78,6 +81,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(): CheckoutSession {
         totalSummary = totalSummary?.asTotalSummary(),
         lineItems = lineItems.map { it.asLineItem() },
         shippingOptions = shippingOptions.map { it.asShippingRate() },
+        currencySelectorOptions = CurrencySelectorOptionsFactory.create(adaptivePricingInfo = adaptivePricingInfo)
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
@@ -7,10 +7,10 @@ import java.util.Locale
 
 internal object CurrencySelectorOptionsFactory {
     fun create(
-        adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo,
+        adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo?,
         locale: Locale = Locale.getDefault(),
     ): CurrencySelectorOptions? {
-        val localOption = adaptivePricingInfo.localCurrencyOptions.firstOrNull() ?: return null
+        val localOption = adaptivePricingInfo?.localCurrencyOptions?.firstOrNull() ?: return null
 
         val integrationCode = adaptivePricingInfo.integrationCurrency.uppercase()
         val localCode = localOption.currency.uppercase()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCurrencySelectorContentUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCurrencySelectorContentUITest.kt
@@ -1,0 +1,114 @@
+package com.stripe.android.checkout
+
+import android.app.Application
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.turbineScope
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_CURRENCY_OPTION_PREFIX
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_CURRENCY_SELECTOR
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutCurrencySelectorContentUITest {
+
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    private val networkRule = NetworkRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(networkRule)
+        .around(PaymentConfigurationTestRule(applicationContext))
+        .around(CheckoutInstancesTestRule())
+
+    @Test
+    fun whenAdaptivePricingInfoIsNull_currencySelectorDoesNotRender() = runScenario(
+        adaptivePricingInfo = null,
+    ) {
+        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertDoesNotExist()
+    }
+
+    @Test
+    fun whenAdaptivePricingInfoIsPresent_currencySelectorRenders() = runScenario {
+        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertExists()
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD").assertExists()
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR").assertExists()
+    }
+
+    @Test
+    fun clickingSelectedOption_doesNotTriggerNetworkRequest() = runScenario {
+        // EUR is the selected option. Clicking it is a no-op.
+        // If it triggered a network request, NetworkRule teardown would fail
+        // because no response is enqueued.
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR").performClick()
+    }
+
+    private fun runScenario(
+        adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = DEFAULT_ADAPTIVE_PRICING_INFO,
+        setContent: Boolean = true,
+        block: suspend () -> Unit,
+    ) {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+        )
+        val state = CheckoutStateFactory.create(
+            checkoutSessionResponse = checkoutSessionResponse,
+        )
+        val checkout = Checkout.createWithState(applicationContext, state)
+
+        runTest {
+            turbineScope {
+                val checkoutSessionTurbine = checkout.checkoutSession.testIn(backgroundScope)
+
+                // Consume initialization.
+                assertThat(checkoutSessionTurbine.awaitItem()).isNotNull()
+
+                if (setContent) {
+                    composeRule.setContent {
+                        checkout.CurrencySelectorContent()
+                    }
+                    composeRule.waitForIdle()
+                }
+
+                block()
+            }
+        }
+    }
+
+    companion object {
+        private val DEFAULT_ADAPTIVE_PRICING_INFO = CheckoutSessionResponse.AdaptivePricingInfo(
+            activePresentmentCurrency = "eur",
+            integrationAmount = 5099,
+            integrationCurrency = "usd",
+            localCurrencyOptions = listOf(
+                CheckoutSessionResponse.LocalCurrencyOption(
+                    amount = 4594,
+                    conversionMarkupBps = 400,
+                    currency = "eur",
+                    presentmentExchangeRate = "0.900961",
+                ),
+            ),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -854,6 +854,40 @@ class CheckoutTest {
     }
 
     @Test
+    fun `updateCurrency updates checkoutSession on success`() = runCreateWithStateScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("updated_currency", "eur"),
+            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        assertThat(checkoutSessionTurbine.awaitItem().totalSummary).isNull()
+
+        val result = checkout.updateCurrency("eur")
+
+        val updated = checkoutSessionTurbine.awaitItem()
+        result.getOrThrow()
+        assertThat(updated.totalSummary).isNotNull()
+    }
+
+    @Test
+    fun `updateCurrency returns failure on error response`() = runCreateWithStateScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid currency"}}""")
+        }
+
+        val initial = checkoutSessionTurbine.awaitItem()
+
+        val result = checkout.updateCurrency("invalid")
+        assertThat(result.isFailure).isTrue()
+
+        checkoutSessionTurbine.expectNoEvents()
+        assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+    }
+
+    @Test
     fun `configure sends adaptive_pricing allowed false by default`() = runConfigureScenario(
         clientSecret = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example",
         networkSetup = {


### PR DESCRIPTION
# Summary
Adds currency selector functionality to the Checkout API, allowing users to switch between different currency options when available.

# Motivation
Enable multi-currency support in Checkout sessions by exposing a composable UI component for currency selection and integrating it with the backend currency update API.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
[Added] - Currency selector support in Checkout API for multi-currency payment flows.