### PR TITLE
Fix white screen during payment confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ NEXT_VERSION_BUMP: MINOR
 ## XX.XX.XX - 20XX-XX-XX
 
 ### PaymentSheet
+* [FIXED][12965](https://github.com/stripe/stripe-android/issues/12965) Fixed an issue where a white screen would briefly appear during payment confirmation, hiding the bottom sheet.
 * [FIXED][12973](https://github.com/stripe/stripe-android/pull/12973) Fixed an issue where `FlowController` would bypass mandate display when `setupFutureUsage` was added via `configureWithIntentConfiguration()` after the user had already entered card details.
 * [CHANGED][12975](https://github.com/stripe/stripe-android/pull/12975) When `paymentMethodLayout` is set to `Automatic`, the layout is now horizontal when there are 2 or fewer payment methods available.
 

--- a/payments-core/res/values/themes.xml
+++ b/payments-core/res/values/themes.xml
@@ -46,6 +46,7 @@
     <style name="StripePayLauncherDefaultTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowSoftInputMode">adjustResize</item>
         <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowIsFloating">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowNoTitle">true</item>


### PR DESCRIPTION
## Summary
- Fixed a bug where a white screen appeared during payment confirmation, hiding the PaymentSheet bottom sheet for ~1 second while the payment API call completed.

## Motivation
https://github.com/stripe/stripe-android/issues/12965
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5347

## Root Cause
`PaymentLauncherConfirmationActivity` is a transparent coordination activity (no content view) that runs while confirming a payment. Its theme (`StripePayLauncherDefaultTheme`) declared `windowIsTranslucent=true` and `windowBackground=transparent` but was missing `windowIsFloating=true`. Without floating, the full-screen translucent window renders as opaque white on modern Android (API 34+).

Other transparent activities in the SDK (`PassiveChallengeActivity`, `PaymentRelayActivity`) use `StripeTransparentTheme` which includes `windowIsFloating=true` and work correctly.

## Fix
Add `android:windowIsFloating=true` to `StripePayLauncherDefaultTheme`. This makes the activity a floating overlay that doesn't occlude the activity behind it, keeping the bottom sheet visible throughout confirmation.

## Testing
- Verified no other activities are affected (all other translucent activities set content views)
- No code in PaymentSheetActivity/ViewModel depends on being PAUSED during confirmation

## Changelog
Added an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)