### PR TITLE
Force vertical payment method layout based on elements/session flag

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -101,6 +101,9 @@ internal data class ElementsSession(
     val onBehalfOf: String?
         get() = accountId.takeIf { !it.equals(merchantId) }
 
+    val forceVerticalPaymentMethodLayout: Boolean
+        get() = flags[Flag.ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT] == true
+
     @Parcelize
     data class LinkSettings(
         val linkFundingSources: List<String>,
@@ -240,6 +243,9 @@ internal data class ElementsSession(
         ELEMENTS_MOBILE_ALLOW_STRIPECARDSCAN("elements_mobile_allow_stripecardscan"),
         ELEMENTS_MOBILE_CARDSCAN_USE_MLKIT("elements_mobile_cardscan_use_mlkit"),
         ELEMENTS_MOBILE_CARDSCAN_DISABLE_SSDOCR("elements_mobile_cardscan_disable_ssdocr"),
+        ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT(
+            "elements_mobile_force_vertical_payment_method_layout"
+        ),
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -525,8 +525,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             is PaymentElementLoader.Configuration.Embedded -> PaymentMethodLayout.Vertical
             is PaymentElementLoader.Configuration.PaymentSheet ->
                 if (
-                    elementsSession.forceVerticalPaymentMethodLayout
-                    && integrationConfiguration.configuration.paymentMethodLayout == PaymentMethodLayout.Automatic
+                    elementsSession.forceVerticalPaymentMethodLayout &&
+                    integrationConfiguration.configuration.paymentMethodLayout == PaymentMethodLayout.Automatic
                 ) {
                     PaymentMethodLayout.Vertical
                 } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -492,12 +492,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             isTapToAddAvailable = isTapToAddAvailable,
         )
 
-        val paymentMethodLayout = when (integrationConfiguration) {
-            is PaymentElementLoader.Configuration.PaymentSheet ->
-                integrationConfiguration.configuration.paymentMethodLayout
-            is PaymentElementLoader.Configuration.CryptoOnramp,
-            is PaymentElementLoader.Configuration.Embedded -> PaymentMethodLayout.Vertical
-        }
+        val paymentMethodLayout = getPaymentMethodLayout(
+            integrationConfiguration = integrationConfiguration,
+            elementsSession = elementsSession,
+        )
 
         val paymentMethodMetadata = PaymentMethodMetadata.createForPaymentElement(
             elementsSession = elementsSession,
@@ -516,6 +514,25 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         )
 
         return paymentMethodMetadata
+    }
+
+    private fun getPaymentMethodLayout(
+        integrationConfiguration: PaymentElementLoader.Configuration,
+        elementsSession: ElementsSession,
+    ): PaymentMethodLayout {
+        return when (integrationConfiguration) {
+            is PaymentElementLoader.Configuration.CryptoOnramp,
+            is PaymentElementLoader.Configuration.Embedded -> PaymentMethodLayout.Vertical
+            is PaymentElementLoader.Configuration.PaymentSheet ->
+                if (
+                    elementsSession.forceVerticalPaymentMethodLayout
+                    && integrationConfiguration.configuration.paymentMethodLayout == PaymentMethodLayout.Automatic
+                ) {
+                    PaymentMethodLayout.Vertical
+                } else {
+                    integrationConfiguration.configuration.paymentMethodLayout
+                }
+        }
     }
 
     private suspend fun isGooglePayReady(

--- a/paymentsheet/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -1683,6 +1683,47 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `Parses elements_mobile_force_vertical_payment_method_layout flag when present and enabled`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val json = JSONObject(
+            """
+            {
+              "payment_method_preference": {
+                "object": "payment_method_preference",
+                "country_code": "US",
+                "payment_intent": {
+                  "id": "pi_123",
+                  "object": "payment_intent",
+                  "amount": 1099,
+                  "currency": "usd",
+                  "status": "requires_payment_method"
+                },
+                "ordered_payment_method_types": ["card"]
+              },
+              "flags": {
+                "elements_mobile_force_vertical_payment_method_layout": true
+              }
+            }
+            """.trimIndent()
+        )
+
+        val session = parser.parse(json)
+
+        assertThat(session?.flags?.get(ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT))
+            .isTrue()
+        assertThat(session?.forceVerticalPaymentMethodLayout).isTrue()
+    }
+
+    @Test
     fun `Parses elements_mobile_card_funding_filtering flag as false when disabled`() {
         testCardFundingFilteringFlag(enabled = false)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -34,8 +34,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.AnalyticsMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.AnalyticsMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
@@ -3680,6 +3681,42 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
     }
+
+    @Test
+    fun `Uses vertical payment method orientation when forced by elements session flag and layout is automatic`() =
+        runScenario {
+            val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna"),
+            )
+            val loader = createPaymentElementLoader(
+                stripeIntent = stripeIntent,
+                elementsSessionRepository = FakeElementsSessionRepository(
+                    stripeIntent = stripeIntent,
+                    error = null,
+                    linkSettings = null,
+                    flags = mapOf(
+                        ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT to true,
+                    ),
+                ),
+            )
+
+            val config = PaymentSheetFixtures.CONFIG_MINIMUM.newBuilder()
+                .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
+                .build()
+
+            val result = loader.load(
+                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
+                paymentSheetConfiguration = config,
+                metadata = PaymentElementLoader.Metadata(initializedViaCompose = false),
+            ).getOrThrow()
+
+            assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
+                .isEqualTo(PaymentMethodOrientation.Vertical)
+            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+        }
 
     @OptIn(CardFundingFilteringPrivatePreview::class)
     private fun testCardFundingFiltering(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Force vertical payment method layout based on elements/session flag

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Enables us to disable the new automatic payment method layout logic if specific merchants need us to

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
