### PR TITLE
Validate setup intent parameters in `TapToAddCollectionHandler`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
@@ -4,6 +4,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -20,6 +21,7 @@ import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.SetupIntentCallback
 import com.stripe.stripeterminal.external.models.AllowRedisplay
 import com.stripe.stripeterminal.external.models.CollectSetupIntentConfiguration
+import com.stripe.stripeterminal.external.models.PaymentMethodType
 import com.stripe.stripeterminal.external.models.SetupIntent
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import com.stripe.stripeterminal.external.models.TerminalErrorCode
@@ -62,6 +64,7 @@ internal interface TapToAddCollectionHandler {
             paymentConfiguration: PaymentConfiguration,
             connectionManager: TapToAddConnectionManager,
             tapToPayUxConfiguration: TapToPayUxConfiguration,
+            isSimulatedProvider: TapToAddIsSimulatedProvider,
             userFacingLogger: UserFacingLogger,
             errorReporter: ErrorReporter,
             createCardPresentSetupIntentCallbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
@@ -73,6 +76,7 @@ internal interface TapToAddCollectionHandler {
                     stripeRepository = stripeRepository,
                     paymentConfiguration = paymentConfiguration,
                     tapToPayUxConfiguration = tapToPayUxConfiguration,
+                    isSimulatedProvider = isSimulatedProvider,
                     userFacingLogger = userFacingLogger,
                     errorReporter = errorReporter,
                     createCardPresentSetupIntentCallbackRetriever = createCardPresentSetupIntentCallbackRetriever,
@@ -91,6 +95,7 @@ internal class DefaultTapToAddCollectionHandler(
     private val paymentConfiguration: PaymentConfiguration,
     private val connectionManager: TapToAddConnectionManager,
     private val errorReporter: ErrorReporter,
+    private val isSimulatedProvider: TapToAddIsSimulatedProvider,
     private val userFacingLogger: UserFacingLogger,
     private val tapToPayUxConfiguration: TapToPayUxConfiguration,
     private val createCardPresentSetupIntentCallbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
@@ -163,6 +168,11 @@ internal class DefaultTapToAddCollectionHandler(
         customerMetadata: CustomerMetadata,
     ): TapToAddCollectionHandler.CollectionState {
         val setupIntent = retrieveSetupIntent(clientSecret)
+
+        validateSetupIntent(customerMetadata, setupIntent)?.let { failedValidationResult ->
+            return failedValidationResult
+        }
+
         val setupIntentWithAttachedPaymentMethod = collectPaymentMethod(setupIntent)
         val confirmedIntent = confirmSetupIntent(setupIntentWithAttachedPaymentMethod)
         val paymentMethod = fetchPaymentMethod(confirmedIntent, customerMetadata)
@@ -219,6 +229,55 @@ internal class DefaultTapToAddCollectionHandler(
                 options = getApiOptions(customerMetadata),
             ).getOrThrow()
         } ?: paymentMethod
+    }
+
+    private fun validateSetupIntent(
+        customerMetadata: CustomerMetadata,
+        setupIntent: SetupIntent,
+    ): TapToAddCollectionHandler.CollectionState.FailedCollection? {
+        val isSimulated = isSimulatedProvider.get()
+
+        if (!setupIntent.paymentMethodTypes.contains(PaymentMethodType.CARD_PRESENT.typeName)) {
+            val error = IllegalStateException("Missing 'card_present' payment method type on setup intent!")
+
+            return TapToAddCollectionHandler.CollectionState.FailedCollection(
+                error = error,
+                errorCode = DefaultErrorCode.Internal.MissingCardPresentPaymentMethodType,
+                errorMessage = if (isSimulated) {
+                    TapToAddErrorMessage(
+                        title = INTEGRATION_ERROR_TITLE.resolvableString,
+                        action = MISSING_CARD_PRESENT_ACTION.resolvableString,
+                    )
+                } else {
+                    TapToAddErrorMessageBuilder.build(error)
+                }
+            )
+        }
+
+        val setupIntentCustomer = setupIntent.customerId
+        val expectedCustomer = getCustomerId(customerMetadata)
+
+        if (setupIntentCustomer != expectedCustomer) {
+            val error = IllegalStateException("Incorrect customer attached to setup intent!")
+
+            return TapToAddCollectionHandler.CollectionState.FailedCollection(
+                error = error,
+                errorCode = DefaultErrorCode.Internal.IncorrectCustomerOnSetupIntent,
+                errorMessage = if (isSimulated) {
+                    TapToAddErrorMessage(
+                        title = INTEGRATION_ERROR_TITLE.resolvableString,
+                        action = createIncorrectCustomerActionMessage(
+                            actualCustomer = setupIntentCustomer,
+                            expectedCustomer = expectedCustomer,
+                        ).resolvableString,
+                    )
+                } else {
+                    TapToAddErrorMessageBuilder.build(error)
+                }
+            )
+        }
+
+        return null
     }
 
     private fun validatePaymentMethod(
@@ -306,17 +365,9 @@ internal class DefaultTapToAddCollectionHandler(
                 )
             }
 
-        val (customerId) = when (customerMetadata) {
-            is CustomerMetadata.CustomerSession -> customerMetadata.id to customerMetadata.ephemeralKeySecret
-            is CustomerMetadata.LegacyEphemeralKey -> customerMetadata.id to customerMetadata.ephemeralKeySecret
-            is CustomerMetadata.CheckoutSession -> {
-                throw NotImplementedError("Checkout sessions do not support retrieving individual payment methods!")
-            }
-        }
-
         return stripeRepository.retrieveSavedPaymentMethodFromCardPresentPaymentMethod(
             cardPresentPaymentMethodId = paymentMethodId,
-            customerId = customerId,
+            customerId = getCustomerId(customerMetadata),
             options = getApiOptions(customerMetadata)
         ).getOrThrow()
     }
@@ -345,6 +396,14 @@ internal class DefaultTapToAddCollectionHandler(
         }
     }
 
