### PR TITLE
Remove `RestrictTo` annotation from `TapToAddPreview`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -649,6 +649,9 @@ public abstract interface annotation class com/stripe/android/paymentelement/Shi
 public abstract interface annotation class com/stripe/android/paymentelement/ShopPayPreview : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/stripe/android/paymentelement/TapToAddPreview : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/stripe/android/paymentelement/WalletButtonsPreview : java/lang/annotation/Annotation {
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/TapToAddPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/TapToAddPreview.kt
@@ -1,8 +1,5 @@
 package com.stripe.android.paymentelement
 
-import androidx.annotation.RestrictTo
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,
     message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."


### PR DESCRIPTION
# Summary
Remove `RestrictTo` annotation from `TapToAddPreview`

# Motivation
Forgot to remove this during the last release.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified