### PR TITLE
Add runServerUpdate method to Checkout for server-side mutations.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -207,35 +207,16 @@ class Checkout private constructor(
      */
     suspend fun runServerUpdate(
         serverUpdate: suspend () -> Result<Unit>,
-    ): Result<Unit> {
-        if (internalState.integrationLaunched) {
-            return Result.failure(
-                IllegalStateException(
-                    "Cannot mutate checkout session while a payment flow is presented."
+    ): Result<Unit> = withInternalState { sessionId ->
+        serverUpdate().fold(
+            onSuccess = {
+                component.checkoutSessionRepository.init(
+                    sessionId = sessionId,
+                    adaptivePricingAllowed = configuration.adaptivePricingAllowed,
                 )
-            )
-        }
-        return mutex.withLock {
-            _isLoading.value = true
-            val result = runCatching {
-                serverUpdate().getOrThrow()
-            }.fold(
-                onSuccess = {
-                    component.checkoutSessionRepository.init(
-                        sessionId = internalState.checkoutSessionResponse.id,
-                        adaptivePricingAllowed = internalState.configuration.adaptivePricingAllowed,
-                    ).map { response ->
-                        internalState = internalState.copy(checkoutSessionResponse = response)
-                        _checkoutSession.value = response.asCheckoutSession()
-                    }
-                },
-                onFailure = { throwable ->
-                    Result.failure(throwable)
-                },
-            )
-            _isLoading.value = false
-            result
-        }
+            },
+            onFailure = { Result.failure(it) },
+        )
     }
 
     /**
@@ -355,7 +336,9 @@ class Checkout private constructor(
         // Run network requests with a mutex to ensure events are processed in order.
         return mutex.withLock {
             _isLoading.value = true
-            val result = internalState.block(internalState.checkoutSessionResponse.id).map { response ->
+            val result = runCatching {
+                internalState.block(internalState.checkoutSessionResponse.id).getOrThrow()
+            }.map { response ->
                 internalState = internalState.copy(checkoutSessionResponse = response).additionalStateMutations()
                 _checkoutSession.value = response.asCheckoutSession()
             }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -199,6 +199,46 @@ class Checkout private constructor(
     }
 
     /**
+     * Wraps an asynchronous function that communicates with your server to modify the
+     * Checkout Session. After the function completes, the session is re-fetched from the server.
+     *
+     * @param serverUpdate A suspend function responsible for making a server request that updates
+     * the Checkout Session.
+     */
+    suspend fun runServerUpdate(
+        serverUpdate: suspend () -> Result<Unit>,
+    ): Result<Unit> {
+        if (internalState.integrationLaunched) {
+            return Result.failure(
+                IllegalStateException(
+                    "Cannot mutate checkout session while a payment flow is presented."
+                )
+            )
+        }
+        return mutex.withLock {
+            _isLoading.value = true
+            val result = runCatching {
+                serverUpdate().getOrThrow()
+            }.fold(
+                onSuccess = {
+                    component.checkoutSessionRepository.init(
+                        sessionId = internalState.checkoutSessionResponse.id,
+                        adaptivePricingAllowed = internalState.configuration.adaptivePricingAllowed,
+                    ).map { response ->
+                        internalState = internalState.copy(checkoutSessionResponse = response)
+                        _checkoutSession.value = response.asCheckoutSession()
+                    }
+                },
+                onFailure = { throwable ->
+                    Result.failure(throwable)
+                },
+            )
+            _isLoading.value = false
+            result
+        }
+    }
+
+    /**
      * Selects a shipping option.
      *
      * @param id The ID of the shipping option to select.

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -979,6 +979,117 @@ class CheckoutTest {
         isLoadingTurbine.ensureAllEventsConsumed()
     }
 
+    @Test
+    fun `runServerUpdate refreshes checkoutSession after serverUpdate completes`() = runCreateWithStateScenario {
+        networkRule.checkoutInit { response ->
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        assertThat(checkoutSessionTurbine.awaitItem().totalSummary).isNull()
+
+        val result = checkout.runServerUpdate { Result.success(Unit) }
+
+        val updated = checkoutSessionTurbine.awaitItem()
+        result.getOrThrow()
+        assertThat(updated.totalSummary).isNotNull()
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when serverUpdate throws`() = runCreateWithStateScenario {
+        val initial = checkoutSessionTurbine.awaitItem()
+
+        val result = checkout.runServerUpdate {
+            throw IllegalStateException("Server error")
+        }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo("Server error")
+
+        checkoutSessionTurbine.expectNoEvents()
+        assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when serverUpdate fails`() = runCreateWithStateScenario {
+        val initial = checkoutSessionTurbine.awaitItem()
+
+        val result = checkout.runServerUpdate {
+            Result.failure(IllegalStateException("Server error"))
+        }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo("Server error")
+
+        checkoutSessionTurbine.expectNoEvents()
+        assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when refresh fails`() = runCreateWithStateScenario {
+        networkRule.checkoutInit { response ->
+            response.setResponseCode(500)
+            response.setBody("""{"error": {"message": "Internal server error"}}""")
+        }
+
+        val initial = checkoutSessionTurbine.awaitItem()
+
+        val result = checkout.runServerUpdate { Result.success(Unit) }
+
+        assertThat(result.isFailure).isTrue()
+
+        checkoutSessionTurbine.expectNoEvents()
+        assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when integrationLaunched is true`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        checkout.markIntegrationLaunched()
+
+        val result = checkout.runServerUpdate { Result.success(Unit) }
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
+    }
+
+    @Test
+    fun `runServerUpdate is serialized with other mutations`() = runCreateWithStateScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+        ) { response ->
+            response.setBodyDelay(200, TimeUnit.MILLISECONDS)
+            response.testBodyFromFile("checkout-session-concurrent-apply-promo.json")
+        }
+
+        // After runServerUpdate executes, it re-fetches using the updated session ID from the first mutation.
+        networkRule.checkoutInit(
+            sessionId = "cs_test_after_promo",
+        ) { response ->
+            response.testBodyFromFile("checkout-session-concurrent-update-address.json")
+        }
+
+        val initial = checkoutSessionTurbine.awaitItem()
+        assertThat(initial.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+
+        val results = listOf(
+            async { checkout.applyPromotionCode("10OFF") },
+            async { checkout.runServerUpdate { Result.success(Unit) } },
+        ).awaitAll()
+
+        assertThat(results[0].isSuccess).isTrue()
+        assertThat(results[1].isSuccess).isTrue()
+
+        val afterPromo = checkoutSessionTurbine.awaitItem()
+        assertThat(afterPromo.id).isEqualTo("cs_test_after_promo")
+
+        val afterRefresh = checkoutSessionTurbine.awaitItem()
+        assertThat(afterRefresh.id).isEqualTo("cs_test_after_address")
+    }
+
     private fun runCreateWithStateScenario(
         checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
         shouldValidateEvents: Boolean = true,


### PR DESCRIPTION
# Summary
Added a new `runServerUpdate` method to the Checkout API that enables server-side mutations of the Checkout Session with automatic refresh after the update completes.

# Motivation
This method provides a way for merchants to make server-side updates to their Checkout Session (such as updating line items, shipping details, or applying custom logic) while ensuring the client-side session state remains synchronized. The method handles the refresh automatically after the server update completes, maintaining consistency between server and client state.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
[Added] - Added `runServerUpdate` method to Checkout API for server-side session mutations with automatic refresh.