### PR TITLE
[Financial Connections] Refactor `AnnotatedText` composable for accessibility

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
@@ -88,44 +88,44 @@ internal fun buildAnnotatedStringResource(
     pressedLinkColor: Color,
 ): AnnotatedString {
     val spannedString = SpannedString(resource)
-    return AnnotatedString.Builder(spannedString.toString()).apply {
-        spannedString
-            .getSpans<Any>(0, spannedString.length)
-            .forEach { rawAnnotation ->
-                val spanStart = spannedString.getSpanStart(rawAnnotation)
-                val spanEnd = spannedString.getSpanEnd(rawAnnotation)
-                rawAnnotation.toAnnotation()?.let { annotation ->
-                    val matchingAnnotation = annotation.matchingStringAnnotation()
-                    val spanStyle = annotationStyles[matchingAnnotation]
-                    when (matchingAnnotation) {
-                        StringAnnotation.CLICKABLE -> {
-                            addLink(
-                                url = annotation.toLinkAnnotation(
-                                    onClickableTextClick = onClickableTextClick,
-                                    style = spanStyle,
-                                    pressedLinkColor = pressedLinkColor,
-                                ),
-                                start = spanStart,
-                                end = spanEnd
-                            )
-                        }
+    val resultBuilder = AnnotatedString.Builder(spannedString.toString())
+    spannedString
+        .getSpans<Any>(0, spannedString.length)
+        .forEach { annotation ->
+            val spanStart = spannedString.getSpanStart(annotation)
+            val spanEnd = spannedString.getSpanEnd(annotation)
+            annotation.toAnnotation()?.let {
+                val matchingAnnotation = it.matchingStringAnnotation()
+                val spanStyle = annotationStyles[matchingAnnotation]
+                when (matchingAnnotation) {
+                    StringAnnotation.CLICKABLE -> {
+                        resultBuilder.addLink(
+                            url = it.toLinkAnnotation(
+                                onClickableTextClick = onClickableTextClick,
+                                style = spanStyle,
+                                pressedLinkColor = pressedLinkColor,
+                            ),
+                            start = spanStart,
+                            end = spanEnd
+                        )
+                    }
 
-                        null,
-                        StringAnnotation.BOLD -> {
-                            addStringAnnotation(
-                                tag = annotation.key,
-                                annotation = annotation.value,
-                                start = spanStart,
-                                end = spanEnd
-                            )
-                            spanStyle?.let { style ->
-                                addStyle(style, spanStart, spanEnd)
-                            }
+                    null,
+                    StringAnnotation.BOLD -> {
+                        resultBuilder.addStringAnnotation(
+                            tag = it.key,
+                            annotation = it.value,
+                            start = spanStart,
+                            end = spanEnd
+                        )
+                        spanStyle?.let { style ->
+                            resultBuilder.addStyle(style, spanStart, spanEnd)
                         }
                     }
                 }
             }
-    }.toAnnotatedString()
+        }
+    return resultBuilder.toAnnotatedString()
 }
 
 private fun Annotation.matchingStringAnnotation(): StringAnnotation? =

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
@@ -6,24 +6,16 @@ import android.text.SpannedString
 import android.text.style.StyleSpan
 import android.text.style.URLSpan
 import androidx.annotation.StringRes
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.onClick
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,83 +37,20 @@ internal fun AnnotatedText(
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Clip
 ) {
-    val pressedColor = FinancialConnectionsTheme.colors.textDefault
-    var pressedAnnotation: String? by remember { mutableStateOf(null) }
     val resource = annotatedStringResource(
         resource = text,
-        spanStyleForAnnotation = { annotation ->
-            val matchingAnnotation = StringAnnotation.entries
-                .firstOrNull { it.value == annotation.key }
-            val spanStyle = annotationStyles[matchingAnnotation]
-            if (pressedAnnotation == annotation.value) {
-                spanStyle?.copy(color = pressedColor)
-            } else {
-                spanStyle
-            }
-        }
+        onClickableTextClick = onClickableTextClick,
+        annotationStyles = annotationStyles,
+        pressedLinkColor = FinancialConnectionsTheme.colors.textDefault,
     )
-    val standaloneClickableAnnotation = remember(resource) { resource.standaloneClickableAnnotation() }
-    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-    val pressIndicator = Modifier.pointerInput(onClickableTextClick) {
-        detectTapGestures(
-            onPress = { offset ->
-                val clickedAnnotation = layoutResult?.clickedAnnotation(offset, resource)
-                // mark the current clickable text portion as pressed
-                pressedAnnotation = clickedAnnotation?.item
-                // release the current pressed text portion.
-                tryAwaitRelease()
-                pressedAnnotation = null
-            },
-            onTap = { offset ->
-                layoutResult?.clickedAnnotation(offset, resource)?.let {
-                    onClickableTextClick(it.item)
-                }
-            }
-        )
-    }
     BasicText(
         text = resource,
-        modifier = modifier
-            .then(
-                if (standaloneClickableAnnotation != null) {
-                    Modifier.semantics {
-                        role = Role.Button
-                        onClick {
-                            onClickableTextClick(standaloneClickableAnnotation.item)
-                            true
-                        }
-                    }
-                } else {
-                    Modifier
-                }
-            )
-            .then(pressIndicator),
+        modifier = modifier,
         style = defaultStyle,
         softWrap = true,
         overflow = overflow,
         maxLines = maxLines,
-        onTextLayout = {
-            layoutResult = it
-        }
     )
-}
-
-private fun AnnotatedString.standaloneClickableAnnotation(): AnnotatedString.Range<String>? =
-    getStringAnnotations(
-        tag = StringAnnotation.CLICKABLE.value,
-        start = 0,
-        end = length
-    ).singleOrNull { it.start == 0 && it.end == length }
-
-private fun TextLayoutResult.clickedAnnotation(
-    offset: Offset,
-    resource: AnnotatedString,
-): AnnotatedString.Range<String>? = getOffsetForPosition(offset).let {
-    resource.getStringAnnotations(
-        tag = StringAnnotation.CLICKABLE.value,
-        start = it,
-        end = it
-    ).firstOrNull()
 }
 
 private fun Any.toAnnotation(): Annotation? = when (this) {
@@ -142,30 +71,88 @@ private fun Any.toAnnotation(): Annotation? = when (this) {
 @Composable
 private fun annotatedStringResource(
     resource: TextResource,
-    spanStyleForAnnotation: (Annotation) -> SpanStyle? = { null }
+    onClickableTextClick: (String) -> Unit,
+    annotationStyles: Map<StringAnnotation, SpanStyle>,
+    pressedLinkColor: Color,
+): AnnotatedString = buildAnnotatedStringResource(
+    resource = resource.toText(),
+    onClickableTextClick = onClickableTextClick,
+    annotationStyles = annotationStyles,
+    pressedLinkColor = pressedLinkColor,
+)
+
+internal fun buildAnnotatedStringResource(
+    resource: CharSequence,
+    onClickableTextClick: (String) -> Unit,
+    annotationStyles: Map<StringAnnotation, SpanStyle>,
+    pressedLinkColor: Color,
 ): AnnotatedString {
-    val spannedString = SpannedString(resource.toText())
-    val resultBuilder = AnnotatedString.Builder()
-    resultBuilder.append(spannedString.toString())
-    spannedString
-        .getSpans<Any>(0, spannedString.length)
-        .forEach { annotation ->
-            val spanStart = spannedString.getSpanStart(annotation)
-            val spanEnd = spannedString.getSpanEnd(annotation)
-            annotation.toAnnotation()?.let {
-                resultBuilder.addStringAnnotation(
-                    tag = it.key,
-                    annotation = it.value,
-                    start = spanStart,
-                    end = spanEnd
-                )
-                spanStyleForAnnotation(it)?.let { style ->
-                    resultBuilder.addStyle(style, spanStart, spanEnd)
+    val spannedString = SpannedString(resource)
+    return AnnotatedString.Builder(spannedString.toString()).apply {
+        spannedString
+            .getSpans<Any>(0, spannedString.length)
+            .forEach { rawAnnotation ->
+                val spanStart = spannedString.getSpanStart(rawAnnotation)
+                val spanEnd = spannedString.getSpanEnd(rawAnnotation)
+                rawAnnotation.toAnnotation()?.let { annotation ->
+                    val matchingAnnotation = annotation.matchingStringAnnotation()
+                    val spanStyle = annotationStyles[matchingAnnotation]
+                    when (matchingAnnotation) {
+                        StringAnnotation.CLICKABLE -> {
+                            addLink(
+                                url = annotation.toLinkAnnotation(
+                                    onClickableTextClick = onClickableTextClick,
+                                    style = spanStyle,
+                                    pressedLinkColor = pressedLinkColor,
+                                ),
+                                start = spanStart,
+                                end = spanEnd
+                            )
+                        }
+
+                        null,
+                        StringAnnotation.BOLD -> {
+                            addStringAnnotation(
+                                tag = annotation.key,
+                                annotation = annotation.value,
+                                start = spanStart,
+                                end = spanEnd
+                            )
+                            spanStyle?.let { style ->
+                                addStyle(style, spanStart, spanEnd)
+                            }
+                        }
+                    }
                 }
             }
-        }
-    return resultBuilder.toAnnotatedString()
+    }.toAnnotatedString()
 }
+
+private fun Annotation.matchingStringAnnotation(): StringAnnotation? =
+    StringAnnotation.entries.firstOrNull { it.value == key }
+
+private fun Annotation.toLinkAnnotation(
+    onClickableTextClick: (String) -> Unit,
+    style: SpanStyle?,
+    pressedLinkColor: Color,
+): LinkAnnotation.Url {
+    val url = value
+    return LinkAnnotation.Url(
+        url = url,
+        styles = style.toTextLinkStyles(pressedLinkColor),
+        linkInteractionListener = LinkInteractionListener {
+            onClickableTextClick(url)
+        }
+    )
+}
+
+private fun SpanStyle?.toTextLinkStyles(pressedLinkColor: Color): TextLinkStyles? =
+    this?.let { style ->
+        TextLinkStyles(
+            style = style,
+            pressedStyle = style.copy(color = pressedLinkColor)
+        )
+    }
 
 @Composable
 internal fun pluralStringResource(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ui/components/AnnotatedTextResourceTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ui/components/AnnotatedTextResourceTest.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.financialconnections.ui.components
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.URLSpan
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.style.TextDecoration
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class AnnotatedTextResourceTest {
+
+    @Test
+    fun `buildAnnotatedStringResource converts URL spans into link annotations`() {
+        val linkText = "Access Data"
+        val expectedUrl = "stripe://data-access-notice"
+        val resource = SpannableString("$linkText takes 1-2 business days").apply {
+            setSpan(
+                URLSpan(expectedUrl),
+                0,
+                linkText.length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+        val linkStyle = SpanStyle(textDecoration = TextDecoration.Underline)
+        var clickedUrl: String? = null
+
+        val annotatedString = buildAnnotatedStringResource(
+            resource = resource,
+            onClickableTextClick = { clickedUrl = it },
+            annotationStyles = mapOf(StringAnnotation.CLICKABLE to linkStyle),
+            pressedLinkColor = Color.Red,
+        )
+
+        val link = annotatedString.getLinkAnnotations(0, annotatedString.length).single()
+        assertThat(link.start).isEqualTo(0)
+        assertThat(link.end).isEqualTo(linkText.length)
+        assertThat(link.item).isInstanceOf(LinkAnnotation.Url::class.java)
+
+        val linkAnnotation = link.item as LinkAnnotation.Url
+        assertThat(linkAnnotation.url).isEqualTo(expectedUrl)
+        assertThat(linkAnnotation.styles).isEqualTo(
+            TextLinkStyles(
+                style = linkStyle,
+                pressedStyle = linkStyle.copy(color = Color.Red)
+            )
+        )
+
+        linkAnnotation.linkInteractionListener?.onClick(linkAnnotation)
+
+        assertThat(clickedUrl).isEqualTo(expectedUrl)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request refactors the `AnnotatedText` composable in Financial Connections for accessibility improvements.

Instead of reading annotated text as simple plain text, TalkBack now recognizes links and allows the user to open them with a gesture.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-146](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-146)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screen recordings

See the TalkBack output that's rendered on the screen. The 3-finger tap gesture doesn't seem possible in the emulator, where I recorded, but I confirmed that it works on a real device as well.

## Before

https://github.com/user-attachments/assets/ca731aab-034b-4c15-8548-56a87825388f

## After

https://github.com/user-attachments/assets/e5207a9e-e4a5-454b-a697-94a74a3fc957

## Physical device with interaction

https://github.com/user-attachments/assets/2c6a496c-7de5-421f-b2b5-17d1c6cfcab8

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
