### PR TITLE
Add payment method orientation to analytics events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -557,7 +557,12 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     private fun defaultParams(paymentMethodMetadata: PaymentMethodMetadata?): Map<String, Any> {
-        return paymentMethodMetadata?.analyticsMetadata?.paramsMap ?: emptyMap()
+        return if (paymentMethodMetadata != null) {
+            paymentMethodMetadata.analyticsMetadata.paramsMap +
+                ("payment_method_orientation" to paymentMethodMetadata.paymentMethodOrientation().name.lowercase())
+        } else {
+            emptyMap()
+        }
     }
 
     private fun fireEvent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -101,6 +101,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("ordered_lpms", "card")
         assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
+        assertThat(request.params).containsEntry("payment_method_orientation", "horizontal")
     }
 
     @Test
@@ -189,6 +190,7 @@ class DefaultEventReporterTest {
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_dismiss")
         assertThat(request.params).containsEntry("example_from_test", true)
+        assertThat(request.params).containsEntry("payment_method_orientation", "horizontal")
     }
 
     @Test
@@ -203,6 +205,7 @@ class DefaultEventReporterTest {
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_sheet_savedpm_show")
         assertThat(request.params).containsEntry("example_from_test", true)
+        assertThat(request.params).containsEntry("payment_method_orientation", "horizontal")
     }
 
     @Test
@@ -1044,6 +1047,7 @@ class DefaultEventReporterTest {
         assertThat(request.params).doesNotContainKey("deferred_intent_confirmation_type")
         assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
+        assertThat(request.params).containsEntry("payment_method_orientation", "horizontal")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add payment method orientation to analytics events

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Now that there's some more complex logic for what we show when payment method layout is automatic, we should have some info in our analytics about which layout the customer actually sees

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
