### PR TITLE
Rename form activity helpers to sheet activity helpers.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -22,11 +22,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.embedded.form.DefaultFormActivityRegistrar
-import com.stripe.android.paymentelement.embedded.form.DefaultFormActivityStateHelper
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
-import com.stripe.android.paymentelement.embedded.form.FormActivityRegistrar
-import com.stripe.android.paymentelement.embedded.form.FormActivityStateHelper
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
 import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentelement.embedded.manage.DefaultEmbeddedManageScreenInteractorFactory
@@ -36,8 +32,12 @@ import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInt
 import com.stripe.android.paymentelement.embedded.manage.InitialManageScreenFactory
 import com.stripe.android.paymentelement.embedded.manage.ManageSavedPaymentMethodMutatorFactory
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityConfirmationHelper
+import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityRegistrar
+import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmationHelper
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -81,7 +81,7 @@ internal interface EmbeddedActivityModule {
     fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
 
     @Binds
-    fun bindsFormActivityStateHelper(helper: DefaultFormActivityStateHelper): FormActivityStateHelper
+    fun bindsSheetActivityStateHolder(helper: DefaultSheetActivityStateHolder): SheetActivityStateHolder
 
     @Binds
     fun bindsPrefsRepositoryFactory(factory: DefaultPrefsRepository.Factory): PrefsRepository.Factory
@@ -100,9 +100,9 @@ internal interface EmbeddedActivityModule {
     ): LinkInlineSignupAvailability
 
     @Binds
-    fun providesFormActivityConfirmationHandlerRegistrar(
-        implementation: DefaultFormActivityRegistrar
-    ): FormActivityRegistrar
+    fun providesSheetActivityRegistrar(
+        implementation: DefaultSheetActivityRegistrar
+    ): SheetActivityRegistrar
 
     @Binds
     fun bindsConfirmationHelper(
@@ -214,13 +214,13 @@ internal interface EmbeddedActivityModule {
         fun provideSavedPaymentMethodConfirmInteractorFactory(
             @ViewModelScope coroutineScope: CoroutineScope,
             paymentMethodMetadata: PaymentMethodMetadata,
-            formActivityStateHelper: FormActivityStateHelper,
+            sheetActivityStateHolder: SheetActivityStateHolder,
             savedPaymentMethodLinkFormHelper: SavedPaymentMethodLinkFormHelper,
         ): SavedPaymentMethodConfirmInteractor.Factory {
             return DefaultSavedPaymentMethodConfirmInteractor.Factory(
                 paymentMethodMetadata = paymentMethodMetadata,
                 savedPaymentMethodLinkFormHelper = savedPaymentMethodLinkFormHelper,
-                processing = formActivityStateHelper.state.mapAsStateFlow {
+                processing = sheetActivityStateHolder.state.mapAsStateFlow {
                     it.isProcessing
                 },
                 coroutineScope = coroutineScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -28,7 +29,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
     private val embeddedSelectionHolder: EmbeddedSelectionHolder,
     private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
     @ViewModelScope private val viewModelScope: CoroutineScope,
-    private val formActivityStateHelper: FormActivityStateHelper,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
     private val tapToAddHelper: TapToAddHelper,
     private val eventReporter: EventReporter,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
@@ -53,10 +54,10 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             hasSavedPaymentMethods = hasSavedPaymentMethods,
             onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
             onMandateTextChanged = { mandateText, _ ->
-                formActivityStateHelper.updateMandate(mandateText)
+                sheetActivityStateHolder.updateMandate(mandateText)
             },
-            onUpdatePrimaryButtonUIState = formActivityStateHelper::updatePrimaryButton,
-            onError = formActivityStateHelper::updateError,
+            onUpdatePrimaryButtonUIState = sheetActivityStateHolder::updatePrimaryButton,
+            onError = sheetActivityStateHolder::updateError,
             onFormCompleted = { eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code) },
         )
 
@@ -84,7 +85,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
                 customerHasSavedPaymentMethods = hasSavedPaymentMethods
             ),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-            processing = formActivityStateHelper.state.mapAsStateFlow { it.isProcessing },
+            processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
             paymentMethodIncentive = PaymentMethodIncentiveInteractor(
                 paymentMethodMetadata.paymentMethodIncentive
             ).displayedIncentive,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
@@ -15,12 +15,13 @@ import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
-import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.collectAsState
@@ -43,19 +44,16 @@ internal class FormActivity : AppCompatActivity() {
     lateinit var formScreen: EmbeddedNavigator.Screen.Form
 
     @Inject
-    lateinit var formInteractor: DefaultVerticalModeFormInteractor
-
-    @Inject
     lateinit var eventReporter: EventReporter
 
     @Inject
-    lateinit var formActivityStateHelper: FormActivityStateHelper
+    lateinit var sheetActivityStateHolder: SheetActivityStateHolder
 
     @Inject
     lateinit var customerStateHolder: CustomerStateHolder
 
     @Inject
-    lateinit var formActivityRegistrar: FormActivityRegistrar
+    lateinit var sheetActivityRegistrar: SheetActivityRegistrar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -69,13 +67,13 @@ internal class FormActivity : AppCompatActivity() {
 
         viewModel.component.inject(this)
 
-        formActivityRegistrar.registerAndBootstrap(
+        sheetActivityRegistrar.registerAndBootstrap(
             activityResultCaller = this,
             lifecycleOwner = this,
         )
 
         lifecycleScope.launch {
-            formActivityStateHelper.result.collect {
+            sheetActivityStateHolder.result.collect {
                 setFormResult(it)
                 finish()
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.ErrorMessage
@@ -33,7 +34,7 @@ internal fun FormScreenContent(
     eventReporter: EventReporter,
     onClick: () -> Unit,
     onProcessingCompleted: () -> Unit,
-    state: FormActivityStateHelper.State,
+    state: SheetActivityStateHolder.State,
     updateSelection: (PaymentSelection.Saved) -> Unit,
     savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
 ) {
@@ -69,7 +70,7 @@ internal fun FormScreenContent(
 
 @Composable
 internal fun USBankAccountMandate(
-    state: FormActivityStateHelper.State
+    state: SheetActivityStateHolder.State
 ) {
     state.mandateText?.let {
         Mandate(
@@ -83,7 +84,7 @@ internal fun USBankAccountMandate(
 
 @Composable
 internal fun FormActivityError(
-    state: FormActivityStateHelper.State
+    state: SheetActivityStateHolder.State
 ) {
     state.error?.let {
         ErrorMessage(
@@ -97,7 +98,7 @@ internal fun FormActivityError(
 
 @Composable
 internal fun FormActivityPrimaryButton(
-    state: FormActivityStateHelper.State,
+    state: SheetActivityStateHolder.State,
     onProcessingCompleted: () -> Unit = {},
     onClick: () -> Unit,
 ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.form.FormActivityStateHelper
 import com.stripe.android.paymentelement.embedded.form.FormResult
 import com.stripe.android.paymentelement.embedded.form.FormScreenContent
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -166,7 +165,7 @@ internal class EmbeddedNavigator private constructor(
         class Form @Inject constructor(
             private val formInteractor: DefaultVerticalModeFormInteractor,
             private val eventReporter: EventReporter,
-            private val formActivityStateHelper: FormActivityStateHelper,
+            private val sheetActivityStateHolder: SheetActivityStateHolder,
             private val confirmationHelper: SheetActivityConfirmationHelper,
             private val embeddedSelectionHolder: EmbeddedSelectionHolder,
             private val savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
@@ -184,12 +183,12 @@ internal class EmbeddedNavigator private constructor(
             override fun title(): StateFlow<ResolvableString?> = stateFlowOf(null)
 
             override fun isPerformingNetworkOperation(): Boolean {
-                return formActivityStateHelper.state.value.isProcessing
+                return sheetActivityStateHolder.state.value.isProcessing
             }
 
             @Composable
             override fun Content() {
-                val state by formActivityStateHelper.state.collectAsState()
+                val state by sheetActivityStateHolder.state.collectAsState()
                 FormScreenContent(
                     interactor = formInteractor,
                     eventReporter = eventReporter,
@@ -197,7 +196,7 @@ internal class EmbeddedNavigator private constructor(
                         confirmationHelper.confirm()
                     },
                     onProcessingCompleted = {
-                        formActivityStateHelper.setResult(
+                        sheetActivityStateHolder.setResult(
                             FormResult.Complete(
                                 selection = null,
                                 hasBeenConfirmed = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
@@ -36,6 +37,7 @@ import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 internal class EmbeddedSheetActivity : AppCompatActivity() {
@@ -61,6 +63,12 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
     @Inject
     lateinit var selectionHolder: EmbeddedSelectionHolder
 
+    @Inject
+    lateinit var sheetActivityRegistrar: SheetActivityRegistrar
+
+    @Inject
+    lateinit var sheetActivityStateHolder: SheetActivityStateHolder
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -71,6 +79,21 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
 
         renderEdgeToEdge()
         viewModel.component.inject(this)
+
+        sheetActivityRegistrar.registerAndBootstrap(
+            activityResultCaller = this,
+            lifecycleOwner = this,
+        )
+
+        lifecycleScope.launch {
+            sheetActivityStateHolder.result.collect {
+                setEmbeddedResult(
+                    shouldInvokeSelectionCallback = false,
+                    hasBeenConfirmed = true,
+                )
+                finish()
+            }
+        }
 
         onBackPressedDispatcher.addCallback {
             if (!embeddedNavigator.screen.value.isPerformingNetworkOperation()) {
@@ -176,10 +199,13 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         }
     }
 
-    private fun setEmbeddedResult(shouldInvokeSelectionCallback: Boolean) {
+    private fun setEmbeddedResult(
+        shouldInvokeSelectionCallback: Boolean,
+        hasBeenConfirmed: Boolean = false,
+    ) {
         val result = EmbeddedSheetResult.Complete(
             selection = selectionHolder.selection.value,
-            hasBeenConfirmed = false,
+            hasBeenConfirmed = hasBeenConfirmed,
             customerState = customerStateHolder.customer.value,
             shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -7,7 +7,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.form.FormActivityStateHelper
 import com.stripe.android.paymentelement.embedded.form.FormResult
 import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -25,7 +24,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val configuration: EmbeddedPaymentElement.Configuration,
     private val selectionHolder: EmbeddedSelectionHolder,
-    private val stateHelper: FormActivityStateHelper,
+    private val stateHelper: SheetActivityStateHolder,
     private val onClickDelegate: OnClickOverrideDelegate,
     private val eventReporter: EventReporter,
     private val customerStateHolder: CustomerStateHolder,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityRegistrar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityRegistrar.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.form
+package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
@@ -8,7 +8,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import javax.inject.Inject
 import javax.inject.Singleton
 
-internal interface FormActivityRegistrar {
+internal interface SheetActivityRegistrar {
     fun registerAndBootstrap(
         activityResultCaller: ActivityResultCaller,
         lifecycleOwner: LifecycleOwner,
@@ -16,11 +16,11 @@ internal interface FormActivityRegistrar {
 }
 
 @Singleton
-internal class DefaultFormActivityRegistrar @Inject constructor(
+internal class DefaultSheetActivityRegistrar @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val tapToAddHelper: TapToAddHelper,
     private val paymentMethodMetadata: PaymentMethodMetadata,
-) : FormActivityRegistrar {
+) : SheetActivityRegistrar {
 
     private var isBootstrapped = false
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.form
+package com.stripe.android.paymentelement.embedded.sheet
 
 import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddNextStep
@@ -10,6 +10,8 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.form.FormResult
+import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -32,7 +34,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
-internal interface FormActivityStateHelper {
+internal interface SheetActivityStateHolder {
     val state: StateFlow<State>
     val result: SharedFlow<FormResult>
     fun updateMandate(mandateText: ResolvableString?)
@@ -56,7 +58,7 @@ internal interface FormActivityStateHelper {
 }
 
 @Singleton
-internal class DefaultFormActivityStateHelper @Inject constructor(
+internal class DefaultSheetActivityStateHolder @Inject constructor(
     private val paymentMethodMetadata: PaymentMethodMetadata,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val configuration: EmbeddedPaymentElement.Configuration,
@@ -66,9 +68,9 @@ internal class DefaultFormActivityStateHelper @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val tapToAddHelper: TapToAddHelper,
     private val customerStateHolder: CustomerStateHolder,
-) : FormActivityStateHelper {
+) : SheetActivityStateHolder {
     private val _state = MutableStateFlow(
-        FormActivityStateHelper.State(
+        SheetActivityStateHolder.State(
             primaryButtonLabel = primaryButtonLabel(paymentMethodMetadata.stripeIntent, configuration),
             isEnabled = false,
             processingState = PrimaryButtonProcessingState.Idle(null),
@@ -77,7 +79,7 @@ internal class DefaultFormActivityStateHelper @Inject constructor(
             savedPaymentSelectionToConfirm = null,
         )
     )
-    override val state: StateFlow<FormActivityStateHelper.State> = _state
+    override val state: StateFlow<SheetActivityStateHolder.State> = _state
 
     private val _result = MutableSharedFlow<FormResult>()
     override val result: SharedFlow<FormResult> = _result
@@ -193,9 +195,9 @@ internal class DefaultFormActivityStateHelper @Inject constructor(
         }
     }
 
-    private fun FormActivityStateHelper.State.updateWithConfirmationState(
+    private fun SheetActivityStateHolder.State.updateWithConfirmationState(
         state: ConfirmationHandler.State
-    ): FormActivityStateHelper.State {
+    ): SheetActivityStateHolder.State {
         return when (state) {
             is ConfirmationHandler.State.Complete -> {
                 eventReporter.reportPaymentResult(state.result, selectionHolder.selection.value)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
+import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -120,7 +121,7 @@ internal class FormActivityScreenShotTest {
         val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
         val confirmationHandler = FakeConfirmationHandler()
         confirmationHandler.state.value = confirmationState
-        val stateHolder = DefaultFormActivityStateHelper(
+        val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
             configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
@@ -146,7 +147,7 @@ internal class FormActivityScreenShotTest {
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
-            formActivityStateHelper = stateHolder,
+            sheetActivityStateHolder = stateHolder,
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
@@ -89,9 +89,9 @@ internal class FormActivityTest {
     }
 
     @Test
-    fun `When FormActivityStateHelper has result, activity finishes with that result`() = launch { scenario ->
+    fun `When SheetActivityStateHolder has result, activity finishes with that result`() = launch { scenario ->
         scenario.onActivity { activity ->
-            activity.formActivityStateHelper.setResult(
+            activity.sheetActivityStateHolder.setResult(
                 FormResult.Complete(
                     selection = null,
                     hasBeenConfirmed = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.form.FakeFormActivityStateHelper
 import com.stripe.android.paymentelement.embedded.form.FormResult
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
@@ -108,7 +107,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
             .configurationModifier()
             .build()
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val stateHelper = FakeFormActivityStateHelper()
+        val stateHelper = FakeSheetActivityStateHolder()
         val onClickDelegate = OnClickDelegateOverrideImpl()
         val eventReporter = FakeEventReporter()
         val confirmationHelper = DefaultSheetActivityConfirmationHelper(
@@ -140,7 +139,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
     private class Scenario(
         val confirmationHelper: DefaultSheetActivityConfirmationHelper,
         val confirmationHandler: FakeConfirmationHandler,
-        val stateHelper: FakeFormActivityStateHelper,
+        val stateHelper: FakeSheetActivityStateHolder,
         val onClickDelegate: OnClickDelegateOverrideImpl,
         val eventReporter: FakeEventReporter,
         val selectionHolder: EmbeddedSelectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityRegistrarTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityRegistrarTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.form
+package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
@@ -15,7 +15,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 
-internal class DefaultFormActivityRegistrarTest {
+internal class DefaultSheetActivityRegistrarTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -67,7 +67,7 @@ internal class DefaultFormActivityRegistrarTest {
         val activityResultCaller = mock<ActivityResultCaller>()
         val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined)
 
-        val registrar = DefaultFormActivityRegistrar(
+        val registrar = DefaultSheetActivityRegistrar(
             confirmationHandler = confirmationHandler,
             tapToAddHelper = tapToAddHelper,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -88,7 +88,7 @@ internal class DefaultFormActivityRegistrarTest {
     }
 
     private class Scenario(
-        val registrar: DefaultFormActivityRegistrar,
+        val registrar: DefaultSheetActivityRegistrar,
         val confirmationHandler: FakeConfirmationHandler,
         val tapToAddHelper: FakeTapToAddHelper,
         val activityResultCaller: ActivityResultCaller,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.paymentelement.embedded.form
+package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.TurbineTestContext
@@ -18,6 +18,11 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
+import com.stripe.android.paymentelement.embedded.form.FormResult
+import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
+import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
+import com.stripe.android.paymentelement.embedded.form.confirmationStateComplete
+import com.stripe.android.paymentelement.embedded.form.confirmationStateConfirming
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -29,7 +34,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-class DefaultFormActivityStateHelperTest {
+class DefaultSheetActivityStateHolderTest {
     @Test
     fun `state initializes correctly`() = testScenario {
         stateHolder.state.test {
@@ -412,7 +417,7 @@ class DefaultFormActivityStateHelperTest {
 
     private class Scenario(
         val selectionHolder: EmbeddedSelectionHolder,
-        val stateHolder: DefaultFormActivityStateHelper,
+        val stateHolder: DefaultSheetActivityStateHolder,
         val confirmationHandler: FakeConfirmationHandler,
         val onClickOverrideDelegate: OnClickOverrideDelegate,
     )
@@ -428,7 +433,7 @@ class DefaultFormActivityStateHelperTest {
         val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
         val onClickOverrideDelegate = OnClickDelegateOverrideImpl()
         val confirmationHandler = FakeConfirmationHandler()
-        val stateHolder = DefaultFormActivityStateHelper(
+        val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
             configuration = config,
@@ -448,7 +453,7 @@ class DefaultFormActivityStateHelperTest {
         ).block()
     }
 
-    private suspend fun TurbineTestContext<FormActivityStateHelper.State>.awaitAndVerifyInitialState() {
+    private suspend fun TurbineTestContext<SheetActivityStateHolder.State>.awaitAndVerifyInitialState() {
         val initialState = awaitItem()
         assertThat(initialState.processingState).isEqualTo(PrimaryButtonProcessingState.Idle(null))
         assertThat(initialState.isEnabled).isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
@@ -1,8 +1,9 @@
-package com.stripe.android.paymentelement.embedded.form
+package com.stripe.android.paymentelement.embedded.sheet
 
 import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentelement.embedded.form.FormResult
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
@@ -11,12 +12,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
-internal class FakeFormActivityStateHelper : FormActivityStateHelper {
+internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
     val selectionTurbine = Turbine<PaymentSelection.Saved?>()
 
-    override val state: StateFlow<FormActivityStateHelper.State>
+    override val state: StateFlow<SheetActivityStateHolder.State>
         get() = stateFlowOf(
-            FormActivityStateHelper.State(
+            SheetActivityStateHolder.State(
                 primaryButtonLabel = "".resolvableString,
                 isEnabled = false,
                 processingState = PrimaryButtonProcessingState.Idle(null),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -15,9 +15,9 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
-import com.stripe.android.paymentelement.embedded.form.DefaultFormActivityStateHelper
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
+import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
@@ -246,7 +246,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             isPaymentMethodSetAsDefaultEnabled = true,
         )
         val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
-        val stateHolder = DefaultFormActivityStateHelper(
+        val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
             configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
@@ -272,7 +272,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
-            formActivityStateHelper = stateHolder,
+            sheetActivityStateHolder = stateHolder,
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
@@ -300,7 +300,7 @@ internal class DefaultVerticalModeFormInteractorTest {
         )
         val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
         selectionHolder.set(paymentSelection)
-        val stateHolder = DefaultFormActivityStateHelper(
+        val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
             configuration = EmbeddedConfirmationStateFixtures.defaultStateWithOpenCardScanAutomatically().configuration,
@@ -326,7 +326,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
-            formActivityStateHelper = stateHolder,
+            sheetActivityStateHolder = stateHolder,
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()


### PR DESCRIPTION
# Summary
Renamed `FormActivityStateHelper`, `FormActivityRegistrar` and related classes to use "Sheet" naming instead of "Form" to better reflect their broader usage across sheet activities.

# Motivation
These helper classes are used by both form and embedded sheet activities. The previous "Form" naming was misleading since the functionality extends beyond just form activities. This refactoring improves code clarity and maintainability.

# Testing
- [x] Modified tests
- [x] Manually verified