### PR TITLE
Add payment method orientation to load analytics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -84,7 +84,8 @@ internal class DefaultEventReporter @Inject internal constructor(
                 paymentSelection = paymentSelection,
                 duration = duration,
                 orderedLpms = paymentMethodMetadata.sortedSupportedPaymentMethods().map { it.code },
-                hasCardArt = paymentMethodMetadata.cardArts.isNotEmpty()
+                hasCardArt = paymentMethodMetadata.cardArts.isNotEmpty(),
+                paymentMethodOrientation = paymentMethodMetadata.paymentMethodOrientation(),
             ),
             paymentMethodMetadata = paymentMethodMetadata,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.analytics
 import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.utils.mapOfDurationInSeconds
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
@@ -31,6 +32,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         orderedLpms: List<String>,
         duration: Duration?,
         hasCardArt: Boolean,
+        paymentMethodOrientation: PaymentMethodOrientation,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_succeeded"
         override val params: Map<String, Any?> = buildMap {
@@ -38,6 +40,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             put(FIELD_SELECTED_LPM, paymentSelection.defaultAnalyticsValue)
             put(FIELD_ORDERED_LPMS, orderedLpms.joinToString(","))
             put(FIELD_HAS_CARD_ART, hasCardArt)
+            put(FIELD_PAYMENT_METHOD_ORIENTATION, paymentMethodOrientation.name.lowercase())
         }
 
         private val PaymentSelection?.defaultAnalyticsValue: String
@@ -614,6 +617,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_CAN_COLLECT_LINK_SIGNUP_INPUT = "can_collect_link_signup_input"
         const val FIELD_COMPLETED_LINK_SIGNUP_INPUT = "completed_link_signup_input"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"
+        const val FIELD_PAYMENT_METHOD_ORIENTATION = "payment_method_orientation"
         const val FIELD_ORDERED_LPMS = "ordered_lpms"
         const val FIELD_HAS_CARD_ART = "has_card_art"
         const val INTENT_ID = "intent_id"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -100,6 +100,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("selected_lpm", "google_pay")
         assertThat(request.params).containsEntry("ordered_lpms", "card")
         assertThat(request.params).containsEntry("has_card_art", false)
+        assertThat(request.params).containsEntry("payment_method_orientation", "horizontal")
         assertThat(request.params).containsEntry("example_from_test", true)
     }
 


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Add payment method orientation to load analytics

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Now that there's some more complex logic for what we show when payment method layout is automatic, we should have some info in our analytics about which layout the customer actually sees

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
