### PR TITLE
Fix CustomerSheetLoader to return filtered payment methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][13020](https://github.com/stripe/stripe-android/pull/13020) `CustomerSheet` now correctly filters out unsupported payment method types.
+
 ## 23.7.0 - 2026-05-04
 
 ### PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -218,7 +218,7 @@ internal class DefaultCustomerSheetLoader(
                 "Ensure your integration is configured to accept card or US bank account payments."
         }
 
-        return supportedPaymentMethods
+        return validSupportedPaymentMethods
     }
 
     private fun getPaymentSelection(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -710,6 +710,30 @@ internal class DefaultCustomerSheetLoaderTest {
             .inOrder()
     }
 
+    @Test
+    fun `supportedPaymentMethods filters out unsupported types`() = runTest {
+        val loader = createCustomerSheetLoader(
+            isFinancialConnectionsAvailable = { true },
+            intent = STRIPE_INTENT.copy(
+                clientSecret = null,
+                paymentMethodTypes = listOf("card", "us_bank_account", "sepa_debit", "klarna"),
+                paymentMethodOptionsJsonString = """
+                        {
+                            "us_bank_account": {
+                                "verification_method": "automatic"
+                            }
+                        }
+                """.trimIndent(),
+            ),
+        )
+
+        val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
+
+        val supportedPaymentMethods = loader.load(config).getOrThrow().supportedPaymentMethods
+        assertThat(supportedPaymentMethods.map { it.code })
+            .containsExactly("card", "us_bank_account")
+    }
+
     private fun createCustomerSheetLoader(
         isGooglePayReady: Boolean = true,
         isCbcEligible: Boolean? = null,


### PR DESCRIPTION
# Summary
Fixed a bug in `CustomerSheetLoader` where unfiltered payment methods were being returned instead of the filtered valid ones.

Originally introduced here: https://github.com/stripe/stripe-android/pull/12752/changes#diff-7e1c4fa61c4e70690ef87fb3dfdb252c9c074d31d29d1040f31030a10a864489R221

# Motivation
The `CustomerSheetLoader` was incorrectly returning `supportedPaymentMethods` instead of `validSupportedPaymentMethods`, which meant that unsupported payment method types (like SEPA debit and Klarna) were not being filtered out properly. This could cause issues when CustomerSheet tries to display payment methods that aren't actually supported.

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Fixed] CustomerSheet now correctly filters out unsupported payment method types.