### PR TITLE
Separate screenshot and unit testing in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,8 +93,14 @@ workflows:
     steps:
       - script@1:
           timeout: 1200
+          is_always_run: true
           inputs:
-            - content: ./scripts/retry.sh 3 ./gradlew testDebugUnitTest verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest --continue
+            - content: ./scripts/retry.sh 3 ./gradlew -Pstripe.android.unit.tests.include=onlyUnitTests testDebugUnitTest -x :stripe-test-e2e:testDebugUnitTest --continue
+      - script@1:
+          timeout: 1200
+          is_always_run: true
+          inputs:
+            - content: ./scripts/retry.sh 3 ./gradlew -Pstripe.android.unit.tests.include=onlyScreenshots verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest --continue
   build-connect-debug:
     envs:
       - BUILD_VARIANT: debug

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -94,6 +94,30 @@ android {
     }
 }
 
+tasks.withType(Test).configureEach { test ->
+    if (!project.plugins.hasPlugin("app.cash.paparazzi")) {
+        return
+    }
+
+    def includeMode = project.property("stripe.android.unit.tests.include")
+
+    if (includeMode != "onlyScreenshots" && includeMode != "onlyUnitTests") {
+        return
+    }
+
+    def category = "com.stripe.android.screenshottesting.PaparazziTest"
+
+    if (includeMode == "onlyScreenshots") {
+        test.useJUnit {
+            includeCategories category
+        }
+    } else if (includeMode == "onlyUnitTests") {
+        test.useJUnit {
+            excludeCategories category
+        }
+    }
+}
+
 if (project.hasProperty("enable_dokka") && project.enable_dokka) {
     dokka {
         dokkaSourceSets {

--- a/connect/src/test/java/com/stripe/android/connect/StripeComponentDialogFragmentViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/StripeComponentDialogFragmentViewTest.kt
@@ -15,9 +15,12 @@ import com.stripe.android.connect.appearance.fonts.CustomFontSource
 import com.stripe.android.connect.test.TestComponentView
 import com.stripe.android.screenshottesting.Orientation
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class StripeComponentDialogFragmentViewTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/connect/src/test/java/com/stripe/android/connect/StripeComponentViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/StripeComponentViewTest.kt
@@ -12,9 +12,12 @@ import com.stripe.android.connect.appearance.Colors
 import com.stripe.android.connect.test.TestComponentView
 import com.stripe.android.connect.webview.StripeConnectWebViewContainerState
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class StripeComponentViewTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeWebViewSpinnerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeWebViewSpinnerTest.kt
@@ -8,9 +8,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.stripe.android.connect.test.TestClock
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class StripeWebViewSpinnerTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     kspDebug libs.showkaseProcessor
 
+    testImplementation project(":screenshot-testing")
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.core
     testImplementation testLibs.androidx.fragment

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
@@ -20,10 +20,13 @@ import com.stripe.android.financialconnections.getMetadata
 import com.stripe.android.financialconnections.ui.LocalTopAppBarHost
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 import com.stripe.android.financialconnections.utils.TimeZoneRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 
+@Category(PaparazziTest::class)
 @RunWith(TestParameterInjector::class)
 class PaparazziSampleScreenshotTest {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,8 @@ android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
+stripe.android.unit.tests.include=all
+
 org.gradle.jvmargs=-Xms4g -Xmx8g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 org.gradle.configuration-cache=true

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentScreenshotTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentScreenshotTest.kt
@@ -13,9 +13,12 @@ import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessageLegalDisclosure
 import com.stripe.android.paymentmethodmessaging.R
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PaymentMethodMessagingContentScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddButtonUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddButtonUIScreenshotTest.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class TapToAddButtonUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardScreenshotTest.kt
@@ -6,9 +6,12 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.common.taptoadd.ui.TapToAddCard
 import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class TapToAddCardScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/TapToAddLayoutScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/TapToAddLayoutScreenshotTest.kt
@@ -11,12 +11,15 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import kotlinx.coroutines.delay
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import kotlin.String
 
+@Category(PaparazziTest::class)
 class TapToAddLayoutScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/common/ui/ElementsBottomSheetLayoutScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/ui/ElementsBottomSheetLayoutScreenshotTest.kt
@@ -11,11 +11,14 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class ElementsBottomSheetLayoutScreenshotTest {
     @get:Rule
     val paparazzi = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/common/ui/PrimaryButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/ui/PrimaryButtonScreenshotTest.kt
@@ -6,13 +6,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 private const val BUTTON_TEXT = "Save Address"
 
+@Category(PaparazziTest::class)
 class PrimaryButtonScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
@@ -37,7 +38,9 @@ import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class CustomerSheetScreenshotTest {
     @get:Rule
     val paparazzi = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
@@ -18,11 +18,14 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class LinkControllerPaymentMethodPreviewScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(SystemAppearance.entries)

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarMenuScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarMenuScreenshotTest.kt
@@ -7,10 +7,13 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class LinkAppBarMenuScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarScreenshotTest.kt
@@ -10,13 +10,16 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+@Category(PaparazziTest::class)
 internal class LinkAppBarScreenshotTest(
     private val testCase: TestCase
 ) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkButtonScreenshotTest.kt
@@ -14,10 +14,12 @@ import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.Locale
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance.DefaultAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 private enum class LinkButtonAppearance(private val appearance: PaymentSheet.Appearance) : PaparazziConfigOption {
 
@@ -64,6 +66,7 @@ private enum class LinkButtonThemes(val buttonThemes: PaymentSheet.ButtonThemes)
     }
 }
 
+@Category(PaparazziTest::class)
 internal class LinkButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkContentScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkContentScreenshotTest.kt
@@ -19,12 +19,15 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class LinkContentScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkLoadingScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkLoadingScreenTest.kt
@@ -8,10 +8,13 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class LinkLoadingScreenTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/MinScreenHeightBoxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/MinScreenHeightBoxTest.kt
@@ -13,10 +13,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class MinScreenHeightBoxTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/PrimaryButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/PrimaryButtonScreenshotTest.kt
@@ -10,10 +10,13 @@ import com.stripe.android.link.LinkAppearanceFixtures
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PrimaryButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/SecondaryButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/SecondaryButtonScreenshotTest.kt
@@ -10,10 +10,13 @@ import com.stripe.android.link.LinkAppearanceFixtures
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class SecondaryButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkFieldsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkFieldsScreenshotTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
@@ -17,7 +18,9 @@ import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.SectionController
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class LinkFieldsScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkInlineSignupScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkInlineSignupScreenshotTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.uicore.elements.EmailConfig
@@ -16,8 +17,10 @@ import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.SectionController
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import java.util.Locale
 
+@Category(PaparazziTest::class)
 class LinkInlineSignupScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignupScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkOptionalInlineSignupScreenshotTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.uicore.elements.EmailConfig
@@ -16,8 +17,10 @@ import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.SectionController
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import java.util.Locale
 
+@Category(PaparazziTest::class)
 class LinkOptionalInlineSignupScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/oauth/OAuthConsentScreenScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/oauth/OAuthConsentScreenScreenShotTest.kt
@@ -1,10 +1,13 @@
 package com.stripe.android.link.ui.oauth
 
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class OAuthConsentScreenScreenShotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -21,7 +22,9 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodScreenScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/EmailCollectionSectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/EmailCollectionSectionScreenshotTest.kt
@@ -6,14 +6,17 @@ import com.stripe.android.link.theme.StripeThemeForLink
 import com.stripe.android.link.ui.LinkScreenshotSurface
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.elements.EmailConfig
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+@Category(PaparazziTest::class)
 internal class EmailCollectionSectionScreenshotTest(
     private val testCase: TestCase
 ) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenshotTest.kt
@@ -5,16 +5,19 @@ import com.stripe.android.link.ui.LinkScreenshotSurface
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+@Category(PaparazziTest::class)
 internal class SignUpScreenshotTest(
     private val testCase: TestCase
 ) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
@@ -19,13 +19,16 @@ import com.stripe.android.paymentsheet.ui.EditCardDetailsInteractor
 import com.stripe.android.paymentsheet.ui.EditCardPayload
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+@Category(PaparazziTest::class)
 internal class UpdateCardScreenshotTest(
     private val testCase: TestCase
 ) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenshotTest.kt
@@ -5,14 +5,17 @@ import com.stripe.android.link.ui.LinkScreenshotSurface
 import com.stripe.android.model.ConsentUi
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.uicore.elements.OTPElement
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+@Category(PaparazziTest::class)
 internal class VerificationScreenshotTest(
     private val testCase: TestCase
 ) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/LinkInline2FASectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/LinkInline2FASectionScreenshotTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -17,8 +18,10 @@ import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import java.util.Locale
 
+@Category(PaparazziTest::class)
 class LinkInline2FASectionScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/PaymentDetailsListItemScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/PaymentDetailsListItemScreenShotTest.kt
@@ -11,10 +11,13 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentDetailsListItemScreenShotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletPaymentMethodMenuScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletPaymentMethodMenuScreenshotTest.kt
@@ -9,10 +9,13 @@ import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class WalletPaymentMethodMenuScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.CvcCheck
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.screenshottesting.Orientation
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.uicore.elements.DateConfig
@@ -24,7 +25,9 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class WalletScreenScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.screenshottesting.LayoutDirection
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
@@ -24,7 +25,9 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance.DefaultAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class CardUiDefinitionFactoryTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactoryTest.kt
@@ -8,10 +8,13 @@ import com.stripe.android.lpmfoundations.paymentmethod.TestUiDefinitionFactoryAr
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.ui.core.FormUI
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class CustomPaymentMethodUiDefinitionFactoryTest {
     @get:Rule
     val paparazziRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentScreenshotTest.kt
@@ -8,10 +8,13 @@ import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
+import org.junit.experimental.categories.Category
 import kotlin.test.Test
 
+@Category(PaparazziTest::class)
 internal class EmbeddedContentScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
@@ -32,7 +33,9 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class FormActivityScreenShotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenUIScreenshotTest.kt
@@ -5,13 +5,16 @@ import androidx.compose.runtime.Composable
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class AutocompleteScreenUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest.kt
@@ -13,10 +13,13 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
@@ -25,12 +25,15 @@ import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance.DefaultAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenAddFirstPaymentMethodScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenCvcRecollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenCvcRecollectionScreenshotTest.kt
@@ -10,10 +10,13 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetFlowType
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenCvcRecollectionScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenLoadingScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenLoadingScreenshotTest.kt
@@ -9,10 +9,13 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetFlowType
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenLoadingScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
@@ -14,10 +14,13 @@ import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
@@ -14,11 +14,14 @@ import com.stripe.android.paymentsheet.ui.SelectSavedPaymentMethodsInteractor
 import com.stripe.android.paymentsheet.utils.OutlinedIconsAppearance
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.flow.update
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
@@ -28,13 +28,16 @@ import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutI
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import kotlinx.coroutines.flow.update
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenVerticalModeScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
@@ -23,7 +24,9 @@ import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.utils.BankFormScreenStateFactory
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class AccountPreviewScreenshotTest {
     @get:Rule
     val paparazzi = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
@@ -20,7 +21,9 @@ import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.utils.stateFlowOf
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class BillingDetailsCollectionScreenshotTest {
     @get:Rule
     val paparazzi = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateButtonScreenshotTest.kt
@@ -2,11 +2,14 @@ package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class BacsMandateButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationFormScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationFormScreenshotTest.kt
@@ -4,11 +4,14 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class BacsMandateConfirmationFormScreenshotTest {
     @get:Rule
     val paparazziSingleVariantRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionFieldScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionFieldScreenshotTest.kt
@@ -3,11 +3,14 @@ package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
 import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class CvcRecollectionFieldScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreenScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
 import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
@@ -10,7 +11,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class CvcRecollectionScreenScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CvcRecollectionFieldScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CvcRecollectionFieldScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.ui
 import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
@@ -10,7 +11,9 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class CvcRecollectionFieldScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultPaymentMethodLabelScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultPaymentMethodLabelScreenshotTest.kt
@@ -5,11 +5,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class DefaultPaymentMethodLabelScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/EnterManuallyTextScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/EnterManuallyTextScreenshotTest.kt
@@ -3,11 +3,14 @@ package com.stripe.android.paymentsheet.ui
 import com.stripe.android.paymentsheet.addresselement.EnterManuallyText
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class EnterManuallyTextScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ErrorMessageScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ErrorMessageScreenshotTest.kt
@@ -2,11 +2,14 @@ package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class ErrorMessageScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/MandateSnapshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/MandateSnapshotTest.kt
@@ -5,12 +5,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class MandateSnapshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodUIScreenshotTest.kt
@@ -5,13 +5,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.R
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.mockito.Mockito.mock
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
@@ -7,13 +7,16 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPayme
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.ui.core.R
 import com.stripe.android.utils.MockPaymentMethodsFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.mockito.kotlin.mock
 
+@Category(PaparazziTest::class)
 class PaymentMethodsUIScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtensionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtensionScreenshotTest.kt
@@ -23,13 +23,16 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.DefaultStripeTheme
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.stripeColors
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PaymentMethodsUiExtensionScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionScreenshotTest.kt
@@ -5,11 +5,14 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PaymentOptionScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -8,9 +8,12 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PaymentOptionsScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -9,11 +9,14 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.strings.resolve
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
@@ -6,11 +6,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PaymentSheetTopBarScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PrimaryButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PrimaryButtonScreenshotTest.kt
@@ -11,11 +11,14 @@ import androidx.compose.ui.unit.sp
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PrimaryButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PromoBadgeScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PromoBadgeScreenshotTest.kt
@@ -4,12 +4,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import java.util.Locale
 
+@Category(PaparazziTest::class)
 internal class PromoBadgeScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateScreenSnapshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SepaMandateScreenSnapshotTest.kt
@@ -2,11 +2,14 @@ package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class SepaMandateScreenSnapshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUIScreenshotTest.kt
@@ -8,10 +8,13 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.ViewActionRecorder
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class UpdatePaymentMethodUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/WalletButtonsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/WalletButtonsScreenshotTest.kt
@@ -3,12 +3,15 @@ package com.stripe.android.paymentsheet.ui
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 @OptIn(WalletButtonsPreview::class)
+@Category(PaparazziTest::class)
 class WalletButtonsScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/WalletsDividerScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/WalletsDividerScreenshotTest.kt
@@ -4,11 +4,14 @@ import androidx.compose.ui.res.stringResource
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class WalletsDividerScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
@@ -5,11 +5,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class CurrencySelectorToggleScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUIScreenshotTest.kt
@@ -8,10 +8,13 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class ManageScreenUIScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButtonScreenshotTest.kt
@@ -6,13 +6,16 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.R
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.mockito.Mockito
 
+@Category(PaparazziTest::class)
 internal class NewPaymentMethodRowButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -5,12 +5,15 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.ui.core.R
 import com.stripe.android.utils.MockPaymentMethodsFactory
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.mockito.kotlin.mock
 
+@Category(PaparazziTest::class)
 internal class NewPaymentMethodVerticalLayoutUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUIScreenshotTest.kt
@@ -16,13 +16,16 @@ import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle.FlatWithRadio
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.utils.MockPaymentMethodsFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.mockito.kotlin.mock
 import kotlin.reflect.KClass
 
+@Category(PaparazziTest::class)
 class PaymentMethodEmbeddedLayoutUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(PaymentSheetAppearance.entries)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowCheckmarkButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowCheckmarkButtonScreenshotTest.kt
@@ -13,13 +13,16 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle.FlatWithCheckmark
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodRowCheckmarkButtonScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowDisclosureButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowDisclosureButtonScreenshotTest.kt
@@ -13,13 +13,16 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle.FlatWithDisclosure
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodRowDisclosureButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowFloatingButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowFloatingButtonScreenshotTest.kt
@@ -23,13 +23,16 @@ import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle
 import com.stripe.android.paymentsheet.verticalmode.UIConstants.iconHeight
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodRowFloatingButtonScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowRadioButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowRadioButtonScreenshotTest.kt
@@ -23,13 +23,16 @@ import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle
 import com.stripe.android.paymentsheet.verticalmode.UIConstants.iconHeight
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodRowRadioButtonScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -6,12 +6,15 @@ import androidx.compose.ui.Modifier
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.utils.MockPaymentMethodsFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.mockito.kotlin.mock
 
+@Category(PaparazziTest::class)
 internal class PaymentMethodVerticalLayoutUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(PaymentSheetAppearance.entries)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUIScreenshotTest.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
+import org.junit.experimental.categories.Category
 import kotlin.test.Test
 
+@Category(PaparazziTest::class)
 internal class SavedPaymentMethodConfirmUIScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
@@ -10,11 +10,14 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
+import org.junit.experimental.categories.Category
 import kotlin.test.Test
 
+@Category(PaparazziTest::class)
 internal class SavedPaymentMethodRowButtonScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormHeaderUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormHeaderUITest.kt
@@ -3,10 +3,13 @@ package com.stripe.android.paymentsheet.verticalmode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.ui.core.R
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class VerticalModeFormHeaderUITest {
     @get:Rule
     val paparazziRule = PaparazziRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -23,11 +23,14 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.flow.update
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class VerticalModeFormUIScreenshotTest {
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayButtonScreenshotTest.kt
@@ -6,10 +6,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class ShopPayButtonScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziRule.kt
+++ b/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziRule.kt
@@ -13,6 +13,7 @@ import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import com.android.ide.common.rendering.api.SessionParams
 import com.stripe.android.uicore.StripeTheme
+import org.junit.experimental.categories.Category
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -32,9 +33,25 @@ class PaparazziRule(
 
     override fun apply(base: Statement, description: Description): Statement {
         this.description = description
-        return object : Statement() {
-            override fun evaluate() {
-                base.evaluate()
+
+        val categoryAnnotation = description.testClass.getAnnotation(Category::class.java)
+
+        return categoryAnnotation?.takeIf {
+            categoryAnnotation.value.any { it == PaparazziTest::class }
+        }?.let {
+            object : Statement() {
+                override fun evaluate() {
+                    base.evaluate()
+                }
+            }
+        } ?: run {
+            object : Statement() {
+                override fun evaluate() {
+                    throw IllegalStateException(
+                        "PaparazziRule was used without @Category(PaparazziTest::class). " +
+                            "Please annotate your test class with @Category(PaparazziTest::class)"
+                    )
+                }
             }
         }
     }

--- a/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziTest.kt
+++ b/screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziTest.kt
@@ -1,0 +1,3 @@
+package com.stripe.android.screenshottesting
+
+interface PaparazziTest

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CenteredTextLayoutTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CenteredTextLayoutTest.kt
@@ -12,9 +12,12 @@ import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.DeviceConfig
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 internal class CenteredTextLayoutTest {
     private enum class FontSize(val scaleFactor: Float) : PaparazziConfigOption {
         SmallFont(scaleFactor = 0.5f),

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CheckboxFieldUIViewScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CheckboxFieldUIViewScreenshotTest.kt
@@ -8,11 +8,14 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.StripeTheme
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class CheckboxFieldUIViewScreenshotTest {
     private val label =
         @Composable

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/DropdownScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/DropdownScreenshotTest.kt
@@ -6,10 +6,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class DropdownScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUiScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUiScreenshotTest.kt
@@ -6,10 +6,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class OTPElementUiScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberElementUIScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberElementUIScreenshotTest.kt
@@ -7,10 +7,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class PhoneNumberElementUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SectionUIScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SectionUIScreenshotTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -16,7 +17,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class SectionUIScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SelectorScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SelectorScreenshotTest.kt
@@ -5,10 +5,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class SelectorScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldUiScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldUiScreenshotTest.kt
@@ -8,11 +8,14 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.R
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class TextFieldUiScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/text/HtmlScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/text/HtmlScreenshotTest.kt
@@ -6,12 +6,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.screenshottesting.PaparazziTest
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.StripeTheme
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@Category(PaparazziTest::class)
 class HtmlScreenshotTest {
     @get:Rule
     val paparazziRule = PaparazziRule(


### PR DESCRIPTION
# Summary
Separate screenshot and unit testing in CI. Paparazzi's `verifyPaparazziDebug` task runs on `testDebugUnitTest` which runs all the other non-screenshot tests, ignoring their results. This also happens vice versa when just running unit tests.

This PR allows for the Paparazzi tests to be filtered in and out of the test tasks for that CI is not repeating tests multiple times, improving overall pipeline test time.

# Motivation
Part of work to allow test results to displayed in Bitrise & enable quarantining.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified