### PR TITLE
Improve NetworkRule test infrastructure debuggability

### DIFF
--- a/.claude/skills/network-tests/SKILL.md
+++ b/.claude/skills/network-tests/SKILL.md
@@ -129,20 +129,29 @@ networkRule.checkoutConfirm(
 
 ### bodyPart Encoding
 
-`bodyPart()` matches against the raw URL-encoded form body. Use `urlEncode()` for keys with brackets and values with special characters:
+`bodyPart()`, `hasBodyPart()`, and `query(name, value)` auto-decode both the matcher arguments and the request body before comparing. Use plain readable strings — `urlEncode()` is unnecessary:
 
 ```kotlin
-import com.stripe.android.core.utils.urlEncode
+// Keys with brackets and values with special characters — just use plain strings
+bodyPart("billing_details[email]", "user@example.com")
+bodyPart("billing_details[address][line1]", "123 Main St")
+bodyPart("payment_method_data[allow_redisplay]", "unspecified")
 
-// Encode keys with brackets and special-char values
-bodyPart(urlEncode("billing_details[email]"), urlEncode("user@example.com"))
-bodyPart(urlEncode("billing_details[address][line1]"), urlEncode("123 Main St"))
+// urlEncode() still works (backward compatible) but is unnecessary
+// bodyPart(urlEncode("billing_details[email]"), urlEncode("user@example.com"))
+```
 
-// Simple alphanumeric keys/values don't need encoding
-bodyPart("allow_redisplay", "unspecified")
+### Mismatch Debugging
 
-// Without encoding, bracket keys won't match
-bodyPart("billing_details[email]", "user@example.com") // WRONG
+When a request doesn't match a mock, the error message shows per-matcher diagnostics with the nearest-miss mock:
+
+```
+POST https://localhost/v1/payment_intents/pi_123/confirm
+  Body params: {billing_details[email]=actual@test.com, payment_method=pm_123}
+  Nearest mock: composite(path(/v1/confirm), bodyPart(billing_details[email], expected@test.com))
+    + PASS: path(/v1/confirm)
+    + PASS: method(POST)
+    - FAIL: bodyPart(billing_details[email], expected@test.com)
 ```
 
 See `PaymentSheetBillingConfigurationTest.kt` for more examples.

--- a/network-testing/build.gradle
+++ b/network-testing/build.gradle
@@ -7,5 +7,8 @@ dependencies {
     implementation testLibs.junit
     implementation testLibs.okhttpTls
 
+    testImplementation testLibs.junit
+    testImplementation testLibs.truth
+
     androidTestImplementation project(':stripe-ui-core') // Resources defined here, but used in payments-core.
 }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -128,8 +128,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
             )
         )
 
-        @Suppress("MagicNumber")
-        return MockResponse().setResponseCode(500).setBody("Request not mocked")
+        return MockResponse().setResponseCode(UNMATCHED_RESPONSE_CODE).setBody("Request not mocked")
     }
 
     private fun buildNearMissDiagnostics(request: TestRecordedRequest): String {
@@ -172,5 +171,7 @@ private class UnmatchedRequest(
         return lines.joinToString("\n")
     }
 }
+
+private const val UNMATCHED_RESPONSE_CODE = 500
 
 internal class RequestNotFoundException(message: String) : Exception(message)

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.networktesting
 
-import com.stripe.android.networktesting.RequestMatchers.composite
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
@@ -12,12 +11,12 @@ import kotlin.time.Duration.Companion.milliseconds
 
 internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dispatcher() {
     private val enqueuedResponses: Queue<Entry> = ConcurrentLinkedQueue()
-    private val extraRequests: MutableList<RecordedRequest> = Collections.synchronizedList(mutableListOf())
+    private val unmatchedRequests: MutableList<UnmatchedRequest> = Collections.synchronizedList(mutableListOf())
 
     fun enqueue(vararg requestMatcher: RequestMatcher, responseFactory: (MockResponse) -> Unit) {
         validateEnqueueState()
         enqueuedResponses.add(
-            Entry(composite(*requestMatcher)) {
+            Entry(RequestMatchers.composite(*requestMatcher)) {
                 val response = MockResponse()
                 response.setResponseCode(200)
                 responseFactory(response)
@@ -32,7 +31,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     ) {
         validateEnqueueState()
         enqueuedResponses.add(
-            Entry(composite(*requestMatcher)) {
+            Entry(RequestMatchers.composite(*requestMatcher)) {
                 val response = MockResponse()
                 response.setResponseCode(200)
                 responseFactory(it, response)
@@ -52,7 +51,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
 
     fun clear() {
         enqueuedResponses.clear()
-        extraRequests.clear()
+        unmatchedRequests.clear()
     }
 
     fun validate() {
@@ -70,13 +69,13 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     }
 
     private fun addExtraRequestsToExceptionMessage(exceptionMessage: StringBuilder) {
-        if (extraRequests.isNotEmpty()) {
+        if (unmatchedRequests.isNotEmpty()) {
             if (exceptionMessage.isNotEmpty()) {
                 exceptionMessage.append('\n')
             }
             exceptionMessage.append(
-                "Production code made extra requests that your test did not enqueue. Remaining: " +
-                    "${extraRequests.size}.\n${extraRequestDescriptions()}"
+                "Production code made extra requests that your test did not enqueue. " +
+                    "Remaining: ${unmatchedRequests.size}.\n${extraRequestDescriptions()}"
             )
         }
     }
@@ -100,7 +99,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     }
 
     private fun extraRequestDescriptions(): String {
-        return extraRequests.joinToString { it.requestUrl.toString() }
+        return unmatchedRequests.joinToString(separator = "\n\n") { it.describe() }
     }
 
     override fun dispatch(request: RecordedRequest): MockResponse {
@@ -114,12 +113,42 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
             return capturedEntry.responseFactory(testRequest)
         }
 
-        val exception = RequestNotFoundException("$request not mocked\n${testRequest.bodyText}")
-        println(exception)
+        val diagnostics = buildNearMissDiagnostics(testRequest)
+        val message = "$request not mocked\n" +
+            "Request body params: ${testRequest.bodyParams}\n" +
+            diagnostics
+        System.err.println("NetworkDispatcher: $message")
 
-        extraRequests.add(request)
+        unmatchedRequests.add(
+            UnmatchedRequest(
+                url = request.requestUrl.toString(),
+                method = request.method ?: "UNKNOWN",
+                bodyParams = testRequest.bodyParams,
+                diagnostics = diagnostics,
+            )
+        )
 
-        throw exception
+        @Suppress("MagicNumber")
+        return MockResponse().setResponseCode(500).setBody("Request not mocked")
+    }
+
+    private fun buildNearMissDiagnostics(request: TestRecordedRequest): String {
+        if (enqueuedResponses.isEmpty()) return "No enqueued mocks to match against."
+
+        val nearestMiss = enqueuedResponses.maxByOrNull { entry ->
+            val matcher = entry.requestMatcher
+            if (matcher is CompositeRequestMatcher) matcher.passCount(request) else 0
+        } ?: return "No enqueued mocks to match against."
+
+        val matcher = nearestMiss.requestMatcher
+        val lines = mutableListOf("Nearest mock: $matcher")
+        if (matcher is CompositeRequestMatcher) {
+            lines.add(matcher.diagnose(request))
+        } else {
+            val matched = matcher.matches(request)
+            lines.add(if (matched) "  + PASS" else "  - FAIL")
+        }
+        return lines.joinToString("\n")
     }
 }
 
@@ -127,5 +156,21 @@ private class Entry(
     val requestMatcher: RequestMatcher,
     val responseFactory: (TestRecordedRequest) -> MockResponse
 )
+
+private class UnmatchedRequest(
+    val url: String,
+    val method: String,
+    val bodyParams: Map<String, String>,
+    val diagnostics: String,
+) {
+    fun describe(): String {
+        val lines = mutableListOf("$method $url")
+        if (bodyParams.isNotEmpty()) {
+            lines.add("  Body params: $bodyParams")
+        }
+        lines.add("  $diagnostics")
+        return lines.joinToString("\n")
+    }
+}
 
 internal class RequestNotFoundException(message: String) : Exception(message)

--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -13,6 +13,31 @@ private class ToStringRequestMatcher(
     }
 }
 
+internal class CompositeRequestMatcher(
+    private val matchers: List<RequestMatcher>,
+) : RequestMatcher {
+    override fun matches(request: TestRecordedRequest): Boolean {
+        return matchers.all { it.matches(request) }
+    }
+
+    fun passCount(request: TestRecordedRequest): Int {
+        return matchers.count { it.matches(request) }
+    }
+
+    fun diagnose(request: TestRecordedRequest): String {
+        val results = matchers.map { matcher ->
+            val matched = matcher.matches(request)
+            val prefix = if (matched) "  + PASS" else "  - FAIL"
+            "$prefix: $matcher"
+        }
+        return results.joinToString("\n")
+    }
+
+    override fun toString(): String {
+        return "composite(${matchers.joinToString { it.toString() }})"
+    }
+}
+
 object RequestMatchers {
     fun host(host: String): RequestMatcher {
         return header("original-host", host)
@@ -75,9 +100,7 @@ object RequestMatchers {
 
     fun query(name: String, value: String?): RequestMatcher {
         return ToStringRequestMatcher("query($name, $value)") { request ->
-            request.path.substringAfter("?")
-                .split("&")
-                .associate { Pair(it.substringBefore("="), it.substringAfter("=")) }[name] == value
+            request.queryParams[name] == value || request.queryParams[urlDecode(name)] == urlDecode(value ?: "")
         }
     }
 
@@ -96,32 +119,22 @@ object RequestMatchers {
 
     fun hasBodyPart(name: String): RequestMatcher {
         return ToStringRequestMatcher("hasBodyPart($name)") { request ->
-            request.bodyText.substringAfter("?")
-                .split("&")
-                .map { it.substringBefore("=") }
-                .contains(name)
+            request.bodyParams.containsKey(name) || request.bodyParams.containsKey(urlDecode(name))
         }
     }
 
     fun bodyPart(name: String, value: String): RequestMatcher {
         return ToStringRequestMatcher("bodyPart($name, $value)") { request ->
-            request.bodyText.substringAfter("?")
-                .split("&")
-                .associate { Pair(it.substringBefore("="), it.substringAfter("=")) }[name] == value
+            request.bodyParams[name] == value ||
+                request.bodyParams[urlDecode(name)] == urlDecode(value)
         }
     }
 
     fun bodyPart(name: String, regex: Regex): RequestMatcher {
         return ToStringRequestMatcher("bodyPart($name, $regex)") { request ->
-            request.bodyText.substringAfter("?")
-                .split("&")
-                .associate {
-                    Pair(
-                        it.substringBefore("="),
-                        it.substringAfter("=")
-                    )
-                }.getOrElse(name) { "" }
-                .matches(regex)
+            request.bodyParams.getOrElse(name) {
+                request.bodyParams.getOrElse(urlDecode(name)) { "" }
+            }.matches(regex)
         }
     }
 
@@ -132,9 +145,6 @@ object RequestMatchers {
     }
 
     fun composite(vararg matchers: RequestMatcher): RequestMatcher {
-        val friendlyName = "composite(${matchers.joinToString { it.toString() }})"
-        return ToStringRequestMatcher(friendlyName) { request ->
-            matchers.all { it.matches(request) }
-        }
+        return CompositeRequestMatcher(matchers.toList())
     }
 }

--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestRecordedRequest.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestRecordedRequest.kt
@@ -25,6 +25,15 @@ class TestRecordedRequest(private val recordedRequest: RecordedRequest) {
             return _bodyText.get()!!
         }
 
+    val bodyParams: Map<String, String> by lazy {
+        parseUrlEncodedParams(bodyText)
+    }
+
+    val queryParams: Map<String, String> by lazy {
+        val queryString = if (path.contains("?")) path.substringAfter("?") else ""
+        parseUrlEncodedParams(queryString)
+    }
+
     fun queryParameterValues(name: String): List<String?> {
         val url = HttpUrl.Builder()
             .scheme("https")

--- a/network-testing/src/main/java/com/stripe/android/networktesting/UrlUtils.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/UrlUtils.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.networktesting
+
+import java.net.URLDecoder
+
+internal fun urlDecode(value: String): String {
+    return URLDecoder.decode(value, Charsets.UTF_8.name())
+}
+
+internal fun parseUrlEncodedParams(input: String): Map<String, String> {
+    if (input.isBlank()) return emptyMap()
+    return input.split("&")
+        .filter { it.contains("=") }
+        .associate {
+            urlDecode(it.substringBefore("=")) to urlDecode(it.substringAfter("="))
+        }
+}

--- a/network-testing/src/test/java/com/stripe/android/networktesting/MockRecordedRequestBuilder.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/MockRecordedRequestBuilder.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.networktesting
+
+import okhttp3.Headers
+import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
+import java.net.Socket
+import java.net.URLEncoder
+
+internal class MockRecordedRequestBuilder {
+    private var path: String = "/v1/test"
+    private var body: String = ""
+    private var method: String = "GET"
+
+    fun path(path: String) = apply { this.path = path }
+    fun body(body: String) = apply { this.body = body }
+    fun method(method: String) = apply { this.method = method }
+
+    fun formBody(vararg params: Pair<String, String>) = apply {
+        this.body = params.joinToString("&") { (key, value) ->
+            "${URLEncoder.encode(key, "UTF-8")}=${URLEncoder.encode(value, "UTF-8")}"
+        }
+    }
+
+    fun build(): RecordedRequest {
+        val buffer = Buffer().writeUtf8(body)
+        return RecordedRequest(
+            "$method $path HTTP/1.1",
+            Headers.headersOf(),
+            emptyList(),
+            body.length.toLong(),
+            buffer,
+            0,
+            Socket(),
+        )
+    }
+}

--- a/network-testing/src/test/java/com/stripe/android/networktesting/NetworkDispatcherTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/NetworkDispatcherTest.kt
@@ -49,7 +49,6 @@ class NetworkDispatcherTest {
         assertThat(lines).contains("  Body params: {email=actual@test.com}")
     }
 
-
     @Test
     fun `validate shows only nearest miss when multiple mocks remain`() = runScenario {
         enqueue(RequestMatchers.path("/v1/payment_methods"), RequestMatchers.method("POST"))

--- a/network-testing/src/test/java/com/stripe/android/networktesting/NetworkDispatcherTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/NetworkDispatcherTest.kt
@@ -1,0 +1,106 @@
+package com.stripe.android.networktesting
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NetworkDispatcherTest {
+
+    @Test
+    fun `dispatch returns 500 for unmatched request`() = runScenario {
+        enqueue(RequestMatchers.path("/v1/expected"))
+
+        val response = dispatch(path = "/v1/unexpected")
+
+        assertThat(response.status).isEqualTo("HTTP/1.1 500 Server Error")
+    }
+
+    @Test
+    fun `dispatch matches and consumes enqueued response`() = runScenario {
+        enqueue(RequestMatchers.path("/v1/test"))
+
+        val response = dispatch(path = "/v1/test")
+
+        assertThat(response.status).isEqualTo("HTTP/1.1 200 OK")
+        dispatcher.validate()
+    }
+
+    @Test
+    fun `validate fails when mocks remain unconsumed`() = runScenario {
+        enqueue(RequestMatchers.path("/v1/confirm"))
+
+        val error = assertValidationFails()
+
+        assertThat(error.message).startsWith("Mock responses is not empty. Remaining: 1.")
+    }
+
+    @Test
+    fun `validate fails when extra requests were made`() = runScenario {
+        enqueue(
+            RequestMatchers.path("/v1/confirm"),
+            RequestMatchers.bodyPart("email", "expected@test.com"),
+        )
+
+        dispatch(path = "/v1/confirm", body = "email" to "actual@test.com")
+
+        val error = assertValidationFails()
+        val message = error.message!!
+        val lines = message.lines()
+
+        assertThat(lines).contains("  Body params: {email=actual@test.com}")
+    }
+
+
+    @Test
+    fun `validate shows only nearest miss when multiple mocks remain`() = runScenario {
+        enqueue(RequestMatchers.path("/v1/payment_methods"), RequestMatchers.method("POST"))
+        enqueue(
+            RequestMatchers.path("/v1/confirm"),
+            RequestMatchers.method("POST"),
+            RequestMatchers.bodyPart("email", "expected@test.com"),
+        )
+
+        dispatch(path = "/v1/confirm", body = "email" to "actual@test.com")
+
+        val error = assertValidationFails()
+        val lines = error.message!!.lines()
+
+        assertThat(lines).containsAtLeast(
+            "  + PASS: path(/v1/confirm)",
+            "  + PASS: method(POST)",
+            "  - FAIL: bodyPart(email, expected@test.com)",
+        )
+        assertThat(lines).containsNoneOf(
+            "  + PASS: path(/v1/payment_methods)",
+            "  - FAIL: path(/v1/payment_methods)",
+        )
+    }
+
+    private fun runScenario(block: Scenario.() -> Unit) {
+        Scenario().block()
+    }
+
+    private class Scenario {
+        val dispatcher = NetworkDispatcher(validationTimeout = null)
+
+        fun enqueue(vararg matchers: RequestMatcher) {
+            dispatcher.enqueue(*matchers) { it.setBody("{}") }
+        }
+
+        fun dispatch(
+            path: String = "/v1/test",
+            body: Pair<String, String>? = null,
+        ) = dispatcher.dispatch(
+            MockRecordedRequestBuilder()
+                .path(path)
+                .method("POST")
+                .apply { if (body != null) formBody(body) }
+                .build()
+        )
+
+        fun assertValidationFails(): IllegalStateException {
+            val error = runCatching { dispatcher.validate() }.exceptionOrNull()
+            assertThat(error).isInstanceOf(IllegalStateException::class.java)
+            return error as IllegalStateException
+        }
+    }
+}

--- a/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
@@ -1,0 +1,150 @@
+package com.stripe.android.networktesting
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RequestMatchersTest {
+
+    @Test
+    fun `bodyPart matches plain args and pre-encoded args`() {
+        val request = postWithFormBody("billing_details[email]" to "foo@bar.com")
+
+        val plain = RequestMatchers.bodyPart("billing_details[email]", "foo@bar.com")
+        val encoded = RequestMatchers.bodyPart("billing_details%5Bemail%5D", "foo%40bar.com")
+
+        assertThat(plain.matches(request)).isTrue()
+        assertThat(encoded.matches(request)).isTrue()
+    }
+
+    @Test
+    fun `bodyPart fails on wrong value or missing key`() {
+        val request = postWithFormBody("billing_details[email]" to "foo@bar.com")
+
+        val wrongValue = RequestMatchers.bodyPart("billing_details[email]", "wrong@bar.com")
+        val missingKey = RequestMatchers.bodyPart("nonexistent_key", "foo@bar.com")
+
+        assertThat(wrongValue.matches(request)).isFalse()
+        assertThat(missingKey.matches(request)).isFalse()
+    }
+
+    @Test
+    fun `bodyPart regex matches against decoded value`() {
+        val request = postWithFormBody("user_agent" to "stripe-android/1.2.3;PaymentSheet")
+        val matcher = RequestMatchers.bodyPart(
+            "user_agent",
+            Regex("stripe-android/\\d+\\.\\d+\\.\\d+;PaymentSheet")
+        )
+        assertThat(matcher.matches(request)).isTrue()
+    }
+
+    @Test
+    fun `bodyPart handles plus sign encoding correctly`() {
+        // Literal + in value (phone number) — preserved, not treated as space
+        val phoneRequest = postWithFormBody("phone" to "+11234567890")
+        assertThat(RequestMatchers.bodyPart("phone", "+11234567890").matches(phoneRequest)).isTrue()
+
+        // Space in value — encoded as + in form body, decoded back to space
+        val nameRequest = postWithFormBody("name" to "John Doe")
+        assertThat(RequestMatchers.bodyPart("name", "John Doe").matches(nameRequest)).isTrue()
+
+        // Backward compat: urlEncode("John Doe") produces "John+Doe", must still match via fallback
+        assertThat(RequestMatchers.bodyPart("name", "John+Doe").matches(nameRequest)).isTrue()
+    }
+
+    @Test
+    fun `hasBodyPart matches plain and pre-encoded keys`() {
+        val request = postWithFormBody("billing_details[name]" to "Jane")
+
+        val plain = RequestMatchers.hasBodyPart("billing_details[name]")
+        val encoded = RequestMatchers.hasBodyPart("billing_details%5Bname%5D")
+
+        assertThat(plain.matches(request)).isTrue()
+        assertThat(encoded.matches(request)).isTrue()
+    }
+
+    @Test
+    fun `query matches plain and pre-encoded keys`() {
+        val request = getWithQuery("deferred_intent[on_behalf_of]" to "acct_123")
+
+        val plain = RequestMatchers.query("deferred_intent[on_behalf_of]", "acct_123")
+        val encoded = RequestMatchers.query("deferred_intent%5Bon_behalf_of%5D", "acct_123")
+
+        assertThat(plain.matches(request)).isTrue()
+        assertThat(encoded.matches(request)).isTrue()
+    }
+
+    @Test
+    fun `composite diagnose reports per-matcher pass and fail`() {
+        val request = postWithFormBody(
+            "billing_details[email]" to "actual@test.com",
+            path = "/v1/payment_intents/confirm",
+        )
+
+        val composite = RequestMatchers.composite(
+            RequestMatchers.path("/v1/payment_intents/confirm"),
+            RequestMatchers.method("POST"),
+            RequestMatchers.bodyPart("billing_details[email]", "expected@test.com"),
+        ) as CompositeRequestMatcher
+
+        assertThat(composite.matches(request)).isFalse()
+        assertThat(composite.diagnose(request).lines()).containsExactly(
+            "  + PASS: path(/v1/payment_intents/confirm)",
+            "  + PASS: method(POST)",
+            "  - FAIL: bodyPart(billing_details[email], expected@test.com)",
+        ).inOrder()
+    }
+
+    @Test
+    fun `bodyParams and queryParams parse and decode correctly`() {
+        val postRequest = postWithFormBody(
+            "key1" to "value1",
+            "billing_details[email]" to "foo@bar.com",
+        )
+        assertThat(postRequest.bodyParams).isEqualTo(
+            mapOf("key1" to "value1", "billing_details[email]" to "foo@bar.com")
+        )
+
+        val queryRequest = getWithQuery("deferred_intent[mode]" to "setup", "type" to "card")
+        assertThat(queryRequest.queryParams).isEqualTo(
+            mapOf("deferred_intent[mode]" to "setup", "type" to "card")
+        )
+
+        val emptyRequest = createRequest()
+        assertThat(emptyRequest.bodyParams).isEmpty()
+        assertThat(emptyRequest.queryParams).isEmpty()
+    }
+
+    private fun postWithFormBody(
+        vararg params: Pair<String, String>,
+        path: String = "/v1/test",
+    ): TestRecordedRequest {
+        return TestRecordedRequest(
+            MockRecordedRequestBuilder()
+                .path(path)
+                .method("POST")
+                .formBody(*params)
+                .build()
+        )
+    }
+
+    private fun getWithQuery(vararg params: Pair<String, String>): TestRecordedRequest {
+        val queryString = params.joinToString("&") { (key, value) ->
+            "${java.net.URLEncoder.encode(key, "UTF-8")}=${java.net.URLEncoder.encode(value, "UTF-8")}"
+        }
+        return createRequest(path = "/v1/test?$queryString")
+    }
+
+    private fun createRequest(
+        path: String = "/v1/test",
+        body: String = "",
+        method: String = "GET",
+    ): TestRecordedRequest {
+        return TestRecordedRequest(
+            MockRecordedRequestBuilder()
+                .path(path)
+                .body(body)
+                .method(method)
+                .build()
+        )
+    }
+}

--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementnetwork/PaymentMethodModificationExtensions.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementnetwork/PaymentMethodModificationExtensions.kt
@@ -3,7 +3,6 @@
 package com.stripe.paymentelementnetwork
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -40,7 +39,7 @@ fun NetworkRule.setupPaymentMethodUpdateResponse(
         host("api.stripe.com"),
         method("POST"),
         path("/v1/payment_methods/${paymentMethodDetails.id}"),
-        bodyPart(urlEncode("card[networks][preferred]"), cardBrand)
+        bodyPart("card[networks][preferred]", cardBrand)
     ) { response ->
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
         response.setBody(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -5,7 +5,6 @@ import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -239,7 +238,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart("confirmation_token", "ctoken_example"),
-            bodyPart("return_url", urlEncode("stripesdk://payment_return_url/com.stripe.android.paymentsheet.test")),
+            bodyPart("return_url", "stripesdk://payment_return_url/com.stripe.android.paymentsheet.test"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement
 import com.google.android.gms.wallet.IsReadyToPayRequest
 import com.google.android.gms.wallet.PaymentsClient
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.PaymentMethod
@@ -357,7 +356,7 @@ internal class EmbeddedPaymentElementTest {
     ) { testContext ->
         val oboMerchantID = "acct_connected_1234"
         networkRule.elementsSession(
-            query(urlEncode("deferred_intent[on_behalf_of]"), oboMerchantID)
+            query("deferred_intent[on_behalf_of]", oboMerchantID)
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ClientAttributionMetadataRequestMatchers.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ClientAttributionMetadataRequestMatchers.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers
@@ -10,32 +9,32 @@ import com.stripe.android.networktesting.RequestMatchers.bodyPart
 internal fun clientAttributionMetadataParamsInPaymentMethodData(): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][elements_session_config_id]"),
-            urlEncode("e961790f-43ed-4fcc-a534-74eeca28d042")
+            "payment_method_data[client_attribution_metadata][elements_session_config_id]",
+            "e961790f-43ed-4fcc-a534-74eeca28d042"
         ),
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][payment_intent_creation_flow]"),
-            urlEncode("standard")
+            "payment_method_data[client_attribution_metadata][payment_intent_creation_flow]",
+            "standard"
         ),
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][payment_method_selection_flow]"),
-            urlEncode("automatic")
+            "payment_method_data[client_attribution_metadata][payment_method_selection_flow]",
+            "automatic"
         ),
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][merchant_integration_source]"),
-            urlEncode("elements")
+            "payment_method_data[client_attribution_metadata][merchant_integration_source]",
+            "elements"
         ),
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][merchant_integration_subtype]"),
-            urlEncode("mobile")
+            "payment_method_data[client_attribution_metadata][merchant_integration_subtype]",
+            "mobile"
         ),
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][merchant_integration_version]"),
-            urlEncode("stripe-android/${StripeSdkVersion.VERSION_NAME}")
+            "payment_method_data[client_attribution_metadata][merchant_integration_version]",
+            "stripe-android/${StripeSdkVersion.VERSION_NAME}"
         ),
         bodyPart(
-            urlEncode("payment_method_data[client_attribution_metadata][client_session_id]"),
-            urlEncode(AnalyticsRequestFactory.sessionId.toString())
+            "payment_method_data[client_attribution_metadata][client_session_id]",
+            AnalyticsRequestFactory.sessionId.toString()
         ),
     )
 }
@@ -43,32 +42,32 @@ internal fun clientAttributionMetadataParamsInPaymentMethodData(): RequestMatche
 internal fun topLevelClientAttributionMetadataParams(): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart(
-            urlEncode("client_attribution_metadata[elements_session_config_id]"),
-            urlEncode("e961790f-43ed-4fcc-a534-74eeca28d042")
+            "client_attribution_metadata[elements_session_config_id]",
+            "e961790f-43ed-4fcc-a534-74eeca28d042"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[payment_intent_creation_flow]"),
-            urlEncode("standard")
+            "client_attribution_metadata[payment_intent_creation_flow]",
+            "standard"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[payment_method_selection_flow]"),
-            urlEncode("automatic")
+            "client_attribution_metadata[payment_method_selection_flow]",
+            "automatic"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_source]"),
-            urlEncode("elements")
+            "client_attribution_metadata[merchant_integration_source]",
+            "elements"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_subtype]"),
-            urlEncode("mobile")
+            "client_attribution_metadata[merchant_integration_subtype]",
+            "mobile"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_version]"),
-            urlEncode("stripe-android/${StripeSdkVersion.VERSION_NAME}")
+            "client_attribution_metadata[merchant_integration_version]",
+            "stripe-android/${StripeSdkVersion.VERSION_NAME}"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[client_session_id]"),
-            urlEncode(AnalyticsRequestFactory.sessionId.toString())
+            "client_attribution_metadata[client_session_id]",
+            AnalyticsRequestFactory.sessionId.toString()
         ),
     )
 }
@@ -76,32 +75,32 @@ internal fun topLevelClientAttributionMetadataParams(): RequestMatcher {
 internal fun clientAttributionMetadataParamsForDeferredIntent(): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart(
-            urlEncode("client_attribution_metadata[elements_session_config_id]"),
-            urlEncode("e961790f-43ed-4fcc-a534-74eeca28d042")
+            "client_attribution_metadata[elements_session_config_id]",
+            "e961790f-43ed-4fcc-a534-74eeca28d042"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[payment_intent_creation_flow]"),
-            urlEncode("deferred")
+            "client_attribution_metadata[payment_intent_creation_flow]",
+            "deferred"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[payment_method_selection_flow]"),
-            urlEncode("merchant_specified")
+            "client_attribution_metadata[payment_method_selection_flow]",
+            "merchant_specified"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_source]"),
-            urlEncode("elements")
+            "client_attribution_metadata[merchant_integration_source]",
+            "elements"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_subtype]"),
-            urlEncode("mobile")
+            "client_attribution_metadata[merchant_integration_subtype]",
+            "mobile"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_version]"),
-            urlEncode("stripe-android/${StripeSdkVersion.VERSION_NAME}")
+            "client_attribution_metadata[merchant_integration_version]",
+            "stripe-android/${StripeSdkVersion.VERSION_NAME}"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[client_session_id]"),
-            urlEncode(AnalyticsRequestFactory.sessionId.toString())
+            "client_attribution_metadata[client_session_id]",
+            AnalyticsRequestFactory.sessionId.toString()
         ),
     )
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ConfirmWithAttestationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ConfirmWithAttestationTest.kt
@@ -9,7 +9,6 @@ import androidx.test.espresso.intent.rule.IntentsRule
 import com.stripe.android.attestation.AttestationActivityContract
 import com.stripe.android.attestation.AttestationActivityResult
 
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -139,7 +138,7 @@ internal class ConfirmWithAttestationTest {
         networkRule.enqueue(
             method("POST"),
             path(PAYMENT_INTENT_CONFIRM_PATH),
-            bodyPart(urlEncode(tokenPath), ATTESTATION_TOKEN),
+            bodyPart(tokenPath, ATTESTATION_TOKEN),
         ) { response ->
             response.testBodyFromFile(PAYMENT_INTENT_CONFIRM_FILE)
         }
@@ -149,7 +148,7 @@ internal class ConfirmWithAttestationTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_methods"),
-            bodyPart(urlEncode(SAVED_PM_ATTESTATION_TOKEN_PATH), ATTESTATION_TOKEN),
+            bodyPart(SAVED_PM_ATTESTATION_TOKEN_PATH, ATTESTATION_TOKEN),
         ) { response ->
             response.testBodyFromFile(PAYMENT_METHOD_CREATE_FILE)
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
@@ -6,7 +6,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -63,7 +62,7 @@ class CustomPaymentMethodsAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(urlEncode("mpe_config[custom_payment_methods]"), "cpmt_123")
+            query("mpe_config[custom_payment_methods]", "cpmt_123")
         )
         validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
         validateAnalyticsRequest(eventName = "mc_form_shown")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetNetworkRequests.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetNetworkRequests.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers
@@ -45,20 +44,20 @@ internal fun retrieveSetupIntentParams(): RequestMatcher {
 
 internal fun billingDetailsParams(): RequestMatcher {
     return RequestMatchers.composite(
-        bodyPart(urlEncode("billing_details[address][postal_code]"), CustomerSheetPage.ZIP_CODE),
-        bodyPart(urlEncode("billing_details[address][country]"), CustomerSheetPage.COUNTRY)
+        bodyPart("billing_details[address][postal_code]", CustomerSheetPage.ZIP_CODE),
+        bodyPart("billing_details[address][country]", CustomerSheetPage.COUNTRY)
     )
 }
 
 internal fun fullBillingDetailsParams(): RequestMatcher {
     return RequestMatchers.composite(
-        bodyPart(urlEncode("billing_details[name]"), urlEncode(CustomerSheetPage.NAME)),
-        bodyPart(urlEncode("billing_details[phone]"), urlEncode("+1${CustomerSheetPage.PHONE_NUMBER}")),
-        bodyPart(urlEncode("billing_details[email]"), urlEncode(CustomerSheetPage.EMAIL)),
-        bodyPart(urlEncode("billing_details[address][line1]"), urlEncode(CustomerSheetPage.ADDRESS_LINE_ONE)),
-        bodyPart(urlEncode("billing_details[address][line2]"), urlEncode(CustomerSheetPage.ADDRESS_LINE_TWO)),
-        bodyPart(urlEncode("billing_details[address][city]"), urlEncode(CustomerSheetPage.CITY)),
-        bodyPart(urlEncode("billing_details[address][state]"), urlEncode(CustomerSheetPage.STATE)),
+        bodyPart("billing_details[name]", CustomerSheetPage.NAME),
+        bodyPart("billing_details[phone]", "+1${CustomerSheetPage.PHONE_NUMBER}"),
+        bodyPart("billing_details[email]", CustomerSheetPage.EMAIL),
+        bodyPart("billing_details[address][line1]", CustomerSheetPage.ADDRESS_LINE_ONE),
+        bodyPart("billing_details[address][line2]", CustomerSheetPage.ADDRESS_LINE_TWO),
+        bodyPart("billing_details[address][city]", CustomerSheetPage.CITY),
+        bodyPart("billing_details[address][state]", CustomerSheetPage.STATE),
         billingDetailsParams()
     )
 }
@@ -68,17 +67,17 @@ internal fun cardDetailsParams(
 ): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart("type", "card"),
-        bodyPart(urlEncode("card[number]"), cardNumber),
-        bodyPart(urlEncode("card[exp_month]"), CustomerSheetPage.EXPIRY_MONTH),
-        bodyPart(urlEncode("card[exp_year]"), CustomerSheetPage.EXPIRY_YEAR),
-        bodyPart(urlEncode("card[cvc]"), CustomerSheetPage.CVC),
+        bodyPart("card[number]", cardNumber),
+        bodyPart("card[exp_month]", CustomerSheetPage.EXPIRY_MONTH),
+        bodyPart("card[exp_year]", CustomerSheetPage.EXPIRY_YEAR),
+        bodyPart("card[cvc]", CustomerSheetPage.CVC),
     )
 }
 
 internal fun cardBrandChoiceParams(): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart(
-            urlEncode("card[networks][preferred]"),
+            "card[networks][preferred]",
             "cartes_bancaires"
         )
     )
@@ -95,24 +94,24 @@ internal fun confirmSetupIntentParams(): RequestMatcher {
 internal fun clientAttributionMetadataParams(): RequestMatcher {
     return RequestMatchers.composite(
         bodyPart(
-            urlEncode("client_attribution_metadata[elements_session_config_id]"),
-            urlEncode("e961790f-43ed-4fcc-a534-74eeca28d042")
+            "client_attribution_metadata[elements_session_config_id]",
+            "e961790f-43ed-4fcc-a534-74eeca28d042"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_source]"),
-            urlEncode("elements")
+            "client_attribution_metadata[merchant_integration_source]",
+            "elements"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_subtype]"),
-            urlEncode("mobile")
+            "client_attribution_metadata[merchant_integration_subtype]",
+            "mobile"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[merchant_integration_version]"),
-            urlEncode("stripe-android/${StripeSdkVersion.VERSION_NAME}")
+            "client_attribution_metadata[merchant_integration_version]",
+            "stripe-android/${StripeSdkVersion.VERSION_NAME}"
         ),
         bodyPart(
-            urlEncode("client_attribution_metadata[client_session_id]"),
-            urlEncode(AnalyticsRequestFactory.sessionId.toString())
+            "client_attribution_metadata[client_session_id]",
+            AnalyticsRequestFactory.sessionId.toString()
         ),
     )
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -317,7 +316,7 @@ internal class FlowControllerAnalyticsTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart("confirmation_token", "ctoken_example"),
-            bodyPart("return_url", urlEncode("stripesdk://payment_return_url/com.stripe.android.paymentsheet.test")),
+            bodyPart("return_url", "stripesdk://payment_return_url/com.stripe.android.paymentsheet.test"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -18,7 +18,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
@@ -594,7 +593,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet.FlowController;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -612,8 +611,8 @@ internal class FlowControllerTest {
             path("/v1/payment_intents/pi_example/confirm"),
             not(
                 bodyPart(
-                    urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
+                    "payment_method_data[payment_user_agent]",
+                    Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet.FlowController;deferred-intent;autopm")
                 )
             ),
         ) { response ->
@@ -734,7 +733,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet.FlowController;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -787,7 +786,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet.FlowController;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -848,7 +847,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet.FlowController;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -919,7 +918,7 @@ internal class FlowControllerTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_options[card][cvc]"), "123")
+            bodyPart("payment_method_options[card][cvc]", "123")
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -1287,7 +1286,7 @@ internal class FlowControllerTest {
     ) { testContext ->
         val oboMerchantID = "acct_connected_1234"
         networkRule.elementsSession(
-            query(urlEncode("deferred_intent[on_behalf_of]"), oboMerchantID)
+            query("deferred_intent[on_behalf_of]", oboMerchantID)
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.intent.rule.IntentsRule
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -264,7 +263,7 @@ internal class HCaptchaTokenTest {
         networkRule.enqueue(
             method("POST"),
             path(PAYMENT_INTENT_CONFIRM_PATH),
-            bodyPart(urlEncode(tokenPath), HCAPTCHA_TOKEN)
+            bodyPart(tokenPath, HCAPTCHA_TOKEN)
         ) { response ->
             response.testBodyFromFile(PAYMENT_INTENT_CONFIRM_FILE)
         }
@@ -274,7 +273,7 @@ internal class HCaptchaTokenTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_methods"),
-            bodyPart(urlEncode(SAVED_PM_HCAPTCHA_TOKEN_PATH), HCAPTCHA_TOKEN),
+            bodyPart(SAVED_PM_HCAPTCHA_TOKEN_PATH, HCAPTCHA_TOKEN),
         ) { response ->
             response.testBodyFromFile(PAYMENT_METHOD_CREATE_FILE)
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -4,7 +4,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.link.account.DefaultLinkStore
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.NetworkRule
@@ -84,16 +83,16 @@ internal class LinkTest {
             /*
              * Make sure card number is included
              */
-            bodyPart(urlEncode("card[number]"), "4242424242424242"),
+            bodyPart("card[number]", "4242424242424242"),
             /*
              * Make sure card expiration month is included
              */
-            bodyPart(urlEncode("card[exp_month]"), "12"),
+            bodyPart("card[exp_month]", "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart(urlEncode("card[exp_year]"), "2034"),
+            bodyPart("card[exp_year]", "2034"),
             topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("consumer-payment-details-success.json")
@@ -207,7 +206,7 @@ internal class LinkTest {
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("payment_method_options[link][setup_future_usage]"), "off_session"),
+                bodyPart("payment_method_options[link][setup_future_usage]", "off_session"),
                 topLevelClientAttributionMetadataParams(),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
@@ -267,20 +266,20 @@ internal class LinkTest {
             /*
              * Ensures card number is included
              */
-            bodyPart(urlEncode("card[number]"), "4000002500001001"),
+            bodyPart("card[number]", "4000002500001001"),
             /*
              * Ensures card expiration month is included
              */
-            bodyPart(urlEncode("card[exp_month]"), "12"),
+            bodyPart("card[exp_month]", "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart(urlEncode("card[exp_year]"), "2034"),
+            bodyPart("card[exp_year]", "2034"),
             /*
              * Ensures card brand choice is passed properly.
              */
-            bodyPart(urlEncode("card[preferred_network]"), "cartes_bancaires"),
+            bodyPart("card[preferred_network]", "cartes_bancaires"),
             topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("consumer-payment-details-success.json")
@@ -348,16 +347,16 @@ internal class LinkTest {
             /*
              * Make sure card number is included
              */
-            bodyPart(urlEncode("card[number]"), "4242424242424242"),
+            bodyPart("card[number]", "4242424242424242"),
             /*
              * Make sure card expiration month is included
              */
-            bodyPart(urlEncode("card[exp_month]"), "12"),
+            bodyPart("card[exp_month]", "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart(urlEncode("card[exp_year]"), "2034"),
+            bodyPart("card[exp_year]", "2034"),
             /*
              * In passthrough mode, this needs to be true
              */
@@ -496,7 +495,7 @@ internal class LinkTest {
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("payment_method_options[card][setup_future_usage]"), "off_session"),
+                bodyPart("payment_method_options[card][setup_future_usage]", "off_session"),
                 topLevelClientAttributionMetadataParams(),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
@@ -556,20 +555,20 @@ internal class LinkTest {
             /*
              * Make sure card number is included
              */
-            bodyPart(urlEncode("card[number]"), "4000002500001001"),
+            bodyPart("card[number]", "4000002500001001"),
             /*
              * Make sure card expiration month is included
              */
-            bodyPart(urlEncode("card[exp_month]"), "12"),
+            bodyPart("card[exp_month]", "12"),
             /*
              * Ensures we are passing the full expiration year and not the
              * 2-digit shorthand (should send "2034", not "34")
              */
-            bodyPart(urlEncode("card[exp_year]"), "2034"),
+            bodyPart("card[exp_year]", "2034"),
             /*
              * Ensures card brand choice is passed properly.
              */
-            bodyPart(urlEncode("card[preferred_network]"), "cartes_bancaires"),
+            bodyPart("card[preferred_network]", "cartes_bancaires"),
             /*
              * In passthrough mode, this needs to be true
              */
@@ -1128,7 +1127,7 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_options[card][setup_future_usage]"), "off_session"),
+            bodyPart("payment_method_options[card][setup_future_usage]", "off_session"),
             topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
@@ -1150,15 +1149,15 @@ internal class LinkTest {
     private fun linkInformation(): RequestMatcher {
         return composite(
             bodyPart(
-                name = urlEncode("payment_method_data[link][card][cvc]"),
+                name = "payment_method_data[link][card][cvc]",
                 value = "123"
             ),
             bodyPart(
-                name = urlEncode("payment_method_data[link][payment_details_id]"),
+                name = "payment_method_data[link][payment_details_id]",
                 value = "QAAAKJ6"
             ),
             bodyPart(
-                name = urlEncode("payment_method_data[link][credentials][consumer_session_client_secret]"),
+                name = "payment_method_data[link][credentials][consumer_session_client_secret]",
                 value = "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDUzNTFkNjNhLTZkNGMtND"
             ),
         )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -16,7 +15,7 @@ internal fun NetworkRule.validateAnalyticsRequest(
         host("q.stripe.com"),
         method("GET"),
         query("event", eventName),
-        query("product_usage", urlEncode(productUsage.joinToString(","))),
+        query("product_usage", productUsage.joinToString(",")),
         *requestMatchers,
     ) { response ->
         response.status = "HTTP/1.1 200 OK"

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import android.text.SpannableString
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -202,20 +201,20 @@ class PaymentSheetAddressAutocompleteTest {
             method("POST"),
             path("/v1/payment_intents/pi_123/confirm"),
             bodyPart(
-                urlEncode("payment_method_data[billing_details][address][line1]"),
-                urlEncode("123 Main Street")
+                "payment_method_data[billing_details][address][line1]",
+                "123 Main Street"
             ),
             bodyPart(
-                urlEncode("payment_method_data[billing_details][address][line2]"),
-                urlEncode("Unit #123")
+                "payment_method_data[billing_details][address][line2]",
+                "Unit #123"
             ),
             bodyPart(
-                urlEncode("payment_method_data[billing_details][address][city]"),
-                urlEncode("South San Francisco")
+                "payment_method_data[billing_details][address][city]",
+                "South San Francisco"
             ),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][state]"), "CA"),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][country]"), "US"),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][postal_code]"), "94111"),
+            bodyPart("payment_method_data[billing_details][address][state]", "CA"),
+            bodyPart("payment_method_data[billing_details][address][country]", "US"),
+            bodyPart("payment_method_data[billing_details][address][postal_code]", "94111"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -290,7 +289,7 @@ internal class PaymentSheetAnalyticsTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart("confirmation_token", "ctoken_example"),
-            bodyPart("return_url", urlEncode("stripesdk://payment_return_url/com.stripe.android.paymentsheet.test")),
+            bodyPart("return_url", "stripesdk://payment_return_url/com.stripe.android.paymentsheet.test"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
@@ -92,11 +91,11 @@ internal class PaymentSheetBillingConfigurationTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_data[billing_details][name]"), urlEncode("Jane Doe")),
-            bodyPart(urlEncode("payment_method_data[billing_details][email]"), urlEncode("mail@mail.com")),
-            bodyPart(urlEncode("payment_method_data[billing_details][phone]"), urlEncode("+13105551234")),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][country]"), "US"),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][postal_code]"), "94111"),
+            bodyPart("payment_method_data[billing_details][name]", "Jane Doe"),
+            bodyPart("payment_method_data[billing_details][email]", "mail@mail.com"),
+            bodyPart("payment_method_data[billing_details][phone]", "+13105551234"),
+            bodyPart("payment_method_data[billing_details][address][country]", "US"),
+            bodyPart("payment_method_data[billing_details][address][postal_code]", "94111"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -160,11 +159,11 @@ internal class PaymentSheetBillingConfigurationTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(bodyPart(urlEncode("payment_method_data[billing_details][name]"), urlEncode("Jenny Rosen"))),
-            not(bodyPart(urlEncode("payment_method_data[billing_details][email]"), urlEncode("foo@bar.com"))),
-            not(bodyPart(urlEncode("payment_method_data[billing_details][phone]"), urlEncode("+13105551234"))),
-            not(bodyPart(urlEncode("payment_method_data[billing_details][address][country]"), "US")),
-            not(bodyPart(urlEncode("payment_method_data[billing_details][address][postal_code]"), "94111")),
+            not(bodyPart("payment_method_data[billing_details][name]", "Jenny Rosen")),
+            not(bodyPart("payment_method_data[billing_details][email]", "foo@bar.com")),
+            not(bodyPart("payment_method_data[billing_details][phone]", "+13105551234")),
+            not(bodyPart("payment_method_data[billing_details][address][country]", "US")),
+            not(bodyPart("payment_method_data[billing_details][address][postal_code]", "94111")),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -266,24 +265,24 @@ internal class PaymentSheetBillingConfigurationTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_data[billing_details][name]"), urlEncode("Jenny Rosen")),
-            bodyPart(urlEncode("payment_method_data[billing_details][email]"), urlEncode("foo@bar.com")),
-            bodyPart(urlEncode("payment_method_data[billing_details][phone]"), urlEncode("+13105551234")),
+            bodyPart("payment_method_data[billing_details][name]", "Jenny Rosen"),
+            bodyPart("payment_method_data[billing_details][email]", "foo@bar.com"),
+            bodyPart("payment_method_data[billing_details][phone]", "+13105551234"),
             bodyPart(
-                urlEncode("payment_method_data[billing_details][address][line1]"),
-                urlEncode("123 Main Street")
+                "payment_method_data[billing_details][address][line1]",
+                "123 Main Street"
             ),
             bodyPart(
-                urlEncode("payment_method_data[billing_details][address][line2]"),
-                urlEncode("Unit #123")
+                "payment_method_data[billing_details][address][line2]",
+                "Unit #123"
             ),
             bodyPart(
-                urlEncode("payment_method_data[billing_details][address][city]"),
-                urlEncode("South San Francisco")
+                "payment_method_data[billing_details][address][city]",
+                "South San Francisco"
             ),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][state]"), "CA"),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][country]"), "US"),
-            bodyPart(urlEncode("payment_method_data[billing_details][address][postal_code]"), "94111"),
+            bodyPart("payment_method_data[billing_details][address][state]", "CA"),
+            bodyPart("payment_method_data[billing_details][address][country]", "US"),
+            bodyPart("payment_method_data[billing_details][address][postal_code]", "94111"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
@@ -254,7 +253,7 @@ internal class PaymentSheetConfirmationTokenTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart("confirmation_token", "ctoken_example"),
-            bodyPart("return_url", urlEncode("stripesdk://payment_return_url/com.stripe.android.paymentsheet.test")),
+            bodyPart("return_url", "stripesdk://payment_return_url/com.stripe.android.paymentsheet.test"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -270,7 +269,7 @@ internal class PaymentSheetConfirmationTokenTest {
             method("POST"),
             path("/v1/setup_intents/seti_example/confirm"),
             bodyPart("confirmation_token", "ctoken_example"),
-            bodyPart("return_url", urlEncode("stripesdk://payment_return_url/com.stripe.android.paymentsheet.test")),
+            bodyPart("return_url", "stripesdk://payment_return_url/com.stripe.android.paymentsheet.test"),
         ) { response ->
             response.testBodyFromFile("setup-intent-confirm.json")
         }
@@ -279,11 +278,11 @@ internal class PaymentSheetConfirmationTokenTest {
     private fun clientContext(isLiveMode: Boolean, isPayment: Boolean = true): RequestMatcher {
         // The client_context param is only sent in test mode when creating a confirmation token
         return if (isLiveMode) {
-            not(hasBodyPart(urlEncode("client_context[mode]")))
+            not(hasBodyPart("client_context[mode]"))
         } else {
             // we only verify client context is not null here
             bodyPart(
-                urlEncode("client_context[mode]"),
+                "client_context[mode]",
                 if (isPayment) {
                     "payment"
                 } else {
@@ -296,11 +295,11 @@ internal class PaymentSheetConfirmationTokenTest {
     private fun cvcRecollection(paymentMethodType: PaymentMethodType): RequestMatcher {
         return if (paymentMethodType == PaymentMethodType.SavedCardWithCvcRecollection) {
             bodyPart(
-                urlEncode("payment_method_options[card][cvc]"),
+                "payment_method_options[card][cvc]",
                 "123"
             )
         } else {
-            not(hasBodyPart(urlEncode("payment_method_options[card][cvc]")))
+            not(hasBodyPart("payment_method_options[card][cvc]"))
         }
     }
 
@@ -311,23 +310,23 @@ internal class PaymentSheetConfirmationTokenTest {
         return if (paymentMethodType == PaymentMethodType.CashAppWithSetupFutureUsage) {
             RequestMatchers.composite(
                 bodyPart(
-                    urlEncode("mandate_data[customer_acceptance][type]"),
+                    "mandate_data[customer_acceptance][type]",
                     "online"
                 ),
                 bodyPart(
-                    urlEncode("setup_future_usage"),
-                    urlEncode("off_session")
+                    "setup_future_usage",
+                    "off_session"
                 ),
             )
         } else {
             RequestMatchers.composite(
-                not(hasBodyPart(urlEncode("mandate_data[customer_acceptance][type]"))),
+                not(hasBodyPart("mandate_data[customer_acceptance][type]")),
                 if (isPayment) {
-                    not(hasBodyPart(urlEncode("setup_future_usage")))
+                    not(hasBodyPart("setup_future_usage"))
                 } else {
                     bodyPart(
-                        urlEncode("setup_future_usage"),
-                        urlEncode("off_session")
+                        "setup_future_usage",
+                        "off_session"
                     )
                 }
             )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -187,7 +186,7 @@ class PaymentSheetCustomerSessionTest {
         return networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_data[allow_redisplay]"), allowRedisplay)
+            bodyPart("payment_method_data[allow_redisplay]", allowRedisplay)
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -197,7 +196,7 @@ class PaymentSheetCustomerSessionTest {
         return networkRule.enqueue(
             method("POST"),
             path("/v1/setup_intents/seti_example/confirm"),
-            bodyPart(urlEncode("payment_method_data[allow_redisplay]"), allowRedisplay)
+            bodyPart("payment_method_data[allow_redisplay]", allowRedisplay)
         ) { response ->
             response.testBodyFromFile("setup-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
@@ -75,7 +74,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
             clientAttributionMetadataParamsForDeferredIntent(),
         ) { response ->
@@ -94,14 +93,14 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_intents/pi_example/confirm"),
             not(
                 bodyPart(
-                    urlEncode("payment_method_options[card][setup_future_usage]"),
+                    "payment_method_options[card][setup_future_usage]",
                     "off_session"
                 )
             ),
             not(
                 bodyPart(
-                    urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                    "payment_method_data[payment_user_agent]",
+                    Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
                 )
             ),
         ) { response ->
@@ -267,7 +266,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -285,14 +284,14 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_intents/pi_example/confirm"),
             not(
                 bodyPart(
-                    urlEncode("payment_method_options[card][setup_future_usage]"),
+                    "payment_method_options[card][setup_future_usage]",
                     "off_session"
                 )
             ),
             not(
                 bodyPart(
-                    urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                    "payment_method_data[payment_user_agent]",
+                    Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
                 )
             ),
         ) { response ->
@@ -410,7 +409,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -427,13 +426,13 @@ internal class PaymentSheetDeferredTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart(
-                urlEncode("payment_method_options[card][setup_future_usage]"),
+                "payment_method_options[card][setup_future_usage]",
                 "off_session"
             ),
             not(
                 bodyPart(
-                    urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                    "payment_method_data[payment_user_agent]",
+                    Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
                 )
             ),
         ) { response ->
@@ -480,7 +479,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -527,7 +526,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -580,7 +579,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
             clientAttributionMetadataParamsForDeferredIntent(),
         ) { response ->
@@ -598,13 +597,13 @@ internal class PaymentSheetDeferredTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart(
-                urlEncode("payment_method_options[konbini][confirmation_number]"),
+                "payment_method_options[konbini][confirmation_number]",
                 phone
             ),
             not(
                 bodyPart(
-                    urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                    "payment_method_data[payment_user_agent]",
+                    Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
                 )
             ),
         ) { response ->
@@ -649,7 +648,7 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -667,14 +666,14 @@ internal class PaymentSheetDeferredTest {
             path("/v1/payment_intents/pi_example/confirm"),
             not(
                 bodyPart(
-                    urlEncode("payment_method_options[card][setup_future_usage]"),
+                    "payment_method_options[card][setup_future_usage]",
                     "off_session"
                 )
             ),
             not(
                 bodyPart(
-                    urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                    "payment_method_data[payment_user_agent]",
+                    Regex("stripe-android/\\d*.\\d*.\\d*;PaymentSheet;deferred-intent;autopm")
                 )
             ),
         ) { response ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
@@ -339,7 +338,7 @@ internal class PaymentSheetTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart(
-                urlEncode("payment_method_data[card][networks][preferred]"),
+                "payment_method_data[card][networks][preferred]",
                 "cartes_bancaires"
             ),
         ) { response ->
@@ -480,7 +479,7 @@ internal class PaymentSheetTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_options[card][cvc]"), "123")
+            bodyPart("payment_method_options[card][cvc]", "123")
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -500,7 +499,7 @@ internal class PaymentSheetTest {
         }
     ) { testContext ->
         networkRule.elementsSession(
-            query(urlEncode("deferred_intent[payment_method_options][card][require_cvc_recollection]"), "true")
+            query("deferred_intent[payment_method_options][card][require_cvc_recollection]", "true")
         ) { response ->
             val cardsArray = JSONArray()
 
@@ -559,7 +558,7 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(urlEncode("payment_method_options[card][cvc]"), "123")
+            bodyPart("payment_method_options[card][cvc]", "123")
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -899,7 +898,7 @@ internal class PaymentSheetTest {
         val oboMerchantID = "acct_connected_1234"
 
         networkRule.elementsSession(
-            query(urlEncode("deferred_intent[on_behalf_of]"), oboMerchantID)
+            query("deferred_intent[on_behalf_of]", oboMerchantID)
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PreparePaymentMethodTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PreparePaymentMethodTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.checkouttesting.createPaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -235,8 +234,8 @@ internal class PreparePaymentMethodTest {
         externalId: String,
     ) {
         networkRule.elementsSession(
-            query(urlEncode("seller_details[network_id]"), networkId),
-            query(urlEncode("seller_details[external_id]"), externalId),
+            query("seller_details[network_id]", networkId),
+            query("seller_details[external_id]", externalId),
         ) { response ->
             response.testBodyFromFile(
                 filename = "elements-sessions-requires_pm_with_cs.json",

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ConfirmationType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ConfirmationType.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.utils
 
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -54,8 +53,8 @@ internal sealed class ConfirmationType(
             return networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("payment_method_data[allow_redisplay]"), "always"),
-                bodyPart(urlEncode("set_as_default_payment_method"), setAsDefault.toString())
+                bodyPart("payment_method_data[allow_redisplay]", "always"),
+                bodyPart("set_as_default_payment_method", setAsDefault.toString())
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -68,8 +67,8 @@ internal sealed class ConfirmationType(
             return networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("payment_method_data[allow_redisplay]"), "always"),
-                bodyPart(urlEncode("set_as_default_payment_method"), setAsDefault.toString())
+                bodyPart("payment_method_data[allow_redisplay]", "always"),
+                bodyPart("set_as_default_payment_method", setAsDefault.toString())
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -79,8 +78,8 @@ internal sealed class ConfirmationType(
             return networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("payment_method_data[allow_redisplay]"), "unspecified"),
-                not(bodyPart(urlEncode("set_as_default_payment_method"), "true")),
+                bodyPart("payment_method_data[allow_redisplay]", "unspecified"),
+                not(bodyPart("set_as_default_payment_method", "true")),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -132,7 +131,7 @@ internal sealed class ConfirmationType(
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("set_as_default_payment_method"), setAsDefault.toString()),
+                bodyPart("set_as_default_payment_method", setAsDefault.toString()),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -159,7 +158,7 @@ internal sealed class ConfirmationType(
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                bodyPart(urlEncode("set_as_default_payment_method"), setAsDefault.toString()),
+                bodyPart("set_as_default_payment_method", setAsDefault.toString()),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm-us_bank_account.json")
             }
@@ -183,7 +182,7 @@ internal sealed class ConfirmationType(
             networkRule.enqueue(
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
-                not(bodyPart(urlEncode("set_as_default_payment_method"), "true")),
+                not(bodyPart("set_as_default_payment_method", "true")),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -9,7 +9,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
@@ -184,9 +183,9 @@ class CheckoutTest {
     @Test
     fun `updateLineItemQuantity updates checkoutSession on success`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
-            bodyPart(urlEncode("updated_line_item_quantity[line_item_id]"), "li_1"),
-            bodyPart(urlEncode("updated_line_item_quantity[quantity]"), "3"),
-            bodyPart(urlEncode("updated_line_item_quantity[fail_update_on_discount_error]"), "true"),
+            bodyPart("updated_line_item_quantity[line_item_id]", "li_1"),
+            bodyPart("updated_line_item_quantity[quantity]", "3"),
+            bodyPart("updated_line_item_quantity[fail_update_on_discount_error]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-update-quantity.json")
         }
@@ -221,7 +220,7 @@ class CheckoutTest {
     fun `selectShippingOption updates checkoutSession on success`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
             bodyPart("shipping_rate", "shr_express"),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-select-shipping-rate.json")
         }
@@ -248,11 +247,11 @@ class CheckoutTest {
     fun `updateShippingAddress sends address fields and updates checkoutSession on success`() =
         runCreateWithStateScenario {
             networkRule.checkoutUpdate(
-                bodyPart(urlEncode("tax_region[country]"), "US"),
-                bodyPart(urlEncode("tax_region[city]"), "Denver"),
-                bodyPart(urlEncode("tax_region[state]"), "CO"),
-                bodyPart(urlEncode("tax_region[postal_code]"), "80202"),
-                bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("tax_region[city]", "Denver"),
+                bodyPart("tax_region[state]", "CO"),
+                bodyPart("tax_region[postal_code]", "80202"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
             ) { response ->
                 response.testBodyFromFile("checkout-session-update-shipping-address.json")
             }
@@ -311,13 +310,13 @@ class CheckoutTest {
     @Test
     fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
-            bodyPart(urlEncode("tax_region[country]"), "US"),
-            bodyPart(urlEncode("tax_region[postal_code]"), "80202"),
-            not(hasBodyPart(urlEncode("tax_region[city]"))),
-            not(hasBodyPart(urlEncode("tax_region[state]"))),
-            not(hasBodyPart(urlEncode("tax_region[line1]"))),
-            not(hasBodyPart(urlEncode("tax_region[line2]"))),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("tax_region[country]", "US"),
+            bodyPart("tax_region[postal_code]", "80202"),
+            not(hasBodyPart("tax_region[city]")),
+            not(hasBodyPart("tax_region[state]")),
+            not(hasBodyPart("tax_region[line1]")),
+            not(hasBodyPart("tax_region[line2]")),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-update-shipping-address.json")
         }
@@ -337,11 +336,11 @@ class CheckoutTest {
     fun `updateBillingAddress sends address fields and updates checkoutSession on success`() =
         runCreateWithStateScenario {
             networkRule.checkoutUpdate(
-                bodyPart(urlEncode("tax_region[country]"), "US"),
-                bodyPart(urlEncode("tax_region[city]"), "Denver"),
-                bodyPart(urlEncode("tax_region[state]"), "CO"),
-                bodyPart(urlEncode("tax_region[postal_code]"), "80202"),
-                bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("tax_region[city]", "Denver"),
+                bodyPart("tax_region[state]", "CO"),
+                bodyPart("tax_region[postal_code]", "80202"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
             ) { response ->
                 response.testBodyFromFile("checkout-session-update-shipping-address.json")
             }
@@ -552,13 +551,13 @@ class CheckoutTest {
     @Test
     fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
-            bodyPart(urlEncode("tax_region[country]"), "US"),
-            bodyPart(urlEncode("tax_region[postal_code]"), "80202"),
-            not(hasBodyPart(urlEncode("tax_region[city]"))),
-            not(hasBodyPart(urlEncode("tax_region[state]"))),
-            not(hasBodyPart(urlEncode("tax_region[line1]"))),
-            not(hasBodyPart(urlEncode("tax_region[line2]"))),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("tax_region[country]", "US"),
+            bodyPart("tax_region[postal_code]", "80202"),
+            not(hasBodyPart("tax_region[city]")),
+            not(hasBodyPart("tax_region[state]")),
+            not(hasBodyPart("tax_region[line1]")),
+            not(hasBodyPart("tax_region[line2]")),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-update-shipping-address.json")
         }
@@ -577,9 +576,9 @@ class CheckoutTest {
     @Test
     fun `updateTaxId sends type and value and updates checkoutSession on success`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
-            bodyPart(urlEncode("tax_id_collection[tax_id][type]"), "us_ein"),
-            bodyPart(urlEncode("tax_id_collection[tax_id][value]"), "123456789"),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("tax_id_collection[tax_id][type]", "us_ein"),
+            bodyPart("tax_id_collection[tax_id][value]", "123456789"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-apply-discount.json")
         }
@@ -611,9 +610,9 @@ class CheckoutTest {
     @Test
     fun `updateTaxId trims whitespace from type and value`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
-            bodyPart(urlEncode("tax_id_collection[tax_id][type]"), "us_ein"),
-            bodyPart(urlEncode("tax_id_collection[tax_id][value]"), "123456789"),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("tax_id_collection[tax_id][type]", "us_ein"),
+            bodyPart("tax_id_collection[tax_id][value]", "123456789"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-apply-discount.json")
         }
@@ -655,9 +654,9 @@ class CheckoutTest {
         // Second call: updateShippingAddress must use the session ID from the first response,
         // proving the mutex serialized the calls.
         networkRule.checkoutUpdate(
-            bodyPart(urlEncode("tax_region[country]"), "US"),
-            bodyPart(urlEncode("tax_region[postal_code]"), "80202"),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("tax_region[country]", "US"),
+            bodyPart("tax_region[postal_code]", "80202"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
             sessionId = "cs_test_after_promo",
         ) { response ->
             response.testBodyFromFile("checkout-session-concurrent-update-address.json")
@@ -854,7 +853,7 @@ class CheckoutTest {
     fun `updateCurrency updates checkoutSession on success`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
             bodyPart("updated_currency", "eur"),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-apply-discount.json")
         }
@@ -888,7 +887,7 @@ class CheckoutTest {
         clientSecret = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example",
         networkSetup = {
             networkRule.checkoutInit(
-                bodyPart(urlEncode("adaptive_pricing[allowed]"), "false"),
+                bodyPart("adaptive_pricing[allowed]", "false"),
             ) { response ->
                 response.testBodyFromFile("checkout-session-init.json")
             }
@@ -903,7 +902,7 @@ class CheckoutTest {
         configuration = Checkout.Configuration().adaptivePricingAllowed(true),
         networkSetup = {
             networkRule.checkoutInit(
-                bodyPart(urlEncode("adaptive_pricing[allowed]"), "true"),
+                bodyPart("adaptive_pricing[allowed]", "true"),
             ) { response ->
                 response.testBodyFromFile("checkout-session-init.json")
             }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
@@ -477,11 +476,11 @@ class CustomerSessionCustomerSheetActivityTest {
     ) {
         networkRule.elementsSession(
             query("type", "deferred_intent"),
-            query(urlEncode("deferred_intent[setup_future_usage]"), "off_session"),
-            query(urlEncode("deferred_intent[mode]"), "setup"),
-            query(urlEncode("deferred_intent[payment_method_types][0]"), "card"),
-            query(urlEncode("deferred_intent[payment_method_types][1]"), "us_bank_account"),
-            query(urlEncode("deferred_intent[on_behalf_of]"), onBehalfOf),
+            query("deferred_intent[setup_future_usage]", "off_session"),
+            query("deferred_intent[mode]", "setup"),
+            query("deferred_intent[payment_method_types][0]", "card"),
+            query("deferred_intent[payment_method_types][1]", "us_bank_account"),
+            query("deferred_intent[on_behalf_of]", onBehalfOf),
             query("customer_session_client_secret", "cuss_123"),
         ) { response ->
             response.createElementsSessionResponse(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -6,7 +6,6 @@ import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
-import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.testBodyFromFile
@@ -38,9 +37,9 @@ class CheckoutSessionRepositoryTest {
     fun `init sends elements_session_client params`() = runTest {
         val expectedSessionId = AnalyticsRequestFactory.sessionId.toString()
         networkRule.checkoutInit(
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
-            bodyPart(urlEncode("elements_session_client[mobile_session_id]"), expectedSessionId),
-            bodyPart(urlEncode("elements_session_client[mobile_app_id]"), clientParams.mobileAppId),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+            bodyPart("elements_session_client[mobile_session_id]", expectedSessionId),
+            bodyPart("elements_session_client[mobile_app_id]", clientParams.mobileAppId),
         ) { response ->
             response.testBodyFromFile("checkout-session-init.json")
         }
@@ -57,7 +56,7 @@ class CheckoutSessionRepositoryTest {
     fun `updateCurrency sends currency code and returns response on success`() = runTest {
         networkRule.checkoutUpdate(
             bodyPart("updated_currency", "eur"),
-            bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-init.json")
         }


### PR DESCRIPTION
## Summary
- Auto-decode URL-encoded body/query params in `bodyPart()`, `hasBodyPart()`, and `query()` matchers so tests no longer need `urlEncode()` wrappers
- Add per-matcher PASS/FAIL diagnostics via `CompositeRequestMatcher.diagnose()` — when a request doesn't match a mock, the error message shows the nearest-miss mock with exactly which sub-matchers passed/failed
- Return 500 instead of throwing from `dispatch()` so `validate()` reliably runs even when the test fails before reaching it
- Show decoded body params for unmatched requests in error messages
- Add unit tests for matchers, auto-decode, and dispatcher diagnostics (22 tests)
- Remove `urlEncode()` from ~130 matcher call sites across 22 test files
- Update `network-tests` skill documentation

## Motivation

When a `bodyPart()` matcher doesn't match (e.g., due to missing `urlEncode()`), the only error was "Mock responses is not empty / Production code made extra requests" with no visibility into WHY the match failed. This has caused hours of debugging production code that was actually correct.

**Before:**
```
Mock responses is not empty. Remaining: 1.
Remaining Matchers: composite(path(/v1/confirm), bodyPart(billing_details%5Bemail%5D, foo%40bar.com))
Production code made extra requests. Remaining: 1.
https://localhost:12345/v1/payment_intents/pi_123/confirm
```

**After:**
```
Mock responses is not empty. Remaining: 1.
Remaining Matchers: composite(path(/v1/confirm), bodyPart(billing_details[email], foo@bar.com))
Production code made extra requests. Remaining: 1.

POST https://localhost:12345/v1/payment_intents/pi_123/confirm
  Body params: {billing_details[email]=bar@bar.com, payment_method=pm_123}
  Nearest mock: composite(path(/v1/confirm), method(POST), bodyPart(billing_details[email], foo@bar.com))
    + PASS: path(/v1/confirm)
    + PASS: method(POST)
    - FAIL: bodyPart(billing_details[email], foo@bar.com)
```

## How auto-decode works

Matchers try matching the plain string against the decoded body first. If that fails, they also try decoding the matcher arg (for backward compat with existing `urlEncode()` callers). This means:
- `bodyPart("billing_details[email]", "foo@bar.com")` — works (plain match against decoded body)
- `bodyPart("billing_details[phone]", "+11234567890")` — works (literal `+` preserved)
- `bodyPart(urlEncode("billing_details[email]"), urlEncode("foo@bar.com"))` — still works (fallback decodes matcher arg)

## Test plan
- [x] 22 new unit tests for matchers, auto-decode, and dispatcher diagnostics
- [x] `CustomerSheetTest` instrumentation tests pass locally (18/18)
- [x] `TapToAddActivityTest.successWithLinkInlineSignupInCompleteMode` passes locally
- [x] Detekt passes
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)