### PR TITLE
Send `customer_ephemeral_key` through `consumers/payment_details/from_payment_method`

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -127,6 +127,7 @@ interface ConsumersApiService {
         paymentMethodId: String,
         requestSurface: String,
         requestOptions: ApiRequest.Options,
+        customerEphemeralKey: String
     ): Result<ConsumerPaymentDetails>
 
     suspend fun sharePaymentDetails(
@@ -455,7 +456,8 @@ class ConsumersApiServiceImpl(
         consumerSessionClientSecret: String,
         paymentMethodId: String,
         requestSurface: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        customerEphemeralKey: String,
     ): Result<ConsumerPaymentDetails> {
         return executeRequestWithResultParser(
             stripeErrorJsonParser = stripeErrorJsonParser,
@@ -469,7 +471,11 @@ class ConsumersApiServiceImpl(
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
-                )
+                ) + if (customerEphemeralKey.isNotEmpty()) {
+                    mapOf("customer_ephemeral_key" to customerEphemeralKey)
+                } else {
+                    emptyMap()
+                }
             ),
             responseJsonParser = ConsumerPaymentDetailsJsonParser,
         )

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -471,11 +471,8 @@ class ConsumersApiServiceImpl(
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
-                ) + if (customerEphemeralKey.isNotEmpty()) {
-                    mapOf("customer_ephemeral_key" to customerEphemeralKey)
-                } else {
-                    emptyMap()
-                }
+                    "customer_ephemeral_key_secret" to customerEphemeralKey
+                )
             ),
             responseJsonParser = ConsumerPaymentDetailsJsonParser,
         )

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -396,6 +396,7 @@ class ConsumersApiServiceImplTest {
         val clientSecret = "secret"
         val paymentMethodId = "pm_123"
         val requestSurface = "android_payment_element"
+        val ephemeralKey = "ek_test_abc"
 
         networkRule.enqueue(
             method("POST"),
@@ -404,6 +405,7 @@ class ConsumersApiServiceImplTest {
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("request_surface", requestSurface),
             bodyPart("payment_method_id", paymentMethodId),
+            bodyPart("customer_ephemeral_key", ephemeralKey),
             bodyPart(urlEncode("credentials[consumer_session_client_secret]"), clientSecret),
         ) { response ->
             response.setBody(ConsumerFixtures.CONSUMER_SINGLE_CARD_PAYMENT_DETAILS_JSON.toString())
@@ -414,6 +416,7 @@ class ConsumersApiServiceImplTest {
             paymentMethodId = paymentMethodId,
             requestSurface = requestSurface,
             requestOptions = DEFAULT_OPTIONS,
+            customerEphemeralKey = ephemeralKey,
         ).getOrThrow()
 
         val cardDetails = paymentDetails.paymentDetails.first() as ConsumerPaymentDetails.Card

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -405,7 +405,7 @@ class ConsumersApiServiceImplTest {
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("request_surface", requestSurface),
             bodyPart("payment_method_id", paymentMethodId),
-            bodyPart("customer_ephemeral_key", ephemeralKey),
+            bodyPart("customer_ephemeral_key_secret", ephemeralKey),
             bodyPart(urlEncode("credentials[consumer_session_client_secret]"), clientSecret),
         ) { response ->
             response.setBody(ConsumerFixtures.CONSUMER_SINGLE_CARD_PAYMENT_DETAILS_JSON.toString())

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -262,7 +262,10 @@ internal class TapToAddTest {
         savedPaymentMethodPage.fillLink()
 
         linkHelper.enqueueSignup(withName = false)
-        linkHelper.enqueueCreatePaymentDetailsFromPaymentMethod(info.cardPaymentMethod.id)
+        linkHelper.enqueueCreatePaymentDetailsFromPaymentMethod(
+            paymentMethodId = info.cardPaymentMethod.id,
+            ephemeralKey = "ek_12345",
+        )
         enqueueConfirmRequests()
         enqueueLinkLogout(integrationType)
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
@@ -41,6 +41,7 @@ internal interface LinkConfigurationCoordinator {
 
     suspend fun attachExistingCardToAccount(
         configuration: LinkConfiguration,
+        customerEphemeralKey: String,
         paymentMethod: PaymentMethod,
     ): Result<LinkPaymentDetails.Saved>
 
@@ -123,10 +124,11 @@ internal class RealLinkConfigurationCoordinator @Inject internal constructor(
 
     override suspend fun attachExistingCardToAccount(
         configuration: LinkConfiguration,
+        customerEphemeralKey: String,
         paymentMethod: PaymentMethod
     ): Result<LinkPaymentDetails.Saved> {
         val accountManager = getLinkPaymentLauncherComponent(configuration).linkAccountManager
-        return accountManager.createPaymentDetailsFromPaymentMethod(paymentMethod)
+        return accountManager.createPaymentDetailsFromPaymentMethod(customerEphemeralKey, paymentMethod)
     }
 
     override suspend fun logOut(

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -229,6 +229,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
     }
 
     override suspend fun createPaymentDetailsFromPaymentMethod(
+        customerEphemeralKey: String,
         paymentMethod: PaymentMethod
     ): Result<LinkPaymentDetails.Saved> {
         val linkAccountValue = linkAccountHolder.linkAccountInfo.value.account
@@ -239,6 +240,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 stripeIntent = config.stripeIntent,
                 consumerSessionClientSecret = account.clientSecret,
                 clientAttributionMetadata = config.clientAttributionMetadata,
+                customerEphemeralKey = customerEphemeralKey,
             ).onSuccess {
                 errorReporter.report(ErrorReporter.SuccessEvent.LINK_CREATE_CARD_SUCCESS)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -117,6 +117,7 @@ internal interface LinkAccountManager {
     ): Result<LinkPaymentDetails.New>
 
     suspend fun createPaymentDetailsFromPaymentMethod(
+        customerEphemeralKey: String,
         paymentMethod: PaymentMethod,
     ): Result<LinkPaymentDetails.Saved>
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -262,13 +262,15 @@ internal class LinkApiRepository @Inject constructor(
         userEmail: String,
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
-        clientAttributionMetadata: ClientAttributionMetadata
+        clientAttributionMetadata: ClientAttributionMetadata,
+        customerEphemeralKey: String,
     ): Result<LinkPaymentDetails.Saved> {
         return consumersApiService.createPaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentMethodId = paymentMethod.id,
             requestSurface = requestSurface.value,
             requestOptions = apiRequestOptions,
+            customerEphemeralKey = customerEphemeralKey,
         ).mapCatching {
             LinkPaymentDetails.Saved(
                 paymentDetails = it.paymentDetails.first(),

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -120,6 +120,7 @@ internal interface LinkRepository {
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
         clientAttributionMetadata: ClientAttributionMetadata,
+        customerEphemeralKey: String,
     ): Result<LinkPaymentDetails.Saved>
 
     suspend fun createBankAccountPaymentDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -9,6 +9,7 @@ import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -38,7 +39,10 @@ internal class LinkInlineSignupConfirmationDefinition(
         confirmationOption: LinkInlineSignupConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args
     ): ConfirmationDefinition.Action<LauncherArguments> {
-        val nextConfirmationOption = createPaymentMethodConfirmationOption(confirmationOption)
+        val nextConfirmationOption = createPaymentMethodConfirmationOption(
+            customerMetadata = confirmationArgs.paymentMethodMetadata.customerMetadata,
+            linkInlineSignupConfirmationOption = confirmationOption,
+        )
 
         return ConfirmationDefinition.Action.Launch(
             launcherArguments = LauncherArguments(nextConfirmationOption),
@@ -75,13 +79,32 @@ internal class LinkInlineSignupConfirmationDefinition(
     }
 
     private suspend fun createPaymentMethodConfirmationOption(
+        customerMetadata: CustomerMetadata?,
         linkInlineSignupConfirmationOption: LinkInlineSignupConfirmationOption,
     ): PaymentMethodConfirmationOption {
+        val ephemeralKeySecret = when (customerMetadata) {
+            is CustomerMetadata.LegacyEphemeralKey -> customerMetadata.ephemeralKeySecret
+            is CustomerMetadata.CustomerSession -> customerMetadata.ephemeralKeySecret
+            is CustomerMetadata.CheckoutSession,
+            null -> null
+        }
+
+        if (
+            linkInlineSignupConfirmationOption is LinkInlineSignupConfirmationOption.Saved &&
+            ephemeralKeySecret == null
+        ) {
+            return linkInlineSignupConfirmationOption.toOption()
+        }
+
         val configuration = linkInlineSignupConfirmationOption.linkConfiguration
         val userInput = linkInlineSignupConfirmationOption.sanitizedUserInput
 
         return when (linkConfigurationCoordinator.getAccountStatusFlow(configuration).first()) {
-            is AccountStatus.Verified -> createOptionAfterAttachingToLink(linkInlineSignupConfirmationOption, userInput)
+            is AccountStatus.Verified -> createOptionAfterAttachingToLink(
+                linkInlineSignupConfirmationOption = linkInlineSignupConfirmationOption,
+                ephemeralKeySecret = ephemeralKeySecret,
+                userInput = userInput,
+            )
             AccountStatus.VerificationStarted,
             is AccountStatus.NeedsVerification -> {
                 linkAnalyticsHelper.onLinkPopupSkipped()
@@ -93,7 +116,10 @@ internal class LinkInlineSignupConfirmationDefinition(
                 linkConfigurationCoordinator.signInWithUserInput(configuration, userInput).fold(
                     onSuccess = {
                         // If successful, the account was fetched or created, so try again
-                        createPaymentMethodConfirmationOption(linkInlineSignupConfirmationOption)
+                        createPaymentMethodConfirmationOption(
+                            customerMetadata = customerMetadata,
+                            linkInlineSignupConfirmationOption = linkInlineSignupConfirmationOption
+                        )
                     },
                     onFailure = {
                         linkInlineSignupConfirmationOption.toOption()
@@ -105,6 +131,7 @@ internal class LinkInlineSignupConfirmationDefinition(
 
     private suspend fun createOptionAfterAttachingToLink(
         linkInlineSignupConfirmationOption: LinkInlineSignupConfirmationOption,
+        ephemeralKeySecret: String?,
         userInput: UserInput,
     ): PaymentMethodConfirmationOption {
         if (userInput is UserInput.SignIn) {
@@ -148,9 +175,13 @@ internal class LinkInlineSignupConfirmationDefinition(
                 }
             }
             is LinkInlineSignupConfirmationOption.Saved -> {
+                val ephemeralKeySecret = ephemeralKeySecret
+                    ?: return linkInlineSignupConfirmationOption.toOption()
+
                 val linkPaymentDetails = linkConfigurationCoordinator.attachExistingCardToAccount(
-                    configuration,
-                    linkInlineSignupConfirmationOption.paymentMethod,
+                    configuration = configuration,
+                    customerEphemeralKey = ephemeralKeySecret,
+                    paymentMethod = linkInlineSignupConfirmationOption.paymentMethod,
                 ).getOrNull()
 
                 when (linkPaymentDetails) {

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -272,7 +272,10 @@ class TapToAddActivityTest {
 
         linkHelper.enqueueLookup()
         linkHelper.enqueueSignup()
-        linkHelper.enqueueCreatePaymentDetailsFromPaymentMethod(info.cardPaymentMethod.id)
+        linkHelper.enqueueCreatePaymentDetailsFromPaymentMethod(
+            paymentMethodId = info.cardPaymentMethod.id,
+            ephemeralKey = "ek_123",
+        )
 
         confirmationHelper.intendingPaymentConfirmationToBeLaunched(
             InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED)

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
@@ -173,7 +173,8 @@ internal open class FakeConsumersApiService : ConsumersApiService {
         consumerSessionClientSecret: String,
         paymentMethodId: String,
         requestSurface: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        customerEphemeralKey: String,
     ): Result<ConsumerPaymentDetails> {
         createPaymentDetailsFromPaymentMethodCalls.add(
             CreatePaymentDetailsFromPaymentMethodCall(
@@ -181,6 +182,7 @@ internal open class FakeConsumersApiService : ConsumersApiService {
                 paymentMethodId = paymentMethodId,
                 requestSurface = requestSurface,
                 requestOptions = requestOptions,
+                customerEphemeralKey = customerEphemeralKey,
             )
         )
         return createPaymentDetailsFromPaymentMethodResult
@@ -269,5 +271,6 @@ internal open class FakeConsumersApiService : ConsumersApiService {
         val paymentMethodId: String,
         val requestSurface: String,
         val requestOptions: ApiRequest.Options,
+        val customerEphemeralKey: String,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
@@ -84,8 +84,10 @@ class LinkConfigurationCoordinatorTest {
             )
         )
 
+        val ephemeralKey = "ek_123"
         val result = coordinator.attachExistingCardToAccount(
             configuration = TestFactory.LINK_CONFIGURATION,
+            customerEphemeralKey = ephemeralKey,
             paymentMethod = paymentMethod,
         )
 
@@ -97,8 +99,10 @@ class LinkConfigurationCoordinatorTest {
         assertThat(linkPaymentDetails.paymentMethod).isEqualTo(paymentMethod)
         assertThat(linkPaymentDetails.paymentDetails).isEqualTo(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
 
-        assertThat(accountManager.awaitCreatePaymentDetailsFromPaymentMethodTurbineCall())
-            .isEqualTo(paymentMethod)
+        val createPaymentDetailsCall = accountManager.awaitCreatePaymentDetailsFromPaymentMethodTurbineCall()
+
+        assertThat(createPaymentDetailsCall.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(createPaymentDetailsCall.customerEphemeralKey).isEqualTo(ephemeralKey)
 
         accountManager.ensureAllEventsConsumed()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -479,14 +479,17 @@ class DefaultLinkAccountManagerTest {
     fun `createPaymentDetailsFromPaymentMethod returns success when account exists`() = runSuspendTest {
         val linkRepository = object : FakeLinkRepository() {
             var createPaymentDetailsFromPaymentMethodCallCount = 0
+            var capturedCustomerEphemeralKey = "not_called"
             override suspend fun createPaymentDetailsFromPaymentMethod(
                 paymentMethod: PaymentMethod,
                 userEmail: String,
                 stripeIntent: StripeIntent,
                 consumerSessionClientSecret: String,
                 clientAttributionMetadata: ClientAttributionMetadata,
+                customerEphemeralKey: String,
             ): Result<LinkPaymentDetails.Saved> {
                 createPaymentDetailsFromPaymentMethodCallCount += 1
+                capturedCustomerEphemeralKey = customerEphemeralKey
                 return Result.success(
                     LinkPaymentDetails.Saved(
                         paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
@@ -503,11 +506,16 @@ class DefaultLinkAccountManagerTest {
         )
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val result = accountManager.createPaymentDetailsFromPaymentMethod(paymentMethod)
+        val ephemeralKey = "ek_test_key"
+        val result = accountManager.createPaymentDetailsFromPaymentMethod(
+            customerEphemeralKey = ephemeralKey,
+            paymentMethod = paymentMethod,
+        )
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()?.paymentMethod).isEqualTo(paymentMethod)
         assertThat(linkRepository.createPaymentDetailsFromPaymentMethodCallCount).isEqualTo(1)
+        assertThat(linkRepository.capturedCustomerEphemeralKey).isEqualTo(ephemeralKey)
     }
 
     @Test
@@ -516,7 +524,8 @@ class DefaultLinkAccountManagerTest {
         accountManager.setTestAccount(null, null)
 
         val result = accountManager.createPaymentDetailsFromPaymentMethod(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            customerEphemeralKey = "ek_test_key",
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
         )
 
         assertThat(result.isFailure).isTrue()
@@ -1084,7 +1093,7 @@ class DefaultLinkAccountManagerTest {
         linkRepository: LinkRepository = FakeLinkRepository(),
         linkEventsReporter: LinkEventsReporter = AccountManagerEventsReporter(),
         allowUserEmailEdits: Boolean = true,
-        linkAuth: LinkAuth = fakeLinkAuth()
+        linkAuth: LinkAuth = fakeLinkAuth(),
     ): DefaultLinkAccountManager {
         val customerInfo = TestFactory.LINK_CONFIGURATION.customerInfo.copy(
             email = customerEmail,
@@ -1095,7 +1104,7 @@ class DefaultLinkAccountManagerTest {
                 stripeIntent = stripeIntent,
                 passthroughModeEnabled = passthroughModeEnabled,
                 customerInfo = customerInfo,
-                allowUserEmailEdits = allowUserEmailEdits
+                allowUserEmailEdits = allowUserEmailEdits,
             ),
             linkRepository = linkRepository,
             linkEventsReporter = linkEventsReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -130,7 +130,12 @@ internal open class FakeLinkAccountManager(
 
     private val updateCardDetailsTurbine = Turbine<ConsumerPaymentDetailsUpdateParams>()
     private val startVerificationTurbine = Turbine<Boolean>()
-    private val createPaymentDetailsFromPaymentMethodTurbine = Turbine<PaymentMethod>()
+    private val createPaymentDetailsFromPaymentMethodTurbine = Turbine<CreatePaymentDetailsFromPaymentMethodCall>()
+
+    internal data class CreatePaymentDetailsFromPaymentMethodCall(
+        val customerEphemeralKey: String,
+        val paymentMethod: PaymentMethod,
+    )
 
     val confirmVerificationTurbine = Turbine<String>()
 
@@ -215,9 +220,12 @@ internal open class FakeLinkAccountManager(
     }
 
     override suspend fun createPaymentDetailsFromPaymentMethod(
+        customerEphemeralKey: String,
         paymentMethod: PaymentMethod,
     ): Result<LinkPaymentDetails.Saved> {
-        createPaymentDetailsFromPaymentMethodTurbine.add(paymentMethod)
+        createPaymentDetailsFromPaymentMethodTurbine.add(
+            CreatePaymentDetailsFromPaymentMethodCall(customerEphemeralKey, paymentMethod)
+        )
         return createPaymentDetailsFromPaymentMethodResult
     }
 
@@ -310,7 +318,7 @@ internal open class FakeLinkAccountManager(
         return confirmVerificationTurbine.awaitItem()
     }
 
-    suspend fun awaitCreatePaymentDetailsFromPaymentMethodTurbineCall(): PaymentMethod {
+    suspend fun awaitCreatePaymentDetailsFromPaymentMethodTurbineCall(): CreatePaymentDetailsFromPaymentMethodCall {
         return createPaymentDetailsFromPaymentMethodTurbine.awaitItem()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -174,6 +174,7 @@ internal open class FakeLinkRepository : LinkRepository {
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
         clientAttributionMetadata: ClientAttributionMetadata,
+        customerEphemeralKey: String,
     ): Result<LinkPaymentDetails.Saved> = createPaymentDetailsFromPaymentMethodResult
 
     override suspend fun createBankAccountPaymentDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -555,6 +555,7 @@ class LinkApiRepositoryTest {
     @Test
     fun `createPaymentDetailsFromPaymentMethod sends correct parameters and returns Saved`() = runTest {
         val secret = "consumer_secret"
+        val ephemeralKey = "ek_test_abc"
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val paymentDetails = PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS
 
@@ -569,6 +570,7 @@ class LinkApiRepositoryTest {
             stripeIntent = paymentIntent,
             consumerSessionClientSecret = secret,
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            customerEphemeralKey = ephemeralKey,
         )
 
         assertThat(result.isSuccess).isTrue()
@@ -593,6 +595,7 @@ class LinkApiRepositoryTest {
                 stripeAccount = STRIPE_ACCOUNT_ID
             )
         )
+        assertThat(createDetailsCall.customerEphemeralKey).isEqualTo(ephemeralKey)
     }
 
     @Test
@@ -611,6 +614,7 @@ class LinkApiRepositoryTest {
             stripeIntent = paymentIntent,
             consumerSessionClientSecret = "secret",
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            customerEphemeralKey = "ek_test_abc",
         )
 
         assertThat(result.isFailure).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -232,7 +232,8 @@ class LinkFormElementTest {
 
         override suspend fun attachExistingCardToAccount(
             configuration: LinkConfiguration,
-            paymentMethod: PaymentMethod
+            customerEphemeralKey: String,
+            paymentMethod: PaymentMethod,
         ): Result<LinkPaymentDetails.Saved> {
             error("Not implemented!")
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
@@ -30,6 +31,7 @@ import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -38,6 +40,7 @@ import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.PAYMENT_INTENT
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNew
@@ -379,7 +382,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
             val action = definition.action(
                 confirmationOption = savedOption,
-                confirmationArgs = CONFIRMATION_PARAMETERS,
+                confirmationArgs = CONFIRMATION_ARGS_WITH_CUSTOMER_EK,
             )
 
             val getAccountStatusFlowCall = coordinatorScenario.getAccountStatusFlowCalls.awaitItem()
@@ -387,6 +390,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
             val attachExistingCardCall = coordinatorScenario.attachExistingCardToAccountCalls.awaitItem()
             assertThat(attachExistingCardCall.configuration).isEqualTo(savedOption.linkConfiguration)
+            assertThat(attachExistingCardCall.customerEphemeralKey).isEqualTo("ek_123")
             assertThat(attachExistingCardCall.paymentMethod).isEqualTo(savedOption.paymentMethod)
 
             assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
@@ -413,12 +417,13 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
             val action = definition.action(
                 confirmationOption = savedOption,
-                confirmationArgs = CONFIRMATION_PARAMETERS,
+                confirmationArgs = CONFIRMATION_ARGS_WITH_CUSTOMER_EK,
             )
 
             assertThat(coordinatorScenario.getAccountStatusFlowCalls.awaitItem()).isNotNull()
 
             val attachExistingCardCall = coordinatorScenario.attachExistingCardToAccountCalls.awaitItem()
+            assertThat(attachExistingCardCall.customerEphemeralKey).isEqualTo("ek_123")
             assertThat(attachExistingCardCall.paymentMethod).isEqualTo(savedOption.paymentMethod)
 
             assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
@@ -959,9 +964,16 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
         override suspend fun attachExistingCardToAccount(
             configuration: LinkConfiguration,
+            customerEphemeralKey: String,
             paymentMethod: PaymentMethod,
         ): Result<LinkPaymentDetails.Saved> {
-            attachExistingCardToAccountCalls.add(AttachExistingCardToAccountCall(configuration, paymentMethod))
+            attachExistingCardToAccountCalls.add(
+                AttachExistingCardToAccountCall(
+                    configuration = configuration,
+                    customerEphemeralKey = customerEphemeralKey,
+                    paymentMethod = paymentMethod,
+                )
+            )
 
             return attachExistingCardToAccountResult
         }
@@ -986,6 +998,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
         data class AttachExistingCardToAccountCall(
             val configuration: LinkConfiguration,
+            val customerEphemeralKey: String,
             val paymentMethod: PaymentMethod,
         )
 
@@ -1033,6 +1046,14 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     }
 
     private companion object {
+        private val CONFIRMATION_ARGS_WITH_CUSTOMER_EK = CONFIRMATION_PARAMETERS.copy(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PAYMENT_INTENT,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                hasCustomerConfiguration = true,
+            )
+        )
+
         private val DEFAULT_CONSUMER_CARD = ConsumerPaymentDetails.Card(
             id = "pm_123",
             last4 = "4242",

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -110,7 +110,8 @@ internal class FakeLinkConfigurationCoordinator(
 
     override suspend fun attachExistingCardToAccount(
         configuration: LinkConfiguration,
-        paymentMethod: PaymentMethod
+        customerEphemeralKey: String,
+        paymentMethod: PaymentMethod,
     ): Result<LinkPaymentDetails.Saved> {
         return attachExistingCardToAccountResult
     }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddLinkTestHelper.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddLinkTestHelper.kt
@@ -44,11 +44,15 @@ class TapToAddLinkTestHelper(
         }
     }
 
-    fun enqueueCreatePaymentDetailsFromPaymentMethod(paymentMethodId: String) {
+    fun enqueueCreatePaymentDetailsFromPaymentMethod(
+        paymentMethodId: String,
+        ephemeralKey: String,
+    ) {
         networkRule.enqueue(
             method("POST"),
             path("/v1/consumers/payment_details/from_payment_method"),
             bodyPart("payment_method_id", urlEncode(paymentMethodId)),
+            bodyPart("customer_ephemeral_key", urlEncode(ephemeralKey)),
         ) { response ->
             response.testBodyFromFile("consumer-payment-details-success.json")
         }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddLinkTestHelper.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddLinkTestHelper.kt
@@ -52,7 +52,7 @@ class TapToAddLinkTestHelper(
             method("POST"),
             path("/v1/consumers/payment_details/from_payment_method"),
             bodyPart("payment_method_id", urlEncode(paymentMethodId)),
-            bodyPart("customer_ephemeral_key", urlEncode(ephemeralKey)),
+            bodyPart("customer_ephemeral_key_secret", urlEncode(ephemeralKey)),
         ) { response ->
             response.testBodyFromFile("consumer-payment-details-success.json")
         }


### PR DESCRIPTION
# Summary
Send `customer_ephemeral_key` through `consumers/payment_details/from_payment_method` in order to authenticate that the user owns the `payment_method_id` they are passing along.

# Motivation
Ensure authentication with tapped PM.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified