### PR TITLE
Add accessibility descriptions for card brand icons.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardBrandView.kt
@@ -167,6 +167,7 @@ internal class CardBrandView @JvmOverloads constructor(
                 else -> state.brand.icon
             }
         )
+        iconView.contentDescription = state.brand.displayName
     }
 
     private fun determineCardBrandToDisplay() {
@@ -304,7 +305,10 @@ internal class BrandAdapter(
     private fun updateView(view: View, position: Int) {
         brands.getOrNull(position - 1)?.let { brand ->
             val isSelected = brand == selectedBrand
-            view.findViewById<ImageView>(R.id.brand_icon)?.setImageResource(brand.icon)
+            view.findViewById<ImageView>(R.id.brand_icon)?.apply {
+                setImageResource(brand.icon)
+                contentDescription = brand.displayName
+            }
             view.findViewById<ImageView>(R.id.brand_check).apply {
                 if (isSelected) {
                     visibility = View.VISIBLE

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -28,6 +28,8 @@
   <string name="stripe_blik_code">BLIK code</string>
   <!-- Label for Boleto Payment method Tax ID -->
   <string name="stripe_boleto_tax_id_label">CPF/CNPJ</string>
+  <!-- Accessibility content description for card brand icons shown in the card number field. %1$s is a comma-separated list of brand names (e.g. "Visa, Mastercard, American Express, Discover"). -->
+  <string name="stripe_card_brand_icons_content_description">Supported cards: %1$s</string>
   <!-- Shown in a dropdown picker next to a card brand that is not accepted by a merchant. E.g. \"Visa (not accepted)\" -->
   <string name="stripe_card_brand_not_accepted">(not accepted)</string>
   <!-- Shown in a dropdown picker next to a card brand that is not accepted by a merchant. E.g. "Visa (not accepted)" -->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -558,9 +558,20 @@ internal class DefaultCardNumberController(
             addAll(cardBrands.drop(STATIC_ICON_COUNT).map { TextFieldIcon.Trailing(it.icon, isTintable = false) })
         }
 
+        val allBrands = cardBrands.toMutableList()
+        if (isEligibleForCardBrandChoice && cardBrandFilter.isAccepted(CardBrand.CartesBancaires)) {
+            if (CardBrand.CartesBancaires !in allBrands) {
+                allBrands.add(CardBrand.CartesBancaires)
+            }
+        }
+
         return TextFieldIcon.MultiTrailing(
             staticIcons = staticIcons,
-            animatedIcons = animatedIcons
+            animatedIcons = animatedIcons,
+            contentDescription = resolvableString(
+                R.string.stripe_card_brand_icons_content_description,
+                allBrands.joinToString(", ") { it.displayName }
+            )
         )
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -53,6 +53,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 import com.stripe.android.R as StripeR
+import com.stripe.android.ui.core.R as PaymentsUiCoreR
 import com.stripe.android.uicore.R as StripeUiCoreR
 
 @Suppress("LargeClass")
@@ -133,6 +134,10 @@ internal class CardNumberControllerTest {
                             TextFieldIcon.Trailing(CardBrand.JCB.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.DinersClub.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.UnionPay.icon, isTintable = false)
+                        ),
+                        contentDescription = resolvableString(
+                            PaymentsUiCoreR.string.stripe_card_brand_icons_content_description,
+                            "Visa, Mastercard, American Express, Discover, JCB, Diners Club, UnionPay"
                         )
                     )
                 )
@@ -164,6 +169,10 @@ internal class CardNumberControllerTest {
                             TextFieldIcon.Trailing(CardBrand.JCB.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.DinersClub.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.UnionPay.icon, isTintable = false)
+                        ),
+                        contentDescription = resolvableString(
+                            PaymentsUiCoreR.string.stripe_card_brand_icons_content_description,
+                            "Visa, Mastercard, American Express, Discover, JCB, Diners Club, UnionPay, Cartes Bancaires"
                         )
                     )
                 )
@@ -195,6 +204,10 @@ internal class CardNumberControllerTest {
                             TextFieldIcon.Trailing(CardBrand.JCB.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.DinersClub.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.UnionPay.icon, isTintable = false)
+                        ),
+                        contentDescription = resolvableString(
+                            PaymentsUiCoreR.string.stripe_card_brand_icons_content_description,
+                            "Visa, Mastercard, American Express, Discover, JCB, Diners Club, UnionPay"
                         )
                     )
                 )
@@ -217,6 +230,10 @@ internal class CardNumberControllerTest {
                 TextFieldIcon.Trailing(CardBrand.DinersClub.icon, isTintable = false),
                 TextFieldIcon.Trailing(CardBrand.UnionPay.icon, isTintable = false),
             ),
+            contentDescription = resolvableString(
+                PaymentsUiCoreR.string.stripe_card_brand_icons_content_description,
+                "Visa, Mastercard, American Express, Discover, JCB, Diners Club, UnionPay"
+            ),
         )
 
         val visaIcon = TextFieldIcon.Trailing(CardBrand.Visa.icon, isTintable = false)
@@ -224,6 +241,10 @@ internal class CardNumberControllerTest {
         val multiTrailingIconWithJustVisa = TextFieldIcon.MultiTrailing(
             staticIcons = listOf(visaIcon),
             animatedIcons = emptyList(),
+            contentDescription = resolvableString(
+                PaymentsUiCoreR.string.stripe_card_brand_icons_content_description,
+                "Visa"
+            ),
         )
 
         cardNumberController.trailingIcon.test {
@@ -300,6 +321,10 @@ internal class CardNumberControllerTest {
                         animatedIcons = listOf(
                             TextFieldIcon.Trailing(CardBrand.DinersClub.icon, isTintable = false),
                             TextFieldIcon.Trailing(CardBrand.UnionPay.icon, isTintable = false)
+                        ),
+                        contentDescription = resolvableString(
+                            PaymentsUiCoreR.string.stripe_card_brand_icons_content_description,
+                            "Visa, Discover, JCB, Diners Club, UnionPay"
                         )
                     )
                 )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -90,7 +90,8 @@ sealed class TextFieldIcon {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class MultiTrailing(
         val staticIcons: List<Trailing>,
-        val animatedIcons: List<Trailing>
+        val animatedIcons: List<Trailing>,
+        val contentDescription: ResolvableString? = null
     ) : TextFieldIcon()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -336,7 +336,20 @@ private fun TextFieldIcon.Composable(
             }
 
             is TextFieldIcon.MultiTrailing -> {
-                Row(modifier = Modifier.padding(10.dp)) {
+                val resolvedContentDescription = contentDescription?.resolve()
+                Row(
+                    modifier = Modifier
+                        .padding(10.dp)
+                        .then(
+                            if (resolvedContentDescription != null) {
+                                Modifier.clearAndSetSemantics {
+                                    this.contentDescription = resolvedContentDescription
+                                }
+                            } else {
+                                Modifier
+                            }
+                        )
+                ) {
                     staticIcons.forEach {
                         TrailingIcon(it, loading)
                     }


### PR DESCRIPTION
# Summary
Added content descriptions to card brand icons for improved accessibility support in card input fields and brand selection views.

# Motivation
Card brand icons were missing accessibility labels, making it difficult for users with screen readers to understand which payment cards are supported. This change ensures all card brand icons have proper content descriptions for better accessibility compliance.

Fixes https://github.com/stripe/stripe-android/issues/10358
Fixes https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5331

# Testing
- [x] Modified tests
- [x] Manually verified

# Changelog
[Added] - Added accessibility content descriptions for card brand icons in payment forms.