### PR TITLE
[link] Thread Link brand enum to more places

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -229,18 +229,25 @@ internal class DefaultCustomerSheetLoader(
         return if (metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
             getDefaultPaymentMethodAsPaymentSelection(paymentMethods, customerSheetSession.defaultPaymentMethodId)
         } else {
-            useLocalSelectionAsPaymentSelection(customerSheetSession, paymentMethods)
+            useLocalSelectionAsPaymentSelection(
+                customerSheetSession = customerSheetSession,
+                metadata = metadata,
+                paymentMethods = paymentMethods,
+            )
         }
     }
 
     private fun useLocalSelectionAsPaymentSelection(
         customerSheetSession: CustomerSheetSession,
+        metadata: PaymentMethodMetadata,
         paymentMethods: List<PaymentMethod>
     ): PaymentSelection? {
         return customerSheetSession.savedSelection?.let { selection ->
             when (selection) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay
-                is SavedSelection.Link -> PaymentSelection.Link()
+                is SavedSelection.Link -> PaymentSelection.Link(
+                    linkBrand = metadata.linkBrandOrDefault
+                )
                 is SavedSelection.PaymentMethod -> {
                     paymentMethods.find { paymentMethod ->
                         paymentMethod.id == selection.id

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -246,7 +246,7 @@ internal class DefaultCustomerSheetLoader(
             when (selection) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay
                 is SavedSelection.Link -> PaymentSelection.Link(
-                    linkBrand = metadata.linkBrandOrDefault
+                    linkBrand = metadata.linkBrand
                 )
                 is SavedSelection.PaymentMethod -> {
                     paymentMethods.find { paymentMethod ->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -161,6 +161,7 @@ internal fun SelectPaymentMethod(
         SavedPaymentMethodTabLayoutUI(
             paymentOptionsItems = paymentOptionsState.items,
             selectedPaymentOptionsItem = paymentOptionsState.selectedItem,
+            linkBrand = null,
             isEditing = viewState.isEditing,
             isProcessing = viewState.isProcessing,
             onAddCardPressed = { viewActionHandler(CustomerSheetViewAction.OnAddCardPressed) },

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -55,6 +55,9 @@ internal data class LinkConfiguration(
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null
 
+    val linkBrandOrDefault: LinkBrand
+        get() = linkBrand
+
     val enableLinkPaymentSelectionHint: Boolean
         get() = flags["link_show_prefer_debit_card_hint"] == true
 
@@ -75,6 +78,3 @@ internal data class LinkConfiguration(
         val preferredNetworks: List<String>,
     ) : Parcelable
 }
-
-internal val LinkConfiguration?.linkBrandOrDefault: LinkBrand
-    get() = this?.linkBrand ?: LinkBrand.Link

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -55,9 +55,6 @@ internal data class LinkConfiguration(
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null
 
-    val linkBrandOrDefault: LinkBrand
-        get() = linkBrand
-
     val enableLinkPaymentSelectionHint: Boolean
         get() = flags["link_show_prefer_debit_card_hint"] == true
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -75,3 +75,6 @@ internal data class LinkConfiguration(
         val preferredNetworks: List<String>,
     ) : Parcelable
 }
+
+internal val LinkConfiguration?.linkBrandOrDefault: LinkBrand
+    get() = this?.linkBrand ?: LinkBrand.Link

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -16,6 +16,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.LinkCardBrand
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntent
@@ -101,6 +102,10 @@ internal data class PaymentMethodMetadata(
             is LinkState -> result
             is LinkDisabledState, null -> null
         }
+
+    @IgnoredOnParcel
+    val linkBrandOrDefault: LinkBrand
+        get() = linkState?.configuration?.linkBrand ?: LinkBrand.Link
 
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {
         return when (stripeIntent) {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -104,7 +104,7 @@ internal data class PaymentMethodMetadata(
         }
 
     @IgnoredOnParcel
-    val linkBrandOrDefault: LinkBrand
+    val linkBrand: LinkBrand
         get() = linkState?.configuration?.linkBrand ?: LinkBrand.Link
 
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.embedded.content
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -41,7 +40,7 @@ internal class DefaultEmbeddedWalletsHelper @Inject constructor(
                 walletsAllowedInHeader = emptyList(), // Embedded: all wallets inline, none in header
                 cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
                 cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
-                linkBrand = paymentMethodMetadata.linkState?.configuration?.linkBrand ?: LinkBrand.Link,
+                linkBrand = paymentMethodMetadata.linkBrandOrDefault,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
@@ -40,7 +40,7 @@ internal class DefaultEmbeddedWalletsHelper @Inject constructor(
                 walletsAllowedInHeader = emptyList(), // Embedded: all wallets inline, none in header
                 cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
                 cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
-                linkBrand = paymentMethodMetadata.linkBrandOrDefault,
+                linkBrand = paymentMethodMetadata.linkBrand,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
@@ -33,7 +33,10 @@ internal class DefaultEmbeddedManageScreenInteractorFactory @Inject constructor(
             canEdit = savedPaymentMethodMutator.canEdit,
             toggleEdit = savedPaymentMethodMutator::toggleEditing,
             onSelectPaymentMethod = {
-                val savedPmSelection = PaymentSelection.Saved(it.paymentMethod)
+                val savedPmSelection = PaymentSelection.Saved(
+                    paymentMethod = it.paymentMethod,
+                    linkBrand = it.linkBrand,
+                )
                 selectionHolder.set(savedPmSelection)
                 eventReporter.onSelectPaymentOption(savedPmSelection)
                 embeddedNavigatorProvider.get().performAction(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
@@ -35,7 +35,6 @@ internal class DefaultEmbeddedManageScreenInteractorFactory @Inject constructor(
             onSelectPaymentMethod = {
                 val savedPmSelection = PaymentSelection.Saved(
                     paymentMethod = it.paymentMethod,
-                    linkBrand = it.linkBrand,
                 )
                 selectionHolder.set(savedPmSelection)
                 eventReporter.onSelectPaymentOption(savedPmSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.embedded.manage
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
+import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
@@ -38,34 +39,9 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,
             allowedBillingCountries =
-            paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
-            removeExecutor = { method ->
-                val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
-                if (result == null) {
-                    val currentSelection = selectionHolder.selection.value
-                    if (method.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
-                        selectionHolder.set(null)
-                    }
-                }
-                result
-            },
-            updatePaymentMethodExecutor = { method, cardUpdateParams ->
-                savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(
-                    paymentMethod = method,
-                    cardUpdateParams = cardUpdateParams,
-                    onSuccess = { paymentMethod ->
-                        val currentSelection = selectionHolder.selection.value
-                        if (paymentMethod.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
-                            selectionHolder.set(
-                                PaymentSelection.Saved(
-                                    paymentMethod = paymentMethod,
-                                    linkBrand = currentSelection.linkBrand,
-                                )
-                            )
-                        }
-                    },
-                )
-            },
+                paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
+            removeExecutor = createRemoveExecutor(),
+            updatePaymentMethodExecutor = createUpdatePaymentMethodExecutor(),
             setDefaultPaymentMethodExecutor = { method ->
                 savedPaymentMethodMutatorProvider.get().setDefaultPaymentMethod(method)
             },
@@ -89,5 +65,42 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 embeddedNavigatorProvider.get().performAction(EmbeddedNavigator.Action.Back)
             },
         )
+    }
+
+    private fun createRemoveExecutor(): suspend (com.stripe.android.model.PaymentMethod) -> Throwable? {
+        return { method ->
+            val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
+            if (result == null && method.id == currentSavedSelection()?.paymentMethod?.id) {
+                selectionHolder.set(null)
+            }
+            result
+        }
+    }
+
+    private fun createUpdatePaymentMethodExecutor():
+        suspend (com.stripe.android.model.PaymentMethod, CardUpdateParams) ->
+        Result<com.stripe.android.model.PaymentMethod> {
+        return { method, cardUpdateParams ->
+            savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(
+                paymentMethod = method,
+                cardUpdateParams = cardUpdateParams,
+                onSuccess = { updatedPaymentMethod ->
+                    currentSavedSelection()?.takeIf { currentSelection ->
+                        updatedPaymentMethod.id == currentSelection.paymentMethod.id
+                    }?.let { currentSelection ->
+                        selectionHolder.set(
+                            PaymentSelection.Saved(
+                                paymentMethod = updatedPaymentMethod,
+                                linkBrand = currentSelection.linkBrand,
+                            )
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    private fun currentSavedSelection(): PaymentSelection.Saved? {
+        return selectionHolder.selection.value as? PaymentSelection.Saved
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -56,7 +56,12 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                     onSuccess = { paymentMethod ->
                         val currentSelection = selectionHolder.selection.value
                         if (paymentMethod.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
-                            selectionHolder.set(PaymentSelection.Saved(paymentMethod))
+                            selectionHolder.set(
+                                PaymentSelection.Saved(
+                                    paymentMethod = paymentMethod,
+                                    linkBrand = currentSelection.linkBrand,
+                                )
+                            )
                         }
                     },
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -27,6 +27,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
     private val eventReporter: EventReporter,
     private val embeddedNavigatorProvider: Provider<EmbeddedNavigator>,
 ) : EmbeddedUpdateScreenInteractorFactory {
+    @Suppress("LongMethod")
     override fun createUpdateScreenInteractor(
         displayableSavedPaymentMethod: DisplayableSavedPaymentMethod
     ): UpdatePaymentMethodInteractor {
@@ -41,7 +42,10 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
             removeExecutor = { method ->
                 val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
-                if (result == null && method.id == (selectionHolder.selection.value as? PaymentSelection.Saved)?.paymentMethod?.id) {
+                if (
+                    result == null &&
+                    method.id == (selectionHolder.selection.value as? PaymentSelection.Saved)?.paymentMethod?.id
+                ) {
                     selectionHolder.set(null)
                 }
                 result

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -59,7 +59,6 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                                     paymentMethod = updatedPaymentMethod,
                                     paymentMethodOptionsParams = currentSelection.paymentMethodOptionsParams,
                                     linkInput = currentSelection.linkInput,
-                                    linkBrand = currentSelection.linkBrand,
                                 )
                             )
                         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.embedded.manage
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
-import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
@@ -40,8 +39,33 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,
             allowedBillingCountries =
                 paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
-            removeExecutor = createRemoveExecutor(),
-            updatePaymentMethodExecutor = createUpdatePaymentMethodExecutor(),
+            removeExecutor = { method ->
+                val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
+                if (result == null && method.id == (selectionHolder.selection.value as? PaymentSelection.Saved)?.paymentMethod?.id) {
+                    selectionHolder.set(null)
+                }
+                result
+            },
+            updatePaymentMethodExecutor = { method, cardUpdateParams ->
+                savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(
+                    paymentMethod = method,
+                    cardUpdateParams = cardUpdateParams,
+                    onSuccess = { updatedPaymentMethod ->
+                        (selectionHolder.selection.value as? PaymentSelection.Saved)?.takeIf { currentSelection ->
+                            updatedPaymentMethod.id == currentSelection.paymentMethod.id
+                        }?.let { currentSelection ->
+                            selectionHolder.set(
+                                PaymentSelection.Saved(
+                                    paymentMethod = updatedPaymentMethod,
+                                    paymentMethodOptionsParams = currentSelection.paymentMethodOptionsParams,
+                                    linkInput = currentSelection.linkInput,
+                                    linkBrand = currentSelection.linkBrand,
+                                )
+                            )
+                        }
+                    },
+                )
+            },
             setDefaultPaymentMethodExecutor = { method ->
                 savedPaymentMethodMutatorProvider.get().setDefaultPaymentMethod(method)
             },
@@ -65,42 +89,5 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 embeddedNavigatorProvider.get().performAction(EmbeddedNavigator.Action.Back)
             },
         )
-    }
-
-    private fun createRemoveExecutor(): suspend (com.stripe.android.model.PaymentMethod) -> Throwable? {
-        return { method ->
-            val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
-            if (result == null && method.id == currentSavedSelection()?.paymentMethod?.id) {
-                selectionHolder.set(null)
-            }
-            result
-        }
-    }
-
-    private fun createUpdatePaymentMethodExecutor():
-        suspend (com.stripe.android.model.PaymentMethod, CardUpdateParams) ->
-        Result<com.stripe.android.model.PaymentMethod> {
-        return { method, cardUpdateParams ->
-            savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(
-                paymentMethod = method,
-                cardUpdateParams = cardUpdateParams,
-                onSuccess = { updatedPaymentMethod ->
-                    currentSavedSelection()?.takeIf { currentSelection ->
-                        updatedPaymentMethod.id == currentSelection.paymentMethod.id
-                    }?.let { currentSelection ->
-                        selectionHolder.set(
-                            PaymentSelection.Saved(
-                                paymentMethod = updatedPaymentMethod,
-                                linkBrand = currentSelection.linkBrand,
-                            )
-                        )
-                    }
-                },
-            )
-        }
-    }
-
-    private fun currentSavedSelection(): PaymentSelection.Saved? {
-        return selectionHolder.selection.value as? PaymentSelection.Saved
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
@@ -24,6 +24,7 @@ internal class InitialManageScreenFactory @Inject constructor(
             val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
                 displayName = displayName,
                 paymentMethod = paymentMethod,
+                linkBrand = paymentMethodMetadata.linkBrandOrDefault,
                 isCbcEligible = paymentMethodMetadata.cbcEligibility is CardBrandChoiceEligibility.Eligible,
             )
             EmbeddedNavigator.Screen.ManageUpdate(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.paymentelement.embedded.manage
 
-import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
-import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
 import javax.inject.Inject
 
 internal class InitialManageScreenFactory @Inject constructor(
@@ -18,18 +16,12 @@ internal class InitialManageScreenFactory @Inject constructor(
         val paymentMethods = customerStateHolder.customer.value?.paymentMethods
         return if (paymentMethods?.size == 1) {
             val paymentMethod = paymentMethods.first()
-            val displayName = paymentMethod.type?.code?.let { code ->
-                paymentMethodMetadata.supportedPaymentMethodForCode(code)
-            }?.displayName.orEmpty()
-            val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
-                displayName = displayName,
-                paymentMethod = paymentMethod,
-                linkBrand = paymentMethodMetadata.linkBrand,
-                isCbcEligible = paymentMethodMetadata.cbcEligibility is CardBrandChoiceEligibility.Eligible,
-            )
             EmbeddedNavigator.Screen.ManageUpdate(
                 interactor = updateScreenInteractorFactory.createUpdateScreenInteractor(
-                    displayableSavedPaymentMethod = displayableSavedPaymentMethod
+                    displayableSavedPaymentMethod = paymentMethod.toDisplayableSavedPaymentMethod(
+                        paymentMethodMetadata = paymentMethodMetadata,
+                        defaultPaymentMethodId = null,
+                    )
                 )
             )
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactory.kt
@@ -24,7 +24,7 @@ internal class InitialManageScreenFactory @Inject constructor(
             val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
                 displayName = displayName,
                 paymentMethod = paymentMethod,
-                linkBrand = paymentMethodMetadata.linkBrandOrDefault,
+                linkBrand = paymentMethodMetadata.linkBrand,
                 isCbcEligible = paymentMethodMetadata.cbcEligibility is CardBrandChoiceEligibility.Eligible,
             )
             EmbeddedNavigator.Screen.ManageUpdate(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.DateUtils
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
 
@@ -11,6 +12,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
     val displayName: ResolvableString,
     val paymentMethod: PaymentMethod,
     val savedPaymentMethod: SavedPaymentMethod,
+    val linkBrand: LinkBrand,
     val isCbcEligible: Boolean = false,
     val shouldShowDefaultBadge: Boolean = false,
 ) {
@@ -129,6 +131,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
         fun create(
             displayName: ResolvableString,
             paymentMethod: PaymentMethod,
+            linkBrand: LinkBrand,
             isCbcEligible: Boolean = false,
             shouldShowDefaultBadge: Boolean = false,
         ): DisplayableSavedPaymentMethod {
@@ -158,6 +161,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
                 displayName = displayName,
                 paymentMethod = paymentMethod,
                 savedPaymentMethod = savedPaymentMethod ?: SavedPaymentMethod.Unexpected,
+                linkBrand = linkBrand,
                 isCbcEligible = isCbcEligible,
                 shouldShowDefaultBadge = shouldShowDefaultBadge,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -19,7 +20,9 @@ sealed class PaymentOptionsItem {
         override val isEnabledDuringEditing: Boolean = false
     }
 
-    internal object Link : PaymentOptionsItem() {
+    internal data class Link(
+        val linkBrand: LinkBrand = LinkBrand.Link,
+    ) : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.Link
         override val isEnabledDuringEditing: Boolean = false
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -20,9 +19,7 @@ sealed class PaymentOptionsItem {
         override val isEnabledDuringEditing: Boolean = false
     }
 
-    internal data class Link(
-        val linkBrand: LinkBrand = LinkBrand.Link,
-    ) : PaymentOptionsItem() {
+    internal data object Link : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.Link
         override val isEnabledDuringEditing: Boolean = false
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -16,6 +17,7 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
+        linkBrand: LinkBrand = LinkBrand.Link,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         isCbcEligible: Boolean,
         defaultPaymentMethodId: String?,
@@ -23,7 +25,7 @@ internal object PaymentOptionsStateFactory {
         return listOfNotNull(
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay.takeIf { showGooglePay },
-            PaymentOptionsItem.Link.takeIf { showLink }
+            PaymentOptionsItem.Link(linkBrand).takeIf { showLink }
         ) + paymentMethods.map {
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
@@ -49,6 +51,7 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
+        linkBrand: LinkBrand = LinkBrand.Link,
         currentSelection: PaymentSelection?,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         isCbcEligible: Boolean,
@@ -58,6 +61,7 @@ internal object PaymentOptionsStateFactory {
             paymentMethods = paymentMethods,
             showGooglePay = showGooglePay,
             showLink = showLink,
+            linkBrand = linkBrand,
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible,
             defaultPaymentMethodId = defaultPaymentMethodId
@@ -100,7 +104,7 @@ internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
     return when (this) {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
-        is PaymentOptionsItem.Link -> PaymentSelection.Link()
+        is PaymentOptionsItem.Link -> PaymentSelection.Link(linkBrand = linkBrand)
         is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(paymentMethod)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -31,6 +31,7 @@ internal object PaymentOptionsStateFactory {
                 DisplayableSavedPaymentMethod.create(
                     displayName = nameProvider(it.type?.code),
                     paymentMethod = it,
+                    linkBrand = linkBrand,
                     isCbcEligible = isCbcEligible,
                     shouldShowDefaultBadge = it.id == defaultPaymentMethodId,
                 ),
@@ -105,6 +106,9 @@ internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
         is PaymentOptionsItem.Link -> PaymentSelection.Link(linkBrand = linkBrand)
-        is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(paymentMethod)
+        is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(
+            paymentMethod = paymentMethod,
+            linkBrand = displayableSavedPaymentMethod.linkBrand,
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
@@ -17,7 +18,6 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
-        linkBrand: LinkBrand = LinkBrand.Link,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         isCbcEligible: Boolean,
         defaultPaymentMethodId: String?,
@@ -25,13 +25,13 @@ internal object PaymentOptionsStateFactory {
         return listOfNotNull(
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay.takeIf { showGooglePay },
-            PaymentOptionsItem.Link(linkBrand).takeIf { showLink }
+            PaymentOptionsItem.Link.takeIf { showLink }
         ) + paymentMethods.map {
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = nameProvider(it.type?.code),
                     paymentMethod = it,
-                    linkBrand = linkBrand,
+                    linkBrand = LinkBrand.Link,
                     isCbcEligible = isCbcEligible,
                     shouldShowDefaultBadge = it.id == defaultPaymentMethodId,
                 ),
@@ -52,7 +52,6 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
-        linkBrand: LinkBrand = LinkBrand.Link,
         currentSelection: PaymentSelection?,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         isCbcEligible: Boolean,
@@ -62,7 +61,6 @@ internal object PaymentOptionsStateFactory {
             paymentMethods = paymentMethods,
             showGooglePay = showGooglePay,
             showLink = showLink,
-            linkBrand = linkBrand,
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible,
             defaultPaymentMethodId = defaultPaymentMethodId
@@ -105,10 +103,9 @@ internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
     return when (this) {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
-        is PaymentOptionsItem.Link -> PaymentSelection.Link(linkBrand = linkBrand)
+        PaymentOptionsItem.Link -> PaymentSelection.Link()
         is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(
             paymentMethod = paymentMethod,
-            linkBrand = displayableSavedPaymentMethod.linkBrand,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -24,7 +24,6 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.linkBrandOrDefault
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.gate.LinkGate
@@ -178,7 +177,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             },
             onLinkPressed = {
                 updateSelection(
-                    Link(linkBrand = linkConfiguration.linkBrandOrDefault)
+                    Link(linkBrand = linkConfiguration?.linkBrandOrDefault ?: LinkBrand.Link)
                 )
                 onUserSelection()
             },
@@ -193,7 +192,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 hasLinkWithSelectedPayment.not(),
             cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
-            linkBrand = linkConfiguration.linkBrandOrDefault,
+            linkBrand = linkConfiguration?.linkBrandOrDefault ?: LinkBrand.Link,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -310,6 +310,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     PaymentOptionsActivityResult.Succeeded(
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         paymentSelection = Link(
+                            linkBrand = args.state.paymentMethodMetadata.linkBrandOrDefault,
                             selectedPayment = result.selectedPayment,
                             shippingAddress = result.shippingAddress,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -24,6 +24,7 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.linkBrandOrDefault
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.gate.LinkGate
@@ -176,7 +177,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 onUserSelection()
             },
             onLinkPressed = {
-                updateSelection(Link())
+                updateSelection(
+                    Link(linkBrand = linkConfiguration.linkBrandOrDefault)
+                )
                 onUserSelection()
             },
             onShopPayPressed = {
@@ -190,7 +193,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 hasLinkWithSelectedPayment.not(),
             cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
-            linkBrand = linkConfiguration?.linkBrand ?: LinkBrand.Link,
+            linkBrand = linkConfiguration.linkBrandOrDefault,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -177,7 +177,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             },
             onLinkPressed = {
                 updateSelection(
-                    Link(linkBrand = linkConfiguration?.linkBrandOrDefault ?: LinkBrand.Link)
+                    Link(linkBrand = linkConfiguration?.linkBrand ?: LinkBrand.Link)
                 )
                 onUserSelection()
             },
@@ -192,7 +192,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 hasLinkWithSelectedPayment.not(),
             cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
-            linkBrand = linkConfiguration?.linkBrandOrDefault ?: LinkBrand.Link,
+            linkBrand = linkConfiguration?.linkBrand ?: LinkBrand.Link,
         )
     }
 
@@ -310,7 +310,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     PaymentOptionsActivityResult.Succeeded(
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         paymentSelection = Link(
-                            linkBrand = args.state.paymentMethodMetadata.linkBrandOrDefault,
+                            linkBrand = args.state.paymentMethodMetadata.linkBrand,
                             selectedPayment = result.selectedPayment,
                             shippingAddress = result.shippingAddress,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -216,7 +216,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             walletsAllowedInHeader = WalletType.entries, // PaymentSheet: all wallets in header
             cardFundingFilter = paymentMethodMetadata?.cardFundingFilter ?: DefaultCardFundingFilter,
             cardBrandFilter = paymentMethodMetadata?.cardBrandFilter ?: DefaultCardBrandFilter,
-            linkBrand = paymentMethodMetadata?.linkState?.configuration?.linkBrand ?: LinkBrand.Link,
+            linkBrand = paymentMethodMetadata?.linkBrandOrDefault ?: LinkBrand.Link,
         )
     }
 
@@ -433,6 +433,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     fun checkoutWithLink() {
         checkout(
             PaymentSelection.Link(
+                linkBrand = paymentMethodMetadata.value?.linkBrandOrDefault ?: LinkBrand.Link,
                 linkExpressMode = LinkExpressMode.DISABLED
             ),
             CheckoutIdentifier.SheetTopWallet
@@ -444,6 +445,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         // fails on payment sheet given the OTP shows on launch.
         checkout(
             PaymentSelection.Link(
+                linkBrand = paymentMethodMetadata.value?.linkBrandOrDefault ?: LinkBrand.Link,
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
             ),
             CheckoutIdentifier.SheetTopWallet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -216,7 +216,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             walletsAllowedInHeader = WalletType.entries, // PaymentSheet: all wallets in header
             cardFundingFilter = paymentMethodMetadata?.cardFundingFilter ?: DefaultCardFundingFilter,
             cardBrandFilter = paymentMethodMetadata?.cardBrandFilter ?: DefaultCardBrandFilter,
-            linkBrand = paymentMethodMetadata?.linkBrandOrDefault ?: LinkBrand.Link,
+            linkBrand = paymentMethodMetadata?.linkBrand ?: LinkBrand.Link,
         )
     }
 
@@ -433,7 +433,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     fun checkoutWithLink() {
         checkout(
             PaymentSelection.Link(
-                linkBrand = paymentMethodMetadata.value?.linkBrandOrDefault ?: LinkBrand.Link,
+                linkBrand = paymentMethodMetadata.value?.linkBrand ?: LinkBrand.Link,
                 linkExpressMode = LinkExpressMode.DISABLED
             ),
             CheckoutIdentifier.SheetTopWallet
@@ -445,7 +445,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         // fails on payment sheet given the OTP shows on launch.
         checkout(
             PaymentSelection.Link(
-                linkBrand = paymentMethodMetadata.value?.linkBrandOrDefault ?: LinkBrand.Link,
+                linkBrand = paymentMethodMetadata.value?.linkBrand ?: LinkBrand.Link,
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
             ),
             CheckoutIdentifier.SheetTopWallet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -513,7 +513,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 selection = PaymentSelection.Saved(
                     paymentMethod = it.paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
-                    linkBrand = it.linkBrand,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -512,7 +512,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             updateSelection(
                 selection = PaymentSelection.Saved(
                     paymentMethod = it.paymentMethod,
-                    paymentMethodOptionsParams = paymentMethodOptionsParams
+                    paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    linkBrand = it.linkBrand,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.analytics.EventReporter

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -74,6 +75,7 @@ internal class SavedPaymentMethodMutator(
             customerState = customerStateHolder.customer,
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
             isLinkEnabled = isLinkEnabled,
+            linkBrand = paymentMethodMetadataFlow.mapAsStateFlow { it?.linkBrandOrDefault ?: LinkBrand.Link },
             isNotPaymentFlow = isNotPaymentFlow,
             nameProvider = { paymentMethodMetadataFlow.value?.displayNameForCode(it).orEmpty() },
             isCbcEligible = { paymentMethodMetadataFlow.value?.cbcEligibility is CardBrandChoiceEligibility.Eligible },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -217,7 +217,12 @@ internal class SavedPaymentMethodMutator(
         }.onSuccess {
             withContext(uiContext) {
                 customerStateHolder.setDefaultPaymentMethod(paymentMethod = paymentMethod)
-                setSelection(PaymentSelection.Saved(paymentMethod = paymentMethod))
+                setSelection(
+                    PaymentSelection.Saved(
+                        paymentMethod = paymentMethod,
+                        linkBrand = paymentMethodMetadataFlow.value?.linkBrandOrDefault ?: LinkBrand.Link,
+                    )
+                )
             }
 
             eventReporter.onSetAsDefaultPaymentMethodSucceeded(
@@ -289,7 +294,12 @@ internal class SavedPaymentMethodMutator(
                     )
                 )
                 if (isSelectedPaymentMethod(updatedMethod)) {
-                    setSelection(PaymentSelection.Saved(updatedMethod))
+                    setSelection(
+                        PaymentSelection.Saved(
+                            paymentMethod = updatedMethod,
+                            linkBrand = paymentMethodMetadataFlow.value?.linkBrandOrDefault ?: LinkBrand.Link,
+                        )
+                    )
                 }
 
                 onSuccess(updatedMethod)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -75,7 +75,6 @@ internal class SavedPaymentMethodMutator(
             customerState = customerStateHolder.customer,
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
             isLinkEnabled = isLinkEnabled,
-            linkBrand = paymentMethodMetadataFlow.mapAsStateFlow { it?.linkBrand ?: LinkBrand.Link },
             isNotPaymentFlow = isNotPaymentFlow,
             nameProvider = { paymentMethodMetadataFlow.value?.displayNameForCode(it).orEmpty() },
             isCbcEligible = { paymentMethodMetadataFlow.value?.cbcEligibility is CardBrandChoiceEligibility.Eligible },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -75,7 +75,7 @@ internal class SavedPaymentMethodMutator(
             customerState = customerStateHolder.customer,
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
             isLinkEnabled = isLinkEnabled,
-            linkBrand = paymentMethodMetadataFlow.mapAsStateFlow { it?.linkBrandOrDefault ?: LinkBrand.Link },
+            linkBrand = paymentMethodMetadataFlow.mapAsStateFlow { it?.linkBrand ?: LinkBrand.Link },
             isNotPaymentFlow = isNotPaymentFlow,
             nameProvider = { paymentMethodMetadataFlow.value?.displayNameForCode(it).orEmpty() },
             isCbcEligible = { paymentMethodMetadataFlow.value?.cbcEligibility is CardBrandChoiceEligibility.Eligible },
@@ -220,7 +220,7 @@ internal class SavedPaymentMethodMutator(
                 setSelection(
                     PaymentSelection.Saved(
                         paymentMethod = paymentMethod,
-                        linkBrand = paymentMethodMetadataFlow.value?.linkBrandOrDefault ?: LinkBrand.Link,
+                        linkBrand = paymentMethodMetadataFlow.value?.linkBrand ?: LinkBrand.Link,
                     )
                 )
             }
@@ -297,7 +297,7 @@ internal class SavedPaymentMethodMutator(
                     setSelection(
                         PaymentSelection.Saved(
                             paymentMethod = updatedMethod,
-                            linkBrand = paymentMethodMetadataFlow.value?.linkBrandOrDefault ?: LinkBrand.Link,
+                            linkBrand = paymentMethodMetadataFlow.value?.linkBrand ?: LinkBrand.Link,
                         )
                     )
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -219,7 +219,6 @@ internal class SavedPaymentMethodMutator(
                 setSelection(
                     PaymentSelection.Saved(
                         paymentMethod = paymentMethod,
-                        linkBrand = paymentMethodMetadataFlow.value?.linkBrand ?: LinkBrand.Link,
                     )
                 )
             }
@@ -296,7 +295,6 @@ internal class SavedPaymentMethodMutator(
                     setSelection(
                         PaymentSelection.Saved(
                             paymentMethod = updatedMethod,
-                            linkBrand = paymentMethodMetadataFlow.value?.linkBrand ?: LinkBrand.Link,
                         )
                     )
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -427,7 +427,7 @@ internal class DefaultFlowController @Inject internal constructor(
             }
             is LinkActivityResult.Completed -> with(
                 Link(
-                    linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrandOrDefault
+                    linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrand
                         ?: LinkBrand.Link,
                     selectedPayment = result.selectedPayment,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -308,9 +308,11 @@ internal class DefaultFlowController @Inject internal constructor(
             val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
 
             val shouldPresentLink = linkConfiguration != null && shouldPresentLinkInsteadOfPaymentOptions(
+                declinedLink2FA = viewModel.state?.declinedLink2FA == true,
                 paymentSelection = paymentSelection,
                 linkAccountInfo = linkAccountInfo,
-                linkConfiguration = linkConfiguration
+                linkGateFactory = linkGateFactory,
+                linkConfiguration = linkConfiguration,
             )
 
             if (shouldPresentLink) {
@@ -328,21 +330,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 showPaymentOptionList(state, paymentSelection)
             }
         }
-    }
-
-    private fun shouldPresentLinkInsteadOfPaymentOptions(
-        paymentSelection: PaymentSelection?,
-        linkAccountInfo: LinkAccountUpdate.Value,
-        linkConfiguration: LinkConfiguration
-    ): Boolean {
-        // If the user has declined to use Link in the past, do not show it again.
-        return viewModel.state?.declinedLink2FA != true &&
-            // The current payment selection is Link
-            paymentSelection is Link &&
-            // The current user has a Link account (not necessarily logged in)
-            linkAccountInfo.account != null &&
-            // feature flag and other conditions are met
-            linkGateFactory.create(linkConfiguration).showRuxInFlowController
     }
 
     private fun showPaymentOptionList(
@@ -374,131 +361,25 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    fun onLinkResultFromFlowController(result: LinkActivityResult) {
-        result.linkAccountUpdate?.updateLinkAccount()
-        when (result) {
-            is LinkActivityResult.PaymentMethodObtained,
-            is LinkActivityResult.Failed -> Unit
-            is LinkActivityResult.Canceled -> when (result.reason) {
-                Reason.BackPressed -> withCurrentState {
-                    val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
-                    // The user dismissed the Link 2FA -> prevent from showing it again
-                    if (accountStatus == AccountStatus.VerificationStarted) {
-                        viewModel.updateState { it?.copy(declinedLink2FA = true) }
-                    }
-                    // just show the payment option list if
-                    // the user didn't have any preselected Link payment details
-                    // (preselected Link payment means the user is attempting to change their Link payment method)
-                    if (viewModel.paymentSelection?.readyToPayWithLink() == false) {
-                        showPaymentOptionList(it, viewModel.paymentSelection)
-                    }
-                }
-                Reason.LoggedOut -> {
-                    updateLinkPaymentSelection(linkPaymentMethod = null, canceled = true)
-                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-                }
-                Reason.PayAnotherWay -> {
-                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-                }
-            }
+    fun onLinkResultFromFlowController(result: LinkActivityResult) = handleFlowControllerLinkResult(
+        result = result,
+        viewModel = viewModel,
+        linkAccountHolder = linkAccountHolder,
+        paymentOptionFactory = paymentOptionFactory,
+        paymentOptionResultCallback = paymentOptionResultCallback,
+        withCurrentState = ::withCurrentState,
+        showPaymentOptionList = ::showPaymentOptionList,
+    )
 
-            is LinkActivityResult.Completed -> {
-                updateLinkPaymentSelection(linkPaymentMethod = result.selectedPayment, canceled = false)
-            }
-        }
-    }
-
-    fun onLinkResultFromWalletsButton(result: LinkActivityResult) {
-        result.linkAccountUpdate?.updateLinkAccount()
-        viewModel.flowControllerStateComponent.linkInlineInteractor.onLinkResult()
-        when (result) {
-            is LinkActivityResult.PaymentMethodObtained,
-            is LinkActivityResult.Failed -> Unit
-            is LinkActivityResult.Canceled -> when (result.reason) {
-                // User pressed back in Link
-                Reason.BackPressed -> Unit
-                // User logged out of Link -> clear the Link payment selection
-                Reason.LoggedOut -> updateLinkPaymentSelection(null, canceled = true)
-                // User pressed "Pay another way" in Link -> show the payment option list
-                Reason.PayAnotherWay -> withCurrentState {
-                    showPaymentOptionList(it, viewModel.paymentSelection)
-                }
-            }
-            is LinkActivityResult.Completed -> with(
-                Link(
-                    linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrandOrDefault
-                        ?: LinkBrand.Link,
-                    selectedPayment = result.selectedPayment,
-                )
-            ) {
-                viewModel.paymentSelection = this
-                paymentOptionResultCallback.onPaymentOptionResult(
-                    PaymentOptionResult(
-                        paymentOption = paymentOptionFactory.create(this),
-                        didCancel = false,
-                    )
-                )
-            }
-        }
-    }
-
-    fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
-        is Link -> selectedPayment != null
-        else -> isLink
-    }
-
-    /**
-     * Updates the Link account state in FlowController after receiving a [LinkAccountUpdate]
-     *
-     * - Calls [LinkAccountHolder.set] to update the Link account state
-     * - Updates the Link account state in the [PaymentSheetState] with the latest [AccountStatus]
-     */
-    private fun LinkAccountUpdate.updateLinkAccount() {
-        updateLinkAccount(linkAccountHolder)
-        when (this) {
-            is LinkAccountUpdate.Value -> {
-                val currentState = viewModel.state ?: return
-                val metadata = currentState.paymentSheetState.paymentMethodMetadata
-                val accountStatus = account?.accountStatus ?: AccountStatus.SignedOut
-                val linkStateResult = when (val result = metadata.linkStateResult) {
-                    is LinkState -> result.copy(loginState = accountStatus.toLoginState())
-                    is LinkDisabledState, null -> result
-                }
-                val updatedMetadata = metadata.copy(linkStateResult = linkStateResult)
-                viewModel.state = currentState.copyPaymentSheetState(metadata = updatedMetadata)
-            }
-            LinkAccountUpdate.None -> Unit
-        }
-    }
-
-    /**
-     * If the current payment selection is Link and Link details changed, update the payment selection accordingly.
-     */
-    private fun updateLinkPaymentSelection(
-        linkPaymentMethod: LinkPaymentMethod?,
-        canceled: Boolean,
-    ) {
-        val paymentSelection = viewModel.paymentSelection
-        if (paymentSelection is Link) {
-            val newSelection = if (linkPaymentMethod != null) {
-                // User updated their Link PM - update the Link selection
-                paymentSelection.copy(
-                    selectedPayment = linkPaymentMethod
-                )
-            } else {
-                // User logged out - determine best fallback payment method,
-                // or clear selection if there is no fallback
-                viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
-            }
-            viewModel.paymentSelection = newSelection
-            val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }
-            val result = PaymentOptionResult(
-                paymentOption = paymentOption,
-                didCancel = canceled,
-            )
-            paymentOptionResultCallback.onPaymentOptionResult(result)
-        }
-    }
+    fun onLinkResultFromWalletsButton(result: LinkActivityResult) = handleWalletsButtonLinkResult(
+        result = result,
+        viewModel = viewModel,
+        linkAccountHolder = linkAccountHolder,
+        paymentOptionFactory = paymentOptionFactory,
+        paymentOptionResultCallback = paymentOptionResultCallback,
+        withCurrentState = ::withCurrentState,
+        showPaymentOptionList = ::showPaymentOptionList,
+    )
 
     override fun confirm() {
         val state = viewModel.state
@@ -618,26 +499,24 @@ internal class DefaultFlowController @Inject internal constructor(
         when (result) {
             is PaymentOptionsActivityResult.Succeeded -> {
                 viewModel.paymentSelection = result.paymentSelection.also { it.hasAcknowledgedSepaMandate = true }
-                onPaymentSelection(canceled = false)
+                onPaymentSelection(
+                    paymentSelection = viewModel.paymentSelection,
+                    canceled = false,
+                    paymentOptionFactory = paymentOptionFactory,
+                    paymentOptionResultCallback = paymentOptionResultCallback,
+                )
             }
             null,
             is PaymentOptionsActivityResult.Canceled -> {
                 viewModel.paymentSelection = result?.paymentSelection
-                onPaymentSelection(canceled = true)
+                onPaymentSelection(
+                    paymentSelection = viewModel.paymentSelection,
+                    canceled = true,
+                    paymentOptionFactory = paymentOptionFactory,
+                    paymentOptionResultCallback = paymentOptionResultCallback,
+                )
             }
         }
-    }
-
-    private fun onPaymentSelection(canceled: Boolean) {
-        val paymentSelection = viewModel.paymentSelection
-        val paymentOption = paymentSelection?.let { paymentOptionFactory.create(it) }
-
-        paymentOptionResultCallback.onPaymentOptionResult(
-            PaymentOptionResult(
-                paymentOption = paymentOption,
-                didCancel = canceled,
-            )
-        )
     }
 
     private fun onIntentResult(result: ConfirmationHandler.Result) {
@@ -678,22 +557,18 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             }
             is ConfirmationHandler.Result.Canceled -> {
-                handleCancellation(result)
-            }
-        }
-    }
-
-    private fun handleCancellation(canceled: ConfirmationHandler.Result.Canceled) {
-        when (canceled.action) {
-            ConfirmationHandler.Result.Canceled.Action.InformCancellation -> {
-                onPaymentResult(
-                    paymentResult = PaymentResult.Canceled,
-                    deferredIntentConfirmationType = null,
-                    shouldLog = false,
+                handleCancellation(
+                    canceled = result,
+                    presentPaymentOptions = ::presentPaymentOptions,
+                    onPaymentResult = { paymentResult ->
+                        onPaymentResult(
+                            paymentResult = paymentResult,
+                            deferredIntentConfirmationType = null,
+                            shouldLog = false,
+                        )
+                    }
                 )
             }
-            ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails -> presentPaymentOptions()
-            ConfirmationHandler.Result.Canceled.Action.None -> Unit
         }
     }
 
@@ -705,12 +580,18 @@ internal class DefaultFlowController @Inject internal constructor(
         intentId: String? = null,
     ) {
         if (shouldLog) {
-            logPaymentResult(paymentResult, deferredIntentConfirmationType, intentId)
+            logPaymentResult(
+                paymentResult = paymentResult,
+                paymentSelection = viewModel.paymentSelection,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
+                intentId = intentId,
+                eventReporter = eventReporter,
+            )
         }
 
         val selection = viewModel.paymentSelection
 
-        if (shouldLogOutFromLink(paymentResult, selection)) {
+        if (shouldLogOutFromLink(paymentResult, selection, viewModel.state?.linkConfiguration)) {
             linkHandler.logOut()
         }
 
@@ -728,63 +609,12 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    private fun shouldLogOutFromLink(
-        paymentResult: PaymentResult,
-        selection: PaymentSelection?
-    ): Boolean {
-        val verifiedMerchant = viewModel.state?.linkConfiguration?.useAttestationEndpointsForLink == true
-        return paymentResult is PaymentResult.Completed && selection != null &&
-            selection.isLink &&
-            // Only log out non-verified merchants.
-            verifiedMerchant.not()
-    }
-
-    internal fun onSepaMandateResult(sepaMandateResult: SepaMandateResult) {
-        when (sepaMandateResult) {
-            SepaMandateResult.Acknowledged -> {
-                viewModel.paymentSelection?.hasAcknowledgedSepaMandate = true
-                confirm()
-            }
-            SepaMandateResult.Canceled -> {
-                paymentResultCallback.onPaymentSheetResult(PaymentSheetResult.Canceled())
-            }
-        }
-    }
-
-    private fun logPaymentResult(
-        paymentResult: PaymentResult?,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intentId: String?,
-    ) {
-        when (paymentResult) {
-            is PaymentResult.Completed -> {
-                viewModel.paymentSelection?.let { paymentSelection ->
-                    eventReporter.onPaymentSuccess(
-                        paymentSelection = paymentSelection,
-                        deferredIntentConfirmationType = deferredIntentConfirmationType,
-                        intentId = intentId,
-                    )
-                }
-            }
-            is PaymentResult.Failed -> {
-                viewModel.paymentSelection?.let { paymentSelection ->
-                    eventReporter.onPaymentFailure(
-                        paymentSelection = paymentSelection,
-                        error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
-                    )
-                }
-            }
-            else -> {
-                // Nothing to do here
-            }
-        }
-    }
-
-    private fun PaymentResult.convertToPaymentSheetResult() = when (this) {
-        is PaymentResult.Completed -> PaymentSheetResult.Completed()
-        is PaymentResult.Canceled -> PaymentSheetResult.Canceled()
-        is PaymentResult.Failed -> PaymentSheetResult.Failed(throwable)
-    }
+    internal fun onSepaMandateResult(sepaMandateResult: SepaMandateResult) = onSepaMandateResult(
+        sepaMandateResult = sepaMandateResult,
+        viewModel = viewModel,
+        confirm = ::confirm,
+        paymentResultCallback = paymentResultCallback,
+    )
 
     @Parcelize
     data class Args(
@@ -854,4 +684,256 @@ internal class DefaultFlowController @Inject internal constructor(
             return flowController
         }
     }
+}
+
+private fun shouldPresentLinkInsteadOfPaymentOptions(
+    declinedLink2FA: Boolean,
+    paymentSelection: PaymentSelection?,
+    linkAccountInfo: LinkAccountUpdate.Value,
+    linkGateFactory: LinkGate.Factory,
+    linkConfiguration: LinkConfiguration,
+): Boolean {
+    return !declinedLink2FA &&
+        paymentSelection is Link &&
+        linkAccountInfo.account != null &&
+        linkGateFactory.create(linkConfiguration).showRuxInFlowController
+}
+
+private fun handleFlowControllerLinkResult(
+    result: LinkActivityResult,
+    viewModel: FlowControllerViewModel,
+    linkAccountHolder: LinkAccountHolder,
+    paymentOptionFactory: PaymentOptionFactory,
+    paymentOptionResultCallback: PaymentOptionResultCallback,
+    withCurrentState: ((DefaultFlowController.State) -> Unit) -> Unit,
+    showPaymentOptionList: (DefaultFlowController.State, PaymentSelection?) -> Unit,
+) {
+    result.linkAccountUpdate?.updateLinkAccount(viewModel, linkAccountHolder)
+    when (result) {
+        is LinkActivityResult.PaymentMethodObtained,
+        is LinkActivityResult.Failed -> Unit
+        is LinkActivityResult.Canceled -> when (result.reason) {
+            Reason.BackPressed -> withCurrentState { state ->
+                val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
+                if (accountStatus == AccountStatus.VerificationStarted) {
+                    viewModel.updateState { it?.copy(declinedLink2FA = true) }
+                }
+                if (viewModel.paymentSelection?.readyToPayWithLink() == false) {
+                    showPaymentOptionList(state, viewModel.paymentSelection)
+                }
+            }
+            Reason.LoggedOut -> {
+                updateLinkPaymentSelection(
+                    viewModel = viewModel,
+                    linkPaymentMethod = null,
+                    canceled = true,
+                    paymentOptionFactory = paymentOptionFactory,
+                    paymentOptionResultCallback = paymentOptionResultCallback,
+                )
+                withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+            }
+            Reason.PayAnotherWay -> {
+                withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+            }
+        }
+        is LinkActivityResult.Completed -> {
+            updateLinkPaymentSelection(
+                viewModel = viewModel,
+                linkPaymentMethod = result.selectedPayment,
+                canceled = false,
+                paymentOptionFactory = paymentOptionFactory,
+                paymentOptionResultCallback = paymentOptionResultCallback,
+            )
+        }
+    }
+}
+
+private fun handleWalletsButtonLinkResult(
+    result: LinkActivityResult,
+    viewModel: FlowControllerViewModel,
+    linkAccountHolder: LinkAccountHolder,
+    paymentOptionFactory: PaymentOptionFactory,
+    paymentOptionResultCallback: PaymentOptionResultCallback,
+    withCurrentState: ((DefaultFlowController.State) -> Unit) -> Unit,
+    showPaymentOptionList: (DefaultFlowController.State, PaymentSelection?) -> Unit,
+) {
+    result.linkAccountUpdate?.updateLinkAccount(viewModel, linkAccountHolder)
+    viewModel.flowControllerStateComponent.linkInlineInteractor.onLinkResult()
+    when (result) {
+        is LinkActivityResult.PaymentMethodObtained,
+        is LinkActivityResult.Failed -> Unit
+        is LinkActivityResult.Canceled -> when (result.reason) {
+            Reason.BackPressed -> Unit
+            Reason.LoggedOut -> {
+                updateLinkPaymentSelection(
+                    viewModel = viewModel,
+                    linkPaymentMethod = null,
+                    canceled = true,
+                    paymentOptionFactory = paymentOptionFactory,
+                    paymentOptionResultCallback = paymentOptionResultCallback,
+                )
+            }
+            Reason.PayAnotherWay -> withCurrentState {
+                showPaymentOptionList(it, viewModel.paymentSelection)
+            }
+        }
+        is LinkActivityResult.Completed -> with(
+            Link(
+                linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrandOrDefault
+                    ?: LinkBrand.Link,
+                selectedPayment = result.selectedPayment,
+            )
+        ) {
+            viewModel.paymentSelection = this
+            paymentOptionResultCallback.onPaymentOptionResult(
+                PaymentOptionResult(
+                    paymentOption = paymentOptionFactory.create(this),
+                    didCancel = false,
+                )
+            )
+        }
+    }
+}
+
+private fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
+    is Link -> selectedPayment != null
+    else -> isLink
+}
+
+private fun LinkAccountUpdate.updateLinkAccount(
+    viewModel: FlowControllerViewModel,
+    linkAccountHolder: LinkAccountHolder,
+) {
+    updateLinkAccount(linkAccountHolder)
+    when (this) {
+        is LinkAccountUpdate.Value -> {
+            val currentState = viewModel.state ?: return
+            val metadata = currentState.paymentSheetState.paymentMethodMetadata
+            val accountStatus = account?.accountStatus ?: AccountStatus.SignedOut
+            val linkStateResult = when (val result = metadata.linkStateResult) {
+                is LinkState -> result.copy(loginState = accountStatus.toLoginState())
+                is LinkDisabledState, null -> result
+            }
+            val updatedMetadata = metadata.copy(linkStateResult = linkStateResult)
+            viewModel.state = currentState.copyPaymentSheetState(metadata = updatedMetadata)
+        }
+        LinkAccountUpdate.None -> Unit
+    }
+}
+
+private fun updateLinkPaymentSelection(
+    viewModel: FlowControllerViewModel,
+    linkPaymentMethod: LinkPaymentMethod?,
+    canceled: Boolean,
+    paymentOptionFactory: PaymentOptionFactory,
+    paymentOptionResultCallback: PaymentOptionResultCallback,
+) {
+    val paymentSelection = viewModel.paymentSelection
+    if (paymentSelection is Link) {
+        val newSelection = if (linkPaymentMethod != null) {
+            paymentSelection.copy(selectedPayment = linkPaymentMethod)
+        } else {
+            viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
+        }
+        viewModel.paymentSelection = newSelection
+        val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }
+        paymentOptionResultCallback.onPaymentOptionResult(
+            PaymentOptionResult(
+                paymentOption = paymentOption,
+                didCancel = canceled,
+            )
+        )
+    }
+}
+
+private fun onPaymentSelection(
+    paymentSelection: PaymentSelection?,
+    canceled: Boolean,
+    paymentOptionFactory: PaymentOptionFactory,
+    paymentOptionResultCallback: PaymentOptionResultCallback,
+) {
+    val paymentOption = paymentSelection?.let { paymentOptionFactory.create(it) }
+    paymentOptionResultCallback.onPaymentOptionResult(
+        PaymentOptionResult(
+            paymentOption = paymentOption,
+            didCancel = canceled,
+        )
+    )
+}
+
+private fun handleCancellation(
+    canceled: ConfirmationHandler.Result.Canceled,
+    presentPaymentOptions: () -> Unit,
+    onPaymentResult: (PaymentResult) -> Unit,
+) {
+    when (canceled.action) {
+        ConfirmationHandler.Result.Canceled.Action.InformCancellation -> {
+            onPaymentResult(PaymentResult.Canceled)
+        }
+        ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails -> presentPaymentOptions()
+        ConfirmationHandler.Result.Canceled.Action.None -> Unit
+    }
+}
+
+private fun onSepaMandateResult(
+    sepaMandateResult: SepaMandateResult,
+    viewModel: FlowControllerViewModel,
+    confirm: () -> Unit,
+    paymentResultCallback: PaymentSheetResultCallback,
+) {
+    when (sepaMandateResult) {
+        SepaMandateResult.Acknowledged -> {
+            viewModel.paymentSelection?.hasAcknowledgedSepaMandate = true
+            confirm()
+        }
+        SepaMandateResult.Canceled -> {
+            paymentResultCallback.onPaymentSheetResult(PaymentSheetResult.Canceled())
+        }
+    }
+}
+
+private fun shouldLogOutFromLink(
+    paymentResult: PaymentResult,
+    selection: PaymentSelection?,
+    linkConfiguration: LinkConfiguration?,
+): Boolean {
+    val verifiedMerchant = linkConfiguration?.useAttestationEndpointsForLink == true
+    return paymentResult is PaymentResult.Completed && selection != null &&
+        selection.isLink &&
+        verifiedMerchant.not()
+}
+
+private fun logPaymentResult(
+    paymentResult: PaymentResult?,
+    paymentSelection: PaymentSelection?,
+    deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+    intentId: String?,
+    eventReporter: EventReporter,
+) {
+    when (paymentResult) {
+        is PaymentResult.Completed -> {
+            paymentSelection?.let { selection ->
+                eventReporter.onPaymentSuccess(
+                    paymentSelection = selection,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                    intentId = intentId,
+                )
+            }
+        }
+        is PaymentResult.Failed -> {
+            paymentSelection?.let { selection ->
+                eventReporter.onPaymentFailure(
+                    paymentSelection = selection,
+                    error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
+                )
+            }
+        }
+        else -> Unit
+    }
+}
+
+private fun PaymentResult.convertToPaymentSheetResult() = when (this) {
+    is PaymentResult.Completed -> PaymentSheetResult.Completed()
+    is PaymentResult.Canceled -> PaymentSheetResult.Canceled()
+    is PaymentResult.Failed -> PaymentSheetResult.Failed(throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -38,6 +38,7 @@ import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.WalletButtonsPreview
@@ -423,7 +424,13 @@ internal class DefaultFlowController @Inject internal constructor(
                     showPaymentOptionList(it, viewModel.paymentSelection)
                 }
             }
-            is LinkActivityResult.Completed -> with(Link(selectedPayment = result.selectedPayment)) {
+            is LinkActivityResult.Completed -> with(
+                Link(
+                    linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrandOrDefault
+                        ?: LinkBrand.Link,
+                    selectedPayment = result.selectedPayment,
+                )
+            ) {
                 viewModel.paymentSelection = this
                 paymentOptionResultCallback.onPaymentOptionResult(
                     PaymentOptionResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -87,6 +87,7 @@ import javax.inject.Named
 
 @OptIn(WalletButtonsPreview::class)
 @FlowControllerScope
+@Suppress("LargeClass")
 internal class DefaultFlowController @Inject internal constructor(
     private val viewModelScope: CoroutineScope,
     private val lifecycleOwner: LifecycleOwner,
@@ -308,11 +309,9 @@ internal class DefaultFlowController @Inject internal constructor(
             val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
 
             val shouldPresentLink = linkConfiguration != null && shouldPresentLinkInsteadOfPaymentOptions(
-                declinedLink2FA = viewModel.state?.declinedLink2FA == true,
                 paymentSelection = paymentSelection,
                 linkAccountInfo = linkAccountInfo,
-                linkGateFactory = linkGateFactory,
-                linkConfiguration = linkConfiguration,
+                linkConfiguration = linkConfiguration
             )
 
             if (shouldPresentLink) {
@@ -330,6 +329,21 @@ internal class DefaultFlowController @Inject internal constructor(
                 showPaymentOptionList(state, paymentSelection)
             }
         }
+    }
+
+    private fun shouldPresentLinkInsteadOfPaymentOptions(
+        paymentSelection: PaymentSelection?,
+        linkAccountInfo: LinkAccountUpdate.Value,
+        linkConfiguration: LinkConfiguration
+    ): Boolean {
+        // If the user has declined to use Link in the past, do not show it again.
+        return viewModel.state?.declinedLink2FA != true &&
+            // The current payment selection is Link
+            paymentSelection is Link &&
+            // The current user has a Link account (not necessarily logged in)
+            linkAccountInfo.account != null &&
+            // feature flag and other conditions are met
+            linkGateFactory.create(linkConfiguration).showRuxInFlowController
     }
 
     private fun showPaymentOptionList(
@@ -361,25 +375,131 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    fun onLinkResultFromFlowController(result: LinkActivityResult) = handleFlowControllerLinkResult(
-        result = result,
-        viewModel = viewModel,
-        linkAccountHolder = linkAccountHolder,
-        paymentOptionFactory = paymentOptionFactory,
-        paymentOptionResultCallback = paymentOptionResultCallback,
-        withCurrentState = ::withCurrentState,
-        showPaymentOptionList = ::showPaymentOptionList,
-    )
+    fun onLinkResultFromFlowController(result: LinkActivityResult) {
+        result.linkAccountUpdate?.updateLinkAccount()
+        when (result) {
+            is LinkActivityResult.PaymentMethodObtained,
+            is LinkActivityResult.Failed -> Unit
+            is LinkActivityResult.Canceled -> when (result.reason) {
+                Reason.BackPressed -> withCurrentState {
+                    val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
+                    // The user dismissed the Link 2FA -> prevent from showing it again
+                    if (accountStatus == AccountStatus.VerificationStarted) {
+                        viewModel.updateState { it?.copy(declinedLink2FA = true) }
+                    }
+                    // just show the payment option list if
+                    // the user didn't have any preselected Link payment details
+                    // (preselected Link payment means the user is attempting to change their Link payment method)
+                    if (viewModel.paymentSelection?.readyToPayWithLink() == false) {
+                        showPaymentOptionList(it, viewModel.paymentSelection)
+                    }
+                }
+                Reason.LoggedOut -> {
+                    updateLinkPaymentSelection(linkPaymentMethod = null, canceled = true)
+                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+                }
+                Reason.PayAnotherWay -> {
+                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+                }
+            }
 
-    fun onLinkResultFromWalletsButton(result: LinkActivityResult) = handleWalletsButtonLinkResult(
-        result = result,
-        viewModel = viewModel,
-        linkAccountHolder = linkAccountHolder,
-        paymentOptionFactory = paymentOptionFactory,
-        paymentOptionResultCallback = paymentOptionResultCallback,
-        withCurrentState = ::withCurrentState,
-        showPaymentOptionList = ::showPaymentOptionList,
-    )
+            is LinkActivityResult.Completed -> {
+                updateLinkPaymentSelection(linkPaymentMethod = result.selectedPayment, canceled = false)
+            }
+        }
+    }
+
+    fun onLinkResultFromWalletsButton(result: LinkActivityResult) {
+        result.linkAccountUpdate?.updateLinkAccount()
+        viewModel.flowControllerStateComponent.linkInlineInteractor.onLinkResult()
+        when (result) {
+            is LinkActivityResult.PaymentMethodObtained,
+            is LinkActivityResult.Failed -> Unit
+            is LinkActivityResult.Canceled -> when (result.reason) {
+                // User pressed back in Link
+                Reason.BackPressed -> Unit
+                // User logged out of Link -> clear the Link payment selection
+                Reason.LoggedOut -> updateLinkPaymentSelection(null, canceled = true)
+                // User pressed "Pay another way" in Link -> show the payment option list
+                Reason.PayAnotherWay -> withCurrentState {
+                    showPaymentOptionList(it, viewModel.paymentSelection)
+                }
+            }
+            is LinkActivityResult.Completed -> with(
+                Link(
+                    linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrandOrDefault
+                        ?: LinkBrand.Link,
+                    selectedPayment = result.selectedPayment,
+                )
+            ) {
+                viewModel.paymentSelection = this
+                paymentOptionResultCallback.onPaymentOptionResult(
+                    PaymentOptionResult(
+                        paymentOption = paymentOptionFactory.create(this),
+                        didCancel = false,
+                    )
+                )
+            }
+        }
+    }
+
+    fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
+        is Link -> selectedPayment != null
+        else -> isLink
+    }
+
+    /**
+     * Updates the Link account state in FlowController after receiving a [LinkAccountUpdate]
+     *
+     * - Calls [LinkAccountHolder.set] to update the Link account state
+     * - Updates the Link account state in the [PaymentSheetState] with the latest [AccountStatus]
+     */
+    private fun LinkAccountUpdate.updateLinkAccount() {
+        updateLinkAccount(linkAccountHolder)
+        when (this) {
+            is LinkAccountUpdate.Value -> {
+                val currentState = viewModel.state ?: return
+                val metadata = currentState.paymentSheetState.paymentMethodMetadata
+                val accountStatus = account?.accountStatus ?: AccountStatus.SignedOut
+                val linkStateResult = when (val result = metadata.linkStateResult) {
+                    is LinkState -> result.copy(loginState = accountStatus.toLoginState())
+                    is LinkDisabledState, null -> result
+                }
+                val updatedMetadata = metadata.copy(linkStateResult = linkStateResult)
+                viewModel.state = currentState.copyPaymentSheetState(metadata = updatedMetadata)
+            }
+            LinkAccountUpdate.None -> Unit
+        }
+    }
+
+    /**
+     * If the current payment selection is Link and Link details changed, update the payment selection accordingly.
+     */
+    private fun updateLinkPaymentSelection(
+        linkPaymentMethod: LinkPaymentMethod?,
+        canceled: Boolean,
+    ) {
+        val paymentSelection = viewModel.paymentSelection
+        if (paymentSelection is Link) {
+            val newSelection = if (linkPaymentMethod != null) {
+                // User updated their Link PM - update the Link selection
+                paymentSelection.copy(
+                    selectedPayment = linkPaymentMethod
+                )
+            } else {
+                // User logged out - determine best fallback payment method,
+                // or clear selection if there is no fallback
+                viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
+            }
+            viewModel.paymentSelection = newSelection
+            val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }
+            val result = PaymentOptionResult(
+                paymentOption = paymentOption,
+                didCancel = canceled,
+            )
+            paymentOptionResultCallback.onPaymentOptionResult(result)
+        }
+    }
 
     override fun confirm() {
         val state = viewModel.state
@@ -499,24 +619,26 @@ internal class DefaultFlowController @Inject internal constructor(
         when (result) {
             is PaymentOptionsActivityResult.Succeeded -> {
                 viewModel.paymentSelection = result.paymentSelection.also { it.hasAcknowledgedSepaMandate = true }
-                onPaymentSelection(
-                    paymentSelection = viewModel.paymentSelection,
-                    canceled = false,
-                    paymentOptionFactory = paymentOptionFactory,
-                    paymentOptionResultCallback = paymentOptionResultCallback,
-                )
+                onPaymentSelection(canceled = false)
             }
             null,
             is PaymentOptionsActivityResult.Canceled -> {
                 viewModel.paymentSelection = result?.paymentSelection
-                onPaymentSelection(
-                    paymentSelection = viewModel.paymentSelection,
-                    canceled = true,
-                    paymentOptionFactory = paymentOptionFactory,
-                    paymentOptionResultCallback = paymentOptionResultCallback,
-                )
+                onPaymentSelection(canceled = true)
             }
         }
+    }
+
+    private fun onPaymentSelection(canceled: Boolean) {
+        val paymentSelection = viewModel.paymentSelection
+        val paymentOption = paymentSelection?.let { paymentOptionFactory.create(it) }
+
+        paymentOptionResultCallback.onPaymentOptionResult(
+            PaymentOptionResult(
+                paymentOption = paymentOption,
+                didCancel = canceled,
+            )
+        )
     }
 
     private fun onIntentResult(result: ConfirmationHandler.Result) {
@@ -557,18 +679,22 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             }
             is ConfirmationHandler.Result.Canceled -> {
-                handleCancellation(
-                    canceled = result,
-                    presentPaymentOptions = ::presentPaymentOptions,
-                    onPaymentResult = { paymentResult ->
-                        onPaymentResult(
-                            paymentResult = paymentResult,
-                            deferredIntentConfirmationType = null,
-                            shouldLog = false,
-                        )
-                    }
+                handleCancellation(result)
+            }
+        }
+    }
+
+    private fun handleCancellation(canceled: ConfirmationHandler.Result.Canceled) {
+        when (canceled.action) {
+            ConfirmationHandler.Result.Canceled.Action.InformCancellation -> {
+                onPaymentResult(
+                    paymentResult = PaymentResult.Canceled,
+                    deferredIntentConfirmationType = null,
+                    shouldLog = false,
                 )
             }
+            ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails -> presentPaymentOptions()
+            ConfirmationHandler.Result.Canceled.Action.None -> Unit
         }
     }
 
@@ -580,18 +706,12 @@ internal class DefaultFlowController @Inject internal constructor(
         intentId: String? = null,
     ) {
         if (shouldLog) {
-            logPaymentResult(
-                paymentResult = paymentResult,
-                paymentSelection = viewModel.paymentSelection,
-                deferredIntentConfirmationType = deferredIntentConfirmationType,
-                intentId = intentId,
-                eventReporter = eventReporter,
-            )
+            logPaymentResult(paymentResult, deferredIntentConfirmationType, intentId)
         }
 
         val selection = viewModel.paymentSelection
 
-        if (shouldLogOutFromLink(paymentResult, selection, viewModel.state?.linkConfiguration)) {
+        if (shouldLogOutFromLink(paymentResult, selection)) {
             linkHandler.logOut()
         }
 
@@ -609,12 +729,63 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    internal fun onSepaMandateResult(sepaMandateResult: SepaMandateResult) = onSepaMandateResult(
-        sepaMandateResult = sepaMandateResult,
-        viewModel = viewModel,
-        confirm = ::confirm,
-        paymentResultCallback = paymentResultCallback,
-    )
+    private fun shouldLogOutFromLink(
+        paymentResult: PaymentResult,
+        selection: PaymentSelection?
+    ): Boolean {
+        val verifiedMerchant = viewModel.state?.linkConfiguration?.useAttestationEndpointsForLink == true
+        return paymentResult is PaymentResult.Completed && selection != null &&
+            selection.isLink &&
+            // Only log out non-verified merchants.
+            verifiedMerchant.not()
+    }
+
+    internal fun onSepaMandateResult(sepaMandateResult: SepaMandateResult) {
+        when (sepaMandateResult) {
+            SepaMandateResult.Acknowledged -> {
+                viewModel.paymentSelection?.hasAcknowledgedSepaMandate = true
+                confirm()
+            }
+            SepaMandateResult.Canceled -> {
+                paymentResultCallback.onPaymentSheetResult(PaymentSheetResult.Canceled())
+            }
+        }
+    }
+
+    private fun logPaymentResult(
+        paymentResult: PaymentResult?,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        intentId: String?,
+    ) {
+        when (paymentResult) {
+            is PaymentResult.Completed -> {
+                viewModel.paymentSelection?.let { paymentSelection ->
+                    eventReporter.onPaymentSuccess(
+                        paymentSelection = paymentSelection,
+                        deferredIntentConfirmationType = deferredIntentConfirmationType,
+                        intentId = intentId,
+                    )
+                }
+            }
+            is PaymentResult.Failed -> {
+                viewModel.paymentSelection?.let { paymentSelection ->
+                    eventReporter.onPaymentFailure(
+                        paymentSelection = paymentSelection,
+                        error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
+                    )
+                }
+            }
+            else -> {
+                // Nothing to do here
+            }
+        }
+    }
+
+    private fun PaymentResult.convertToPaymentSheetResult() = when (this) {
+        is PaymentResult.Completed -> PaymentSheetResult.Completed()
+        is PaymentResult.Canceled -> PaymentSheetResult.Canceled()
+        is PaymentResult.Failed -> PaymentSheetResult.Failed(throwable)
+    }
 
     @Parcelize
     data class Args(
@@ -684,256 +855,4 @@ internal class DefaultFlowController @Inject internal constructor(
             return flowController
         }
     }
-}
-
-private fun shouldPresentLinkInsteadOfPaymentOptions(
-    declinedLink2FA: Boolean,
-    paymentSelection: PaymentSelection?,
-    linkAccountInfo: LinkAccountUpdate.Value,
-    linkGateFactory: LinkGate.Factory,
-    linkConfiguration: LinkConfiguration,
-): Boolean {
-    return !declinedLink2FA &&
-        paymentSelection is Link &&
-        linkAccountInfo.account != null &&
-        linkGateFactory.create(linkConfiguration).showRuxInFlowController
-}
-
-private fun handleFlowControllerLinkResult(
-    result: LinkActivityResult,
-    viewModel: FlowControllerViewModel,
-    linkAccountHolder: LinkAccountHolder,
-    paymentOptionFactory: PaymentOptionFactory,
-    paymentOptionResultCallback: PaymentOptionResultCallback,
-    withCurrentState: ((DefaultFlowController.State) -> Unit) -> Unit,
-    showPaymentOptionList: (DefaultFlowController.State, PaymentSelection?) -> Unit,
-) {
-    result.linkAccountUpdate?.updateLinkAccount(viewModel, linkAccountHolder)
-    when (result) {
-        is LinkActivityResult.PaymentMethodObtained,
-        is LinkActivityResult.Failed -> Unit
-        is LinkActivityResult.Canceled -> when (result.reason) {
-            Reason.BackPressed -> withCurrentState { state ->
-                val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
-                if (accountStatus == AccountStatus.VerificationStarted) {
-                    viewModel.updateState { it?.copy(declinedLink2FA = true) }
-                }
-                if (viewModel.paymentSelection?.readyToPayWithLink() == false) {
-                    showPaymentOptionList(state, viewModel.paymentSelection)
-                }
-            }
-            Reason.LoggedOut -> {
-                updateLinkPaymentSelection(
-                    viewModel = viewModel,
-                    linkPaymentMethod = null,
-                    canceled = true,
-                    paymentOptionFactory = paymentOptionFactory,
-                    paymentOptionResultCallback = paymentOptionResultCallback,
-                )
-                withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-            }
-            Reason.PayAnotherWay -> {
-                withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-            }
-        }
-        is LinkActivityResult.Completed -> {
-            updateLinkPaymentSelection(
-                viewModel = viewModel,
-                linkPaymentMethod = result.selectedPayment,
-                canceled = false,
-                paymentOptionFactory = paymentOptionFactory,
-                paymentOptionResultCallback = paymentOptionResultCallback,
-            )
-        }
-    }
-}
-
-private fun handleWalletsButtonLinkResult(
-    result: LinkActivityResult,
-    viewModel: FlowControllerViewModel,
-    linkAccountHolder: LinkAccountHolder,
-    paymentOptionFactory: PaymentOptionFactory,
-    paymentOptionResultCallback: PaymentOptionResultCallback,
-    withCurrentState: ((DefaultFlowController.State) -> Unit) -> Unit,
-    showPaymentOptionList: (DefaultFlowController.State, PaymentSelection?) -> Unit,
-) {
-    result.linkAccountUpdate?.updateLinkAccount(viewModel, linkAccountHolder)
-    viewModel.flowControllerStateComponent.linkInlineInteractor.onLinkResult()
-    when (result) {
-        is LinkActivityResult.PaymentMethodObtained,
-        is LinkActivityResult.Failed -> Unit
-        is LinkActivityResult.Canceled -> when (result.reason) {
-            Reason.BackPressed -> Unit
-            Reason.LoggedOut -> {
-                updateLinkPaymentSelection(
-                    viewModel = viewModel,
-                    linkPaymentMethod = null,
-                    canceled = true,
-                    paymentOptionFactory = paymentOptionFactory,
-                    paymentOptionResultCallback = paymentOptionResultCallback,
-                )
-            }
-            Reason.PayAnotherWay -> withCurrentState {
-                showPaymentOptionList(it, viewModel.paymentSelection)
-            }
-        }
-        is LinkActivityResult.Completed -> with(
-            Link(
-                linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.linkBrandOrDefault
-                    ?: LinkBrand.Link,
-                selectedPayment = result.selectedPayment,
-            )
-        ) {
-            viewModel.paymentSelection = this
-            paymentOptionResultCallback.onPaymentOptionResult(
-                PaymentOptionResult(
-                    paymentOption = paymentOptionFactory.create(this),
-                    didCancel = false,
-                )
-            )
-        }
-    }
-}
-
-private fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
-    is Link -> selectedPayment != null
-    else -> isLink
-}
-
-private fun LinkAccountUpdate.updateLinkAccount(
-    viewModel: FlowControllerViewModel,
-    linkAccountHolder: LinkAccountHolder,
-) {
-    updateLinkAccount(linkAccountHolder)
-    when (this) {
-        is LinkAccountUpdate.Value -> {
-            val currentState = viewModel.state ?: return
-            val metadata = currentState.paymentSheetState.paymentMethodMetadata
-            val accountStatus = account?.accountStatus ?: AccountStatus.SignedOut
-            val linkStateResult = when (val result = metadata.linkStateResult) {
-                is LinkState -> result.copy(loginState = accountStatus.toLoginState())
-                is LinkDisabledState, null -> result
-            }
-            val updatedMetadata = metadata.copy(linkStateResult = linkStateResult)
-            viewModel.state = currentState.copyPaymentSheetState(metadata = updatedMetadata)
-        }
-        LinkAccountUpdate.None -> Unit
-    }
-}
-
-private fun updateLinkPaymentSelection(
-    viewModel: FlowControllerViewModel,
-    linkPaymentMethod: LinkPaymentMethod?,
-    canceled: Boolean,
-    paymentOptionFactory: PaymentOptionFactory,
-    paymentOptionResultCallback: PaymentOptionResultCallback,
-) {
-    val paymentSelection = viewModel.paymentSelection
-    if (paymentSelection is Link) {
-        val newSelection = if (linkPaymentMethod != null) {
-            paymentSelection.copy(selectedPayment = linkPaymentMethod)
-        } else {
-            viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
-        }
-        viewModel.paymentSelection = newSelection
-        val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }
-        paymentOptionResultCallback.onPaymentOptionResult(
-            PaymentOptionResult(
-                paymentOption = paymentOption,
-                didCancel = canceled,
-            )
-        )
-    }
-}
-
-private fun onPaymentSelection(
-    paymentSelection: PaymentSelection?,
-    canceled: Boolean,
-    paymentOptionFactory: PaymentOptionFactory,
-    paymentOptionResultCallback: PaymentOptionResultCallback,
-) {
-    val paymentOption = paymentSelection?.let { paymentOptionFactory.create(it) }
-    paymentOptionResultCallback.onPaymentOptionResult(
-        PaymentOptionResult(
-            paymentOption = paymentOption,
-            didCancel = canceled,
-        )
-    )
-}
-
-private fun handleCancellation(
-    canceled: ConfirmationHandler.Result.Canceled,
-    presentPaymentOptions: () -> Unit,
-    onPaymentResult: (PaymentResult) -> Unit,
-) {
-    when (canceled.action) {
-        ConfirmationHandler.Result.Canceled.Action.InformCancellation -> {
-            onPaymentResult(PaymentResult.Canceled)
-        }
-        ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails -> presentPaymentOptions()
-        ConfirmationHandler.Result.Canceled.Action.None -> Unit
-    }
-}
-
-private fun onSepaMandateResult(
-    sepaMandateResult: SepaMandateResult,
-    viewModel: FlowControllerViewModel,
-    confirm: () -> Unit,
-    paymentResultCallback: PaymentSheetResultCallback,
-) {
-    when (sepaMandateResult) {
-        SepaMandateResult.Acknowledged -> {
-            viewModel.paymentSelection?.hasAcknowledgedSepaMandate = true
-            confirm()
-        }
-        SepaMandateResult.Canceled -> {
-            paymentResultCallback.onPaymentSheetResult(PaymentSheetResult.Canceled())
-        }
-    }
-}
-
-private fun shouldLogOutFromLink(
-    paymentResult: PaymentResult,
-    selection: PaymentSelection?,
-    linkConfiguration: LinkConfiguration?,
-): Boolean {
-    val verifiedMerchant = linkConfiguration?.useAttestationEndpointsForLink == true
-    return paymentResult is PaymentResult.Completed && selection != null &&
-        selection.isLink &&
-        verifiedMerchant.not()
-}
-
-private fun logPaymentResult(
-    paymentResult: PaymentResult?,
-    paymentSelection: PaymentSelection?,
-    deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-    intentId: String?,
-    eventReporter: EventReporter,
-) {
-    when (paymentResult) {
-        is PaymentResult.Completed -> {
-            paymentSelection?.let { selection ->
-                eventReporter.onPaymentSuccess(
-                    paymentSelection = selection,
-                    deferredIntentConfirmationType = deferredIntentConfirmationType,
-                    intentId = intentId,
-                )
-            }
-        }
-        is PaymentResult.Failed -> {
-            paymentSelection?.let { selection ->
-                eventReporter.onPaymentFailure(
-                    paymentSelection = selection,
-                    error = PaymentSheetConfirmationError.Stripe(paymentResult.throwable),
-                )
-            }
-        }
-        else -> Unit
-    }
-}
-
-private fun PaymentResult.convertToPaymentSheetResult() = when (this) {
-    is PaymentResult.Completed -> PaymentSheetResult.Completed()
-    is PaymentResult.Canceled -> PaymentSheetResult.Canceled()
-    is PaymentResult.Failed -> PaymentSheetResult.Failed(throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import android.content.Context
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -11,16 +12,48 @@ internal class PaymentOptionFactory @Inject constructor(
     private val cardArtDrawableLoader: PaymentOptionCardArtDrawableLoader,
     private val context: Context,
 ) {
-    fun create(selection: PaymentSelection): PaymentOption {
+    fun create(
+        selection: PaymentSelection,
+    ): PaymentOption {
+        return createInternal(
+            selection = selection,
+            linkBrand = null,
+        )
+    }
+
+    fun create(
+        selection: PaymentSelection,
+        linkBrand: LinkBrand,
+    ): PaymentOption {
+        return createInternal(
+            selection = selection,
+            linkBrand = linkBrand,
+        )
+    }
+
+    private fun createInternal(
+        selection: PaymentSelection,
+        linkBrand: LinkBrand?,
+    ): PaymentOption {
         val drawableResourceId = selection.drawableResourceId
         val lightThemeIconUrl = selection.lightThemeIconUrl
         val darkThemeIconUrl = selection.darkThemeIconUrl
 
         return PaymentOption(
             drawableResourceId = drawableResourceId,
-            label = selection.label.resolve(context),
+            label = when (linkBrand) {
+                null -> selection.label
+                else -> selection.label(linkBrand)
+            }.resolve(context),
             paymentMethodType = selection.paymentMethodType,
-            _labels = PaymentOptionLabelsFactory.create(context, selection),
+            _labels = when (linkBrand) {
+                null -> PaymentOptionLabelsFactory.create(context, selection)
+                else -> PaymentOptionLabelsFactory.create(
+                    context = context,
+                    selection = selection,
+                    linkBrand = linkBrand,
+                )
+            },
             billingDetails = selection.billingDetails?.toPaymentSheetBillingDetails(),
             _shippingDetails = selection.shippingDetails,
             imageLoader = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.model
 import android.content.Context
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.wallet.paymentOptionLabel
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkPaymentDetails
@@ -16,7 +17,46 @@ internal object PaymentOptionLabelsFactory {
         context: Context,
         selection: PaymentSelection,
     ): PaymentOption.Labels {
-        val label = selection.label.resolve(context)
+        return createInternal(
+            context = context,
+            selection = selection,
+            linkBrand = null,
+        )
+    }
+
+    fun create(
+        context: Context,
+        selection: PaymentSelection,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): PaymentOption.Labels {
+        return createInternal(
+            context = context,
+            selection = selection,
+            linkBrand = paymentMethodMetadata.linkBrand,
+        )
+    }
+
+    fun create(
+        context: Context,
+        selection: PaymentSelection,
+        linkBrand: LinkBrand,
+    ): PaymentOption.Labels {
+        return createInternal(
+            context = context,
+            selection = selection,
+            linkBrand = linkBrand,
+        )
+    }
+
+    private fun createInternal(
+        context: Context,
+        selection: PaymentSelection,
+        linkBrand: LinkBrand?,
+    ): PaymentOption.Labels {
+        val label = when (linkBrand) {
+            null -> selection.label
+            else -> selection.label(linkBrand)
+        }.resolve(context)
         val fallback = PaymentOption.Labels(
             label = label,
             sublabel = null,
@@ -38,7 +78,7 @@ internal object PaymentOptionLabelsFactory {
             }
             is PaymentSelection.Saved -> {
                 selection.paymentMethod.run {
-                    linkPaymentDetails?.let { savedLink(context, it, selection.linkBrand) }
+                    linkPaymentDetails?.let { savedLink(context, it, linkBrand ?: LinkBrand.Link) }
                         ?: card?.let { savedCard(context, it) }
                         ?: usBankAccount?.let { savedUSBankAccount(it, label) }
                         ?: fallback

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -53,10 +53,7 @@ internal object PaymentOptionLabelsFactory {
         selection: PaymentSelection,
         linkBrand: LinkBrand?,
     ): PaymentOption.Labels {
-        val label = when (linkBrand) {
-            null -> selection.label
-            else -> selection.label(linkBrand)
-        }.resolve(context)
+        val label = selection.resolveLabel(context, linkBrand)
         val fallback = PaymentOption.Labels(
             label = label,
             sublabel = null,
@@ -77,16 +74,36 @@ internal object PaymentOptionLabelsFactory {
                 newUSBankAccount(context, selection)
             }
             is PaymentSelection.Saved -> {
-                selection.paymentMethod.run {
-                    linkPaymentDetails?.let { savedLink(context, it, linkBrand ?: LinkBrand.Link) }
-                        ?: card?.let { savedCard(context, it) }
-                        ?: usBankAccount?.let { savedUSBankAccount(it, label) }
-                        ?: fallback
-                }
+                savedSelection(context, selection, label, linkBrand) ?: fallback
             }
             is PaymentSelection.Link -> {
                 link(context, selection)
             }
+        }
+    }
+
+    private fun PaymentSelection.resolveLabel(
+        context: Context,
+        linkBrand: LinkBrand?,
+    ): String {
+        val resolvableLabel = if (linkBrand == null) {
+            label
+        } else {
+            label(linkBrand)
+        }
+        return resolvableLabel.resolve(context)
+    }
+
+    private fun savedSelection(
+        context: Context,
+        selection: PaymentSelection.Saved,
+        label: String,
+        linkBrand: LinkBrand?,
+    ): PaymentOption.Labels? {
+        return selection.paymentMethod.run {
+            linkPaymentDetails?.let { savedLink(context, it, linkBrand ?: LinkBrand.Link) }
+                ?: card?.let { savedCard(context, it) }
+                ?: usBankAccount?.let { savedUSBankAccount(it, label) }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.wallet.paymentOptionLabel
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ui.createCardLabel
@@ -38,7 +39,7 @@ internal object PaymentOptionLabelsFactory {
             }
             is PaymentSelection.Saved -> {
                 selection.paymentMethod.run {
-                    linkPaymentDetails?.let { savedLink(context, it) }
+                    linkPaymentDetails?.let { savedLink(context, it, selection.linkBrand) }
                         ?: card?.let { savedCard(context, it) }
                         ?: usBankAccount?.let { savedUSBankAccount(it, label) }
                         ?: fallback
@@ -75,9 +76,10 @@ internal object PaymentOptionLabelsFactory {
     private fun savedLink(
         context: Context,
         linkDetails: LinkPaymentDetails,
+        linkBrand: LinkBrand,
     ): PaymentOption.Labels {
         return PaymentOption.Labels(
-            label = R.string.stripe_link.resolvableString.resolve(context),
+            label = linkBrand.resolvableString.resolve(context),
             sublabel = linkDetails.paymentOptionLabel.resolve(context),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.model
 
 import android.content.Context
-import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.wallet.paymentOptionLabel
 import com.stripe.android.model.CardBrand

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.model
 import android.content.Context
 import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.ui.wallet.paymentOptionLabel
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkPaymentDetails
@@ -46,7 +45,7 @@ internal object PaymentOptionLabelsFactory {
                 }
             }
             is PaymentSelection.Link -> {
-                link(context, selection.selectedPayment)
+                link(context, selection)
             }
         }
     }
@@ -126,11 +125,11 @@ internal object PaymentOptionLabelsFactory {
 
     private fun link(
         context: Context,
-        paymentMethod: LinkPaymentMethod?,
+        selection: PaymentSelection.Link,
     ): PaymentOption.Labels {
-        val sublabel = paymentMethod?.details?.paymentOptionLabel?.resolve(context)
+        val sublabel = selection.selectedPayment?.details?.paymentOptionLabel?.resolve(context)
         return PaymentOption.Labels(
-            label = R.string.stripe_link.resolvableString.resolve(context),
+            label = selection.linkBrand.resolvableString.resolve(context),
             sublabel = sublabel,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -163,6 +163,7 @@ internal sealed class PaymentSelection : Parcelable {
         val paymentMethod: PaymentMethod,
         val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
         val linkInput: UserInput? = null,
+        val linkBrand: LinkBrand = LinkBrand.Link,
     ) : PaymentSelection() {
         val showMandateAbovePrimaryButton: Boolean
             get() {
@@ -441,7 +442,10 @@ internal val LinkBrand.resolvableString: ResolvableString
     }
 
 private fun getSavedLabel(selection: PaymentSelection.Saved): ResolvableString? {
-    return selection.paymentMethod.getLabel(canShowSublabel = true)
+    return selection.paymentMethod.getLabel(
+        canShowSublabel = true,
+        linkBrand = selection.linkBrand,
+    )
 }
 
 internal val PaymentSelection.paymentMethodType: String

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -163,7 +163,6 @@ internal sealed class PaymentSelection : Parcelable {
         val paymentMethod: PaymentMethod,
         val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
         val linkInput: UserInput? = null,
-        val linkBrand: LinkBrand = LinkBrand.Link,
     ) : PaymentSelection() {
         val showMandateAbovePrimaryButton: Boolean
             get() {
@@ -423,15 +422,19 @@ internal val PaymentSelection.darkThemeIconUrl: String?
     }
 
 internal val PaymentSelection.label: ResolvableString
-    get() = when (this) {
+    get() = labelWithLinkBrand()
+
+internal fun PaymentSelection.label(linkBrand: LinkBrand): ResolvableString = labelWithLinkBrand(linkBrand)
+
+private fun PaymentSelection.labelWithLinkBrand(linkBrand: LinkBrand? = null): ResolvableString = when (this) {
         is PaymentSelection.ExternalPaymentMethod -> label
         is PaymentSelection.CustomPaymentMethod -> label
         PaymentSelection.GooglePay -> StripeR.string.stripe_google_pay.resolvableString
-        is PaymentSelection.Link -> linkBrand.resolvableString
+        is PaymentSelection.Link -> (linkBrand ?: this.linkBrand).resolvableString
         is PaymentSelection.New.Card -> createCardLabel(last4).orEmpty()
         is PaymentSelection.New.GenericPaymentMethod -> label
         is PaymentSelection.New.USBankAccount -> label.resolvableString
-        is PaymentSelection.Saved -> getSavedLabel(this).orEmpty()
+        is PaymentSelection.Saved -> getSavedLabel(this, linkBrand ?: LinkBrand.Link).orEmpty()
         is PaymentSelection.ShopPay -> StripeR.string.stripe_shop_pay.resolvableString
     }
 
@@ -441,10 +444,13 @@ internal val LinkBrand.resolvableString: ResolvableString
         LinkBrand.Notlink -> StripeR.string.stripe_notlink.resolvableString
     }
 
-private fun getSavedLabel(selection: PaymentSelection.Saved): ResolvableString? {
+private fun getSavedLabel(
+    selection: PaymentSelection.Saved,
+    linkBrand: LinkBrand,
+): ResolvableString? {
     return selection.paymentMethod.getLabel(
         canShowSublabel = true,
-        linkBrand = selection.linkBrand,
+        linkBrand = linkBrand,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -449,7 +449,6 @@ private fun getSavedLabel(
     linkBrand: LinkBrand,
 ): ResolvableString? {
     return selection.paymentMethod.getLabel(
-        canShowSublabel = true,
         linkBrand = linkBrand,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerShippingAddress
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
@@ -73,6 +74,7 @@ internal sealed class PaymentSelection : Parcelable {
 
     @Parcelize
     data class Link(
+        val linkBrand: LinkBrand = LinkBrand.Link,
         val linkExpressMode: LinkExpressMode = LinkExpressMode.DISABLED,
         val selectedPayment: LinkPaymentMethod? = null,
         val shippingAddress: ConsumerShippingAddress? = null,
@@ -424,12 +426,18 @@ internal val PaymentSelection.label: ResolvableString
         is PaymentSelection.ExternalPaymentMethod -> label
         is PaymentSelection.CustomPaymentMethod -> label
         PaymentSelection.GooglePay -> StripeR.string.stripe_google_pay.resolvableString
-        is PaymentSelection.Link -> StripeR.string.stripe_link.resolvableString
+        is PaymentSelection.Link -> linkBrand.resolvableString
         is PaymentSelection.New.Card -> createCardLabel(last4).orEmpty()
         is PaymentSelection.New.GenericPaymentMethod -> label
         is PaymentSelection.New.USBankAccount -> label.resolvableString
         is PaymentSelection.Saved -> getSavedLabel(this).orEmpty()
         is PaymentSelection.ShopPay -> StripeR.string.stripe_shop_pay.resolvableString
+    }
+
+internal val LinkBrand.resolvableString: ResolvableString
+    get() = when (this) {
+        LinkBrand.Link -> StripeR.string.stripe_link.resolvableString
+        LinkBrand.Notlink -> StripeR.string.stripe_notlink.resolvableString
     }
 
 private fun getSavedLabel(selection: PaymentSelection.Saved): ResolvableString? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -586,7 +586,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val primaryPaymentSelection = if (isDefaultPaymentMethodEnabled) {
             customer?.paymentMethods?.firstOrNull {
                 customer.defaultPaymentMethodId != null && it.id == customer.defaultPaymentMethodId
-            }?.toPaymentSelection(linkBrand = metadata.linkBrand)
+            }?.toPaymentSelection()
         } else {
             when (val selection = savedSelection.await()) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay.takeIf {
@@ -600,7 +600,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 is SavedSelection.PaymentMethod -> {
                     val customerPaymentMethod = customer?.paymentMethods?.find { it.id == selection.id }
                     if (customerPaymentMethod != null) {
-                        customerPaymentMethod.toPaymentSelection(linkBrand = metadata.linkBrand)
+                        customerPaymentMethod.toPaymentSelection()
                     } else if (selection.isLinkOrigin) {
                         // The payment method wasn't attached to the customer, but is of Link origin. Offer
                         // Link as the initial payment selection.
@@ -618,7 +618,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
 
         return primaryPaymentSelection
-            ?: customer?.paymentMethods?.firstOrNull()?.toPaymentSelection(linkBrand = metadata.linkBrand)
+            ?: customer?.paymentMethods?.firstOrNull()?.toPaymentSelection()
             ?: PaymentSelection.GooglePay.takeIf {
                 !isUsingWalletButtons && isGooglePayReady
             }
@@ -765,10 +765,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     }
 }
 
-private fun PaymentMethod.toPaymentSelection(linkBrand: LinkBrand = LinkBrand.Link): PaymentSelection.Saved {
+private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
     return PaymentSelection.Saved(
         paymentMethod = this,
-        linkBrand = linkBrand,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -26,7 +26,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.create
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -586,26 +586,26 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val primaryPaymentSelection = if (isDefaultPaymentMethodEnabled) {
             customer?.paymentMethods?.firstOrNull {
                 customer.defaultPaymentMethodId != null && it.id == customer.defaultPaymentMethodId
-            }?.toPaymentSelection(linkBrand = metadata.linkBrandOrDefault)
+            }?.toPaymentSelection(linkBrand = metadata.linkBrand)
         } else {
             when (val selection = savedSelection.await()) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay.takeIf {
                     !isUsingWalletButtons && isGooglePayReady
                 }
                 is SavedSelection.Link -> PaymentSelection.Link(
-                    linkBrand = metadata.linkBrandOrDefault
+                    linkBrand = metadata.linkBrand
                 ).takeIf {
                     !isUsingWalletButtons
                 }
                 is SavedSelection.PaymentMethod -> {
                     val customerPaymentMethod = customer?.paymentMethods?.find { it.id == selection.id }
                     if (customerPaymentMethod != null) {
-                        customerPaymentMethod.toPaymentSelection(linkBrand = metadata.linkBrandOrDefault)
+                        customerPaymentMethod.toPaymentSelection(linkBrand = metadata.linkBrand)
                     } else if (selection.isLinkOrigin) {
                         // The payment method wasn't attached to the customer, but is of Link origin. Offer
                         // Link as the initial payment selection.
                         PaymentSelection.Link(
-                            linkBrand = metadata.linkBrandOrDefault
+                            linkBrand = metadata.linkBrand
                         ).takeIf {
                             !isUsingWalletButtons
                         }
@@ -618,7 +618,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
 
         return primaryPaymentSelection
-            ?: customer?.paymentMethods?.firstOrNull()?.toPaymentSelection(linkBrand = metadata.linkBrandOrDefault)
+            ?: customer?.paymentMethods?.firstOrNull()?.toPaymentSelection(linkBrand = metadata.linkBrand)
             ?: PaymentSelection.GooglePay.takeIf {
                 !isUsingWalletButtons && isGooglePayReady
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -26,6 +26,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.create
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -585,7 +586,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val primaryPaymentSelection = if (isDefaultPaymentMethodEnabled) {
             customer?.paymentMethods?.firstOrNull {
                 customer.defaultPaymentMethodId != null && it.id == customer.defaultPaymentMethodId
-            }?.toPaymentSelection()
+            }?.toPaymentSelection(linkBrand = metadata.linkBrandOrDefault)
         } else {
             when (val selection = savedSelection.await()) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay.takeIf {
@@ -599,7 +600,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 is SavedSelection.PaymentMethod -> {
                     val customerPaymentMethod = customer?.paymentMethods?.find { it.id == selection.id }
                     if (customerPaymentMethod != null) {
-                        customerPaymentMethod.toPaymentSelection()
+                        customerPaymentMethod.toPaymentSelection(linkBrand = metadata.linkBrandOrDefault)
                     } else if (selection.isLinkOrigin) {
                         // The payment method wasn't attached to the customer, but is of Link origin. Offer
                         // Link as the initial payment selection.
@@ -617,7 +618,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
 
         return primaryPaymentSelection
-            ?: customer?.paymentMethods?.firstOrNull()?.toPaymentSelection()
+            ?: customer?.paymentMethods?.firstOrNull()?.toPaymentSelection(linkBrand = metadata.linkBrandOrDefault)
             ?: PaymentSelection.GooglePay.takeIf {
                 !isUsingWalletButtons && isGooglePayReady
             }
@@ -764,8 +765,11 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     }
 }
 
-private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
-    return PaymentSelection.Saved(this)
+private fun PaymentMethod.toPaymentSelection(linkBrand: LinkBrand = LinkBrand.Link): PaymentSelection.Saved {
+    return PaymentSelection.Saved(
+        paymentMethod = this,
+        linkBrand = linkBrand,
+    )
 }
 
 private suspend fun <T> Deferred<T>.completeResultOrNull(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -591,7 +591,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay.takeIf {
                     !isUsingWalletButtons && isGooglePayReady
                 }
-                is SavedSelection.Link -> PaymentSelection.Link().takeIf {
+                is SavedSelection.Link -> PaymentSelection.Link(
+                    linkBrand = metadata.linkBrandOrDefault
+                ).takeIf {
                     !isUsingWalletButtons
                 }
                 is SavedSelection.PaymentMethod -> {
@@ -601,7 +603,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     } else if (selection.isLinkOrigin) {
                         // The payment method wasn't attached to the customer, but is of Link origin. Offer
                         // Link as the initial payment selection.
-                        PaymentSelection.Link().takeIf {
+                        PaymentSelection.Link(
+                            linkBrand = metadata.linkBrandOrDefault
+                        ).takeIf {
                             !isUsingWalletButtons
                         }
                     } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsState.kt
@@ -81,7 +81,7 @@ internal data class WalletsState(
     data class Link(
         val state: LinkButtonState,
         val theme: LinkButtonTheme = LinkButtonTheme.DEFAULT,
-        val linkBrand: LinkBrand = LinkBrand.Link,
+        val linkBrand: LinkBrand,
     ) : Wallet
 
     data class GooglePay(
@@ -116,7 +116,7 @@ internal data class WalletsState(
             ),
             cardFundingFilter: CardFundingFilter,
             cardBrandFilter: CardBrandFilter,
-            linkBrand: LinkBrand = LinkBrand.Link,
+            linkBrand: LinkBrand?,
         ): WalletsState? {
             val link = createLink(
                 isLinkAvailable = isLinkAvailable,
@@ -160,9 +160,9 @@ internal data class WalletsState(
             paymentDetails: DisplayablePaymentDetails?,
             enableDefaultValues: Boolean,
             buttonThemes: PaymentSheet.ButtonThemes,
-            linkBrand: LinkBrand,
+            linkBrand: LinkBrand?,
         ): Link? {
-            return if (isLinkAvailable == true) {
+            return if (isLinkAvailable == true && linkBrand != null) {
                 Link(
                     state = LinkButtonState.create(
                         linkEmail = linkEmail,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -227,22 +227,12 @@ private fun getOverridableIcon(
 
 internal fun PaymentMethod.getLabel(
     canShowSublabel: Boolean = false,
-    linkBrand: LinkBrand = LinkBrand.Link,
+    linkBrand: LinkBrand? = null,
 ): ResolvableString? = when (type) {
-    PaymentMethod.Type.Card -> if (isLinkPassthroughMode) {
-        if (canShowSublabel) {
-            // For Link passthrough mode, show the active Link brand as the main label.
-            linkBrand.resolvableString
-        } else {
-            // Show original card label as sublabel
-            createCardLabel(card?.last4)
-        }
-    } else if (isLinkPaymentMethod) {
-        if (canShowSublabel) {
-            linkPaymentDetails?.label
-        } else {
-            linkPaymentDetails?.sublabel
-        }
+    PaymentMethod.Type.Card -> if (isLinkPassthroughMode || isLinkPaymentMethod) {
+        requireNotNull(linkBrand) {
+            "Link brand is required for Link-backed saved payment method labels."
+        }.resolvableString
     } else {
         createCardLabel(card?.last4)
     }
@@ -250,22 +240,20 @@ internal fun PaymentMethod.getLabel(
         R.string.stripe_paymentsheet_payment_method_item_card_number,
         sepaDebit?.last4
     )
-    PaymentMethod.Type.USBankAccount -> if (isLinkPassthroughMode && canShowSublabel) {
-        // For Link passthrough mode, show the active Link brand as the main label.
-        linkBrand.resolvableString
+    PaymentMethod.Type.USBankAccount -> if (isLinkPassthroughMode) {
+        requireNotNull(linkBrand) {
+            "Link brand is required for Link-backed saved payment method labels."
+        }.resolvableString
     } else {
-        // Show original bank account label
         resolvableString(
             R.string.stripe_paymentsheet_payment_method_item_card_number,
             usBankAccount?.last4
         )
     }
     PaymentMethod.Type.Link -> {
-        if (canShowSublabel) {
-            linkPaymentDetails?.label
-        } else {
-            linkPaymentDetails?.sublabel
-        }
+        requireNotNull(linkBrand) {
+            "Link brand is required for Link-backed saved payment method labels."
+        }.resolvableString
     }
     else -> null
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -8,13 +8,14 @@ import com.stripe.android.link.ui.wallet.label
 import com.stripe.android.link.ui.wallet.sublabel
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardBrand.Unknown
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.resolvableString
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TransformToBankIcon
 import com.stripe.android.uicore.IconStyle
 import com.stripe.android.uicore.LocalIconStyle
-import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as PaymentsUiCoreR
 
 @DrawableRes
@@ -224,11 +225,14 @@ private fun getOverridableIcon(
     }
 }
 
-internal fun PaymentMethod.getLabel(canShowSublabel: Boolean = false): ResolvableString? = when (type) {
+internal fun PaymentMethod.getLabel(
+    canShowSublabel: Boolean = false,
+    linkBrand: LinkBrand = LinkBrand.Link,
+): ResolvableString? = when (type) {
     PaymentMethod.Type.Card -> if (isLinkPassthroughMode) {
         if (canShowSublabel) {
-            // For Link passthrough mode, show "Link" as main label
-            StripeR.string.stripe_link.resolvableString
+            // For Link passthrough mode, show the active Link brand as the main label.
+            linkBrand.resolvableString
         } else {
             // Show original card label as sublabel
             createCardLabel(card?.last4)
@@ -247,8 +251,8 @@ internal fun PaymentMethod.getLabel(canShowSublabel: Boolean = false): Resolvabl
         sepaDebit?.last4
     )
     PaymentMethod.Type.USBankAccount -> if (isLinkPassthroughMode && canShowSublabel) {
-        // For Link passthrough mode, show "Link" as main label
-        StripeR.string.stripe_link.resolvableString
+        // For Link passthrough mode, show the active Link brand as the main label.
+        linkBrand.resolvableString
     } else {
         // Show original bank account label
         resolvableString(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.link.ui.wallet.label
 import com.stripe.android.link.ui.wallet.sublabel
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardBrand.Unknown
@@ -226,7 +225,6 @@ private fun getOverridableIcon(
 }
 
 internal fun PaymentMethod.getLabel(
-    canShowSublabel: Boolean = false,
     linkBrand: LinkBrand? = null,
 ): ResolvableString? = when (type) {
     PaymentMethod.Type.Card -> if (isLinkPassthroughMode || isLinkPaymentMethod) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -178,7 +179,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 
 private val PREVIEW_PAYMENT_OPTION_ITEMS = listOf(
     PaymentOptionsItem.AddCard,
-    PaymentOptionsItem.Link,
+    PaymentOptionsItem.Link(),
     PaymentOptionsItem.GooglePay,
     PaymentOptionsItem.SavedPaymentMethod(
         DisplayableSavedPaymentMethod.create(
@@ -300,6 +301,7 @@ private fun SavedPaymentMethodTab(
         }
         is PaymentOptionsItem.Link -> {
             LinkTab(
+                item = item,
                 width = width,
                 isEnabled = isEnabled,
                 isSelected = isSelected,
@@ -375,12 +377,20 @@ private fun GooglePayTab(
 
 @Composable
 private fun LinkTab(
+    item: PaymentOptionsItem.Link,
     width: Dp,
     isEnabled: Boolean,
     isSelected: Boolean,
     onItemSelected: (PaymentSelection?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val linkLabel = stringResource(
+        id = when (item.linkBrand) {
+            LinkBrand.Link -> StripeR.string.stripe_link
+            LinkBrand.Notlink -> StripeR.string.stripe_notlink
+        }
+    )
+
     SavedPaymentMethodTab(
         viewWidth = width,
         shouldShowModifyBadge = false,
@@ -389,9 +399,9 @@ private fun LinkTab(
         isEnabled = isEnabled,
         iconRes = getLinkIcon(showNightIcon = !MaterialTheme.stripeColors.component.shouldUseDarkDynamicColor()),
         iconTint = null,
-        labelText = stringResource(StripeR.string.stripe_link),
-        description = stringResource(StripeR.string.stripe_link),
-        onItemSelectedListener = { onItemSelected(PaymentSelection.Link()) },
+        labelText = linkLabel,
+        description = linkLabel,
+        onItemSelectedListener = { onItemSelected(PaymentSelection.Link(linkBrand = item.linkBrand)) },
         cardArtUrl = null,
         modifier = modifier,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -54,6 +54,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.key
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.resolvableString
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods.CvcRecollectionState
 import com.stripe.android.paymentsheet.toPaymentSelection
 import com.stripe.android.ui.core.elements.CvcController
@@ -83,6 +84,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
     SavedPaymentMethodTabLayoutUI(
         paymentOptionsItems = state.paymentOptionsItems,
         selectedPaymentOptionsItem = state.selectedPaymentOptionsItem,
+        linkBrand = interactor.linkBrand,
         isEditing = state.isEditing,
         isProcessing = state.isProcessing,
         onAddCardPressed = {
@@ -122,6 +124,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 internal fun SavedPaymentMethodTabLayoutUI(
     paymentOptionsItems: List<PaymentOptionsItem>,
     selectedPaymentOptionsItem: PaymentOptionsItem?,
+    linkBrand: LinkBrand? = null,
     isEditing: Boolean,
     isProcessing: Boolean,
     onAddCardPressed: () -> Unit,
@@ -160,6 +163,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 
                 SavedPaymentMethodTab(
                     item = item,
+                    linkBrand = linkBrand,
                     width = width,
                     isEditing = isEditing,
                     isEnabled = isEnabled,
@@ -179,7 +183,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 
 private val PREVIEW_PAYMENT_OPTION_ITEMS = listOf(
     PaymentOptionsItem.AddCard,
-    PaymentOptionsItem.Link(),
+    PaymentOptionsItem.Link,
     PaymentOptionsItem.GooglePay,
     PaymentOptionsItem.SavedPaymentMethod(
         DisplayableSavedPaymentMethod.create(
@@ -238,6 +242,7 @@ private fun SavedPaymentMethodsTabLayoutPreview() {
         SavedPaymentMethodTabLayoutUI(
             paymentOptionsItems = PREVIEW_PAYMENT_OPTION_ITEMS,
             selectedPaymentOptionsItem = PaymentOptionsItem.AddCard,
+            linkBrand = LinkBrand.Link,
             isEditing = false,
             isProcessing = false,
             onAddCardPressed = { },
@@ -254,6 +259,7 @@ private fun SavedPaymentMethodsTabLayoutWithDefaultPreview() {
         SavedPaymentMethodTabLayoutUI(
             paymentOptionsItems = PREVIEW_PAYMENT_OPTION_ITEMS,
             selectedPaymentOptionsItem = PaymentOptionsItem.AddCard,
+            linkBrand = LinkBrand.Link,
             isEditing = true,
             isProcessing = false,
             onAddCardPressed = { },
@@ -275,6 +281,7 @@ internal fun rememberItemWidth(maxWidth: Dp): Dp = remember(maxWidth) {
 @Composable
 private fun SavedPaymentMethodTab(
     item: PaymentOptionsItem,
+    linkBrand: LinkBrand?,
     width: Dp,
     isEnabled: Boolean,
     isEditing: Boolean,
@@ -302,9 +309,11 @@ private fun SavedPaymentMethodTab(
                 modifier = modifier,
             )
         }
-        is PaymentOptionsItem.Link -> {
+        PaymentOptionsItem.Link -> {
             LinkTab(
-                item = item,
+                linkBrand = requireNotNull(linkBrand) {
+                    "Link brand is required for the Link payment option tab."
+                },
                 width = width,
                 isEnabled = isEnabled,
                 isSelected = isSelected,
@@ -315,6 +324,7 @@ private fun SavedPaymentMethodTab(
         is PaymentOptionsItem.SavedPaymentMethod -> {
             SavedPaymentMethodTab(
                 paymentMethod = item,
+                linkBrand = linkBrand,
                 width = width,
                 isEnabled = isEnabled,
                 isEditing = isEditing,
@@ -380,19 +390,14 @@ private fun GooglePayTab(
 
 @Composable
 private fun LinkTab(
-    item: PaymentOptionsItem.Link,
+    linkBrand: LinkBrand,
     width: Dp,
     isEnabled: Boolean,
     isSelected: Boolean,
     onItemSelected: (PaymentSelection?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val linkLabel = stringResource(
-        id = when (item.linkBrand) {
-            LinkBrand.Link -> StripeR.string.stripe_link
-            LinkBrand.Notlink -> StripeR.string.stripe_notlink
-        }
-    )
+    val linkLabel = linkBrand.resolvableString.resolve()
 
     SavedPaymentMethodTab(
         viewWidth = width,
@@ -404,7 +409,7 @@ private fun LinkTab(
         iconTint = null,
         labelText = linkLabel,
         description = linkLabel,
-        onItemSelectedListener = { onItemSelected(PaymentSelection.Link(linkBrand = item.linkBrand)) },
+        onItemSelectedListener = { onItemSelected(PaymentSelection.Link()) },
         cardArtUrl = null,
         modifier = modifier,
     )
@@ -413,6 +418,7 @@ private fun LinkTab(
 @Composable
 private fun SavedPaymentMethodTab(
     paymentMethod: PaymentOptionsItem.SavedPaymentMethod,
+    linkBrand: LinkBrand?,
     width: Dp,
     isEnabled: Boolean,
     isEditing: Boolean,
@@ -424,7 +430,7 @@ private fun SavedPaymentMethodTab(
     val labelIcon = paymentMethod.paymentMethod.getLabelIcon()
     val labelText = paymentMethod.paymentMethod.getLabel(
         canShowSublabel = false,
-        linkBrand = paymentMethod.displayableSavedPaymentMethod.linkBrand,
+        linkBrand = linkBrand,
     )?.resolve() ?: return
 
     Box(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -429,7 +429,6 @@ private fun SavedPaymentMethodTab(
 ) {
     val labelIcon = paymentMethod.paymentMethod.getLabelIcon()
     val labelText = paymentMethod.paymentMethod.getLabel(
-        canShowSublabel = false,
         linkBrand = linkBrand ?: paymentMethod.displayableSavedPaymentMethod.linkBrand,
     )?.resolve() ?: return
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -430,7 +430,7 @@ private fun SavedPaymentMethodTab(
     val labelIcon = paymentMethod.paymentMethod.getLabelIcon()
     val labelText = paymentMethod.paymentMethod.getLabel(
         canShowSublabel = false,
-        linkBrand = linkBrand,
+        linkBrand = linkBrand ?: paymentMethod.displayableSavedPaymentMethod.linkBrand,
     )?.resolve() ?: return
 
     Box(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -195,6 +195,7 @@ private val PREVIEW_PAYMENT_OPTION_ITEMS = listOf(
                     last4 = "4242",
                 )
             ),
+            linkBrand = LinkBrand.Link,
             shouldShowDefaultBadge = true,
         ),
     ),
@@ -208,6 +209,7 @@ private val PREVIEW_PAYMENT_OPTION_ITEMS = listOf(
                 code = PaymentMethod.Type.SepaDebit.code,
                 type = PaymentMethod.Type.SepaDebit,
             ),
+            linkBrand = LinkBrand.Link,
         ),
     ),
     PaymentOptionsItem.SavedPaymentMethod(
@@ -224,6 +226,7 @@ private val PREVIEW_PAYMENT_OPTION_ITEMS = listOf(
                     last4 = "4242",
                 )
             ),
+            linkBrand = LinkBrand.Link,
         ),
     ),
 )
@@ -419,7 +422,10 @@ private fun SavedPaymentMethodTab(
     modifier: Modifier = Modifier,
 ) {
     val labelIcon = paymentMethod.paymentMethod.getLabelIcon()
-    val labelText = paymentMethod.paymentMethod.getLabel(canShowSublabel = false)?.resolve() ?: return
+    val labelText = paymentMethod.paymentMethod.getLabel(
+        canShowSublabel = false,
+        linkBrand = paymentMethod.displayableSavedPaymentMethod.linkBrand,
+    )?.resolve() ?: return
 
     Box(
         modifier = Modifier.semantics {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -25,6 +26,7 @@ import kotlinx.coroutines.launch
 
 internal interface SelectSavedPaymentMethodsInteractor {
     val isLiveMode: Boolean
+    val linkBrand: LinkBrand?
 
     val state: StateFlow<State>
 
@@ -63,6 +65,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val updateSelection: (selection: PaymentSelection?, isUserInput: Boolean) -> Unit,
     override val isLiveMode: Boolean,
+    override val linkBrand: LinkBrand?,
 ) : SelectSavedPaymentMethodsInteractor {
     private val coroutineScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
@@ -272,6 +275,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
                 },
                 onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+                linkBrand = paymentMethodMetadata.linkBrand,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -26,6 +26,7 @@ import com.stripe.android.common.ui.PrimaryButton
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -335,6 +336,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             type = PaymentMethod.Type.Card,
             card = PaymentMethod.Card(CardBrand.Visa)
         ),
+        linkBrand = LinkBrand.Link,
     )
     UpdatePaymentMethodUI(
         interactor = DefaultUpdatePaymentMethodInteractor(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -11,6 +11,7 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.linkBrandOrDefault
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.link.ui.verification.VerificationViewState
@@ -86,7 +87,10 @@ internal interface WalletButtonsInteractor {
             override val walletType = WalletType.Link
 
             override fun createSelection(): PaymentSelection {
-                return PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED)
+                return PaymentSelection.Link(
+                    linkBrand = linkBrand,
+                    linkExpressMode = LinkExpressMode.DISABLED,
+                )
             }
         }
 
@@ -198,7 +202,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                             ),
                             theme = arguments.configuration.walletButtons?.buttonThemes?.link
                                 ?: LinkButtonTheme.DEFAULT,
-                            linkBrand = linkConfiguration?.linkBrand ?: LinkBrand.Link,
+                            linkBrand = linkConfiguration.linkBrandOrDefault,
                         ).takeIf {
                             // Only show Link button if the Link verification state is resolved.
                             linkEmbeddedState.verificationState is VerificationState.RenderButton &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -11,7 +11,6 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.linkBrandOrDefault
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.link.ui.verification.VerificationViewState
@@ -202,7 +201,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                             ),
                             theme = arguments.configuration.walletButtons?.buttonThemes?.link
                                 ?: LinkButtonTheme.DEFAULT,
-                            linkBrand = linkConfiguration.linkBrandOrDefault,
+                            linkBrand = linkConfiguration?.linkBrandOrDefault ?: LinkBrand.Link,
                         ).takeIf {
                             // Only show Link button if the Link verification state is resolved.
                             linkEmbeddedState.verificationState is VerificationState.RenderButton &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -201,7 +201,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                             ),
                             theme = arguments.configuration.walletButtons?.buttonThemes?.link
                                 ?: LinkButtonTheme.DEFAULT,
-                            linkBrand = linkConfiguration?.linkBrandOrDefault ?: LinkBrand.Link,
+                            linkBrand = linkConfiguration?.linkBrand ?: LinkBrand.Link,
                         ).takeIf {
                             // Only show Link button if the Link verification state is resolved.
                             linkEmbeddedState.verificationState is VerificationState.RenderButton &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -200,7 +200,10 @@ internal class DefaultManageScreenInteractor(
                 canEdit = savedPaymentMethodMutator.canEdit,
                 toggleEdit = savedPaymentMethodMutator::toggleEditing,
                 onSelectPaymentMethod = {
-                    val savedPmSelection = PaymentSelection.Saved(it.paymentMethod)
+                    val savedPmSelection = PaymentSelection.Saved(
+                        paymentMethod = it.paymentMethod,
+                        linkBrand = it.linkBrand,
+                    )
                     viewModel.updateSelection(savedPmSelection)
                     viewModel.eventReporter.onSelectPaymentOption(savedPmSelection)
                 },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -142,7 +142,7 @@ internal class DefaultManageScreenInteractor(
             currentSelection = currentSelection,
             isEditing = editing,
             canEdit = canEdit,
-            linkBrand = paymentMethodMetadata.linkState?.configuration?.linkBrand,
+            linkBrand = paymentMethodMetadata.linkBrand,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.verticalmode
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -36,6 +37,7 @@ internal interface ManageScreenInteractor {
         val currentSelection: DisplayableSavedPaymentMethod?,
         val isEditing: Boolean,
         val canEdit: Boolean,
+        val linkBrand: LinkBrand? = null,
     ) {
         private val containsOnlyCards: Boolean by lazy {
             paymentMethods.isNotEmpty() && paymentMethods.all { it.isCard }
@@ -140,6 +142,7 @@ internal class DefaultManageScreenInteractor(
             currentSelection = currentSelection,
             isEditing = editing,
             canEdit = canEdit,
+            linkBrand = paymentMethodMetadata.linkState?.configuration?.linkBrand,
         )
     }
 
@@ -202,7 +205,6 @@ internal class DefaultManageScreenInteractor(
                 onSelectPaymentMethod = {
                     val savedPmSelection = PaymentSelection.Saved(
                         paymentMethod = it.paymentMethod,
-                        linkBrand = it.linkBrand,
                     )
                     viewModel.updateSelection(savedPmSelection)
                     viewModel.eventReporter.onSelectPaymentOption(savedPmSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -31,6 +31,7 @@ internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
 
             SavedPaymentMethodRowButton(
                 displayableSavedPaymentMethod = it,
+                linkBrand = state.linkBrand,
                 isEnabled = true,
                 isSelected = isSelected,
                 onClick = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
@@ -73,7 +73,7 @@ internal fun ColumnScope.PaymentMethodEmbeddedLayoutUI(
         },
         onSelectSavedPaymentMethod = {
             interactor.handleViewAction(
-                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it.paymentMethod)
+                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it)
             )
         },
         onManageOneSavedPaymentMethod = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle
@@ -63,6 +64,7 @@ internal fun ColumnScope.PaymentMethodEmbeddedLayoutUI(
     PaymentMethodEmbeddedLayoutUI(
         paymentMethods = state.displayablePaymentMethods,
         displayedSavedPaymentMethod = state.displayedSavedPaymentMethod,
+        linkBrand = state.linkBrand,
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
         selection = state.selection,
         isEnabled = !state.isProcessing,
@@ -111,6 +113,7 @@ internal fun ColumnScope.PaymentMethodEmbeddedLayoutUI(
 internal fun PaymentMethodEmbeddedLayoutUI(
     paymentMethods: List<DisplayablePaymentMethod>,
     displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
+    linkBrand: LinkBrand? = null,
     savedPaymentMethodAction: PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction,
     selection: PaymentMethodVerticalLayoutInteractor.Selection?,
     isEnabled: Boolean,
@@ -144,6 +147,7 @@ internal fun PaymentMethodEmbeddedLayoutUI(
         EmbeddedSavedPaymentMethodRowButton(
             paymentMethods = paymentMethods,
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
+            linkBrand = linkBrand,
             savedPaymentMethodAction = savedPaymentMethodAction,
             selection = selection,
             isEnabled = isEnabled,
@@ -257,6 +261,7 @@ private fun Embedded.RowStyle.endSeparatorInset(): Dp {
 internal fun EmbeddedSavedPaymentMethodRowButton(
     paymentMethods: List<DisplayablePaymentMethod>,
     displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
+    linkBrand: LinkBrand? = null,
     savedPaymentMethodAction: PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction,
     selection: PaymentMethodVerticalLayoutInteractor.Selection?,
     isEnabled: Boolean,
@@ -269,6 +274,7 @@ internal fun EmbeddedSavedPaymentMethodRowButton(
     if (displayedSavedPaymentMethod != null) {
         SavedPaymentMethodRowButton(
             displayableSavedPaymentMethod = displayedSavedPaymentMethod,
+            linkBrand = linkBrand,
             isEnabled = isEnabled,
             isSelected = selection?.isSaved == true,
             trailingContent = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -306,7 +306,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
             availableSavedPaymentMethodAction = action,
             mandate = getMandate(temporarySelectionCode, mostRecentSelection),
-            linkBrand = paymentMethodMetadata.linkState?.configuration?.linkBrand,
+            linkBrand = paymentMethodMetadata.linkBrand,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.resolvableString
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.repositories.PromotionSupportedPaymentMethods
@@ -413,7 +414,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
         return DisplayablePaymentMethod(
             code = PaymentMethod.Type.Link.code,
-            displayName = PaymentsCoreR.string.stripe_link.resolvableString,
+            displayName = link.linkBrand.resolvableString,
             iconResource = R.drawable.stripe_ic_paymentsheet_link_arrow,
             iconResourceNight = null,
             lightThemeIconUrl = null,
@@ -421,7 +422,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             iconRequiresTinting = false,
             subtitle = subtitle,
             onClick = {
-                updateSelection(PaymentSelection.Link(), false)
+                updateSelection(PaymentSelection.Link(linkBrand = link.linkBrand), false)
                 invokeRowSelectionCallback?.invoke()
             },
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -60,6 +61,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
         val displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
         val availableSavedPaymentMethodAction: SavedPaymentMethodAction,
         val mandate: ResolvableString?,
+        val linkBrand: LinkBrand? = null,
     )
 
     sealed interface Selection {
@@ -304,6 +306,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
             availableSavedPaymentMethodAction = action,
             mandate = getMandate(temporarySelectionCode, mostRecentSelection),
+            linkBrand = paymentMethodMetadata.linkState?.configuration?.linkBrand,
         )
     }
 
@@ -556,7 +559,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 reportPaymentMethodTypeSelected("saved")
                 val selection = PaymentSelection.Saved(
                     paymentMethod = viewAction.savedPaymentMethod.paymentMethod,
-                    linkBrand = viewAction.savedPaymentMethod.linkBrand,
                 )
                 updateSelection(selection, true)
                 invokeRowSelectionCallback?.invoke()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -7,8 +7,8 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessagePromotion

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -78,7 +78,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
         data object TransitionToManageSavedPaymentMethods : ViewAction
         data class OnManageOneSavedPaymentMethod(val savedPaymentMethod: DisplayableSavedPaymentMethod) : ViewAction
         data class PaymentMethodSelected(val selectedPaymentMethodCode: String) : ViewAction
-        data class SavedPaymentMethodSelected(val savedPaymentMethod: PaymentMethod) : ViewAction
+        data class SavedPaymentMethodSelected(val savedPaymentMethod: DisplayableSavedPaymentMethod) : ViewAction
         data class UpdatePaymentMethodVisibility(val itemCode: String, val coordinates: LayoutCoordinates) : ViewAction
         data object CancelPaymentMethodVisibilityTracking : ViewAction
     }
@@ -554,7 +554,10 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             }
             is ViewAction.SavedPaymentMethodSelected -> {
                 reportPaymentMethodTypeSelected("saved")
-                val selection = PaymentSelection.Saved(viewAction.savedPaymentMethod)
+                val selection = PaymentSelection.Saved(
+                    paymentMethod = viewAction.savedPaymentMethod.paymentMethod,
+                    linkBrand = viewAction.savedPaymentMethod.linkBrand,
+                )
                 updateSelection(selection, true)
                 invokeRowSelectionCallback?.invoke()
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -72,7 +72,7 @@ internal fun PaymentMethodVerticalLayoutUI(
         },
         onSelectSavedPaymentMethod = {
             interactor.handleViewAction(
-                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it.paymentMethod)
+                PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(it)
             )
         },
         onManageOneSavedPaymentMethod = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -62,6 +63,7 @@ internal fun PaymentMethodVerticalLayoutUI(
     PaymentMethodVerticalLayoutUI(
         paymentMethods = state.displayablePaymentMethods,
         displayedSavedPaymentMethod = state.displayedSavedPaymentMethod,
+        linkBrand = state.linkBrand,
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
         selection = state.selection,
         isEnabled = !state.isProcessing,
@@ -105,6 +107,7 @@ internal fun PaymentMethodVerticalLayoutUI(
 internal fun PaymentMethodVerticalLayoutUI(
     paymentMethods: List<DisplayablePaymentMethod>,
     displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
+    linkBrand: LinkBrand? = null,
     savedPaymentMethodAction: PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction,
     selection: PaymentMethodVerticalLayoutInteractor.Selection?,
     isEnabled: Boolean,
@@ -147,6 +150,7 @@ internal fun PaymentMethodVerticalLayoutUI(
                     updatePaymentMethodVisibility.invoke("saved", coordinates)
                 },
                 displayableSavedPaymentMethod = displayedSavedPaymentMethod,
+                linkBrand = linkBrand,
                 isEnabled = isEnabled,
                 isSelected = selection?.isSaved == true,
                 onClick = { onSelectSavedPaymentMethod(displayedSavedPaymentMethod) },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
@@ -6,10 +6,8 @@ import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.spms.withLinkState
-import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -27,6 +25,7 @@ internal interface SavedPaymentMethodConfirmInteractor {
     data class State(
         val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
         val form: Form,
+        val linkBrand: LinkBrand? = null,
     ) {
         data class Form(
             val elements: List<FormElement>,
@@ -44,25 +43,21 @@ internal interface SavedPaymentMethodConfirmInteractor {
 
 internal class DefaultSavedPaymentMethodConfirmInteractor(
     val initialSelection: PaymentSelection.Saved,
-    val displayName: ResolvableString,
+    val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     val savedPaymentMethodLinkFormHelper: SavedPaymentMethodLinkFormHelper,
     val processing: StateFlow<Boolean>,
     val updateSelection: (PaymentSelection.Saved) -> Unit,
     val coroutineScope: CoroutineScope,
+    val linkBrand: LinkBrand?,
 ) : SavedPaymentMethodConfirmInteractor {
-    private val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
-        displayName = displayName,
-        paymentMethod = initialSelection.paymentMethod,
-        linkBrand = initialSelection.linkBrand,
-    )
-
     override val state = processing.mapAsStateFlow { isProcessing ->
         SavedPaymentMethodConfirmInteractor.State(
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             form = SavedPaymentMethodConfirmInteractor.State.Form(
                 elements = savedPaymentMethodLinkFormHelper.formElement?.let { listOf(it) } ?: emptyList(),
                 enabled = !isProcessing,
-            )
+            ),
+            linkBrand = linkBrand,
         )
     }
 
@@ -86,9 +81,10 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
         ): DefaultSavedPaymentMethodConfirmInteractor {
             return DefaultSavedPaymentMethodConfirmInteractor(
                 initialSelection = initialSelection,
-                displayName = paymentMethodMetadata.supportedPaymentMethodForCode(
-                    PaymentMethod.Type.Card.code
-                )?.displayName.orEmpty(),
+                displayableSavedPaymentMethod = initialSelection.paymentMethod.toDisplayableSavedPaymentMethod(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    defaultPaymentMethodId = null,
+                ),
                 savedPaymentMethodLinkFormHelper = DefaultSavedPaymentMethodLinkFormHelper(
                     linkInlineSignupAvailability = DefaultLinkInlineSignupAvailability(paymentMethodMetadata),
                     linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
@@ -98,6 +94,7 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
                 processing = viewModel.processing,
                 updateSelection = viewModel::updateSelection,
                 coroutineScope = viewModel.viewModelScope,
+                linkBrand = paymentMethodMetadata.linkBrand,
             )
         }
     }
@@ -114,13 +111,15 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
         ): SavedPaymentMethodConfirmInteractor {
             return DefaultSavedPaymentMethodConfirmInteractor(
                 initialSelection = initialSelection,
-                displayName = paymentMethodMetadata.supportedPaymentMethodForCode(
-                    PaymentMethod.Type.Card.code
-                )?.displayName.orEmpty(),
+                displayableSavedPaymentMethod = initialSelection.paymentMethod.toDisplayableSavedPaymentMethod(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    defaultPaymentMethodId = null,
+                ),
                 processing = processing,
                 savedPaymentMethodLinkFormHelper = savedPaymentMethodLinkFormHelper,
                 updateSelection = updateSelection,
                 coroutineScope = coroutineScope,
+                linkBrand = paymentMethodMetadata.linkBrand,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
@@ -53,6 +53,7 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
     private val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
         displayName = displayName,
         paymentMethod = initialSelection.paymentMethod,
+        linkBrand = initialSelection.linkBrand,
     )
 
     override val state = processing.mapAsStateFlow { isProcessing ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUI.kt
@@ -35,6 +35,7 @@ internal fun SavedPaymentMethodConfirmUI(
 
         SavedPaymentMethodRowButton(
             displayableSavedPaymentMethod = state.displayableSavedPaymentMethod,
+            linkBrand = state.linkBrand,
             isEnabled = true,
             isSelected = true,
             onClick = { },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -48,7 +48,7 @@ internal fun SavedPaymentMethodRowButton(
     val paymentMethodTitle =
         displayableSavedPaymentMethod.paymentMethod.getLabel(
             canShowSublabel = true,
-            linkBrand = linkBrand,
+            linkBrand = linkBrand ?: displayableSavedPaymentMethod.linkBrand,
         )
             ?: displayableSavedPaymentMethod.displayName
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
@@ -44,7 +45,10 @@ internal fun SavedPaymentMethodRowButton(
         .resolve()
         .readNumbersAsIndividualDigits()
     val paymentMethodTitle =
-        displayableSavedPaymentMethod.paymentMethod.getLabel(canShowSublabel = true)
+        displayableSavedPaymentMethod.paymentMethod.getLabel(
+            canShowSublabel = true,
+            linkBrand = displayableSavedPaymentMethod.linkBrand,
+        )
             ?: displayableSavedPaymentMethod.displayName
 
     val paymentMethodId = displayableSavedPaymentMethod.paymentMethod.id
@@ -105,6 +109,7 @@ internal fun PreviewCardSavedPaymentMethodRowButton() {
                 last4 = "4242",
             )
         ),
+        linkBrand = LinkBrand.Link,
     )
 
     DefaultStripeTheme {
@@ -143,6 +148,7 @@ internal fun PreviewCardDefaultSavedPaymentMethodRowButton() {
                 last4 = "4444",
             )
         ),
+        linkBrand = LinkBrand.Link,
     )
 
     DefaultStripeTheme {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -33,6 +33,7 @@ import com.stripe.android.uicore.strings.resolve
 @Composable
 internal fun SavedPaymentMethodRowButton(
     displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
+    linkBrand: LinkBrand? = null,
     isEnabled: Boolean,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
@@ -47,7 +48,7 @@ internal fun SavedPaymentMethodRowButton(
     val paymentMethodTitle =
         displayableSavedPaymentMethod.paymentMethod.getLabel(
             canShowSublabel = true,
-            linkBrand = displayableSavedPaymentMethod.linkBrand,
+            linkBrand = linkBrand,
         )
             ?: displayableSavedPaymentMethod.displayName
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButton.kt
@@ -47,7 +47,6 @@ internal fun SavedPaymentMethodRowButton(
         .readNumbersAsIndividualDigits()
     val paymentMethodTitle =
         displayableSavedPaymentMethod.paymentMethod.getLabel(
-            canShowSublabel = true,
             linkBrand = linkBrand ?: displayableSavedPaymentMethod.linkBrand,
         )
             ?: displayableSavedPaymentMethod.displayName

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -14,7 +14,7 @@ internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
     return DisplayableSavedPaymentMethod.create(
         displayName = paymentMethodMetadata?.displayNameForCode(type?.code).orEmpty(),
         paymentMethod = this,
-        linkBrand = paymentMethodMetadata?.linkBrandOrDefault ?: LinkBrand.Link,
+        linkBrand = paymentMethodMetadata?.linkBrand ?: LinkBrand.Link,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,
         shouldShowDefaultBadge = id == defaultPaymentMethodId,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -13,6 +14,7 @@ internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
     return DisplayableSavedPaymentMethod.create(
         displayName = paymentMethodMetadata?.displayNameForCode(type?.code).orEmpty(),
         paymentMethod = this,
+        linkBrand = paymentMethodMetadata?.linkBrandOrDefault ?: LinkBrand.Link,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,
         shouldShowDefaultBadge = id == defaultPaymentMethodId,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.viewmodels
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -16,7 +15,6 @@ internal class PaymentOptionsItemsMapper(
     private val customerState: StateFlow<CustomerState?>,
     private val isGooglePayReady: StateFlow<Boolean>,
     private val isLinkEnabled: StateFlow<Boolean?>,
-    private val linkBrand: StateFlow<LinkBrand>,
     private val nameProvider: (PaymentMethodCode?) -> ResolvableString,
     private val isNotPaymentFlow: Boolean,
     private val isCbcEligible: () -> Boolean
@@ -28,13 +26,11 @@ internal class PaymentOptionsItemsMapper(
             isLinkEnabled,
             isGooglePayReady,
             customerMetadata,
-            linkBrand,
-        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata, linkBrand ->
+        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata ->
             createPaymentOptionsItems(
                 paymentMethods = customerState?.paymentMethods ?: listOf(),
                 isLinkEnabled = isLinkEnabled,
                 isGooglePayReady = isGooglePayReady,
-                linkBrand = linkBrand,
                 defaultPaymentMethodId = if (customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
                     customerState?.defaultPaymentMethodId
                 } else {
@@ -49,7 +45,6 @@ internal class PaymentOptionsItemsMapper(
         paymentMethods: List<PaymentMethod>,
         isLinkEnabled: Boolean?,
         isGooglePayReady: Boolean,
-        linkBrand: LinkBrand,
         defaultPaymentMethodId: String?,
     ): List<PaymentOptionsItem>? {
         if (isLinkEnabled == null) return null
@@ -58,7 +53,6 @@ internal class PaymentOptionsItemsMapper(
             paymentMethods = paymentMethods,
             showGooglePay = isGooglePayReady && isNotPaymentFlow,
             showLink = isLinkEnabled && isNotPaymentFlow,
-            linkBrand = linkBrand,
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible(),
             defaultPaymentMethodId = defaultPaymentMethodId,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.viewmodels
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -15,6 +16,7 @@ internal class PaymentOptionsItemsMapper(
     private val customerState: StateFlow<CustomerState?>,
     private val isGooglePayReady: StateFlow<Boolean>,
     private val isLinkEnabled: StateFlow<Boolean?>,
+    private val linkBrand: StateFlow<LinkBrand>,
     private val nameProvider: (PaymentMethodCode?) -> ResolvableString,
     private val isNotPaymentFlow: Boolean,
     private val isCbcEligible: () -> Boolean
@@ -26,11 +28,13 @@ internal class PaymentOptionsItemsMapper(
             isLinkEnabled,
             isGooglePayReady,
             customerMetadata,
-        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata ->
+            linkBrand,
+        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata, linkBrand ->
             createPaymentOptionsItems(
                 paymentMethods = customerState?.paymentMethods ?: listOf(),
                 isLinkEnabled = isLinkEnabled,
                 isGooglePayReady = isGooglePayReady,
+                linkBrand = linkBrand,
                 defaultPaymentMethodId = if (customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
                     customerState?.defaultPaymentMethodId
                 } else {
@@ -45,6 +49,7 @@ internal class PaymentOptionsItemsMapper(
         paymentMethods: List<PaymentMethod>,
         isLinkEnabled: Boolean?,
         isGooglePayReady: Boolean,
+        linkBrand: LinkBrand,
         defaultPaymentMethodId: String?,
     ): List<PaymentOptionsItem>? {
         if (isLinkEnabled == null) return null
@@ -53,6 +58,7 @@ internal class PaymentOptionsItemsMapper(
             paymentMethods = paymentMethods,
             showGooglePay = isGooglePayReady && isNotPaymentFlow,
             showLink = isLinkEnabled && isNotPaymentFlow,
+            linkBrand = linkBrand,
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible(),
             defaultPaymentMethodId = defaultPaymentMethodId,

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -698,6 +698,7 @@ internal object PaymentMethodFixtures {
         return DisplayableSavedPaymentMethod.create(
             displayName = displayName,
             paymentMethod = this,
+            linkBrand = LinkBrand.Link,
             isCbcEligible = true,
             shouldShowDefaultBadge = shouldShowDefaultBadge,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodModifiableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodModifiableTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import junit.framework.TestCase.assertEquals
@@ -22,6 +23,7 @@ class DisplayableSavedPaymentMethodModifiableTest(private val params: IsModifiab
                     expiryYear = if (params.cardExpired) 2005 else 2099
                 )
             ),
+            linkBrand = LinkBrand.Link,
             isCbcEligible = params.isCbcEligible,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodModifiableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodModifiableTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import junit.framework.TestCase.assertEquals
@@ -23,7 +22,7 @@ class DisplayableSavedPaymentMethodModifiableTest(private val params: IsModifiab
                     expiryYear = if (params.cardExpired) 2005 else 2099
                 )
             ),
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
             isCbcEligible = params.isCbcEligible,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -5,8 +5,8 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -6,7 +6,6 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -25,7 +24,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = visaCardUsingCartesBancaires,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
         )
 
         val description = displayableSavedPaymentMethod.getDescription().resolve(context)
@@ -41,7 +40,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = cardWithoutDisplayBrand,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
         )
 
         val description = displayableSavedPaymentMethod.getDescription().resolve(context)
@@ -56,7 +55,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -70,7 +69,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -84,7 +83,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -100,7 +99,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -114,7 +113,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
-            linkBrand = LinkBrand.Link,
+            linkBrand = com.stripe.android.model.LinkBrand.Link,
             isCbcEligible = false,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethodTest.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.runner.RunWith
@@ -24,6 +25,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = visaCardUsingCartesBancaires,
+            linkBrand = LinkBrand.Link,
         )
 
         val description = displayableSavedPaymentMethod.getDescription().resolve(context)
@@ -39,6 +41,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = cardWithoutDisplayBrand,
+            linkBrand = LinkBrand.Link,
         )
 
         val description = displayableSavedPaymentMethod.getDescription().resolve(context)
@@ -53,6 +56,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
+            linkBrand = LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -66,6 +70,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
+            linkBrand = LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -79,6 +84,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
+            linkBrand = LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -94,6 +100,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
+            linkBrand = LinkBrand.Link,
             isCbcEligible = false,
         )
 
@@ -107,6 +114,7 @@ class DisplayableSavedPaymentMethodTest {
         val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = "unused".resolvableString,
             paymentMethod = paymentMethod,
+            linkBrand = LinkBrand.Link,
             isCbcEligible = false,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeSelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeSelectSavedPaymentMethodsInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.ui.SelectSavedPaymentMethodsInteractor
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +14,7 @@ internal class FakeSelectSavedPaymentMethodsInteractor(
         canEdit = false,
         canRemove = false,
     ),
+    override val linkBrand: LinkBrand? = null,
     private val viewActionRecorder: ViewActionRecorder<SelectSavedPaymentMethodsInteractor.ViewAction> =
         ViewActionRecorder(),
 ) : SelectSavedPaymentMethodsInteractor {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -148,7 +148,7 @@ internal class PaymentOptionsActivityTest {
             it.onActivity {
                 // We use US Bank Account because they don't dismiss PaymentSheet upon selection
                 // due to their mandate requirement.
-                val usBankAccountLabel = usBankAccount.getLabel(canShowSublabel = false)?.resolve(context)
+                val usBankAccountLabel = usBankAccount.getLabel()?.resolve(context)
                 composeTestRule
                     .onNodeWithTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_$usBankAccountLabel")
                     .performClick()
@@ -286,7 +286,7 @@ internal class PaymentOptionsActivityTest {
     fun `notes visibility is set correctly`() {
         val usBankAccount = PaymentMethodFixtures.US_BANK_ACCOUNT
 
-        val label = usBankAccount.getLabel(canShowSublabel = false)?.resolve(context)
+        val label = usBankAccount.getLabel()?.resolve(context)
         val mandateText = "By continuing, you agree to authorize payments pursuant to these terms."
 
         val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -43,6 +44,24 @@ class PaymentOptionsStateFactoryTest {
         )
 
         assertThat(state.selectedItem).isNull()
+    }
+
+    @Test
+    fun `Link item round trips brand into selection`() {
+        val state = PaymentOptionsStateFactory.create(
+            paymentMethods = emptyList(),
+            showGooglePay = false,
+            showLink = true,
+            linkBrand = LinkBrand.Notlink,
+            currentSelection = PaymentSelection.Link(linkBrand = LinkBrand.Notlink),
+            nameProvider = { it!!.resolvableString },
+            isCbcEligible = false,
+            defaultPaymentMethodId = null,
+        )
+
+        assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.Link(LinkBrand.Notlink))
+        assertThat(state.selectedItem?.toPaymentSelection())
+            .isEqualTo(PaymentSelection.Link(linkBrand = LinkBrand.Notlink))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -924,12 +925,19 @@ internal class PaymentOptionsViewModelTest {
             linkAccountUpdate = linkAccountUpdate,
             selectedPayment = null
         )
-        val viewModel = createViewModel()
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = LinkTestUtils.createLinkConfiguration(linkBrand = LinkBrand.Notlink),
+                signupMode = null,
+                loginState = LinkState.LoginState.NeedsVerification,
+            )
+        )
         viewModel.paymentOptionsActivityResult.test {
             viewModel.onLinkAuthenticationResult(result)
             val succeeded = awaitItem() as PaymentOptionsActivityResult.Succeeded
             val paymentSelection = succeeded.paymentSelection
             assertThat(paymentSelection).isInstanceOf<PaymentSelection.Link>()
+            assertThat((paymentSelection as PaymentSelection.Link).linkBrand).isEqualTo(LinkBrand.Notlink)
             assertThat(succeeded.linkAccountInfo.account).isEqualTo(linkAccountUpdate.account)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -874,7 +874,12 @@ internal class PaymentOptionsViewModelTest {
 
         viewModel.walletsState.test {
             val state = awaitItem()
-            assertThat(state?.link(WalletLocation.HEADER)).isEqualTo(WalletsState.Link(state = LinkButtonState.Default))
+            assertThat(state?.link(WalletLocation.HEADER)).isEqualTo(
+                WalletsState.Link(
+                    state = LinkButtonState.Default,
+                    linkBrand = LinkBrand.Link,
+                )
+            )
             assertThat(state?.googlePay(WalletLocation.HEADER)).isNull()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -2,9 +2,9 @@ package com.stripe.android.paymentsheet
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
-import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
 import kotlin.test.assertEquals

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -1,6 +1,10 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -34,6 +38,25 @@ class SavedPaymentMethodsExtensionTest {
     fun `shouldShowDefaultBadge is true when defaultPaymentMethodId == paymentMethod id and both are not null`() {
         val actual = testSetup("aaa111", "aaa111")
         assertEquals(actual.shouldShowDefaultBadge, true)
+    }
+
+    @Test
+    fun `uses metadata link brand when available`() {
+        val paymentMethod = PaymentMethodFactory.card("pm_123")
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = LinkTestUtils.createLinkConfiguration(linkBrand = LinkBrand.Notlink),
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            )
+        )
+
+        val actual = paymentMethod.toDisplayableSavedPaymentMethod(
+            paymentMethodMetadata = metadata,
+            defaultPaymentMethodId = null,
+        )
+
+        assertEquals(actual.linkBrand, LinkBrand.Notlink)
     }
 
     private fun testSetup(paymentMethodId: String, defaultPaymentMethodId: String?): DisplayableSavedPaymentMethod {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -481,7 +482,7 @@ class DefaultEventReporterTest {
             paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 
             val walletsState = WalletsState(
-                link = WalletsState.Link(LinkButtonState.Email("test@example.com")),
+                link = WalletsState.Link(LinkButtonState.Email("test@example.com"), linkBrand = LinkBrand.Link),
                 googlePay = WalletsState.GooglePay(
                     buttonType = GooglePayButtonType.Pay,
                     allowCreditCards = true,
@@ -540,7 +541,7 @@ class DefaultEventReporterTest {
             paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 
             val walletsState = WalletsState(
-                link = WalletsState.Link(LinkButtonState.Email("test@example.com")),
+                link = WalletsState.Link(LinkButtonState.Email("test@example.com"), linkBrand = LinkBrand.Link),
                 googlePay = WalletsState.GooglePay(
                     buttonType = GooglePayButtonType.Pay,
                     allowCreditCards = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -45,6 +45,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -96,6 +97,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.ui.SepaMandateContract
 import com.stripe.android.paymentsheet.ui.SepaMandateResult
+import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
@@ -1509,6 +1511,38 @@ internal class DefaultFlowControllerTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
             )
         )
+    }
+
+    @Test
+    fun `onLinkResultFromWalletsButton with Notlink preserves branded payment option label`() = runTest {
+        val flowController = createFlowController(
+            linkState = LinkState(
+                configuration = LinkTestUtils.createLinkConfiguration(linkBrand = LinkBrand.Notlink),
+                loginState = LinkState.LoginState.LoggedIn,
+                signupMode = null,
+            )
+        )
+
+        flowController.configureExpectingSuccess(
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        )
+
+        flowController.onLinkResultFromWalletsButton(
+            LinkActivityResult.Completed(
+                selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                    collectedCvc = null,
+                    billingPhone = null,
+                ),
+                linkAccountUpdate = LinkAccountUpdate.Value(null),
+            )
+        )
+
+        verify(paymentOptionResultCallback).onPaymentOptionResult(
+            argThat { paymentOption?.label == "Notlink" && !didCancel }
+        )
+
+        assertThat(flowController.getPaymentOption()?.label).isEqualTo("Notlink")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -9,9 +9,11 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.ExtendedLabelsInPaymentOptionPreview
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -23,6 +25,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
 @Suppress("DEPRECATION")
+@OptIn(ExtendedLabelsInPaymentOptionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 class PaymentOptionFactoryTest {
 
@@ -160,9 +163,39 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with Link should not include billing details`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.Link())
+        val paymentOption = factory.create(
+            selection = PaymentSelection.Link(),
+            linkBrand = LinkBrand.Link,
+        )
 
         assertThat(paymentOption.billingDetails).isNull()
+    }
+
+    @Test
+    fun `create() with Link uses provided Notlink brand for label`() {
+        val factory = createFactory()
+
+        val paymentOption = factory.create(
+            selection = PaymentSelection.Link(),
+            linkBrand = LinkBrand.Notlink,
+        )
+
+        assertThat(paymentOption.label).isEqualTo("Notlink")
+        assertThat(paymentOption.labels.label).isEqualTo("Notlink")
+    }
+
+    @Test
+    fun `create() with saved Link payment method uses provided Notlink brand for labels`() {
+        val factory = createFactory()
+
+        val paymentOption = factory.create(
+            selection = PaymentSelection.Saved(PaymentMethodFixtures.LINK_PAYMENT_METHOD),
+            linkBrand = LinkBrand.Notlink,
+        )
+
+        assertThat(paymentOption.label).isEqualTo("Notlink")
+        assertThat(paymentOption.labels.label).isEqualTo("Notlink")
+        assertThat(paymentOption.labels.sublabel).isEqualTo("Visa Credit •••• 4242")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -162,6 +163,24 @@ class PaymentOptionLabelsFactoryTest {
         )
 
         assertThat(labels.label).isEqualTo("Link")
+        assertThat(labels.sublabel).isEqualTo("Stripe Test Bank Account •••• 4242")
+    }
+
+    @Test
+    fun `create with Notlink payment selection returns branded labels`() {
+        val labels = PaymentOptionLabelsFactory.create(
+            context = context,
+            selection = PaymentSelection.Link(
+                linkBrand = LinkBrand.Notlink,
+                selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                    collectedCvc = null,
+                    billingPhone = null,
+                ),
+            ),
+        )
+
+        assertThat(labels.label).isEqualTo("Notlink")
         assertThat(labels.sublabel).isEqualTo("Stripe Test Bank Account •••• 4242")
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
@@ -77,11 +77,25 @@ class PaymentOptionLabelsFactoryTest {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
             selection = PaymentSelection.Saved(
-                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD
+                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD,
             )
         )
 
         assertThat(labels.label).isEqualTo("Link")
+        assertThat(labels.sublabel).isEqualTo("Visa Credit •••• 4242")
+    }
+
+    @Test
+    fun `create with saved Notlink payment method returns branded labels`() {
+        val labels = PaymentOptionLabelsFactory.create(
+            context = context,
+            selection = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD,
+                linkBrand = LinkBrand.Notlink,
+            )
+        )
+
+        assertThat(labels.label).isEqualTo("Notlink")
         assertThat(labels.sublabel).isEqualTo("Visa Credit •••• 4242")
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
@@ -5,9 +5,12 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -76,9 +79,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with saved Link payment method returns correct labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentSelection.Saved(
-                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD,
-            )
+            selection = PaymentSelection.Saved(paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD),
+            paymentMethodMetadata = paymentMethodMetadata(LinkBrand.Link),
         )
 
         assertThat(labels.label).isEqualTo("Link")
@@ -89,10 +91,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with saved Notlink payment method returns branded labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentSelection.Saved(
-                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD,
-                linkBrand = LinkBrand.Notlink,
-            )
+            selection = PaymentSelection.Saved(paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD),
+            paymentMethodMetadata = paymentMethodMetadata(LinkBrand.Notlink),
         )
 
         assertThat(labels.label).isEqualTo("Notlink")
@@ -181,11 +181,10 @@ class PaymentOptionLabelsFactoryTest {
     }
 
     @Test
-    fun `create with Notlink payment selection returns branded labels`() {
+    fun `create with Link payment selection returns Link labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
             selection = PaymentSelection.Link(
-                linkBrand = LinkBrand.Notlink,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
                     collectedCvc = null,
@@ -194,7 +193,7 @@ class PaymentOptionLabelsFactoryTest {
             ),
         )
 
-        assertThat(labels.label).isEqualTo("Notlink")
+        assertThat(labels.label).isEqualTo("Link")
         assertThat(labels.sublabel).isEqualTo("Stripe Test Bank Account •••• 4242")
     }
 
@@ -223,4 +222,12 @@ class PaymentOptionLabelsFactoryTest {
         assertThat(labels.label).isEqualTo("PayPal")
         assertThat(labels.sublabel).isNull()
     }
+
+    private fun paymentMethodMetadata(linkBrand: LinkBrand) = PaymentMethodMetadataFactory.create(
+        linkState = LinkState(
+            configuration = LinkTestUtils.createLinkConfiguration(linkBrand = linkBrand),
+            signupMode = null,
+            loginState = LinkState.LoginState.LoggedOut,
+        )
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -19,6 +20,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import com.stripe.android.R as StripeR
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentSelectionTest {
@@ -40,6 +42,14 @@ class PaymentSelectionTest {
         val link = PaymentSelection.Link(selectedPayment = null)
 
         assertThat(link.billingDetails).isNull()
+    }
+
+    @Test
+    fun `Link label uses branded name`() {
+        val result = PaymentSelection.Link(linkBrand = LinkBrand.Notlink).label.resolve(context)
+
+        assertThat(result).isEqualTo("Notlink")
+        assertThat(result).isNotEqualTo(context.getString(StripeR.string.stripe_link))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -45,11 +45,10 @@ class PaymentSelectionTest {
     }
 
     @Test
-    fun `Link label uses branded name`() {
-        val result = PaymentSelection.Link(linkBrand = LinkBrand.Notlink).label.resolve(context)
+    fun `Link label uses Link brand name`() {
+        val result = PaymentSelection.Link().label(linkBrand = LinkBrand.Link).resolve(context)
 
-        assertThat(result).isEqualTo("Notlink")
-        assertThat(result).isNotEqualTo(context.getString(StripeR.string.stripe_link))
+        assertThat(result).isEqualTo(context.getString(StripeR.string.stripe_link))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
@@ -115,6 +116,7 @@ internal class PaymentSheetScreenAddFirstPaymentMethodScreenshotTest {
         viewModel.walletsStateSource.value = WalletsState(
             link = WalletsState.Link(
                 state = LinkButtonState.Email("email@email.com"),
+                linkBrand = LinkBrand.Link,
             ),
             googlePay = null,
             shopPay = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.ManageSavedPaymentMethods
@@ -36,6 +37,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest {
             DisplayableSavedPaymentMethod.create(
                 displayName = it.second.resolvableString,
                 paymentMethod = it.first,
+                linkBrand = LinkBrand.Link,
                 isCbcEligible = true,
             )
         }
@@ -48,6 +50,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest {
             DisplayableSavedPaymentMethod.create(
                 displayName = it.second.resolvableString,
                 paymentMethod = it.first,
+                linkBrand = LinkBrand.Link,
                 isCbcEligible = true,
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.navigation
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
@@ -80,6 +81,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsTest {
                 DisplayableSavedPaymentMethod.create(
                     displayName = paymentMethod.id.resolvableString,
                     paymentMethod = paymentMethod,
+                    linkBrand = LinkBrand.Link,
                 )
             },
             currentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.navigation
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
@@ -81,7 +80,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsTest {
                 DisplayableSavedPaymentMethod.create(
                     displayName = paymentMethod.id.resolvableString,
                     paymentMethod = paymentMethod,
-                    linkBrand = LinkBrand.Link,
+                    linkBrand = com.stripe.android.model.LinkBrand.Link,
                 )
             },
             currentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
@@ -150,7 +151,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
         val initialScreen = VerticalMode(interactor)
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.walletsStateSource.value = WalletsState(
-            link = WalletsState.Link(state = LinkButtonState.Default),
+            link = WalletsState.Link(state = LinkButtonState.Default, linkBrand = LinkBrand.Link),
             googlePay = null,
             shopPay = null,
             buttonsEnabled = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/WalletsStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/WalletsStateTest.kt
@@ -348,7 +348,11 @@ class WalletsStateTest {
         walletsAllowedInHeader: List<WalletType>,
     ): WalletsState {
         return WalletsState(
-            link = if (hasLink) WalletsState.Link(state = LinkButtonState.Default, linkBrand = LinkBrand.Link) else null,
+            link = if (hasLink) {
+                WalletsState.Link(state = LinkButtonState.Default, linkBrand = LinkBrand.Link)
+            } else {
+                null
+            },
             googlePay = if (hasGooglePay) {
                 WalletsState.GooglePay(
                     buttonType = GooglePayButtonType.Pay,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/WalletsStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/WalletsStateTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -148,6 +149,7 @@ class WalletsStateTest {
             walletsAllowedInHeader = emptyList(),
             cardFundingFilter = DefaultCardFundingFilter,
             cardBrandFilter = DefaultCardBrandFilter,
+            linkBrand = LinkBrand.Link,
         )
     }
 
@@ -346,7 +348,7 @@ class WalletsStateTest {
         walletsAllowedInHeader: List<WalletType>,
     ): WalletsState {
         return WalletsState(
-            link = if (hasLink) WalletsState.Link(state = LinkButtonState.Default) else null,
+            link = if (hasLink) WalletsState.Link(state = LinkButtonState.Default, linkBrand = LinkBrand.Link) else null,
             googlePay = if (hasGooglePay) {
                 WalletsState.GooglePay(
                     buttonType = GooglePayButtonType.Pay,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -192,13 +192,13 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(
                     paymentMethods = PaymentMethodFixtures.createCards(2),
-                ).plus(PaymentOptionsItem.Link)
+                ).plus(PaymentOptionsItem.Link())
             ),
             currentSelection = currentSelectionFlow,
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link())
                 }
             }
         }
@@ -213,13 +213,13 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(
                     paymentMethods = PaymentMethodFixtures.createCards(2),
-                ).plus(PaymentOptionsItem.Link).plus(PaymentOptionsItem.GooglePay)
+                ).plus(PaymentOptionsItem.Link()).plus(PaymentOptionsItem.GooglePay)
             ),
             currentSelection = currentSelectionFlow,
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link())
                 }
             }
 
@@ -242,13 +242,13 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(
                     paymentMethods = PaymentMethodFixtures.createCards(2),
-                ).plus(PaymentOptionsItem.Link)
+                ).plus(PaymentOptionsItem.Link())
             ),
             currentSelection = currentSelectionFlow,
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link())
                 }
             }
 
@@ -256,7 +256,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link())
                 }
             }
         }
@@ -378,7 +378,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
         runScenario(
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(paymentMethods = paymentMethods).plus(
-                    PaymentOptionsItem.Link
+                    PaymentOptionsItem.Link()
                 )
             ),
             currentSelection = currentSelectionFlow,
@@ -399,7 +399,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             interactor.state.test {
                 awaitItem().run {
                     assertThat(selectedPaymentOptionsItem).isEqualTo(
-                        PaymentOptionsItem.Link
+                        PaymentOptionsItem.Link()
                     )
                 }
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.DisplayablePaymentDetails
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.AnalyticEvent
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
@@ -259,6 +260,7 @@ class DefaultWalletButtonsInteractorTest {
                 button = WalletButtonsInteractor.WalletButton.Link(
                     state = LinkButtonState.Default,
                     theme = LinkButtonTheme.DEFAULT,
+                    linkBrand = LinkBrand.Link,
                 ),
                 clickHandler = { false },
             )
@@ -294,6 +296,7 @@ class DefaultWalletButtonsInteractorTest {
                 button = WalletButtonsInteractor.WalletButton.Link(
                     state = LinkButtonState.Default,
                     theme = LinkButtonTheme.DEFAULT,
+                    linkBrand = LinkBrand.Link,
                 ),
                 clickHandler = { false },
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -22,10 +22,11 @@ class PaymentOptionsScreenshotTest {
         createSavedPaymentMethodTabLayoutUiScreenshot(
             paymentOptionsItems = listOf(
                 PaymentOptionsItem.AddCard,
-                PaymentOptionsItem.Link(),
+                PaymentOptionsItem.Link,
             ),
-            selectedPaymentOptionsItem = PaymentOptionsItem.Link(),
+            selectedPaymentOptionsItem = PaymentOptionsItem.Link,
             isEditing = false,
+            linkBrand = LinkBrand.Link,
         )
     }
 
@@ -175,12 +176,14 @@ class PaymentOptionsScreenshotTest {
         paymentOptionsItems: List<PaymentOptionsItem>,
         selectedPaymentOptionsItem: PaymentOptionsItem?,
         isEditing: Boolean,
+        linkBrand: LinkBrand? = null,
         scrollState: LazyListState? = null,
     ) {
         paparazziRule.snapshot {
             SavedPaymentMethodTabLayoutUI(
                 paymentOptionsItems = paymentOptionsItems,
                 selectedPaymentOptionsItem = selectedPaymentOptionsItem,
+                linkBrand = linkBrand,
                 isEditing = isEditing,
                 isProcessing = false,
                 onAddCardPressed = {},

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -37,18 +38,21 @@ class PaymentOptionsScreenshotTest {
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4242"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4000"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("1234"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
         )
@@ -69,18 +73,21 @@ class PaymentOptionsScreenshotTest {
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4242"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4000"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("1234"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
         )
@@ -100,18 +107,21 @@ class PaymentOptionsScreenshotTest {
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4242"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("4000"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = createCard("1234", addNetworks = true),
+                    linkBrand = LinkBrand.Link,
                     isCbcEligible = true,
                 ),
             ),
@@ -140,6 +150,7 @@ class PaymentOptionsScreenshotTest {
             DisplayableSavedPaymentMethod.create(
                 displayName = "Card".resolvableString,
                 paymentMethod = createCard("8431"),
+                linkBrand = LinkBrand.Link,
                 shouldShowDefaultBadge = true,
             ),
         ),
@@ -147,12 +158,14 @@ class PaymentOptionsScreenshotTest {
             DisplayableSavedPaymentMethod.create(
                 displayName = "Card".resolvableString,
                 paymentMethod = createCard("4000"),
+                linkBrand = LinkBrand.Link,
             ),
         ),
         PaymentOptionsItem.SavedPaymentMethod(
             DisplayableSavedPaymentMethod.create(
                 displayName = "Card".resolvableString,
                 paymentMethod = createCard("1234", addNetworks = true),
+                linkBrand = LinkBrand.Link,
                 isCbcEligible = true,
             ),
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -21,9 +21,9 @@ class PaymentOptionsScreenshotTest {
         createSavedPaymentMethodTabLayoutUiScreenshot(
             paymentOptionsItems = listOf(
                 PaymentOptionsItem.AddCard,
-                PaymentOptionsItem.Link,
+                PaymentOptionsItem.Link(),
             ),
-            selectedPaymentOptionsItem = PaymentOptionsItem.Link,
+            selectedPaymentOptionsItem = PaymentOptionsItem.Link(),
             isEditing = false,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.ui
 import android.os.Build
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import android.os.Build
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -136,6 +137,46 @@ class PaymentOptionsTest {
         ).assertDoesNotExist()
     }
 
+    @Test
+    fun `Link tab uses provided Notlink brand`() {
+        composeTestRule.setContent {
+            SavedPaymentMethodTabLayoutUI(
+                onAddCardPressed = {},
+                onItemSelected = {},
+                isEditing = false,
+                paymentOptionsItems = listOf(PaymentOptionsItem.Link),
+                selectedPaymentOptionsItem = PaymentOptionsItem.Link,
+                linkBrand = com.stripe.android.model.LinkBrand.Notlink,
+                isProcessing = false,
+                onModifyItem = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_Notlink").assertExists()
+    }
+
+    @Test
+    fun `saved Link tab uses provided Notlink brand`() {
+        composeTestRule.setContent {
+            SavedPaymentMethodTabLayoutUI(
+                onAddCardPressed = {},
+                onItemSelected = {},
+                isEditing = false,
+                paymentOptionsItems = listOf(
+                    PaymentOptionsItem.SavedPaymentMethod(
+                        PaymentMethodFixtures.displayableLinkPaymentMethod()
+                    )
+                ),
+                selectedPaymentOptionsItem = null,
+                linkBrand = com.stripe.android.model.LinkBrand.Notlink,
+                isProcessing = false,
+                onModifyItem = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_Notlink").assertExists()
+    }
+
     private fun createTabLayoutUiForTestingClicks(
         isEditing: Boolean,
         onAddCardPressed: () -> Unit = {},
@@ -148,6 +189,7 @@ class PaymentOptionsTest {
                 isEditing = isEditing,
                 paymentOptionsItems = listOf(PaymentOptionsItem.AddCard, PaymentOptionsItem.GooglePay),
                 selectedPaymentOptionsItem = PaymentOptionsItem.GooglePay,
+                linkBrand = null,
                 isProcessing = false,
                 onModifyItem = {},
             )
@@ -171,6 +213,7 @@ class PaymentOptionsTest {
                 paymentOptionsItems = paymentOptionsItemsWithDefault,
                 isEditing = isEditing,
                 selectedPaymentOptionsItem = null,
+                linkBrand = null,
                 onAddCardPressed = {},
                 onItemSelected = {},
                 isProcessing = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/WalletButtonsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/WalletButtonsScreenshotTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.link.ui.LinkButtonState
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -18,7 +19,8 @@ class WalletButtonsScreenshotTest {
         val walletButtonsContent = createWalletButtonsContent(
             walletButtons = listOf(
                 WalletButtonsInteractor.WalletButton.Link(
-                    state = LinkButtonState.Email("email@email.com")
+                    state = LinkButtonState.Email("email@email.com"),
+                    linkBrand = LinkBrand.Link,
                 )
             ),
             buttonsEnabled = true,
@@ -34,7 +36,8 @@ class WalletButtonsScreenshotTest {
         val walletButtonsContent = createWalletButtonsContent(
             walletButtons = listOf(
                 WalletButtonsInteractor.WalletButton.Link(
-                    state = LinkButtonState.Email("email@email.com")
+                    state = LinkButtonState.Email("email@email.com"),
+                    linkBrand = LinkBrand.Link,
                 ),
             ),
             buttonsEnabled = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -1015,9 +1016,29 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     fun handleViewAction_SelectSavedPaymentMethod_selectsSavedPm() {
         val savedPaymentMethod = PaymentMethodFixtures.displayableCard()
         runScenario {
-            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod.paymentMethod))
+            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod))
             assertThat((selection.value as PaymentSelection.Saved).paymentMethod)
                 .isEqualTo(savedPaymentMethod.paymentMethod)
+            assertThat(reportPaymentMethodTypeSelectedTurbine.awaitItem()).isEqualTo("saved")
+            assertThat(updateSelectionTurbine.awaitItem()).isTrue()
+        }
+    }
+
+    @Test
+    fun handleViewAction_SelectSavedPaymentMethod_preservesLinkBrand() {
+        val linkPaymentMethod = PaymentMethodFixtures.displayableLinkPaymentMethod()
+        val savedPaymentMethod = DisplayableSavedPaymentMethod.create(
+            displayName = linkPaymentMethod.displayName,
+            paymentMethod = linkPaymentMethod.paymentMethod,
+            linkBrand = LinkBrand.Notlink,
+            isCbcEligible = linkPaymentMethod.isCbcEligible,
+            shouldShowDefaultBadge = linkPaymentMethod.shouldShowDefaultBadge,
+        )
+
+        runScenario {
+            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod))
+            assertThat((selection.value as PaymentSelection.Saved).linkBrand)
+                .isEqualTo(LinkBrand.Notlink)
             assertThat(reportPaymentMethodTypeSelectedTurbine.awaitItem()).isEqualTo("saved")
             assertThat(updateSelectionTurbine.awaitItem()).isTrue()
         }
@@ -1032,7 +1053,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 rowSelectionCallbackInvoked = true
             }
         ) {
-            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod.paymentMethod))
+            interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod))
             assertThat(reportPaymentMethodTypeSelectedTurbine.awaitItem()).isEqualTo("saved")
             assertThat(rowSelectionCallbackInvoked).isTrue()
             assertThat(updateSelectionTurbine.awaitItem()).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -493,7 +493,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ),
     ) {
         walletsState.value = WalletsState(
-            link = WalletsState.Link(LinkButtonState.Email("email@email.com")),
+            link = WalletsState.Link(LinkButtonState.Email("email@email.com"), linkBrand = LinkBrand.Link),
             googlePay = WalletsState.GooglePay(
                 buttonType = GooglePayButtonType.Pay,
                 allowCreditCards = true,
@@ -529,7 +529,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ),
     ) {
         walletsState.value = WalletsState(
-            link = WalletsState.Link(LinkButtonState.Email("email@email.com")),
+            link = WalletsState.Link(LinkButtonState.Email("email@email.com"), linkBrand = LinkBrand.Link),
             googlePay = WalletsState.GooglePay(
                 buttonType = GooglePayButtonType.Pay,
                 allowCreditCards = true,
@@ -568,7 +568,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             )
         ) {
             walletsState.value = WalletsState(
-                link = WalletsState.Link(LinkButtonState.Email("email@email.com")),
+                link = WalletsState.Link(LinkButtonState.Email("email@email.com"), linkBrand = LinkBrand.Link),
                 googlePay = WalletsState.GooglePay(
                     buttonType = GooglePayButtonType.Pay,
                     allowCreditCards = true,
@@ -683,7 +683,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ),
     ) {
         walletsState.value = WalletsState(
-            link = WalletsState.Link(LinkButtonState.Email("email@email.com")),
+            link = WalletsState.Link(LinkButtonState.Email("email@email.com"), linkBrand = LinkBrand.Link),
             googlePay = null,
             shopPay = null,
             buttonsEnabled = true,
@@ -753,7 +753,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         )
     ) {
         walletsState.value = WalletsState(
-            link = WalletsState.Link(LinkButtonState.Email("email@email.com")),
+            link = WalletsState.Link(LinkButtonState.Email("email@email.com"), linkBrand = LinkBrand.Link),
             googlePay = null,
             shopPay = null,
             buttonsEnabled = true,
@@ -1025,7 +1025,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun handleViewAction_SelectSavedPaymentMethod_preservesLinkBrand() {
+    fun handleViewAction_SelectSavedPaymentMethod_keepsSelectedPaymentMethod() {
         val linkPaymentMethod = PaymentMethodFixtures.displayableLinkPaymentMethod()
         val savedPaymentMethod = DisplayableSavedPaymentMethod.create(
             displayName = linkPaymentMethod.displayName,
@@ -1037,8 +1037,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
         runScenario {
             interactor.handleViewAction(ViewAction.SavedPaymentMethodSelected(savedPaymentMethod))
-            assertThat((selection.value as PaymentSelection.Saved).linkBrand)
-                .isEqualTo(LinkBrand.Notlink)
+            assertThat((selection.value as PaymentSelection.Saved).paymentMethod)
+                .isEqualTo(savedPaymentMethod.paymentMethod)
             assertThat(reportPaymentMethodTypeSelectedTurbine.awaitItem()).isEqualTo("saved")
             assertThat(updateSelectionTurbine.awaitItem()).isTrue()
         }
@@ -1525,6 +1525,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             walletsAllowedInHeader = emptyList(), // Link inline to test row subtitle
             cardFundingFilter = DefaultCardFundingFilter,
             cardBrandFilter = DefaultCardBrandFilter,
+            linkBrand = LinkBrand.Link,
         )
         runScenario(
             initialWalletsState = walletsState,
@@ -1554,6 +1555,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             walletsAllowedInHeader = emptyList(), // Link inline to test row subtitle
             cardFundingFilter = DefaultCardFundingFilter,
             cardBrandFilter = DefaultCardBrandFilter,
+            linkBrand = LinkBrand.Link,
         )
         runScenario(
             initialWalletsState = walletsState,
@@ -1726,7 +1728,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private val linkAndGooglePayWalletState = WalletsState(
-        link = WalletsState.Link(LinkButtonState.Email("email@email.com")),
+        link = WalletsState.Link(LinkButtonState.Email("email@email.com"), linkBrand = LinkBrand.Link),
         googlePay = WalletsState.GooglePay(
             buttonType = GooglePayButtonType.Pay,
             allowCreditCards = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.elements.FormElement
@@ -78,11 +79,16 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
         val paymentMethod = PaymentMethodFactory.card()
         return DefaultSavedPaymentMethodConfirmInteractor(
             initialSelection = PaymentSelection.Saved(paymentMethod),
-            displayName = "Card".resolvableString,
+            displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+                displayName = "Card".resolvableString,
+                paymentMethod = paymentMethod,
+                linkBrand = com.stripe.android.model.LinkBrand.Link,
+            ),
             savedPaymentMethodLinkFormHelper = linkFormHelper,
             processing = processing,
             updateSelection = updateSelection,
             coroutineScope = coroutineScope,
+            linkBrand = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeManageScreenInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeManageScreenInteractor.kt
@@ -17,6 +17,7 @@ internal class FakeManageScreenInteractor(
                 currentSelection = null,
                 isEditing = false,
                 canEdit = true,
+                linkBrand = null,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
@@ -37,6 +37,7 @@ internal class FakePaymentMethodVerticalLayoutInteractor(
                 availableSavedPaymentMethodAction =
                 PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,
                 mandate = mandate,
+                linkBrand = paymentMethodMetadata.linkBrand,
             )
             return FakePaymentMethodVerticalLayoutInteractor(
                 initialState = initialState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -32,6 +33,7 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
                         last4 = "4242",
                     )
                 ),
+                linkBrand = LinkBrand.Link,
             ),
             form = SavedPaymentMethodConfirmInteractor.State.Form(
                 elements = listOf(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -33,7 +32,7 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
                         last4 = "4242",
                     )
                 ),
-                linkBrand = LinkBrand.Link,
+                linkBrand = com.stripe.android.model.LinkBrand.Link,
             ),
             form = SavedPaymentMethodConfirmInteractor.State.Form(
                 elements = listOf(
@@ -53,6 +52,7 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
                 ),
                 enabled = formEnabled,
             ),
+            linkBrand = null,
         )
     )
     override val state: StateFlow<SavedPaymentMethodConfirmInteractor.State> = _state.asStateFlow()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUITest.kt
@@ -10,8 +10,10 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -73,6 +75,21 @@ class ManageScreenUITest {
             ).assert(
                 hasContentDescriptionExactly("Visa ending in 4 2 4 2 ")
             )
+        }
+    }
+
+    @Test
+    fun savedLinkPaymentMethod_usesProvidedNotlinkBrand() {
+        runScenario(
+            initialState = ManageScreenInteractor.State(
+                paymentMethods = listOf(PaymentMethodFixtures.displayableLinkPaymentMethod()),
+                currentSelection = null,
+                isEditing = false,
+                canEdit = true,
+                linkBrand = LinkBrand.Notlink,
+            )
+        ) {
+            composeRule.onNodeWithText("Notlink").assertExists()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
@@ -237,7 +237,7 @@ internal class PaymentMethodLayoutUITest(
             ).performClick()
             viewActionRecorder.consume(
                 PaymentMethodVerticalLayoutInteractor.ViewAction.SavedPaymentMethodSelected(
-                    savedPaymentMethod.paymentMethod
+                    savedPaymentMethod
                 )
             )
             assertThat(viewActionRecorder.viewActions).isEmpty()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUIScreenshotTest.kt
@@ -20,7 +20,7 @@ internal class SavedPaymentMethodConfirmUIScreenshotTest {
             SavedPaymentMethodConfirmUI(
                 savedPaymentMethodConfirmInteractor = FakeSavedPaymentMethodConfirmInteractor(
                     formEnabled = false,
-                )
+                ),
             )
         }
     }
@@ -31,7 +31,7 @@ internal class SavedPaymentMethodConfirmUIScreenshotTest {
             SavedPaymentMethodConfirmUI(
                 savedPaymentMethodConfirmInteractor = FakeSavedPaymentMethodConfirmInteractor(
                     formEnabled = true,
-                )
+                ),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -39,6 +40,7 @@ internal class SavedPaymentMethodRowButtonScreenshotTest {
                 last4 = "4242",
             )
         ),
+        linkBrand = LinkBrand.Link,
     )
 
     @Test
@@ -159,6 +161,7 @@ internal class SavedPaymentMethodRowButtonScreenshotTest {
                     )
                 )
             ),
-            )
+            linkBrand = LinkBrand.Link,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
@@ -96,6 +96,7 @@ internal class SavedPaymentMethodRowButtonScreenshotTest {
         paparazziRule.snapshot {
             SavedPaymentMethodRowButton(
                 displayableSavedPaymentMethod = savedDefaultVisa,
+                linkBrand = LinkBrand.Link,
                 isEnabled = true,
                 isSelected = false,
             )
@@ -109,6 +110,7 @@ internal class SavedPaymentMethodRowButtonScreenshotTest {
         paparazziRule.snapshot {
             SavedPaymentMethodRowButton(
                 displayableSavedPaymentMethod = savedDefaultVisa,
+                linkBrand = LinkBrand.Link,
                 isEnabled = true,
                 isSelected = false,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.SetupIntentFixtures
@@ -378,6 +379,7 @@ internal class VerticalModeFormUIScreenshotTest {
         viewModel.walletsStateSource.value = WalletsState(
             link = WalletsState.Link(
                 state = LinkButtonState.Default,
+                linkBrand = LinkBrand.Link,
             ),
             googlePay = null,
             shopPay = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.getDefaultCustomerMetadataFlow
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -22,6 +23,7 @@ class PaymentOptionsItemsMapperTest {
     private val customerStateFlow = MutableStateFlow<CustomerState?>(null)
     private val isGooglePayReadyFlow = MutableStateFlow(false)
     private val isLinkEnabledFlow = MutableStateFlow<Boolean?>(null)
+    private val linkBrandFlow = MutableStateFlow(LinkBrand.Link)
 
     @Test
     fun `Only emits value if required flows have emitted values`() = runTest {
@@ -29,6 +31,7 @@ class PaymentOptionsItemsMapperTest {
             customerState = customerStateFlow,
             isGooglePayReady = isGooglePayReadyFlow,
             isLinkEnabled = isLinkEnabledFlow,
+            linkBrand = linkBrandFlow,
             isNotPaymentFlow = true,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },
@@ -48,7 +51,7 @@ class PaymentOptionsItemsMapperTest {
             assertThat(state).hasSize(5)
             assertThat(state[0].viewType).isEqualTo(PaymentOptionsItem.ViewType.AddCard)
             assertThat(state[1].viewType).isEqualTo(PaymentOptionsItem.ViewType.GooglePay)
-            assertThat(state[2].viewType).isEqualTo(PaymentOptionsItem.ViewType.Link)
+            assertThat(state[2]).isEqualTo(PaymentOptionsItem.Link())
             assertThat(state[3].viewType).isEqualTo(PaymentOptionsItem.ViewType.SavedPaymentMethod)
             assertThat(state[4].viewType).isEqualTo(PaymentOptionsItem.ViewType.SavedPaymentMethod)
         }
@@ -60,6 +63,7 @@ class PaymentOptionsItemsMapperTest {
             customerState = customerStateFlow,
             isGooglePayReady = isGooglePayReadyFlow,
             isLinkEnabled = isLinkEnabledFlow,
+            linkBrand = linkBrandFlow,
             isNotPaymentFlow = false,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },
@@ -77,7 +81,7 @@ class PaymentOptionsItemsMapperTest {
 
             assertThat(awaitItem()).containsNoneOf(
                 PaymentOptionsItem.GooglePay,
-                PaymentOptionsItem.Link,
+                PaymentOptionsItem.Link(),
             )
         }
     }
@@ -110,6 +114,7 @@ class PaymentOptionsItemsMapperTest {
             customerState = customerStateFlow,
             isGooglePayReady = isGooglePayReadyFlow,
             isLinkEnabled = isLinkEnabledFlow,
+            linkBrand = linkBrandFlow,
             isNotPaymentFlow = false,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },


### PR DESCRIPTION
# Summary
Thread Link brand enum to more places

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-801
https://jira.corp.stripe.com/browse/LINK_MOBILE-807
https://jira.corp.stripe.com/browse/LINK_MOBILE-812
https://jira.corp.stripe.com/browse/LINK_MOBILE-815
https://jira.corp.stripe.com/browse/LINK_MOBILE-816
https://jira.corp.stripe.com/browse/LINK_MOBILE-819

# Testing

- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

Manual verifications in the payment sheet example app with force Notlink branding enabled - branding now shows Notlink

<img width="500" alt="Screenshot_20260429_084405" src="https://github.com/user-attachments/assets/f45bd312-2269-4c65-be97-cd4af261e704" />

<img width="500" alt="Screenshot_20260429_101241" src="https://github.com/user-attachments/assets/7b7769e4-f218-4e59-8aa7-ee820f630336" />

# Changelog
n/a
