### PR TITLE
Add 'Server Controlled' Link Type option to playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
@@ -30,6 +30,7 @@ internal object LinkTypeSettingsDefinition :
         configurationData: PlaygroundConfigurationData
     ): List<PlaygroundSettingDefinition.Displayable.Option<LinkType>> {
         return listOf(
+            option("Server Controlled", LinkType.ServerControlled),
             option("Native", LinkType.Native),
             option("Native + Attest", LinkType.NativeAttest),
             option("Web", LinkType.Web),
@@ -38,6 +39,10 @@ internal object LinkTypeSettingsDefinition :
 
     override fun setValue(value: LinkType) {
         when (value) {
+            LinkType.ServerControlled -> {
+                FeatureFlags.nativeLinkEnabled.reset()
+                FeatureFlags.nativeLinkAttestationEnabled.reset()
+            }
             LinkType.Native -> {
                 FeatureFlags.nativeLinkEnabled.setEnabled(true)
                 FeatureFlags.nativeLinkAttestationEnabled.setEnabled(false)
@@ -55,6 +60,7 @@ internal object LinkTypeSettingsDefinition :
 }
 
 enum class LinkType(override val value: String) : ValueEnum {
+    ServerControlled("Server Controlled"),
     Native("Native"),
     NativeAttest("Native + Attest"),
     Web("Web"),


### PR DESCRIPTION
## Summary
- Adds a new `LinkType.ServerControlled` playground setting that calls `.reset()` on both `nativeLinkEnabled` and `nativeLinkAttestationEnabled` feature flags
- Makes the server's `link_mobile_use_attestation_endpoints` flag authoritative in the playground
- Keeps "Web" as the default to avoid breaking existing instrumentation tests

## Motivation
Previously, the playground always forced Link behavior via local feature flags, making it impossible to test what production users would experience. With "Server Controlled" selected, the SDK respects the server response — if `link_mobile_use_attestation_endpoints: false`, Link falls through to the web flow, matching iOS behavior.

## Test plan
- [x] Select "Server Controlled" in playground → native/web Link based on server config
- [x] Select "Native" → native Link still works as before
- [x] Select "Web" → web Link still works as before
- [x] `TestLinkCardBrand` and `TestInstantDebits` instrumentation tests pass (default unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)