### PR TITLE
Add RetryRule to SSDOcrTest to fix CI flakiness

### DIFF
--- a/stripecardscan/build.gradle
+++ b/stripecardscan/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation testLibs.truth
     testImplementation testLibs.turbine
 
+    androidTestImplementation project(':payments-core-testing')
     androidTestImplementation testLibs.androidx.coreKtx
     androidTestImplementation testLibs.androidx.testRules
     androidTestImplementation testLibs.androidx.testRunner

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/payment/ml/SSDOcrTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/payment/ml/SSDOcrTest.kt
@@ -11,8 +11,10 @@ import com.stripe.android.camera.framework.image.size
 import com.stripe.android.camera.framework.util.toRect
 import com.stripe.android.stripecardscan.framework.ResourceFetcher
 import com.stripe.android.stripecardscan.test.R
+import com.stripe.android.testing.RetryRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -21,6 +23,9 @@ import kotlin.test.assertTrue
 class SSDOcrTest {
     private val appContext = InstrumentationRegistry.getInstrumentation().targetContext
     private val testContext = InstrumentationRegistry.getInstrumentation().context
+
+    @get:Rule
+    val retryRule = RetryRule(3)
 
     @Before
     fun initializeTfLite() {


### PR DESCRIPTION
## Summary
- Add `RetryRule(3)` to `SSDOcrTest` to handle intermittent GMS TFLite Dynamite initialization failures on CI emulators
- Add `androidTestImplementation` dependency on `payments-core-testing` (was only `testImplementation`)

## Motivation
The `run-cardscan-instrumentation-tests` Bitrise workflow flakes when `TfLite.initialize()` fails with `No acceptable module com.google.android.gms.tflite_dynamite found`. This is a timing issue on CI emulators where GMS hasn't finished setting up the TFLite module after boot.

## Test plan
- [x] Verified `RetryRule` is the established pattern for flaky CI tests across the repo
- [ ] Monitor `run-cardscan-instrumentation-tests` on subsequent builds for reduced flake rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)