+    private fun getCustomerId(customerMetadata: CustomerMetadata): String {
+        return when (customerMetadata) {
+            is CustomerMetadata.CustomerSession -> customerMetadata.id
+            is CustomerMetadata.LegacyEphemeralKey -> customerMetadata.id
+            is CustomerMetadata.CheckoutSession -> customerMetadata.customerId
+        }
+    }
+
     private fun getApiOptions(customerMetadata: CustomerMetadata): ApiRequest.Options {
         val ephemeralKeySecret = when (customerMetadata) {
             is CustomerMetadata.CustomerSession -> customerMetadata.ephemeralKeySecret
@@ -367,7 +426,9 @@ internal class DefaultTapToAddCollectionHandler(
             NoCustomer("noCustomer"),
             NoCardPresentCallbackFailure("noCardPresentCallbackFailure"),
             FailureFromMerchantCardPresentCallback("failureFromMerchantCardPresentCallback"),
-            CardBrandNotSupportedByMerchant("cardBrandNotSupportedByMerchant")
+            CardBrandNotSupportedByMerchant("cardBrandNotSupportedByMerchant"),
+            MissingCardPresentPaymentMethodType("missingCardPresentPaymentMethodType"),
+            IncorrectCustomerOnSetupIntent("incorrectCustomerOnSetupIntent")
         }
 
         class Terminal(exception: TerminalException) : DefaultErrorCode {
@@ -377,6 +438,26 @@ internal class DefaultTapToAddCollectionHandler(
         class Exception(error: Throwable) : DefaultErrorCode {
             override val value: String = error.safeAnalyticsMessage
         }
+    }
+
+    private fun createIncorrectCustomerActionMessage(
+        expectedCustomer: String,
+        actualCustomer: String?,
+    ): String {
+        return when (actualCustomer) {
+            null ->
+                "Please attach the customer ($expectedCustomer) to the setup intent that was used to" +
+                " when initializing Payment Element"
+            else ->
+                "Setup intent had a different customer ($actualCustomer) than the expected customer " +
+                "initialized with Payment Element ($expectedCustomer). Please attach the expected customer."
+        }
+    }
+
+    private companion object {
+        const val INTEGRATION_ERROR_TITLE = "Integration error"
+        const val MISSING_CARD_PRESENT_ACTION = "Ensure the setup intent allows a `card_present` payment method " +
+            "type on it to allow for tapping cards"
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
@@ -42,6 +42,7 @@ internal interface TapToAddModule {
             paymentConfiguration: PaymentConfiguration,
             terminalWrapper: TerminalWrapper,
             tapToPayUxConfiguration: TapToPayUxConfiguration,
+            isSimulatedProvider: TapToAddIsSimulatedProvider,
             userFacingLogger: UserFacingLogger,
             errorReporter: ErrorReporter,
             createCardPresentSetupIntentCallbackRetriever: CreateCardPresentSetupIntentCallbackRetriever
@@ -51,6 +52,7 @@ internal interface TapToAddModule {
                 connectionManager = connectionManager,
                 terminalWrapper = terminalWrapper,
                 stripeRepository = stripeRepository,
+                isSimulatedProvider = isSimulatedProvider,
                 paymentConfiguration = paymentConfiguration,
                 tapToPayUxConfiguration = tapToPayUxConfiguration,
                 errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -38,6 +38,7 @@ import com.stripe.stripeterminal.external.callable.SetupIntentCallback
 import com.stripe.stripeterminal.external.models.AllowRedisplay
 import com.stripe.stripeterminal.external.models.CardDetails
 import com.stripe.stripeterminal.external.models.CollectSetupIntentConfiguration
+import com.stripe.stripeterminal.external.models.PaymentMethodType
 import com.stripe.stripeterminal.external.models.SetupIntent
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import com.stripe.stripeterminal.external.models.TerminalErrorCode
@@ -74,6 +75,7 @@ class TapToAddCollectionHandlerTest {
             paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
             tapToPayUxConfiguration = tapToPayUxConfiguration,
+            isSimulatedProvider = DEFAULT_IS_SIMULATED_PROVIDER,
             userFacingLogger = FakeUserFacingLogger(),
             errorReporter = FakeErrorReporter(),
             createCardPresentSetupIntentCallbackRetriever = FakeCreateCardPresentSetupIntentCallbackRetriever.noOp(
@@ -93,6 +95,7 @@ class TapToAddCollectionHandlerTest {
             paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
             tapToPayUxConfiguration = tapToPayUxConfiguration,
+            isSimulatedProvider = DEFAULT_IS_SIMULATED_PROVIDER,
             userFacingLogger = FakeUserFacingLogger(),
             errorReporter = FakeErrorReporter(),
             createCardPresentSetupIntentCallbackRetriever = FakeCreateCardPresentSetupIntentCallbackRetriever.noOp(
@@ -254,12 +257,167 @@ class TapToAddCollectionHandlerTest {
             assertFailedCollection(
                 result = collectionResult,
                 expectedErrorType = NotImplementedError::class.java,
-                expectedThrowableMessage = "Checkout sessions do not support retrieving individual payment methods!",
+                expectedThrowableMessage = "Checkout sessions does not support Tap to Add!",
                 expectedErrorCodeValue = "unknown",
                 expectedUserError = GENERIC_USER_ERROR,
             )
         }
     }
+
+    @Test
+    fun `handler returns FailedCollection when setup intent is missing card_present payment method type`() =
+        runScenario(
+            callbackResult = Result.success(
+                CreateCardPresentSetupIntentCallback {
+                    CreateIntentResult.Success("si_123_secret")
+                }
+            ),
+            isSimulated = false,
+        ) {
+            val result = testScope.backgroundScope.async {
+                handler.collect(DEFAULT_METADATA)
+            }
+
+            assertThat(retrieverScenario.waitForCallbackCalls.awaitItem()).isNotNull()
+            assertThat(terminalScenario.setTapToPayUxConfigurationCalls.awaitItem()).isNotNull()
+
+            checkRetrieveSetupIntent(
+                clientSecret = "si_123_secret",
+                paymentMethodTypes = listOf("card"),
+            )
+
+            assertFailedCollection(
+                result = result.await(),
+                expectedErrorType = IllegalStateException::class.java,
+                expectedThrowableMessage = "Missing 'card_present' payment method type on setup intent!",
+                expectedErrorCodeValue = "missingCardPresentPaymentMethodType",
+                expectedUserError = GENERIC_USER_ERROR,
+            )
+        }
+
+    @Test
+    fun `handler returns FailedCollection with integration error when SI missing card_present in simulated mode`() =
+        runScenario(
+            callbackResult = Result.success(
+                CreateCardPresentSetupIntentCallback {
+                    CreateIntentResult.Success("si_123_secret")
+                }
+            ),
+            isSimulated = true,
+        ) {
+            val result = testScope.backgroundScope.async {
+                handler.collect(DEFAULT_METADATA)
+            }
+
+            assertThat(retrieverScenario.waitForCallbackCalls.awaitItem()).isNotNull()
+            assertThat(terminalScenario.setTapToPayUxConfigurationCalls.awaitItem()).isNotNull()
+
+            checkRetrieveSetupIntent(
+                clientSecret = "si_123_secret",
+                paymentMethodTypes = listOf("card"),
+            )
+
+            assertFailedCollection(
+                result = result.await(),
+                expectedErrorType = IllegalStateException::class.java,
+                expectedThrowableMessage = "Missing 'card_present' payment method type on setup intent!",
+                expectedErrorCodeValue = "missingCardPresentPaymentMethodType",
+                expectedUserError = SIMULATED_MISSING_CARD_PRESENT_ERROR,
+            )
+        }
+
+    @Test
+    fun `handler returns FailedCollection when setup intent customer does not match Payment Element customer`() =
+        runScenario(
+            callbackResult = Result.success(
+                CreateCardPresentSetupIntentCallback {
+                    CreateIntentResult.Success("si_123_secret")
+                }
+            ),
+            isSimulated = false,
+        ) {
+            val result = testScope.backgroundScope.async {
+                handler.collect(DEFAULT_METADATA)
+            }
+
+            assertThat(retrieverScenario.waitForCallbackCalls.awaitItem()).isNotNull()
+            assertThat(terminalScenario.setTapToPayUxConfigurationCalls.awaitItem()).isNotNull()
+
+            checkRetrieveSetupIntent(
+                clientSecret = "si_123_secret",
+                customerId = "cus_other",
+            )
+
+            assertFailedCollection(
+                result = result.await(),
+                expectedErrorType = IllegalStateException::class.java,
+                expectedThrowableMessage = "Incorrect customer attached to setup intent!",
+                expectedErrorCodeValue = "incorrectCustomerOnSetupIntent",
+                expectedUserError = GENERIC_USER_ERROR,
+            )
+        }
+
+    @Test
+    fun `handler returns FailedCollection with integration error when SI customer mismatches in simulated mode`() =
+        runScenario(
+            callbackResult = Result.success(
+                CreateCardPresentSetupIntentCallback {
+                    CreateIntentResult.Success("si_123_secret")
+                }
+            ),
+            isSimulated = true,
+        ) {
+            val result = testScope.backgroundScope.async {
+                handler.collect(DEFAULT_METADATA)
+            }
+
+            assertThat(retrieverScenario.waitForCallbackCalls.awaitItem()).isNotNull()
+            assertThat(terminalScenario.setTapToPayUxConfigurationCalls.awaitItem()).isNotNull()
+
+            checkRetrieveSetupIntent(
+                clientSecret = "si_123_secret",
+                customerId = "cus_other",
+            )
+
+            assertFailedCollection(
+                result = result.await(),
+                expectedErrorType = IllegalStateException::class.java,
+                expectedThrowableMessage = "Incorrect customer attached to setup intent!",
+                expectedErrorCodeValue = "incorrectCustomerOnSetupIntent",
+                expectedUserError = SIMULATED_INCORRECT_CUSTOMER_DIFFERENT_IDS_ERROR,
+            )
+        }
+
+    @Test
+    fun `handler returns FailedCollection with integration error when SI has no customer in simulated mode`() =
+        runScenario(
+            callbackResult = Result.success(
+                CreateCardPresentSetupIntentCallback {
+                    CreateIntentResult.Success("si_123_secret")
+                }
+            ),
+            isSimulated = true,
+        ) {
+            val result = testScope.backgroundScope.async {
+                handler.collect(DEFAULT_METADATA)
+            }
+
+            assertThat(retrieverScenario.waitForCallbackCalls.awaitItem()).isNotNull()
+            assertThat(terminalScenario.setTapToPayUxConfigurationCalls.awaitItem()).isNotNull()
+
+            checkRetrieveSetupIntent(
+                clientSecret = "si_123_secret",
+                customerId = null,
+            )
+
+            assertFailedCollection(
+                result = result.await(),
+                expectedErrorType = IllegalStateException::class.java,
+                expectedThrowableMessage = "Incorrect customer attached to setup intent!",
+                expectedErrorCodeValue = "incorrectCustomerOnSetupIntent",
+                expectedUserError = SIMULATED_INCORRECT_CUSTOMER_MISSING_ON_SI_ERROR,
+            )
+        }
 
     @Test
     fun `handler returns Collected with updated payment method when attachDefaultsToPaymentMethod is true`() {
@@ -890,9 +1048,13 @@ class TapToAddCollectionHandlerTest {
         updatePaymentMethodResult: Result<PaymentMethod> = Result.failure(
             IllegalStateException("updatePaymentMethod was not expected"),
         ),
+        isSimulated: Boolean = false,
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
         block: suspend Scenario.() -> Unit,
     ) = runTest(coroutineContext) {
+        val isSimulatedProvider = object : TapToAddIsSimulatedProvider {
+            override fun get(): Boolean = isSimulated
+        }
         val terminalScenario = createTerminalScenario()
         val terminalWrapper = TestTerminalWrapper.noOp(terminalScenario.terminalInstance)
         val errorReporter = FakeErrorReporter()
@@ -917,6 +1079,7 @@ class TapToAddCollectionHandlerTest {
                             paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
                             connectionManager = managerScenario.tapToAddConnectionManager,
                             errorReporter = errorReporter,
+                            isSimulatedProvider = isSimulatedProvider,
                             userFacingLogger = FakeUserFacingLogger(),
                             tapToPayUxConfiguration = tapToPayUxConfiguration,
                             createCardPresentSetupIntentCallbackRetriever = retrieverScenario.retriever,
@@ -970,8 +1133,15 @@ class TapToAddCollectionHandlerTest {
         )
     }
 
-    private suspend fun Scenario.checkRetrieveSetupIntent(clientSecret: String): SetupIntent {
-        val retrievedSetupIntent = mock<SetupIntent>()
+    private suspend fun Scenario.checkRetrieveSetupIntent(
+        clientSecret: String,
+        customerId: String? = "cus_123",
+        paymentMethodTypes: List<String> = listOf(PaymentMethodType.CARD_PRESENT.typeName),
+    ): SetupIntent {
+        val retrievedSetupIntent = mock<SetupIntent> {
+            on { this.paymentMethodTypes } doReturn paymentMethodTypes
+            on { this.customerId } doReturn customerId
+        }
         val retrieveSetupIntentCall = terminalScenario.retrieveSetupIntentCalls.awaitItem()
         assertThat(retrieveSetupIntentCall.clientSecret).isEqualTo(clientSecret)
         retrieveSetupIntentCall.callback.onSuccess(retrievedSetupIntent)
@@ -1211,6 +1381,35 @@ class TapToAddCollectionHandlerTest {
             title = StripeCoreR.string.stripe_error.resolvableString,
             action = StripeCoreR.string.stripe_try_again_later.resolvableString,
         )
+
+        private const val INTEGRATION_ERROR_TITLE = "Integration error"
+        private const val MISSING_CARD_PRESENT_ACTION = "Ensure the setup intent allows a `card_present`" +
+            " payment method type on it to allow for tapping cards"
+        private const val SIMULATED_INCORRECT_CUSTOMER_MISSING_ON_SI_ACTION =
+            "Please attach the customer (cus_123) to the setup intent that was used to" +
+                " when initializing Payment Element"
+        private const val SIMULATED_INCORRECT_CUSTOMER_DIFFERENT_IDS_ACTION =
+            "Setup intent had a different customer (cus_other) than the expected customer " +
+                "initialized with Payment Element (cus_123). Please attach the expected customer."
+
+        val SIMULATED_MISSING_CARD_PRESENT_ERROR = TapToAddErrorMessage(
+            title = INTEGRATION_ERROR_TITLE.resolvableString,
+            action = MISSING_CARD_PRESENT_ACTION.resolvableString,
+        )
+
+        val SIMULATED_INCORRECT_CUSTOMER_MISSING_ON_SI_ERROR = TapToAddErrorMessage(
+            title = INTEGRATION_ERROR_TITLE.resolvableString,
+            action = SIMULATED_INCORRECT_CUSTOMER_MISSING_ON_SI_ACTION.resolvableString,
+        )
+
+        val SIMULATED_INCORRECT_CUSTOMER_DIFFERENT_IDS_ERROR = TapToAddErrorMessage(
+            title = INTEGRATION_ERROR_TITLE.resolvableString,
+            action = SIMULATED_INCORRECT_CUSTOMER_DIFFERENT_IDS_ACTION.resolvableString,
+        )
+
+        val DEFAULT_IS_SIMULATED_PROVIDER = object : TapToAddIsSimulatedProvider {
+            override fun get(): Boolean = false
+        }
 
         val tapToPayUxConfiguration = createTapToAddUxConfiguration()
         val DEFAULT_METADATA = PaymentMethodMetadataFactory.create(

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardCollectionTestHelper.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardCollectionTestHelper.kt
@@ -28,13 +28,16 @@ class TapToAddCardCollectionTestHelper(
     private val delegate: TerminalTestDelegate
         get() = delegateRetriever()
 
-    fun enqueueSuccessfulTapToCollectFlow(shouldValidate: Boolean = false): TapToCollectAssertionInfo {
+    fun enqueueSuccessfulTapToCollectFlow(
+        shouldValidate: Boolean = false,
+        customerId: String = "cus_123"
+    ): TapToCollectAssertionInfo {
         val reader = delegate.createReader()
         val generatedPaymentMethod = PaymentMethodFactory.card("pm_1")
         val cardPaymentMethod = PaymentMethodFactory.card("pm_2")
         val setupIntentClientSecret = "seti_123_secret_123"
-        val setupIntent = delegate.createSetupIntent()
-        val confirmedIntent = delegate.createSetupIntent(generatedPaymentMethod)
+        val setupIntent = delegate.createSetupIntent(customerId = customerId)
+        val confirmedIntent = delegate.createSetupIntent(generatedPaymentMethod, customerId)
 
         delegate.setScenario(
             TerminalTestDelegate.Scenario(

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TerminalTestDelegate.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TerminalTestDelegate.kt
@@ -106,10 +106,13 @@ class TerminalTestDelegate(
     }
 
     fun createSetupIntent(
-        paymentMethod: PaymentMethod? = null
+        paymentMethod: PaymentMethod? = null,
+        customerId: String? = null,
     ): SetupIntent {
         return mock {
             on { paymentMethodId } doReturn paymentMethod?.id
+            on { paymentMethodTypes } doReturn listOf("card_present")
+            on { this.customerId } doReturn customerId
         }
     }
 
@@ -145,12 +148,17 @@ class TerminalTestDelegate(
         val discoveredReaders: List<Reader> = listOf(DEFAULT_READER),
         val connectReaderResult: ConnectReaderResult = ConnectReaderResult.Success(DEFAULT_READER),
         val readerSupportResult: ReaderSupportResult = ReaderSupportResult.Supported,
-        val retrieveSetupIntentResult: SetupIntentResult = SetupIntentResult.Success(mock()),
+        val retrieveSetupIntentResult: SetupIntentResult = SetupIntentResult.Success(createSetupIntent()),
         val collectSetupIntentPaymentMethodResult: SetupIntentResult =
-            SetupIntentResult.Success(mock()),
-        val confirmSetupIntentResult: SetupIntentResult = SetupIntentResult.Success(mock()),
+            SetupIntentResult.Success(createSetupIntent()),
+        val confirmSetupIntentResult: SetupIntentResult = SetupIntentResult.Success(createSetupIntent()),
     ) {
         companion object {
+            fun createSetupIntent() = mock<SetupIntent> {
+                on { this.paymentMethodTypes } doReturn listOf("card_present")
+                on { this.customerId } doReturn "cus_123"
+            }
+
             fun withoutMocks() = Scenario(
                 retrieveSetupIntentResult = SetupIntentResult.Failure(DEFAULT_ERROR),
                 collectSetupIntentPaymentMethodResult = SetupIntentResult.Failure(DEFAULT_ERROR),


### PR DESCRIPTION
# Summary
Validate setup intent parameters in `TapToAddCollectionHandler`

# Motivation
Better surface integration errors with Tap to Add to merchants.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified