### PR TITLE
Use network operation state directly in FormActivity sheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
@@ -93,9 +93,8 @@ internal class FormActivity : AppCompatActivity() {
     @OptIn(ExperimentalMaterialApi::class)
     @Composable
     private fun FormSheetContent(formScreen: EmbeddedNavigator.Screen.Form) {
-        val state by formActivityStateHelper.state.collectAsState()
         val bottomSheetState = rememberStripeBottomSheetState(
-            confirmValueChange = { !state.isProcessing }
+            confirmValueChange = { !formScreen.isPerformingNetworkOperation() }
         )
         ElementsBottomSheetLayout(
             state = bottomSheetState,


### PR DESCRIPTION
# Summary
Simplified state management in FormActivity by directly checking the form screen's network operation status instead of using a separate state helper.

# Motivation
This change reduces unnecessary state management complexity by using the existing network operation status from the form screen object, eliminating the need for a separate state collection.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog