### PR TITLE
Delete `run-example-instrumentation-tests` pipeline

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -36,7 +36,6 @@ stages:
       - test: { }
       - run-instrumentation-tests: { }
       - run-paymentsheet-instrumentation-tests: { }
-      - run-example-instrumentation-tests: { }
       - run-financial-connections-instrumentation-tests: { }
       - run-connections-e2e-payments-tests-on-push: { }
       - run-connections-e2e-token-tests-on-push: { }
@@ -271,26 +270,6 @@ workflows:
       bitrise.io:
         stack: linux-docker-android-22.04
         machine_type_id: g2.linux.x-large
-  run-example-instrumentation-tests:
-    before_run:
-      - start_emulator
-      - prepare_all
-    after_run:
-      - conclude_all
-    steps:
-      - script@1:
-          title: Assemble Instrumentation tests
-          timeout: 600
-          inputs:
-            - content: ./gradlew :example:assembleAndroidTest
-      - wait-for-android-emulator@1:
-          inputs:
-            - boot_timeout: 600
-      - script@1:
-          title: Execute instrumentation tests
-          timeout: 1200
-          inputs:
-            - content: ./scripts/retry.sh 3 ./gradlew :example:connectedAndroidTest
   run-financial-connections-instrumentation-tests:
     before_run:
       - start_emulator


### PR DESCRIPTION
# Summary
Delete `run-example-instrumentation-tests` pipeline

# Motivation
There are no tests in the `:example` module so this is a wasted operation & pipeline running on every PR.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified