### PR TITLE
fix(google pay): additionalEnabledNetworks is ignored in one constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ NEXT_VERSION_BUMP: MINOR
 
 ### PaymentSheet
 * [FIXED][12973](https://github.com/stripe/stripe-android/pull/12973) Fixed an issue where `FlowController` would bypass mandate display when `setupFutureUsage` was added via `configureWithIntentConfiguration()` after the user had already entered card details.
+* [FIXED][12983](https://github.com/stripe/stripe-android/pull/12983) Fixed an issue where `additionalEnabledNetworks` would not be respected for Google Pay payments.
 * [CHANGED][12975](https://github.com/stripe/stripe-android/pull/12975) When `paymentMethodLayout` is set to `Automatic`, the layout is now horizontal when there are 2 or fewer payment methods available.
 
 ## 23.6.0 - 2026-04-27

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -58,7 +58,8 @@ class GooglePayJsonFactory internal constructor(
         googlePayConfig = GooglePayConfig(context),
         isJcbEnabled = isJcbEnabled,
         cardBrandFilter = cardBrandFilter,
-        cardFundingFilter = cardFundingFilter
+        cardFundingFilter = cardFundingFilter,
+        additionalEnabledNetworks = additionalEnabledNetworks
     )
 
     constructor(


### PR DESCRIPTION
# Summary
`additionalEnabledNetworks` is never passed from the public to the internal constructor

This is used by `GooglePayButton` which ultimately reads this value from the Google Pay config.

# Motivation
It would be helpful to actually use the config options API users can provide.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [FIXED][12983](https://github.com/stripe/stripe-android/pull/12983) Fixed an issue where `additionalEnabledNetworks` would not be respected for Google Pay payments.

