### PR TITLE
Show horizontal layout when payment method layout is automatic and number of PMs is <= 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
-NEXT_VERSION_BUMP: PATCH
+NEXT_VERSION_BUMP: MINOR
 ## XX.XX.XX - 20XX-XX-XX
 
 ### PaymentSheet
 * [FIXED][12973](https://github.com/stripe/stripe-android/pull/12973) Fixed an issue where `FlowController` would bypass mandate display when `setupFutureUsage` was added via `configureWithIntentConfiguration()` after the user had already entered card details.
+* [CHANGED][12975](https://github.com/stripe/stripe-android/pull/12975) When `paymentMethodLayout` is set to `Automatic`, the layout is now horizontal when there are 2 or fewer payment methods available.
 
 ## 23.6.0 - 2026-04-27
 ### PaymentSheet

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
 import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PaymentSheet as StripePaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetPage
 import com.stripe.android.paymentsheet.utils.FlowControllerTestRunnerContext
@@ -49,6 +50,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
         protected val configuration = StripePaymentSheet.Configuration.Builder(
             merchantDisplayName = "Merchant, Inc.",
         )
+            .paymentMethodLayout(PaymentMethodLayout.Vertical)
             .customer(customerConfig)
             .build()
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -31,6 +31,7 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.WalletButtonsPage
 import com.stripe.android.paymentelement.WalletButtonsPreview
+import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.utils.ActivityLaunchObserver
@@ -1178,6 +1179,7 @@ internal class FlowControllerTest {
                 configuration = PaymentSheet.Configuration.Builder(
                     merchantDisplayName = "Example, Inc."
                 )
+                    .paymentMethodLayout(PaymentMethodLayout.Vertical)
                     .customer(
                         PaymentSheet.CustomerConfiguration.createWithCustomerSession(
                             id = "cus_1",

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -98,8 +98,12 @@ internal data class PaymentMethodMetadata(
     fun paymentMethodOrientation(): PaymentMethodOrientation {
         return when (paymentMethodLayout) {
             PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
-            PaymentSheet.PaymentMethodLayout.Vertical,
-            PaymentSheet.PaymentMethodLayout.Automatic -> PaymentMethodOrientation.Vertical
+            PaymentSheet.PaymentMethodLayout.Vertical -> PaymentMethodOrientation.Vertical
+            PaymentSheet.PaymentMethodLayout.Automatic -> if (supportedPaymentMethodTypes().size > 2) {
+                PaymentMethodOrientation.Vertical
+            } else {
+                PaymentMethodOrientation.Horizontal
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -92,8 +92,16 @@ internal data class PaymentMethodMetadata(
     val elementsSessionId: String? = null,
     val disableSsdOcrCardScan: Boolean,
     val cardArts: List<PaymentMethod.Card.CardArt>,
-    val paymentMethodOrientation: PaymentMethodOrientation,
+    private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
 ) : Parcelable {
+
+    fun paymentMethodOrientation(): PaymentMethodOrientation {
+        return when (paymentMethodLayout) {
+            PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
+            PaymentSheet.PaymentMethodLayout.Vertical,
+            PaymentSheet.PaymentMethodLayout.Automatic -> PaymentMethodOrientation.Vertical
+        }
+    }
 
     @IgnoredOnParcel
     val linkState: LinkState? =
@@ -411,11 +419,7 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = cardArts,
-                paymentMethodOrientation = when (paymentMethodLayout) {
-                    PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
-                    PaymentSheet.PaymentMethodLayout.Vertical,
-                    PaymentSheet.PaymentMethodLayout.Automatic -> PaymentMethodOrientation.Vertical
-                }
+                paymentMethodLayout = paymentMethodLayout,
             )
         }
 
@@ -486,7 +490,7 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = cardArts,
-                paymentMethodOrientation = PaymentMethodOrientation.Horizontal,
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
@@ -54,7 +54,7 @@ internal class MandateHandler(
                 selection = viewModel.selection,
                 merchantDisplayName = viewModel.config.merchantDisplayName,
                 isVerticalModeProvider = {
-                    viewModel.paymentMethodMetadata.value?.paymentMethodOrientation == PaymentMethodOrientation.Vertical
+                    viewModel.paymentMethodMetadata.value?.paymentMethodOrientation() == PaymentMethodOrientation.Vertical
                 },
                 isSetupFlowProvider = { viewModel.paymentMethodMetadata.value?.stripeIntent is SetupIntent },
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/MandateHandler.kt
@@ -54,7 +54,8 @@ internal class MandateHandler(
                 selection = viewModel.selection,
                 merchantDisplayName = viewModel.config.merchantDisplayName,
                 isVerticalModeProvider = {
-                    viewModel.paymentMethodMetadata.value?.paymentMethodOrientation() == PaymentMethodOrientation.Vertical
+                    viewModel.paymentMethodMetadata.value?.paymentMethodOrientation() ==
+                        PaymentMethodOrientation.Vertical
                 },
                 isSetupFlowProvider = { viewModel.paymentMethodMetadata.value?.stripeIntent is SetupIntent },
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -437,7 +437,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerStateHolder: CustomerStateHolder,
     ): List<PaymentSheetScreen> {
-        if (paymentMethodMetadata.paymentMethodOrientation == PaymentMethodOrientation.Vertical) {
+        if (paymentMethodMetadata.paymentMethodOrientation() == PaymentMethodOrientation.Vertical) {
             return VerticalModeInitialScreenFactory.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -697,7 +697,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerStateHolder: CustomerStateHolder,
     ): List<PaymentSheetScreen> {
-        if (paymentMethodMetadata.paymentMethodOrientation == PaymentMethodOrientation.Vertical) {
+        if (paymentMethodMetadata.paymentMethodOrientation() == PaymentMethodOrientation.Vertical) {
             return VerticalModeInitialScreenFactory.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModelCvcHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModelCvcHelper.kt
@@ -6,14 +6,14 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 
 internal fun PaymentSheetViewModel.shouldLaunchCvcRecollectionScreen(selection: PaymentSelection.Saved): Boolean {
     return requiresCvcRecollection(selection) {
-        paymentMethodMetadata.value?.paymentMethodOrientation == PaymentMethodOrientation.Vertical &&
+        paymentMethodMetadata.value?.paymentMethodOrientation() == PaymentMethodOrientation.Vertical &&
             navigationHandler.currentScreen.value !is PaymentSheetScreen.CvcRecollection
     }
 }
 
 internal fun PaymentSheetViewModel.shouldAttachCvc(selection: PaymentSelection.Saved): Boolean {
     return requiresCvcRecollection(selection) {
-        paymentMethodMetadata.value?.paymentMethodOrientation == PaymentMethodOrientation.Horizontal
+        paymentMethodMetadata.value?.paymentMethodOrientation() == PaymentMethodOrientation.Horizontal
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -77,7 +77,7 @@ internal object PaymentMethodMetadataFactory {
         elementsSessionId: String? = null,
         disableSsdOcrCardScan: Boolean = false,
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
-        paymentMethodOrientation: PaymentMethodOrientation = PaymentMethodOrientation.Horizontal,
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -147,7 +147,7 @@ internal object PaymentMethodMetadataFactory {
             elementsSessionId = elementsSessionId,
             disableSsdOcrCardScan = disableSsdOcrCardScan,
             cardArts = cardArts,
-            paymentMethodOrientation = paymentMethodOrientation,
+            paymentMethodLayout = paymentMethodLayout,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -2355,6 +2355,48 @@ internal class PaymentMethodMetadataTest {
             attachDefaultsToPaymentMethod = true,
         )
 
+    @Test
+    fun `paymentMethodOrientation returns Horizontal when layout is Horizontal`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        )
+
+        assertThat(metadata.paymentMethodOrientation()).isEqualTo(PaymentMethodOrientation.Horizontal)
+    }
+
+    @Test
+    fun `paymentMethodOrientation returns Vertical when layout is Vertical`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        )
+
+        assertThat(metadata.paymentMethodOrientation()).isEqualTo(PaymentMethodOrientation.Vertical)
+    }
+
+    @Test
+    fun `paymentMethodOrientation returns Vertical when layout is Automatic and has three payment methods`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna", "affirm"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+        )
+
+        assertThat(metadata.paymentMethodOrientation()).isEqualTo(PaymentMethodOrientation.Vertical)
+    }
+
+    @Test
+    fun `paymentMethodOrientation returns Horizontal when layout is Automatic and has two payment methods`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+        )
+
+        assertThat(metadata.paymentMethodOrientation()).isEqualTo(PaymentMethodOrientation.Horizontal)
+    }
+
     private fun createCustomerSheetConfiguration(
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         defaultBillingDetails: PaymentSheet.BillingDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1216,7 +1216,7 @@ internal class PaymentMethodMetadataTest {
             elementsSessionId = "session_1234",
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
-            paymentMethodOrientation = PaymentMethodOrientation.Horizontal,
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1372,7 +1372,7 @@ internal class PaymentMethodMetadataTest {
             elementsSessionId = "session_1234",
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
-            paymentMethodOrientation = PaymentMethodOrientation.Horizontal,
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -481,7 +481,7 @@ internal class PaymentOptionsViewModelTest {
         }
 
     @Test
-    fun `currentScreen is Form if payment methods is empty and supportedPaymentMethods contains one in automatic`() =
+    fun `currentScreen is AddFirstPaymentMethod if no SPMs and one supportedPaymentMethod in automatic`() =
         runTest {
             val viewModel = createViewModel(
                 args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
@@ -498,12 +498,12 @@ internal class PaymentOptionsViewModelTest {
             )
 
             viewModel.navigationHandler.currentScreen.test {
-                assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
+                assertThat(awaitItem()).isInstanceOf<AddFirstPaymentMethod>()
             }
         }
 
     @Test
-    fun `currentScreen is VerticalMode if payment methods is not empty in automatic`() =
+    fun `currentScreen is SelectSavedPaymentMethods if just one payment method in automatic`() =
         runTest {
             val viewModel = createViewModel(
                 args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
@@ -520,12 +520,12 @@ internal class PaymentOptionsViewModelTest {
             )
 
             viewModel.navigationHandler.currentScreen.test {
-                assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
+                assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
             }
         }
 
     @Test
-    fun `currentScreen is VerticalMode if supportedPaymentMethods is greater than 1 in Automatic`() =
+    fun `currentScreen is VerticalMode if supportedPaymentMethods is greater than 2 in Automatic`() =
         runTest {
             val viewModel = createViewModel(
                 args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
@@ -536,7 +536,7 @@ internal class PaymentOptionsViewModelTest {
                     isGooglePayReady = false,
                     linkState = null,
                     stripeIntent = PaymentIntentFixtures.PI_WITH_PAYMENT_METHOD!!.copy(
-                        paymentMethodTypes = listOf("card", "cashapp")
+                        paymentMethodTypes = listOf("card", "cashapp", "klarna")
                     ),
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -6,7 +6,6 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.BILLING_DETAILS
@@ -193,11 +192,7 @@ internal object PaymentSheetFixtures {
                     stripeIntent = stripeIntent,
                     isGooglePayReady = isGooglePayReady,
                     linkState = linkState,
-                    paymentMethodOrientation = when (config.paymentMethodLayout) {
-                        PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
-                        PaymentSheet.PaymentMethodLayout.Vertical,
-                        PaymentSheet.PaymentMethodLayout.Automatic -> PaymentMethodOrientation.Vertical
-                    }
+                    paymentMethodLayout = config.paymentMethodLayout
                 ),
             ),
             configuration = config,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1526,20 +1526,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `launched with correct screen when in automatic mode`() = runTest {
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
-                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
-                    .build()
-            ),
-        )
-        viewModel.navigationHandler.currentScreen.test {
-            assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.VerticalMode>()
-        }
-    }
-
-    @Test
     fun `handleBackPressed is consumed when processing is true`() = runTest {
         val viewModel = createViewModel(customer = EMPTY_CUSTOMER_STATE)
         viewModel.savedStateHandle[SAVE_PROCESSING] = true
@@ -3058,66 +3044,11 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `requiresCvcRecollection should return correct value in automatic mode`() {
-        var viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
-                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
-                    .build()
-            )
-        )
-
-        val savedSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
-
-        cvcRecollectionHandler.requiresCVCRecollection = true
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isTrue()
-        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
-
-        viewModel.checkout()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
-        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
-
-        cvcRecollectionHandler.requiresCVCRecollection = false
-        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
-
-        viewModel = createViewModel()
-
-        cvcRecollectionHandler.requiresCVCRecollection = true
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
-        assertThat(viewModel.shouldAttachCvc(savedSelection)).isTrue()
-
-        cvcRecollectionHandler.requiresCVCRecollection = false
-        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
-    }
-
-    @Test
     fun `CvcRecollection screen should be displayed on checkout when required in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build()
-            ),
-        )
-
-        cvcRecollectionHandler.requiresCVCRecollection = true
-        cvcRecollectionHandler.cvcRecollectionEnabled = true
-        viewModel.checkout()
-
-        viewModel.navigationHandler.currentScreen.test {
-            val screen = awaitItem()
-            assertThat(screen).isInstanceOf<PaymentSheetScreen.CvcRecollection>()
-        }
-    }
-
-    @Test
-    fun `CvcRecollection screen should be displayed on checkout when required in automatic mode`() = runTest {
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
-                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
                     .build()
             ),
         )
@@ -3181,26 +3112,6 @@ internal class PaymentSheetViewModelTest {
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build()
-            ),
-        )
-
-        cvcRecollectionHandler.requiresCVCRecollection = false
-        cvcRecollectionHandler.cvcRecollectionEnabled = true
-        viewModel.checkout()
-
-        viewModel.navigationHandler.currentScreen.test {
-            val screen = awaitItem()
-            assertThat(screen).isInstanceOf<PaymentSheetScreen.VerticalMode>()
-        }
-    }
-
-    @Test
-    fun `CvcRecollection screen should not be displayed on checkout when not required in automatic mode`() = runTest {
-        val viewModel = createViewModel(
-            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
-                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
                     .build()
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -39,7 +39,6 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
@@ -530,7 +529,7 @@ internal class DefaultFlowControllerTest {
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     hasCustomerConfiguration = true,
                     allowsDelayedPaymentMethods = false,
-                    paymentMethodOrientation = PaymentMethodOrientation.Vertical,
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 ),
             ),
             configuration = PaymentSheet.Configuration("com.stripe.android.paymentsheet.test"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -529,7 +529,7 @@ internal class DefaultFlowControllerTest {
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     hasCustomerConfiguration = true,
                     allowsDelayedPaymentMethods = false,
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
                 ),
             ),
             configuration = PaymentSheet.Configuration("com.stripe.android.paymentsheet.test"),

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -5,7 +5,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
@@ -75,15 +74,11 @@ internal class FakePaymentElementLoader(
             experimentsData = experimentsData,
             integrationMetadata = integrationMetadata
                 ?: PaymentMethodMetadataFactory.defaultIntegrationMetadata(stripeIntent),
-            paymentMethodOrientation = when (integrationConfiguration) {
+            paymentMethodLayout = when (integrationConfiguration) {
                 is PaymentElementLoader.Configuration.CryptoOnramp,
-                is PaymentElementLoader.Configuration.Embedded -> PaymentMethodOrientation.Vertical
+                is PaymentElementLoader.Configuration.Embedded -> PaymentSheet.PaymentMethodLayout.Vertical
                 is PaymentElementLoader.Configuration.PaymentSheet ->
-                    when (integrationConfiguration.configuration.paymentMethodLayout) {
-                        PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
-                        PaymentSheet.PaymentMethodLayout.Vertical,
-                        PaymentSheet.PaymentMethodLayout.Automatic -> PaymentMethodOrientation.Vertical
-                    }
+                    integrationConfiguration.configuration.paymentMethodLayout
             }
         )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Show horizontal layout when payment method layout is automatic and number of PMs is <= 2

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Horizontal mode [ship recommendation](https://docs.google.com/document/d/1yFPCpKiB4q6W_jdvugPI1Bn8WuXMz__W5GfQjKVwqx4/edit?tab=t.sgpiwea5ugmk)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [CHANGED][12975](https://github.com/stripe/stripe-android/pull/12975) When `paymentMethodLayout` is set to `Automatic`, the layout is now horizontal when there are 2 or fewer payment methods available.
