### PR TITLE
Convert supportedPaymentMethodTypes into a field on PaymentMethodMetadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -94,12 +94,18 @@ internal data class PaymentMethodMetadata(
     val cardArts: List<PaymentMethod.Card.CardArt>,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
 ) : Parcelable {
+    @IgnoredOnParcel
+    private val supportedPaymentMethodDefinitions: List<PaymentMethodDefinition> =
+        computeSupportedPaymentMethodDefinitions()
+
+    @IgnoredOnParcel
+    val supportedPaymentMethodTypes: List<String> = computeSupportedPaymentMethodTypes()
 
     fun paymentMethodOrientation(): PaymentMethodOrientation {
         return when (paymentMethodLayout) {
             PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
             PaymentSheet.PaymentMethodLayout.Vertical -> PaymentMethodOrientation.Vertical
-            PaymentSheet.PaymentMethodLayout.Automatic -> if (supportedPaymentMethodTypes().size > 2) {
+            PaymentSheet.PaymentMethodLayout.Automatic -> if (supportedPaymentMethodTypes.size > 2) {
                 PaymentMethodOrientation.Vertical
             } else {
                 PaymentMethodOrientation.Horizontal
@@ -138,8 +144,8 @@ internal data class PaymentMethodMetadata(
         return PaymentMethodRegistry.definitionsByCode[paymentMethodCode]?.requiresMandate(this) ?: false
     }
 
-    fun supportedPaymentMethodTypes(): List<String> {
-        return supportedPaymentMethodDefinitions().map { paymentMethodDefinition ->
+    private fun computeSupportedPaymentMethodTypes(): List<String> {
+        return supportedPaymentMethodDefinitions.map { paymentMethodDefinition ->
             paymentMethodDefinition.type.code
         }.plus(externalPaymentMethodTypes()).plus(customPaymentMethodIds()).run {
             if (paymentMethodOrder.isEmpty()) {
@@ -155,7 +161,7 @@ internal data class PaymentMethodMetadata(
     }
 
     fun supportedSavedPaymentMethodTypes(): List<PaymentMethod.Type> {
-        val supportedTypes = supportedPaymentMethodDefinitions().filter { paymentMethodDefinition ->
+        val supportedTypes = supportedPaymentMethodDefinitions.filter { paymentMethodDefinition ->
             paymentMethodDefinition.supportedAsSavedPaymentMethod
         }.map {
             it.type
@@ -178,7 +184,7 @@ internal data class PaymentMethodMetadata(
             getUiDefinitionFactoryForCustomPaymentMethod(code)
                 ?.createSupportedPaymentMethod(metadata = this)
         } else {
-            val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
+            val definition = supportedPaymentMethodDefinitions.firstOrNull { it.type.code == code } ?: return null
             definition.uiDefinitionFactory(this).supportedPaymentMethod(this, definition, sharedDataSpecs)
         }
     }
@@ -190,7 +196,7 @@ internal data class PaymentMethodMetadata(
     }
 
     fun sortedSupportedPaymentMethods(): List<SupportedPaymentMethod> {
-        return supportedPaymentMethodTypes().mapNotNull { supportedPaymentMethodForCode(it) }
+        return supportedPaymentMethodTypes.mapNotNull { supportedPaymentMethodForCode(it) }
     }
 
     private fun orderedPaymentMethodTypes(): List<String> {
@@ -248,7 +254,7 @@ internal data class PaymentMethodMetadata(
         return ExternalPaymentMethodUiDefinitionFactory(externalPaymentMethodSpecForCode)
     }
 
-    private fun supportedPaymentMethodDefinitions(): List<PaymentMethodDefinition> {
+    private fun computeSupportedPaymentMethodDefinitions(): List<PaymentMethodDefinition> {
         val supportedPaymentMethodTypes = stripeIntent.paymentMethodTypes.mapNotNull {
             PaymentMethodRegistry.definitionsByCode[it]
         }.filter {
@@ -297,7 +303,7 @@ internal data class PaymentMethodMetadata(
                 incentive = null,
             )
         } else {
-            val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
+            val definition = supportedPaymentMethodDefinitions.firstOrNull { it.type.code == code } ?: return null
 
             definition.uiDefinitionFactory(this).formHeaderInformation(
                 metadata = this,
@@ -323,7 +329,7 @@ internal data class PaymentMethodMetadata(
                 arguments = uiDefinitionFactoryArgumentsFactory.create(this, requiresMandate = false)
             )
         } else {
-            val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
+            val definition = supportedPaymentMethodDefinitions.firstOrNull { it.type.code == code } ?: return null
 
             definition.uiDefinitionFactory(this).formElements(
                 metadata = this,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
@@ -117,7 +117,7 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         previousSelection: PaymentSelection,
     ): Boolean {
         // The types that are allowed for this intent, as returned by the backend
-        val allowedTypes = paymentMethodMetadata.supportedPaymentMethodTypes()
+        val allowedTypes = paymentMethodMetadata.supportedPaymentMethodTypes
 
         return when (previousSelection) {
             is PaymentSelection.New -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
@@ -31,7 +31,7 @@ internal class DefaultEmbeddedWalletsHelper @Inject constructor(
                 isGooglePayReady = paymentMethodMetadata.isGooglePayReady == true,
                 isShopPayAvailable = paymentMethodMetadata.availableWallets.contains(WalletType.ShopPay),
                 buttonsEnabled = true,
-                paymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes(),
+                paymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes,
                 googlePayLauncherConfig = null, // This isn't used for embedded.
                 googlePayButtonType = GooglePayButtonType.Pay, // The actual google pay button isn't shown for embedded.
                 onGooglePayPressed = { throw IllegalStateException("Not possible.") },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -168,7 +168,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             isShopPayAvailable = paymentMethodMetadata.availableWallets.contains(WalletType.ShopPay) &&
                 visibleWallets.contains(WalletType.ShopPay),
             buttonsEnabled = buttonsEnabled,
-            paymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes(),
+            paymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes,
             googlePayLauncherConfig = null,
             googlePayButtonType = GooglePayButtonType.Pay,
             onGooglePayPressed = {
@@ -195,7 +195,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     private fun walletsAllowedInHeader(paymentMethodMetadata: PaymentMethodMetadata): List<WalletType> {
-        val showsDirectForm = paymentMethodMetadata.supportedPaymentMethodTypes().size == 1 &&
+        val showsDirectForm = paymentMethodMetadata.supportedPaymentMethodTypes.size == 1 &&
             customerStateHolder.paymentMethods.value.isEmpty()
         return if (showsDirectForm) {
             // Direct to form: show wallets in header

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -206,7 +206,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             isGooglePayReady = paymentMethodMetadata?.isGooglePayReady == true,
             isShopPayAvailable = paymentMethodMetadata?.availableWallets?.contains(WalletType.ShopPay) == true,
             buttonsEnabled = buttonsEnabled,
-            paymentMethodTypes = paymentMethodMetadata?.supportedPaymentMethodTypes().orEmpty(),
+            paymentMethodTypes = paymentMethodMetadata?.supportedPaymentMethodTypes.orEmpty(),
             googlePayLauncherConfig = googlePayLauncherConfig,
             googlePayButtonType = args.googlePayConfig?.buttonType.asGooglePayButtonType,
             onGooglePayPressed = this::checkoutWithGooglePay,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -49,7 +49,7 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
         state: PaymentSheetState.Full,
     ): Boolean {
         // The types that are allowed for this intent, as returned by the backend
-        val allowedTypes = state.paymentMethodMetadata.supportedPaymentMethodTypes()
+        val allowedTypes = state.paymentMethodMetadata.supportedPaymentMethodTypes
 
         return when (potentialSelection) {
             is PaymentSelection.New -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -703,7 +703,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private fun supportsIntent(
         metadata: PaymentMethodMetadata,
     ): Boolean {
-        return metadata.supportedPaymentMethodTypes().isNotEmpty()
+        return metadata.supportedPaymentMethodTypes.isNotEmpty()
     }
 
     private fun reportSuccessfulLoad(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -16,7 +16,7 @@ internal object VerticalModeInitialScreenFactory {
         customerStateHolder: CustomerStateHolder,
         paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
     ): List<PaymentSheetScreen> {
-        val supportedPaymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes()
+        val supportedPaymentMethodTypes = paymentMethodMetadata.supportedPaymentMethodTypes
         val bankFormInteractor = BankFormInteractor.create(viewModel)
 
         if (supportedPaymentMethodTypes.size == 1 && customerStateHolder.paymentMethods.value.isEmpty()) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -150,7 +150,7 @@ internal abstract class BaseSheetViewModel(
 
     val initiallySelectedPaymentMethodType: PaymentMethodCode
         get() = newPaymentSelection?.getPaymentMethodCode()
-            ?: paymentMethodMetadata.value!!.supportedPaymentMethodTypes().first()
+            ?: paymentMethodMetadata.value!!.supportedPaymentMethodTypes.first()
 
     init {
         viewModelScope.launch {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -124,7 +124,7 @@ internal class PaymentMethodMetadataTest {
             paymentMethodTypes = listOf("card", "pay_now"),
         )
         val metadata = PaymentMethodMetadataFactory.create(stripeIntent)
-        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes()
+        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes
         assertThat(supportedPaymentMethods).hasSize(1)
         assertThat(supportedPaymentMethods.first()).isEqualTo("card")
     }
@@ -137,7 +137,7 @@ internal class PaymentMethodMetadataTest {
             ),
             sharedDataSpecs = listOf(SharedDataSpec("card")),
         )
-        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes()
+        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes
         assertThat(supportedPaymentMethods).hasSize(1)
         assertThat(supportedPaymentMethods.first()).isEqualTo("card")
     }
@@ -150,7 +150,7 @@ internal class PaymentMethodMetadataTest {
             ),
             sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna")),
         )
-        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes()
+        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes
         assertThat(supportedPaymentMethods).hasSize(2)
         assertThat(supportedPaymentMethods[0]).isEqualTo("card")
         assertThat(supportedPaymentMethods[1]).isEqualTo("klarna")
@@ -166,7 +166,7 @@ internal class PaymentMethodMetadataTest {
             ),
             sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna")),
         )
-        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes()
+        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes
         assertThat(supportedPaymentMethods).hasSize(1)
         assertThat(supportedPaymentMethods[0]).isEqualTo("card")
     }
@@ -181,7 +181,7 @@ internal class PaymentMethodMetadataTest {
             ),
             sharedDataSpecs = listOf(SharedDataSpec("card"), SharedDataSpec("klarna")),
         )
-        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes()
+        val supportedPaymentMethods = metadata.supportedPaymentMethodTypes
         assertThat(supportedPaymentMethods).hasSize(2)
         assertThat(supportedPaymentMethods[0]).isEqualTo("card")
         assertThat(supportedPaymentMethods[1]).isEqualTo("klarna")
@@ -794,7 +794,7 @@ internal class PaymentMethodMetadataTest {
             externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC)
         )
 
-        assertThat(metadata.supportedPaymentMethodTypes().contains("external_paypal")).isTrue()
+        assertThat(metadata.supportedPaymentMethodTypes.contains("external_paypal")).isTrue()
     }
 
     @Test
@@ -985,7 +985,7 @@ internal class PaymentMethodMetadataTest {
             displayableCustomPaymentMethods = listOf(PaymentMethodFixtures.PAYPAL_CUSTOM_PAYMENT_METHOD),
         )
 
-        assertThat(metadata.supportedPaymentMethodTypes().contains("cpmt_paypal")).isTrue()
+        assertThat(metadata.supportedPaymentMethodTypes.contains("cpmt_paypal")).isTrue()
     }
 
     @Test
@@ -1778,7 +1778,7 @@ internal class PaymentMethodMetadataTest {
             ),
         )
 
-        val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes()
+        val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes
         assertThat(displayedPaymentMethodTypes).containsExactly("card", "link")
     }
 
@@ -1799,7 +1799,7 @@ internal class PaymentMethodMetadataTest {
             ),
         )
 
-        val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes()
+        val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes
         assertThat(displayedPaymentMethodTypes).containsExactly("card")
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3620,7 +3620,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     private val BaseSheetViewModel.supportedPaymentMethodTypes: List<String>
-        get() = paymentMethodMetadata.value?.supportedPaymentMethodTypes().orEmpty()
+        get() = paymentMethodMetadata.value?.supportedPaymentMethodTypes.orEmpty()
 
     private companion object {
         private val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -3855,7 +3855,7 @@ internal class DefaultPaymentElementLoaderTest {
         ).getOrThrow()
 
         assertThat(result.paymentMethodMetadata.linkState).isNotNull()
-        assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes()).contains("link")
+        assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes).contains("link")
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -3885,7 +3885,7 @@ internal class DefaultPaymentElementLoaderTest {
         ).getOrThrow()
 
         assertThat(result.paymentMethodMetadata.linkState).isNull()
-        assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes()).doesNotContain("link")
+        assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes).doesNotContain("link")
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -37,7 +37,7 @@ internal class FakeAddPaymentMethodInteractor(
                     signupMode = null,
                 ),
             ),
-            paymentMethodCode: PaymentMethodCode = metadata.supportedPaymentMethodTypes().first(),
+            paymentMethodCode: PaymentMethodCode = metadata.supportedPaymentMethodTypes.first(),
             isValidating: Boolean = false,
         ): AddPaymentMethodInteractor.State {
             val formArguments = FormArgumentsFactory.create(


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Convert supportedPaymentMethodTypes into a field on PaymentMethodMetadata

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will enable me to compute paymentMethodOrientation at PaymentMethodMetadata creation time, which will in turn enable me to add paymentMethodOrientation to analyticsMetadata, so that we can have info in our analytics about which payment method orientation customers actually see

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

No behavior changes
