### PR TITLE
[link] Add Link brand to payment selection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet
 
 import android.content.Context
 import com.stripe.android.customersheet.injection.DaggerStripeCustomerAdapterComponent
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -144,6 +145,7 @@ interface CustomerAdapter {
         internal data class StripeId(override val id: String) : PaymentOption(id)
 
         internal fun toPaymentSelection(
+            linkBrand: LinkBrand? = null,
             paymentMethodProvider: (paymentMethodId: String) -> PaymentMethod?,
         ): PaymentSelection? {
             return when (this) {
@@ -152,7 +154,7 @@ interface CustomerAdapter {
                 }
 
                 is Link -> {
-                    PaymentSelection.Link()
+                    PaymentSelection.Link(brand = requireNotNull(linkBrand))
                 }
 
                 is StripeId -> {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -2,7 +2,6 @@ package com.stripe.android.customersheet
 
 import android.content.Context
 import com.stripe.android.customersheet.injection.DaggerStripeCustomerAdapterComponent
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -140,23 +139,15 @@ interface CustomerAdapter {
 
         internal object GooglePay : PaymentOption("google_pay")
 
-        internal object Link : PaymentOption("link")
-
         internal data class StripeId(override val id: String) : PaymentOption(id)
 
         internal fun toPaymentSelection(
-            linkBrand: LinkBrand?,
             paymentMethodProvider: (paymentMethodId: String) -> PaymentMethod?,
         ): PaymentSelection? {
             return when (this) {
                 is GooglePay -> {
                     PaymentSelection.GooglePay
                 }
-
-                is Link -> {
-                    linkBrand?.let { PaymentSelection.Link(it) }
-                }
-
                 is StripeId -> {
                     paymentMethodProvider(id)?.let {
                         PaymentSelection.Saved(it)
@@ -168,7 +159,6 @@ interface CustomerAdapter {
         internal fun toSavedSelection(): SavedSelection {
             return when (this) {
                 is GooglePay -> SavedSelection.GooglePay
-                is Link -> SavedSelection.Link
                 is StripeId -> SavedSelection.PaymentMethod(id, isLinkOrigin = false)
             }
         }
@@ -179,7 +169,6 @@ interface CustomerAdapter {
             fun fromId(id: String): PaymentOption {
                 return when (id) {
                     "google_pay" -> GooglePay
-                    "link" -> Link
                     else -> StripeId(id)
                 }
             }
@@ -187,7 +176,7 @@ interface CustomerAdapter {
             internal fun SavedSelection.toPaymentOption(): PaymentOption? {
                 return when (this) {
                     is SavedSelection.GooglePay -> GooglePay
-                    is SavedSelection.Link -> Link
+                    is SavedSelection.Link -> null
                     is SavedSelection.None -> null
                     is SavedSelection.PaymentMethod -> StripeId(id)
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -145,6 +145,7 @@ interface CustomerAdapter {
         internal data class StripeId(override val id: String) : PaymentOption(id)
 
         internal fun toPaymentSelection(
+            linkBrand: LinkBrand?,
             paymentMethodProvider: (paymentMethodId: String) -> PaymentMethod?,
         ): PaymentSelection? {
             return when (this) {
@@ -153,7 +154,7 @@ interface CustomerAdapter {
                 }
 
                 is Link -> {
-                    PaymentSelection.Link(brand = LinkBrand.Link)
+                    linkBrand?.let { PaymentSelection.Link(it) }
                 }
 
                 is StripeId -> {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -145,7 +145,6 @@ interface CustomerAdapter {
         internal data class StripeId(override val id: String) : PaymentOption(id)
 
         internal fun toPaymentSelection(
-            linkBrand: LinkBrand? = null,
             paymentMethodProvider: (paymentMethodId: String) -> PaymentMethod?,
         ): PaymentSelection? {
             return when (this) {
@@ -154,7 +153,7 @@ interface CustomerAdapter {
                 }
 
                 is Link -> {
-                    PaymentSelection.Link(brand = requireNotNull(linkBrand))
+                    PaymentSelection.Link(brand = LinkBrand.Link)
                 }
 
                 is StripeId -> {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -143,7 +143,6 @@ class CustomerSheet internal constructor(
             val paymentMethodsDeferred = async {
                 CustomerSheetHacks.paymentMethodDataSource.await().retrievePaymentMethods().toResult()
             }
-
             val savedSelection = savedSelectionDeferred.await()
             val paymentMethods = paymentMethodsDeferred.await()
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -16,7 +16,6 @@ import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.DefaultPaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.DefaultPaymentOptionCardArtProvider

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -143,23 +143,14 @@ class CustomerSheet internal constructor(
             val paymentMethodsDeferred = async {
                 CustomerSheetHacks.paymentMethodDataSource.await().retrievePaymentMethods().toResult()
             }
-            val elementsSessionDeferred = async {
-                CustomerSheetHacks
-                    .elementsSessionManager.await()
-                    ?.fetchElementsSession()
-                    ?.getOrNull()
-                    ?.elementsSession
-            }
 
             val savedSelection = savedSelectionDeferred.await()
             val paymentMethods = paymentMethodsDeferred.await()
-            val elementsSession = elementsSessionDeferred.await()
-            val linkBrand = elementsSession?.linkSettings?.linkBrand
 
             val selection = savedSelection.map { selection ->
                 selection?.toPaymentOption()
             }.mapCatching { paymentOption ->
-                paymentOption?.toPaymentSelection(linkBrand) {
+                paymentOption?.toPaymentSelection {
                     paymentMethods.getOrNull()?.find {
                         it.id == paymentOption.id
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.DefaultPaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.DefaultPaymentOptionCardArtProvider
@@ -143,13 +144,23 @@ class CustomerSheet internal constructor(
             val paymentMethodsDeferred = async {
                 CustomerSheetHacks.paymentMethodDataSource.await().retrievePaymentMethods().toResult()
             }
+            val elementsSessionDeferred = async {
+                CustomerSheetHacks
+                    .elementsSessionManager.await()
+                    ?.fetchElementsSession()
+                    ?.getOrNull()
+                    ?.elementsSession
+            }
+
             val savedSelection = savedSelectionDeferred.await()
             val paymentMethods = paymentMethodsDeferred.await()
+            val elementsSession = elementsSessionDeferred.await()
+            val linkBrand = elementsSession?.linkSettings?.linkBrand
 
             val selection = savedSelection.map { selection ->
                 selection?.toPaymentOption()
             }.mapCatching { paymentOption ->
-                paymentOption?.toPaymentSelection {
+                paymentOption?.toPaymentSelection(linkBrand) {
                     paymentMethods.getOrNull()?.find {
                         it.id == paymentOption.id
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -28,6 +28,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.model.validate
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -229,18 +230,21 @@ internal class DefaultCustomerSheetLoader(
         return if (metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
             getDefaultPaymentMethodAsPaymentSelection(paymentMethods, customerSheetSession.defaultPaymentMethodId)
         } else {
-            useLocalSelectionAsPaymentSelection(customerSheetSession, paymentMethods)
+            useLocalSelectionAsPaymentSelection(customerSheetSession, metadata, paymentMethods)
         }
     }
 
     private fun useLocalSelectionAsPaymentSelection(
         customerSheetSession: CustomerSheetSession,
+        metadata: PaymentMethodMetadata,
         paymentMethods: List<PaymentMethod>
     ): PaymentSelection? {
         return customerSheetSession.savedSelection?.let { selection ->
             when (selection) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay
-                is SavedSelection.Link -> PaymentSelection.Link()
+                is SavedSelection.Link -> PaymentSelection.Link(
+                    brand = metadata.requireLinkBrand(),
+                )
                 is SavedSelection.PaymentMethod -> {
                     paymentMethods.find { paymentMethod ->
                         paymentMethod.id == selection.id

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -242,9 +242,7 @@ internal class DefaultCustomerSheetLoader(
         return customerSheetSession.savedSelection?.let { selection ->
             when (selection) {
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay
-                is SavedSelection.Link -> PaymentSelection.Link(
-                    brand = metadata.requireLinkBrand(),
-                )
+                is SavedSelection.Link -> null
                 is SavedSelection.PaymentMethod -> {
                     paymentMethods.find { paymentMethod ->
                         paymentMethod.id == selection.id

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -229,13 +229,15 @@ internal class DefaultCustomerSheetLoader(
         return if (metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
             getDefaultPaymentMethodAsPaymentSelection(paymentMethods, customerSheetSession.defaultPaymentMethodId)
         } else {
-            useLocalSelectionAsPaymentSelection(customerSheetSession, metadata, paymentMethods)
+            useLocalSelectionAsPaymentSelection(
+                customerSheetSession = customerSheetSession,
+                paymentMethods = paymentMethods,
+            )
         }
     }
 
     private fun useLocalSelectionAsPaymentSelection(
         customerSheetSession: CustomerSheetSession,
-        metadata: PaymentMethodMetadata,
         paymentMethods: List<PaymentMethod>
     ): PaymentSelection? {
         return customerSheetSession.savedSelection?.let { selection ->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -28,7 +28,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.model.validate
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.di.MobileSessionIdModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.data.CustomerSessionElementsSessionManager
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
@@ -36,6 +37,7 @@ internal interface CustomerSessionDataSourceComponent {
     val customerSheetSavedSelectionDataSource: CustomerSheetSavedSelectionDataSource
     val customerSheetIntentDataSource: CustomerSheetIntentDataSource
     val customerSheetInitializationDataSource: CustomerSheetInitializationDataSource
+    val customerSessionElementsSessionManager: CustomerSessionElementsSessionManager
 
     @Component.Factory
     interface Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -6,7 +6,6 @@ import com.stripe.android.common.di.MobileSessionIdModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerSheet
-import com.stripe.android.customersheet.data.CustomerSessionElementsSessionManager
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
@@ -37,7 +36,6 @@ internal interface CustomerSessionDataSourceComponent {
     val customerSheetSavedSelectionDataSource: CustomerSheetSavedSelectionDataSource
     val customerSheetIntentDataSource: CustomerSheetIntentDataSource
     val customerSheetInitializationDataSource: CustomerSheetInitializationDataSource
-    val customerSessionElementsSessionManager: CustomerSessionElementsSessionManager
 
     @Component.Factory
     interface Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -161,6 +161,7 @@ internal fun SelectPaymentMethod(
         SavedPaymentMethodTabLayoutUI(
             paymentOptionsItems = paymentOptionsState.items,
             selectedPaymentOptionsItem = paymentOptionsState.selectedItem,
+            linkBrand = null, // Link is unsupported in CustomerSheet
             isEditing = viewState.isEditing,
             isProcessing = viewState.isProcessing,
             onAddCardPressed = { viewActionHandler(CustomerSheetViewAction.OnAddCardPressed) },

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.asSingle
 import com.stripe.android.customersheet.CustomerSheetIntegration
+import com.stripe.android.customersheet.data.CustomerSessionElementsSessionManager
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
@@ -37,6 +38,10 @@ internal object CustomerSheetHacks {
     val intentDataSource: Single<CustomerSheetIntentDataSource>
         get() = _intentDataSource.asSingle()
 
+    private val _elementsSessionManager = MutableStateFlow<CustomerSessionElementsSessionManager?>(null)
+    val elementsSessionManager: Single<CustomerSessionElementsSessionManager?>
+        get() = _elementsSessionManager.asSingle()
+
     fun initialize(
         application: Application,
         lifecycleOwner: LifecycleOwner,
@@ -55,6 +60,7 @@ internal object CustomerSheetHacks {
                 _paymentMethodDataSource.value = adapterDataSourceComponent.customerSheetPaymentMethodDataSource
                 _intentDataSource.value = adapterDataSourceComponent.customerSheetIntentDataSource
                 _savedSelectionDataSource.value = adapterDataSourceComponent.customerSheetSavedSelectionDataSource
+                _elementsSessionManager.value = null
             }
             is CustomerSheetIntegration.CustomerSession -> {
                 val customerSessionDataSourceComponent = DaggerCustomerSessionDataSourceComponent
@@ -72,6 +78,8 @@ internal object CustomerSheetHacks {
                     customerSessionDataSourceComponent.customerSheetIntentDataSource
                 _savedSelectionDataSource.value =
                     customerSessionDataSourceComponent.customerSheetSavedSelectionDataSource
+                _elementsSessionManager.value =
+                    customerSessionDataSourceComponent.customerSessionElementsSessionManager
             }
         }
 
@@ -99,5 +107,6 @@ internal object CustomerSheetHacks {
         _paymentMethodDataSource.value = null
         _savedSelectionDataSource.value = null
         _intentDataSource.value = null
+        _elementsSessionManager.value = null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.asSingle
 import com.stripe.android.customersheet.CustomerSheetIntegration
-import com.stripe.android.customersheet.data.CustomerSessionElementsSessionManager
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
@@ -38,10 +37,6 @@ internal object CustomerSheetHacks {
     val intentDataSource: Single<CustomerSheetIntentDataSource>
         get() = _intentDataSource.asSingle()
 
-    private val _elementsSessionManager = MutableStateFlow<CustomerSessionElementsSessionManager?>(null)
-    val elementsSessionManager: Single<CustomerSessionElementsSessionManager?>
-        get() = _elementsSessionManager.asSingle()
-
     fun initialize(
         application: Application,
         lifecycleOwner: LifecycleOwner,
@@ -60,7 +55,6 @@ internal object CustomerSheetHacks {
                 _paymentMethodDataSource.value = adapterDataSourceComponent.customerSheetPaymentMethodDataSource
                 _intentDataSource.value = adapterDataSourceComponent.customerSheetIntentDataSource
                 _savedSelectionDataSource.value = adapterDataSourceComponent.customerSheetSavedSelectionDataSource
-                _elementsSessionManager.value = null
             }
             is CustomerSheetIntegration.CustomerSession -> {
                 val customerSessionDataSourceComponent = DaggerCustomerSessionDataSourceComponent
@@ -78,8 +72,6 @@ internal object CustomerSheetHacks {
                     customerSessionDataSourceComponent.customerSheetIntentDataSource
                 _savedSelectionDataSource.value =
                     customerSessionDataSourceComponent.customerSheetSavedSelectionDataSource
-                _elementsSessionManager.value =
-                    customerSessionDataSourceComponent.customerSessionElementsSessionManager
             }
         }
 
@@ -107,6 +99,5 @@ internal object CustomerSheetHacks {
         _paymentMethodDataSource.value = null
         _savedSelectionDataSource.value = null
         _intentDataSource.value = null
-        _elementsSessionManager.value = null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -96,11 +97,11 @@ private fun List<PaymentOptionsItem>.findSelectedItem(paymentSelection: PaymentS
     }
 }
 
-internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
+internal fun PaymentOptionsItem.toPaymentSelection(linkBrand: LinkBrand? = null): PaymentSelection? {
     return when (this) {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
-        is PaymentOptionsItem.Link -> PaymentSelection.Link()
+        is PaymentOptionsItem.Link -> PaymentSelection.Link(brand = requireNotNull(linkBrand))
         is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(paymentMethod)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -97,11 +97,11 @@ private fun List<PaymentOptionsItem>.findSelectedItem(paymentSelection: PaymentS
     }
 }
 
-internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
+internal fun PaymentOptionsItem.toPaymentSelection(linkBrand: LinkBrand?): PaymentSelection? {
     return when (this) {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
-        is PaymentOptionsItem.Link -> error("Link requires LinkBrand")
+        is PaymentOptionsItem.Link -> linkBrand?.let { PaymentSelection.Link(it) }
         is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(paymentMethod)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -97,11 +97,15 @@ private fun List<PaymentOptionsItem>.findSelectedItem(paymentSelection: PaymentS
     }
 }
 
-internal fun PaymentOptionsItem.toPaymentSelection(linkBrand: LinkBrand? = null): PaymentSelection? {
+internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
     return when (this) {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
-        is PaymentOptionsItem.Link -> PaymentSelection.Link(brand = requireNotNull(linkBrand))
+        is PaymentOptionsItem.Link -> error("Link requires LinkBrand")
         is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(paymentMethod)
     }
+}
+
+internal fun PaymentOptionsItem.Link.toPaymentSelection(linkBrand: LinkBrand): PaymentSelection.Link {
+    return PaymentSelection.Link(brand = linkBrand)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFa
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
+import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
@@ -176,7 +177,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 onUserSelection()
             },
             onLinkPressed = {
-                updateSelection(Link())
+                updateSelection(
+                    Link(
+                        brand = requireNotNull(linkConfiguration?.linkBrand),
+                    )
+                )
                 onUserSelection()
             },
             onShopPayPressed = {
@@ -308,6 +313,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     PaymentOptionsActivityResult.Succeeded(
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         paymentSelection = Link(
+                            brand = args.state.paymentMethodMetadata.requireLinkBrand(),
                             selectedPayment = result.selectedPayment,
                             shippingAddress = result.shippingAddress,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -176,12 +176,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 onUserSelection()
             },
             onLinkPressed = {
-                updateSelection(
-                    Link(
-                        brand = requireNotNull(linkConfiguration?.linkBrand),
-                    )
-                )
-                onUserSelection()
+                if (linkConfiguration?.linkBrand != null) {
+                    updateSelection(Link(linkConfiguration.linkBrand))
+                    onUserSelection()
+                }
             },
             onShopPayPressed = {
                 updateSelection(PaymentSelection.ShopPay)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -39,7 +39,6 @@ import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFa
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
-import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
@@ -309,11 +308,14 @@ internal class PaymentOptionsViewModel @Inject constructor(
             }
             // Link verification dialog completed -> close payment method selection with authenticated state
             is LinkActivityResult.Completed -> {
+                // Should always have Link configuration here.
+                val linkConfiguration = paymentMethodMetadata.value?.linkState?.configuration
+                    ?: return
                 _paymentOptionsActivityResult.tryEmit(
                     PaymentOptionsActivityResult.Succeeded(
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         paymentSelection = Link(
-                            brand = args.state.paymentMethodMetadata.requireLinkBrand(),
+                            brand = linkConfiguration.linkBrand,
                             selectedPayment = result.selectedPayment,
                             shippingAddress = result.shippingAddress,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -47,6 +47,7 @@ import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherCompo
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.isLink
+import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
@@ -433,6 +434,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     fun checkoutWithLink() {
         checkout(
             PaymentSelection.Link(
+                brand = requireNotNull(paymentMethodMetadata.value).requireLinkBrand(),
                 linkExpressMode = LinkExpressMode.DISABLED
             ),
             CheckoutIdentifier.SheetTopWallet
@@ -444,6 +446,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         // fails on payment sheet given the OTP shows on launch.
         checkout(
             PaymentSelection.Link(
+                brand = requireNotNull(paymentMethodMetadata.value).requireLinkBrand(),
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
             ),
             CheckoutIdentifier.SheetTopWallet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -432,9 +432,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     fun checkoutWithLink() {
+        // Should always have Link configuration if we're checking out with Link.
+        val linkConfiguration = paymentMethodMetadata.value?.linkState?.configuration
+            ?: return
         checkout(
             PaymentSelection.Link(
-                brand = requireNotNull(paymentMethodMetadata.value).requireLinkBrand(),
+                brand = linkConfiguration.linkBrand,
                 linkExpressMode = LinkExpressMode.DISABLED
             ),
             CheckoutIdentifier.SheetTopWallet
@@ -444,11 +447,14 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun checkoutWithLinkExpress(
         paymentMethodMetadata: PaymentMethodMetadata = requireNotNull(this.paymentMethodMetadata.value),
     ) {
+        // Should always have Link configuration if we're checking out with Link.
+        val linkConfiguration = paymentMethodMetadata.linkState?.configuration
+            ?: return
         // We don't want to fall back to web on express mode if attestation
         // fails on payment sheet given the OTP shows on launch.
         checkout(
             PaymentSelection.Link(
-                brand = paymentMethodMetadata.requireLinkBrand(),
+                brand = linkConfiguration.linkBrand,
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
             ),
             CheckoutIdentifier.SheetTopWallet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -47,7 +47,6 @@ import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherCompo
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.isLink
-import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
@@ -444,9 +443,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         )
     }
 
-    private fun checkoutWithLinkExpress(
-        paymentMethodMetadata: PaymentMethodMetadata = requireNotNull(this.paymentMethodMetadata.value),
-    ) {
+    private fun checkoutWithLinkExpress(paymentMethodMetadata: PaymentMethodMetadata) {
         // Should always have Link configuration if we're checking out with Link.
         val linkConfiguration = paymentMethodMetadata.linkState?.configuration
             ?: return

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -331,7 +331,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         withContext(Dispatchers.Main.immediate) {
             val shouldLaunchEagerly = linkHandler.setupLinkWithEagerLaunch(state.paymentMethodMetadata.linkState)
             if (shouldLaunchEagerly) {
-                checkoutWithLinkExpress()
+                checkoutWithLinkExpress(state.paymentMethodMetadata)
             }
 
             customerStateHolder.setCustomerState(state.customer)
@@ -441,12 +441,14 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         )
     }
 
-    private fun checkoutWithLinkExpress() {
+    private fun checkoutWithLinkExpress(
+        paymentMethodMetadata: PaymentMethodMetadata = requireNotNull(this.paymentMethodMetadata.value),
+    ) {
         // We don't want to fall back to web on express mode if attestation
         // fails on payment sheet given the OTP shows on launch.
         checkout(
             PaymentSelection.Link(
-                brand = requireNotNull(paymentMethodMetadata.value).requireLinkBrand(),
+                brand = paymentMethodMetadata.requireLinkBrand(),
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
             ),
             CheckoutIdentifier.SheetTopWallet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -68,6 +68,7 @@ import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
 import com.stripe.android.paymentsheet.model.isLink
+import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkDisabledState
@@ -84,6 +85,7 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
 
+@Suppress("LargeClass")
 @OptIn(WalletButtonsPreview::class)
 @FlowControllerScope
 internal class DefaultFlowController @Inject internal constructor(
@@ -423,11 +425,16 @@ internal class DefaultFlowController @Inject internal constructor(
                     showPaymentOptionList(it, viewModel.paymentSelection)
                 }
             }
-            is LinkActivityResult.Completed -> with(Link(selectedPayment = result.selectedPayment)) {
-                viewModel.paymentSelection = this
+            is LinkActivityResult.Completed -> {
+                val selection = Link(
+                    brand = requireNotNull(viewModel.state?.paymentSheetState?.paymentMethodMetadata)
+                        .requireLinkBrand(),
+                    selectedPayment = result.selectedPayment,
+                )
+                viewModel.paymentSelection = selection
                 paymentOptionResultCallback.onPaymentOptionResult(
                     PaymentOptionResult(
-                        paymentOption = paymentOptionFactory.create(this),
+                        paymentOption = paymentOptionFactory.create(selection),
                         didCancel = false,
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -68,7 +68,6 @@ import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
 import com.stripe.android.paymentsheet.model.isLink
-import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkDisabledState
@@ -426,9 +425,11 @@ internal class DefaultFlowController @Inject internal constructor(
                 }
             }
             is LinkActivityResult.Completed -> {
+                // Should always have Link configuration here.
+                val linkConfiguration = viewModel.state?.linkConfiguration
+                    ?: return
                 val selection = Link(
-                    brand = requireNotNull(viewModel.state?.paymentSheetState?.paymentMethodMetadata)
-                        .requireLinkBrand(),
+                    brand = linkConfiguration.linkBrand,
                     selectedPayment = result.selectedPayment,
                 )
                 viewModel.paymentSelection = selection

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.model
 import android.content.Context
 import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.ui.wallet.paymentOptionLabel
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkPaymentDetails
@@ -46,7 +45,7 @@ internal object PaymentOptionLabelsFactory {
                 }
             }
             is PaymentSelection.Link -> {
-                link(context, selection.selectedPayment)
+                link(context, selection)
             }
         }
     }
@@ -126,11 +125,11 @@ internal object PaymentOptionLabelsFactory {
 
     private fun link(
         context: Context,
-        paymentMethod: LinkPaymentMethod?,
+        selection: PaymentSelection.Link,
     ): PaymentOption.Labels {
-        val sublabel = paymentMethod?.details?.paymentOptionLabel?.resolve(context)
+        val sublabel = selection.selectedPayment?.details?.paymentOptionLabel?.resolve(context)
         return PaymentOption.Labels(
-            label = R.string.stripe_link.resolvableString.resolve(context),
+            label = selection.brand.brandName(),
             sublabel = sublabel,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerShippingAddress
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
@@ -73,6 +74,7 @@ internal sealed class PaymentSelection : Parcelable {
 
     @Parcelize
     data class Link(
+        val brand: LinkBrand,
         val linkExpressMode: LinkExpressMode = LinkExpressMode.DISABLED,
         val selectedPayment: LinkPaymentMethod? = null,
         val shippingAddress: ConsumerShippingAddress? = null,
@@ -424,7 +426,7 @@ internal val PaymentSelection.label: ResolvableString
         is PaymentSelection.ExternalPaymentMethod -> label
         is PaymentSelection.CustomPaymentMethod -> label
         PaymentSelection.GooglePay -> StripeR.string.stripe_google_pay.resolvableString
-        is PaymentSelection.Link -> StripeR.string.stripe_link.resolvableString
+        is PaymentSelection.Link -> brand.brandName().resolvableString
         is PaymentSelection.New.Card -> createCardLabel(last4).orEmpty()
         is PaymentSelection.New.GenericPaymentMethod -> label
         is PaymentSelection.New.USBankAccount -> label.resolvableString
@@ -480,6 +482,12 @@ internal fun PaymentSelection.Saved.mandateTextFromPaymentMethodMetadata(
     metadata.merchantName,
     metadata.hasIntentToSetup(paymentMethod.type?.code ?: "")
 ).takeIf { metadata.mandateAllowed(paymentMethod.type) }
+
+internal fun PaymentMethodMetadata.requireLinkBrand(): LinkBrand {
+    return requireNotNull(linkState?.configuration?.linkBrand) {
+        "Expected Link brand to be available when constructing a Link payment selection."
+    }
+}
 
 /**
  * If setup_future_usage is set at the top level to "off_session" the payment method will

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -483,12 +483,6 @@ internal fun PaymentSelection.Saved.mandateTextFromPaymentMethodMetadata(
     metadata.hasIntentToSetup(paymentMethod.type?.code ?: "")
 ).takeIf { metadata.mandateAllowed(paymentMethod.type) }
 
-internal fun PaymentMethodMetadata.requireLinkBrand(): LinkBrand {
-    return requireNotNull(linkState?.configuration?.linkBrand) {
-        "Expected Link brand to be available when constructing a Link payment selection."
-    }
-}
-
 /**
  * If setup_future_usage is set at the top level to "off_session" the payment method will
  * inherit this value so sending [ConfirmPaymentIntentParams.SetupFutureUsage.OnSession] and

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -42,6 +42,7 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
+import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
@@ -608,7 +609,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay.takeIf {
                     !isUsingWalletButtons && isGooglePayReady
                 }
-                is SavedSelection.Link -> PaymentSelection.Link().takeIf {
+                is SavedSelection.Link -> PaymentSelection.Link(
+                    brand = metadata.requireLinkBrand(),
+                ).takeIf {
                     !isUsingWalletButtons
                 }
                 is SavedSelection.PaymentMethod -> {
@@ -618,7 +621,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     } else if (selection.isLinkOrigin) {
                         // The payment method wasn't attached to the customer, but is of Link origin. Offer
                         // Link as the initial payment selection.
-                        PaymentSelection.Link().takeIf {
+                        PaymentSelection.Link(
+                            brand = metadata.requireLinkBrand(),
+                        ).takeIf {
                             !isUsingWalletButtons
                         }
                     } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -42,7 +42,6 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
-import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
@@ -609,11 +608,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 is SavedSelection.GooglePay -> PaymentSelection.GooglePay.takeIf {
                     !isUsingWalletButtons && isGooglePayReady
                 }
-                is SavedSelection.Link -> PaymentSelection.Link(
-                    brand = metadata.requireLinkBrand(),
-                ).takeIf {
-                    !isUsingWalletButtons
-                }
+                is SavedSelection.Link ->
+                    metadata.linkState?.configuration?.linkBrand
+                        ?.let { PaymentSelection.Link(brand = it) }
+                        ?.takeIf { !isUsingWalletButtons }
                 is SavedSelection.PaymentMethod -> {
                     val customerPaymentMethod = customer?.paymentMethods?.find { it.id == selection.id }
                     if (customerPaymentMethod != null) {
@@ -621,11 +619,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     } else if (selection.isLinkOrigin) {
                         // The payment method wasn't attached to the customer, but is of Link origin. Offer
                         // Link as the initial payment selection.
-                        PaymentSelection.Link(
-                            brand = metadata.requireLinkBrand(),
-                        ).takeIf {
-                            !isUsingWalletButtons
-                        }
+                        metadata.linkState?.configuration?.linkBrand
+                            ?.let { PaymentSelection.Link(brand = it) }
+                            ?.takeIf { !isUsingWalletButtons }
                     } else {
                         null
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -591,6 +591,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
     }
 
+    @Suppress("CyclomaticComplexMethod")
     private suspend fun retrieveInitialPaymentSelection(
         savedSelection: Deferred<SavedSelection>,
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -82,6 +83,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
     SavedPaymentMethodTabLayoutUI(
         paymentOptionsItems = state.paymentOptionsItems,
         selectedPaymentOptionsItem = state.selectedPaymentOptionsItem,
+        linkBrand = state.linkBrand,
         isEditing = state.isEditing,
         isProcessing = state.isProcessing,
         onAddCardPressed = {
@@ -121,6 +123,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 internal fun SavedPaymentMethodTabLayoutUI(
     paymentOptionsItems: List<PaymentOptionsItem>,
     selectedPaymentOptionsItem: PaymentOptionsItem?,
+    linkBrand: LinkBrand? = null,
     isEditing: Boolean,
     isProcessing: Boolean,
     onAddCardPressed: () -> Unit,
@@ -163,6 +166,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
                     isEditing = isEditing,
                     isEnabled = isEnabled,
                     isSelected = isSelected,
+                    linkBrand = linkBrand,
                     onAddCardPressed = onAddCardPressed,
                     onItemSelected = onItemSelected,
                     onModifyItem = onModifyItem,
@@ -234,6 +238,7 @@ private fun SavedPaymentMethodsTabLayoutPreview() {
         SavedPaymentMethodTabLayoutUI(
             paymentOptionsItems = PREVIEW_PAYMENT_OPTION_ITEMS,
             selectedPaymentOptionsItem = PaymentOptionsItem.AddCard,
+            linkBrand = LinkBrand.Link,
             isEditing = false,
             isProcessing = false,
             onAddCardPressed = { },
@@ -250,6 +255,7 @@ private fun SavedPaymentMethodsTabLayoutWithDefaultPreview() {
         SavedPaymentMethodTabLayoutUI(
             paymentOptionsItems = PREVIEW_PAYMENT_OPTION_ITEMS,
             selectedPaymentOptionsItem = PaymentOptionsItem.AddCard,
+            linkBrand = LinkBrand.Link,
             isEditing = true,
             isProcessing = false,
             onAddCardPressed = { },
@@ -275,6 +281,7 @@ private fun SavedPaymentMethodTab(
     isEnabled: Boolean,
     isEditing: Boolean,
     isSelected: Boolean,
+    linkBrand: LinkBrand?,
     onAddCardPressed: () -> Unit,
     onItemSelected: (PaymentSelection?) -> Unit,
     onModifyItem: (DisplayableSavedPaymentMethod) -> Unit,
@@ -303,6 +310,7 @@ private fun SavedPaymentMethodTab(
                 width = width,
                 isEnabled = isEnabled,
                 isSelected = isSelected,
+                linkBrand = requireNotNull(linkBrand),
                 onItemSelected = onItemSelected,
                 modifier = modifier,
             )
@@ -378,6 +386,7 @@ private fun LinkTab(
     width: Dp,
     isEnabled: Boolean,
     isSelected: Boolean,
+    linkBrand: LinkBrand,
     onItemSelected: (PaymentSelection?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -391,7 +400,7 @@ private fun LinkTab(
         iconTint = null,
         labelText = stringResource(StripeR.string.stripe_link),
         description = stringResource(StripeR.string.stripe_link),
-        onItemSelectedListener = { onItemSelected(PaymentSelection.Link()) },
+        onItemSelectedListener = { onItemSelected(PaymentSelection.Link(brand = linkBrand)) },
         cardArtUrl = null,
         modifier = modifier,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -400,7 +400,7 @@ private fun LinkTab(
         iconTint = null,
         labelText = stringResource(StripeR.string.stripe_link),
         description = stringResource(StripeR.string.stripe_link),
-        onItemSelectedListener = { onItemSelected(PaymentSelection.Link(brand = linkBrand)) },
+        onItemSelectedListener = { onItemSelected(PaymentOptionsItem.Link.toPaymentSelection(linkBrand)) },
         cardArtUrl = null,
         modifier = modifier,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -310,7 +310,7 @@ private fun SavedPaymentMethodTab(
                 width = width,
                 isEnabled = isEnabled,
                 isSelected = isSelected,
-                linkBrand = requireNotNull(linkBrand),
+                linkBrand = requireNotNull(linkBrand), // non-null: Link tab only shown when linkState != null
                 onItemSelected = onItemSelected,
                 modifier = modifier,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -123,7 +123,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 internal fun SavedPaymentMethodTabLayoutUI(
     paymentOptionsItems: List<PaymentOptionsItem>,
     selectedPaymentOptionsItem: PaymentOptionsItem?,
-    linkBrand: LinkBrand? = null,
+    linkBrand: LinkBrand?,
     isEditing: Boolean,
     isProcessing: Boolean,
     onAddCardPressed: () -> Unit,
@@ -318,6 +318,7 @@ private fun SavedPaymentMethodTab(
         is PaymentOptionsItem.SavedPaymentMethod -> {
             SavedPaymentMethodTab(
                 paymentMethod = item,
+                linkBrand = linkBrand,
                 width = width,
                 isEnabled = isEnabled,
                 isEditing = isEditing,
@@ -409,6 +410,7 @@ private fun LinkTab(
 @Composable
 private fun SavedPaymentMethodTab(
     paymentMethod: PaymentOptionsItem.SavedPaymentMethod,
+    linkBrand: LinkBrand?,
     width: Dp,
     isEnabled: Boolean,
     isEditing: Boolean,
@@ -457,7 +459,7 @@ private fun SavedPaymentMethodTab(
                 .resolve()
                 .readNumbersAsIndividualDigits(),
             onItemSelectedListener = {
-                onItemSelected(paymentMethod.toPaymentSelection())
+                onItemSelected(paymentMethod.toPaymentSelection(linkBrand))
             },
             modifier = modifier,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -8,6 +9,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -35,6 +37,7 @@ internal interface SelectSavedPaymentMethodsInteractor {
     data class State(
         val paymentOptionsItems: List<PaymentOptionsItem>,
         val selectedPaymentOptionsItem: PaymentOptionsItem?,
+        val linkBrand: LinkBrand,
         val isEditing: Boolean,
         val isProcessing: Boolean,
         val canEdit: Boolean,
@@ -63,6 +66,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val updateSelection: (selection: PaymentSelection?, isUserInput: Boolean) -> Unit,
     override val isLiveMode: Boolean,
+    private val linkBrand: LinkBrand,
 ) : SelectSavedPaymentMethodsInteractor {
     private val coroutineScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
@@ -89,6 +93,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
                 mostRecentlySelectedSavedPaymentMethod.value,
                 paymentOptionsItems,
             ),
+            linkBrand = linkBrand,
             isEditing = editing.value,
             isProcessing = isProcessing.value,
             canEdit = canEdit.value,
@@ -272,6 +277,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
                 },
                 onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+                linkBrand = paymentMethodMetadata.requireLinkBrand(),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SelectSavedPaymentMethodsInteractor.kt
@@ -9,7 +9,6 @@ import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.requireLinkBrand
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -37,7 +36,7 @@ internal interface SelectSavedPaymentMethodsInteractor {
     data class State(
         val paymentOptionsItems: List<PaymentOptionsItem>,
         val selectedPaymentOptionsItem: PaymentOptionsItem?,
-        val linkBrand: LinkBrand,
+        val linkBrand: LinkBrand?,
         val isEditing: Boolean,
         val isProcessing: Boolean,
         val canEdit: Boolean,
@@ -66,7 +65,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val updateSelection: (selection: PaymentSelection?, isUserInput: Boolean) -> Unit,
     override val isLiveMode: Boolean,
-    private val linkBrand: LinkBrand,
+    private val linkBrand: LinkBrand?,
 ) : SelectSavedPaymentMethodsInteractor {
     private val coroutineScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
@@ -277,7 +276,7 @@ internal class DefaultSelectSavedPaymentMethodsInteractor(
                 },
                 onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-                linkBrand = paymentMethodMetadata.requireLinkBrand(),
+                linkBrand = paymentMethodMetadata.linkState?.configuration?.linkBrand,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -86,7 +86,10 @@ internal interface WalletButtonsInteractor {
             override val walletType = WalletType.Link
 
             override fun createSelection(): PaymentSelection {
-                return PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED)
+                return PaymentSelection.Link(
+                    brand = linkBrand,
+                    linkExpressMode = LinkExpressMode.DISABLED,
+                )
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -421,7 +421,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             iconRequiresTinting = false,
             subtitle = subtitle,
             onClick = {
-                updateSelection(PaymentSelection.Link(), false)
+                updateSelection(PaymentSelection.Link(brand = link.linkBrand), false)
                 invokeRowSelectionCallback?.invoke()
             },
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -613,22 +614,34 @@ class CustomerAdapterTest {
         val savedPaymentOption = CustomerAdapter.PaymentOption.StripeId(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.id
         )
-        val savedSelection = savedPaymentOption.toPaymentSelection(paymentMethodProvider)
+        val savedSelection = savedPaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
+            paymentMethodProvider = paymentMethodProvider,
+        )
         assertThat(savedSelection)
             .isInstanceOf<PaymentSelection.Saved>()
 
         val googlePaymentOption = CustomerAdapter.PaymentOption.GooglePay
-        val googleSelection = googlePaymentOption.toPaymentSelection(paymentMethodProvider)
+        val googleSelection = googlePaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
+            paymentMethodProvider = paymentMethodProvider,
+        )
         assertThat(googleSelection)
             .isInstanceOf<PaymentSelection.GooglePay>()
 
         val linkPaymentOption = CustomerAdapter.PaymentOption.Link
-        val linkSelection = linkPaymentOption.toPaymentSelection(paymentMethodProvider)
+        val linkSelection = linkPaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
+            paymentMethodProvider = paymentMethodProvider,
+        )
         assertThat(linkSelection)
             .isInstanceOf<PaymentSelection.Link>()
 
         val nullSavedPaymentOption = CustomerAdapter.PaymentOption.StripeId("id_123")
-        val nullSavedSelection = nullSavedPaymentOption.toPaymentSelection(paymentMethodProvider)
+        val nullSavedSelection = nullSavedPaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
+            paymentMethodProvider = paymentMethodProvider,
+        )
         assertThat(nullSavedSelection)
             .isNull()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -530,8 +529,6 @@ class CustomerAdapterTest {
     fun `PersistablePaymentMethodOption to SavedSelection`() {
         assertThat(CustomerAdapter.PaymentOption.GooglePay.toSavedSelection())
             .isEqualTo(SavedSelection.GooglePay)
-        assertThat(CustomerAdapter.PaymentOption.Link.toSavedSelection())
-            .isEqualTo(SavedSelection.Link)
         assertThat(CustomerAdapter.PaymentOption.StripeId("pm_1234").toSavedSelection())
             .isEqualTo(SavedSelection.PaymentMethod("pm_1234"))
     }
@@ -540,8 +537,6 @@ class CustomerAdapterTest {
     fun `SavedSelection to PersistablePaymentMethodOption`() {
         assertThat(SavedSelection.GooglePay.toPaymentOption())
             .isEqualTo(CustomerAdapter.PaymentOption.GooglePay)
-        assertThat(SavedSelection.Link.toPaymentOption())
-            .isEqualTo(CustomerAdapter.PaymentOption.Link)
         assertThat(SavedSelection.PaymentMethod("pm_1234").toPaymentOption())
             .isEqualTo(CustomerAdapter.PaymentOption.StripeId("pm_1234"))
     }
@@ -615,7 +610,6 @@ class CustomerAdapterTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.id
         )
         val savedSelection = savedPaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(savedSelection)
@@ -623,23 +617,13 @@ class CustomerAdapterTest {
 
         val googlePaymentOption = CustomerAdapter.PaymentOption.GooglePay
         val googleSelection = googlePaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(googleSelection)
             .isInstanceOf<PaymentSelection.GooglePay>()
 
-        val linkPaymentOption = CustomerAdapter.PaymentOption.Link
-        val linkSelection = linkPaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
-            paymentMethodProvider = paymentMethodProvider,
-        )
-        assertThat(linkSelection)
-            .isInstanceOf<PaymentSelection.Link>()
-
         val nullSavedPaymentOption = CustomerAdapter.PaymentOption.StripeId("id_123")
         val nullSavedSelection = nullSavedPaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(nullSavedSelection)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -614,6 +615,7 @@ class CustomerAdapterTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.id
         )
         val savedSelection = savedPaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(savedSelection)
@@ -621,6 +623,7 @@ class CustomerAdapterTest {
 
         val googlePaymentOption = CustomerAdapter.PaymentOption.GooglePay
         val googleSelection = googlePaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(googleSelection)
@@ -628,6 +631,7 @@ class CustomerAdapterTest {
 
         val linkPaymentOption = CustomerAdapter.PaymentOption.Link
         val linkSelection = linkPaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(linkSelection)
@@ -635,6 +639,7 @@ class CustomerAdapterTest {
 
         val nullSavedPaymentOption = CustomerAdapter.PaymentOption.StripeId("id_123")
         val nullSavedSelection = nullSavedPaymentOption.toPaymentSelection(
+            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(nullSavedSelection)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -615,7 +614,6 @@ class CustomerAdapterTest {
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.id
         )
         val savedSelection = savedPaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(savedSelection)
@@ -623,7 +621,6 @@ class CustomerAdapterTest {
 
         val googlePaymentOption = CustomerAdapter.PaymentOption.GooglePay
         val googleSelection = googlePaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(googleSelection)
@@ -631,7 +628,6 @@ class CustomerAdapterTest {
 
         val linkPaymentOption = CustomerAdapter.PaymentOption.Link
         val linkSelection = linkPaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(linkSelection)
@@ -639,7 +635,6 @@ class CustomerAdapterTest {
 
         val nullSavedPaymentOption = CustomerAdapter.PaymentOption.StripeId("id_123")
         val nullSavedSelection = nullSavedPaymentOption.toPaymentSelection(
-            linkBrand = LinkBrand.Link,
             paymentMethodProvider = paymentMethodProvider,
         )
         assertThat(nullSavedSelection)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
@@ -404,7 +405,7 @@ class CustomerSheetViewModelTest {
             val error = assertFailsWith<IllegalStateException> {
                 viewModel.handleViewAction(
                     CustomerSheetViewAction.OnItemSelected(
-                        selection = PaymentSelection.Link()
+                        selection = PaymentSelection.Link(brand = LinkBrand.Link)
                     )
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -336,7 +336,7 @@ class ConfirmationHandlerOptionKtxTest {
     @Test
     fun `On Link selection but with no configuration, should return null`() {
         assertThat(
-            PaymentSelection.Link().toConfirmationOption(
+            PaymentSelection.Link(brand = LinkBrand.Link).toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
                 cardFundingFilter = DefaultCardFundingFilter
@@ -347,7 +347,7 @@ class ConfirmationHandlerOptionKtxTest {
     @Test
     fun `On Link selection with configuration, should return Link confirmation option`() {
         assertThat(
-            PaymentSelection.Link().toConfirmationOption(
+            PaymentSelection.Link(brand = LinkBrand.Link).toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = LINK_CONFIGURATION,
                 cardFundingFilter = DefaultCardFundingFilter
@@ -364,6 +364,7 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Link selection with express configuration, should return Link confirmation option with express enabled`() {
         assertThat(
             PaymentSelection.Link(
+                brand = LinkBrand.Link,
                 linkExpressMode = LinkExpressMode.ENABLED
             ).toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -102,7 +103,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
     @Test
     fun confirmCallsConfirmationHandlerStartWithLink() = testScenario(
         loadedState = defaultLoadedState().copy(
-            selection = PaymentSelection.Link(),
+            selection = PaymentSelection.Link(brand = LinkBrand.Link),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 linkState = LinkState(
                     configuration = LinkTestUtils.createLinkConfiguration(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactoryTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerShippingAddress
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
@@ -110,6 +111,7 @@ internal class PaymentOptionDisplayDataFactoryTest {
     fun `create adds shipping details for verified Link user`() {
         val option = displayDataFactory.create(
             selection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null,
@@ -155,6 +157,7 @@ internal class PaymentOptionDisplayDataFactoryTest {
     fun `create adds no shipping details for unverified Link user`() {
         val option = displayDataFactory.create(
             selection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
                 selectedPayment = null,
                 shippingAddress = null,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeSelectSavedPaymentMethodsInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeSelectSavedPaymentMethodsInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.ui.SelectSavedPaymentMethodsInteractor
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -8,6 +9,7 @@ internal class FakeSelectSavedPaymentMethodsInteractor(
     initialState: SelectSavedPaymentMethodsInteractor.State = SelectSavedPaymentMethodsInteractor.State(
         paymentOptionsItems = emptyList(),
         selectedPaymentOptionsItem = null,
+        linkBrand = LinkBrand.Link,
         isEditing = false,
         isProcessing = false,
         canEdit = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -36,7 +37,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
-            currentSelection = PaymentSelection.Link(),
+            currentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
             defaultPaymentMethodId = null,
@@ -99,7 +100,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
-            currentSelection = PaymentSelection.Link(),
+            currentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = isCbcEligible,
             defaultPaymentMethodId = null,
@@ -170,7 +171,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
-            currentSelection = PaymentSelection.Link(),
+            currentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = true,
             defaultPaymentMethodId = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -14,15 +14,15 @@ class PaymentOptionsStateFactoryTest {
     fun `non-Link payment options convert without LinkBrand`() {
         val savedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
-        assertThat(PaymentOptionsItem.AddCard.toPaymentSelection()).isNull()
-        assertThat(PaymentOptionsItem.GooglePay.toPaymentSelection()).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(PaymentOptionsItem.AddCard.toPaymentSelection(linkBrand = null)).isNull()
+        assertThat(PaymentOptionsItem.GooglePay.toPaymentSelection(linkBrand = null)).isEqualTo(PaymentSelection.GooglePay)
         assertThat(
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
                     displayName = "Card".resolvableString,
                     paymentMethod = savedPaymentMethod,
                 )
-            ).toPaymentSelection()
+            ).toPaymentSelection(linkBrand = null)
         ).isEqualTo(PaymentSelection.Saved(savedPaymentMethod))
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -11,6 +11,28 @@ import org.junit.Test
 class PaymentOptionsStateFactoryTest {
 
     @Test
+    fun `non-Link payment options convert without LinkBrand`() {
+        val savedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
+        assertThat(PaymentOptionsItem.AddCard.toPaymentSelection()).isNull()
+        assertThat(PaymentOptionsItem.GooglePay.toPaymentSelection()).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(
+            PaymentOptionsItem.SavedPaymentMethod(
+                DisplayableSavedPaymentMethod.create(
+                    displayName = "Card".resolvableString,
+                    paymentMethod = savedPaymentMethod,
+                )
+            ).toPaymentSelection()
+        ).isEqualTo(PaymentSelection.Saved(savedPaymentMethod))
+    }
+
+    @Test
+    fun `Link payment option conversion requires LinkBrand`() {
+        assertThat(PaymentOptionsItem.Link.toPaymentSelection(LinkBrand.Notlink))
+            .isEqualTo(PaymentSelection.Link(brand = LinkBrand.Notlink))
+    }
+
+    @Test
     fun `Returns current selection if available`() {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
         val paymentMethod = paymentMethods.random()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -15,7 +15,9 @@ class PaymentOptionsStateFactoryTest {
         val savedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         assertThat(PaymentOptionsItem.AddCard.toPaymentSelection(linkBrand = null)).isNull()
-        assertThat(PaymentOptionsItem.GooglePay.toPaymentSelection(linkBrand = null)).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(
+            PaymentOptionsItem.GooglePay.toPaymentSelection(linkBrand = null)
+        ).isEqualTo(PaymentSelection.GooglePay)
         assertThat(
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -244,7 +245,7 @@ internal class PaymentOptionsViewModelTest {
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator()
         )
 
-        viewModel.updateSelection(PaymentSelection.Link())
+        viewModel.updateSelection(PaymentSelection.Link(brand = LinkBrand.Link))
         viewModel.onUserSelection()
 
         verify(linkPaymentLauncher).present(
@@ -263,7 +264,7 @@ internal class PaymentOptionsViewModelTest {
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
         )
 
-        viewModel.updateSelection(PaymentSelection.Link())
+        viewModel.updateSelection(PaymentSelection.Link(brand = LinkBrand.Link))
         viewModel.paymentOptionsActivityResult.test {
             viewModel.onUserSelection()
             val result = awaitItem()
@@ -354,7 +355,7 @@ internal class PaymentOptionsViewModelTest {
             ),
         )
 
-        assertThat(viewModel.selection.value).isNotEqualTo(PaymentSelection.Link())
+        assertThat(viewModel.selection.value).isNotEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
         assertThat(viewModel.linkHandler.isLinkEnabled.value).isTrue()
     }
 
@@ -364,7 +365,7 @@ internal class PaymentOptionsViewModelTest {
             linkState = null,
         )
 
-        assertThat(viewModel.selection.value).isNotEqualTo(PaymentSelection.Link())
+        assertThat(viewModel.selection.value).isNotEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
         assertThat(viewModel.linkHandler.isLinkEnabled.value).isFalse()
     }
 
@@ -616,16 +617,16 @@ internal class PaymentOptionsViewModelTest {
         runTest {
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)
 
-            val viewModel = createViewModel().apply { updateSelection(PaymentSelection.Link()) }
+            val viewModel = createViewModel().apply { updateSelection(PaymentSelection.Link(brand = LinkBrand.Link)) }
 
             viewModel.paymentOptionsActivityResult.test {
                 viewModel.handlePaymentMethodSelected(selection)
                 expectNoEvents()
 
-                viewModel.handlePaymentMethodSelected(PaymentSelection.Link())
+                viewModel.handlePaymentMethodSelected(PaymentSelection.Link(brand = LinkBrand.Link))
 
                 val result = awaitItem() as? PaymentOptionsActivityResult.Succeeded
-                assertThat(result?.paymentSelection).isEqualTo(PaymentSelection.Link())
+                assertThat(result?.paymentSelection).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -925,7 +925,13 @@ internal class PaymentOptionsViewModelTest {
             linkAccountUpdate = linkAccountUpdate,
             selectedPayment = null
         )
-        val viewModel = createViewModel()
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = LinkTestUtils.createLinkConfiguration(),
+                signupMode = null,
+                loginState = LinkState.LoginState.LoggedOut,
+            ),
+        )
         viewModel.paymentOptionsActivityResult.test {
             viewModel.onLinkAuthenticationResult(result)
             val succeeded = awaitItem() as PaymentOptionsActivityResult.Succeeded

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -445,7 +446,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.error.test {
             assertThat(awaitItem()).isNull()
 
-            viewModel.updateSelection(PaymentSelection.Link())
+            viewModel.updateSelection(PaymentSelection.Link(brand = LinkBrand.Link))
             viewModel.checkout()
 
             assertThat(errorReporter.getLoggedErrors()).contains(
@@ -2620,7 +2621,7 @@ internal class PaymentSheetViewModelTest {
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
         assertThat(paymentSuccessCall.paymentSelection)
-            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
+            .isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link, linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @Test
@@ -2658,7 +2659,7 @@ internal class PaymentSheetViewModelTest {
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
         assertThat(paymentFailureCall.paymentSelection)
-            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
+            .isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link, linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @Test
@@ -2694,7 +2695,12 @@ internal class PaymentSheetViewModelTest {
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
         assertThat(paymentSuccessCall.paymentSelection)
-            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK))
+            .isEqualTo(
+                PaymentSelection.Link(
+                    brand = LinkBrand.Link,
+                    linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
+                )
+            )
     }
 
     @Test
@@ -2732,7 +2738,12 @@ internal class PaymentSheetViewModelTest {
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
         assertThat(paymentFailureCall.paymentSelection)
-            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK))
+            .isEqualTo(
+                PaymentSelection.Link(
+                    brand = LinkBrand.Link,
+                    linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
+                )
+            )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -44,6 +44,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -582,6 +583,7 @@ internal class DefaultFlowControllerTest {
         val verifiedLinkAccount = TestFactory.LINK_ACCOUNT
         val flowController = createFlowController(
             paymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null,
@@ -622,6 +624,7 @@ internal class DefaultFlowControllerTest {
         // Create flow controller with Link payment method
         val flowController = createFlowController(
             paymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null,
@@ -687,6 +690,7 @@ internal class DefaultFlowControllerTest {
         val flowController = createFlowController(
             customer = customer,
             paymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null,
@@ -745,6 +749,7 @@ internal class DefaultFlowControllerTest {
             val flowController = createFlowController(
                 customer = customer,
                 paymentSelection = PaymentSelection.Link(
+                    brand = LinkBrand.Link,
                     selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                         details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                         collectedCvc = null,
@@ -1059,7 +1064,7 @@ internal class DefaultFlowControllerTest {
         flowController.configureExpectingSuccess()
 
         flowController.confirmPaymentSelection(
-            paymentSelection = PaymentSelection.Link(),
+            paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             state = PAYMENT_SHEET_STATE_FULL,
         )
 
@@ -1073,7 +1078,7 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `confirmPaymentSelection() with link payment method should launch LinkPaymentLauncher`() = confirmationTest {
         val flowController = createFlowController(
-            paymentSelection = PaymentSelection.Link(),
+            paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
                 loginState = LinkState.LoginState.LoggedOut,
@@ -1111,7 +1116,7 @@ internal class DefaultFlowControllerTest {
             )
 
             val flowController = createFlowController(
-                paymentSelection = PaymentSelection.Link(),
+                paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
                 linkState = LinkState(
                     configuration = TestFactory.LINK_CONFIGURATION,
                     loginState = LinkState.LoginState.LoggedOut,
@@ -1169,7 +1174,7 @@ internal class DefaultFlowControllerTest {
             )
 
             val flowController = createFlowController(
-                paymentSelection = PaymentSelection.Link(),
+                paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
                 linkState = LinkState(
                     configuration = linkConfiguration,
                     loginState = LinkState.LoginState.LoggedOut,
@@ -1223,7 +1228,7 @@ internal class DefaultFlowControllerTest {
             )
 
             val flowController = createFlowController(
-                paymentSelection = PaymentSelection.Link(),
+                paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
                 linkState = LinkState(
                     configuration = linkConfig,
                     loginState = LinkState.LoginState.LoggedOut,
@@ -1496,7 +1501,10 @@ internal class DefaultFlowControllerTest {
         )
         flowController.onPaymentOptionResult(
             PaymentOptionsActivityResult
-                .Succeeded(PaymentSelection.Link(), linkAccountInfo = LinkAccountUpdate.Value(null))
+                .Succeeded(
+                    PaymentSelection.Link(brand = LinkBrand.Link),
+                    linkAccountInfo = LinkAccountUpdate.Value(null),
+                )
         )
         flowController.confirm()
 
@@ -1575,7 +1583,7 @@ internal class DefaultFlowControllerTest {
                 linkHandler = linkHandler,
                 viewModel = viewModel,
                 linkState = linkState,
-                paymentSelection = PaymentSelection.Link()
+                paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
             )
 
             flowController.configureExpectingSuccess()
@@ -1606,7 +1614,7 @@ internal class DefaultFlowControllerTest {
                 linkHandler = linkHandler,
                 viewModel = viewModel,
                 linkState = linkState,
-                paymentSelection = PaymentSelection.Link()
+                paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
             )
 
             flowController.configureExpectingSuccess()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
@@ -104,7 +105,7 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isNotNull()
         assertThat(configurationHandler.isConfigured).isTrue()
-        assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link())
+        assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
         assertThat(viewModel.state).isNotNull()
         assertThat(StripeTheme.primaryButtonStyle.shape.height).isEqualTo(80f)
 
@@ -175,7 +176,7 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
         assertThat(configurationHandler.isConfigured).isTrue()
-        assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link())
+        assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
     }
 
     @Test
@@ -208,7 +209,7 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
         assertThat(configurationHandler.isConfigured).isTrue()
-        assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link())
+        assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
     }
 
     @Test
@@ -449,7 +450,7 @@ class FlowControllerConfigurationHandlerTest {
         return FakePaymentElementLoader(
             customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            paymentSelection = PaymentSelection.Link(),
+            paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedIn,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentM
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -433,7 +434,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            selection = PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED),
+            selection = PaymentSelection.Link(brand = LinkBrand.Link, linkExpressMode = LinkExpressMode.DISABLED),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -453,7 +454,12 @@ class PaymentSelectionUpdaterTest {
             walletButtonsAlreadyShown = false,
         )
 
-        assertThat(result).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
+        assertThat(result).isEqualTo(
+            PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                linkExpressMode = LinkExpressMode.DISABLED,
+            )
+        )
     }
 
     @OptIn(WalletButtonsPreview::class)
@@ -491,7 +497,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            selection = PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED),
+            selection = PaymentSelection.Link(brand = LinkBrand.Link, linkExpressMode = LinkExpressMode.DISABLED),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -511,7 +517,12 @@ class PaymentSelectionUpdaterTest {
             walletButtonsAlreadyShown = false,
         )
 
-        assertThat(result).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
+        assertThat(result).isEqualTo(
+            PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                linkExpressMode = LinkExpressMode.DISABLED,
+            )
+        )
     }
 
     private fun mockPaymentSheetStateWithPaymentIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
@@ -160,7 +161,7 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with Link should not include billing details`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.Link())
+        val paymentOption = factory.create(PaymentSelection.Link(brand = LinkBrand.Link))
 
         assertThat(paymentOption.billingDetails).isNull()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -153,6 +154,7 @@ class PaymentOptionLabelsFactoryTest {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
             selection = PaymentSelection.Link(
+                brand = LinkBrand.Notlink,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
                     collectedCvc = null,
@@ -161,7 +163,7 @@ class PaymentOptionLabelsFactoryTest {
             ),
         )
 
-        assertThat(labels.label).isEqualTo("Link")
+        assertThat(labels.label).isEqualTo("Notlink")
         assertThat(labels.sublabel).isEqualTo("Stripe Test Bank Account •••• 4242")
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -27,7 +28,7 @@ class PaymentSelectionTest {
 
     @Test
     fun `Doesn't display a mandate for Link`() {
-        val link = PaymentSelection.Link()
+        val link = PaymentSelection.Link(brand = LinkBrand.Link)
         val result = link.mandateText(
             merchantName = "Merchant",
             isSetupFlow = false,
@@ -37,7 +38,7 @@ class PaymentSelectionTest {
 
     @Test
     fun `Link billingDetails returns null when selectedPayment is null`() {
-        val link = PaymentSelection.Link(selectedPayment = null)
+        val link = PaymentSelection.Link(brand = LinkBrand.Link, selectedPayment = null)
 
         assertThat(link.billingDetails).isNull()
     }
@@ -75,7 +76,7 @@ class PaymentSelectionTest {
             billingPhone = "+1-555-123-4567"
         )
 
-        val link = PaymentSelection.Link(selectedPayment = selectedPayment)
+        val link = PaymentSelection.Link(brand = LinkBrand.Link, selectedPayment = selectedPayment)
 
         assertThat(link.billingDetails).isEqualTo(
             PaymentMethod.BillingDetails(
@@ -92,6 +93,15 @@ class PaymentSelectionTest {
                 name = "John Doe",
             )
         )
+    }
+
+    @Test
+    fun `Link label uses brand name`() {
+        val label = PaymentSelection.Link(
+            brand = LinkBrand.Notlink,
+        ).label.resolve(context)
+
+        assertThat(label).isEqualTo("Notlink")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.FakeSelectSavedPaymentMethodsInteractor
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -156,6 +157,7 @@ internal class PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest {
                     )
                 },
                 selectedPaymentOptionsItem = savedPaymentOptionItem,
+                linkBrand = LinkBrand.Link,
                 isEditing = isEditing,
                 isProcessing = isProcessing,
                 canEdit = canEdit,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkDisabledReason
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
@@ -1891,7 +1892,7 @@ internal class DefaultPaymentElementLoaderTest {
     @Test
     fun `Emits correct events when loading succeeds with saved Link selection`() = runScenario {
         testSuccessfulLoadSendsEventsCorrectly(
-            paymentSelection = PaymentSelection.Link()
+            paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -186,7 +187,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
     @Test
     fun selectedPaymentOptionItem_currentSelectionIsLink() {
-        val currentSelectionFlow = MutableStateFlow(PaymentSelection.Link())
+        val currentSelectionFlow = MutableStateFlow(PaymentSelection.Link(brand = LinkBrand.Link))
 
         runScenario(
             paymentOptionsItems = MutableStateFlow(
@@ -207,7 +208,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
     @Test
     fun selectedPaymentOptionItem_currentSelectionIsLink_canBeChangedToGooglePay() {
         val currentSelectionFlow: MutableStateFlow<PaymentSelection?> =
-            MutableStateFlow(PaymentSelection.Link())
+            MutableStateFlow(PaymentSelection.Link(brand = LinkBrand.Link))
 
         runScenario(
             paymentOptionsItems = MutableStateFlow(
@@ -236,7 +237,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
     @Test
     fun selectedPaymentOptionItem_currentSelectionIsLink_doesNotChangeWhenSelectionBecomesNew() {
         val currentSelectionFlow: MutableStateFlow<PaymentSelection?> =
-            MutableStateFlow(PaymentSelection.Link())
+            MutableStateFlow(PaymentSelection.Link(brand = LinkBrand.Link))
 
         runScenario(
             paymentOptionsItems = MutableStateFlow(
@@ -394,7 +395,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
                 }
             }
 
-            currentSelectionFlow.value = PaymentSelection.Link()
+            currentSelectionFlow.value = PaymentSelection.Link(brand = LinkBrand.Link)
 
             interactor.state.test {
                 awaitItem().run {
@@ -531,6 +532,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
                 updateSelectionTurbine.add(Pair(selection, isUserInput))
             },
             isLiveMode = true,
+            linkBrand = LinkBrand.Link,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -168,6 +169,7 @@ class PaymentOptionsScreenshotTest {
             SavedPaymentMethodTabLayoutUI(
                 paymentOptionsItems = paymentOptionsItems,
                 selectedPaymentOptionsItem = selectedPaymentOptionsItem,
+                linkBrand = LinkBrand.Link,
                 isEditing = isEditing,
                 isProcessing = false,
                 onAddCardPressed = {},

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -148,6 +149,7 @@ class PaymentOptionsTest {
                 isEditing = isEditing,
                 paymentOptionsItems = listOf(PaymentOptionsItem.AddCard, PaymentOptionsItem.GooglePay),
                 selectedPaymentOptionsItem = PaymentOptionsItem.GooglePay,
+                linkBrand = LinkBrand.Link,
                 isProcessing = false,
                 onModifyItem = {},
             )
@@ -171,6 +173,7 @@ class PaymentOptionsTest {
                 paymentOptionsItems = paymentOptionsItemsWithDefault,
                 isEditing = isEditing,
                 selectedPaymentOptionsItem = null,
+                linkBrand = LinkBrand.Link,
                 onAddCardPressed = {},
                 onItemSelected = {},
                 isProcessing = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -588,7 +589,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             val displayablePaymentMethods = interactor.state.value.displayablePaymentMethods
             displayablePaymentMethods.first { it.code == "link" }.onClick()
-            assertThat(selection.value).isEqualTo(PaymentSelection.Link())
+            assertThat(selection.value).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
             assertThat(updateSelectionTurbine.awaitItem()).isFalse()
             displayablePaymentMethods.first { it.code == "google_pay" }.onClick()
             assertThat(selection.value).isEqualTo(PaymentSelection.GooglePay)
@@ -1041,7 +1042,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_isNotUpdatedToNullWhenOnAnotherScreen() {
-        val expectedPaymentSelection = PaymentSelection.Link()
+        val expectedPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = expectedPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },
@@ -1059,7 +1060,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     @Test
     fun verticalModeScreenSelection_isUpdatedToNullWhenCurrentScreen() {
         runScenario(
-            initialSelection = PaymentSelection.Link(),
+            initialSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             formTypeForCode = { FormHelper.FormType.Empty },
         ) {
             interactor.state.test {
@@ -1078,7 +1079,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_isNeverUpdatedToNewPmWithFormFields() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
@@ -1095,7 +1096,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_isUpdatedToNewPmWithFormFields_withCustomShouldUpdateVerticalModeSelection() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
@@ -1119,7 +1120,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_omitsCardBrand_whenUnknownCardBrand() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
@@ -1143,7 +1144,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_retainsLast4_whenUpdatingTemporarySelection() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
@@ -1240,7 +1241,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_canBeANewPmWithoutFormFields() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },
@@ -1264,7 +1265,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_canBeAnEpm() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },
@@ -1285,7 +1286,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_canBeASavedPm() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },
@@ -1310,7 +1311,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },
         ) {
-            val newSelection = PaymentSelection.Link()
+            val newSelection = PaymentSelection.Link(brand = LinkBrand.Link)
             selectionSource.value = newSelection
 
             interactor.state.test {
@@ -1323,7 +1324,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_canBeGooglePay() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },
@@ -1341,7 +1342,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
     @Test
     fun verticalModeScreenSelection_isUpdatedToTemporarySelection() {
-        val initialPaymentSelection = PaymentSelection.Link()
+        val initialPaymentSelection = PaymentSelection.Link(brand = LinkBrand.Link)
         runScenario(
             initialSelection = initialPaymentSelection,
             formTypeForCode = { FormHelper.FormType.Empty },


### PR DESCRIPTION
# Summary
Thread LinkBrand to PaymentSelection. Ideally `PaymentSelection` wouldn't hold onto something like `LinkBrand`, but that requires a lot of model changes to thread the `LinkConfiguration` down to the right places and exploded the number of changes required everywhere. I think this is probably the smallest-scope change to preserve the LinkBrand for now. Let me know if you feel strongly otherwise

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-816

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
<img width="399" alt="image" src="https://github.com/user-attachments/assets/6ef76283-20dd-48a2-ba02-94dd47806643" />


# Changelog
n/a