### PR TITLE
Use unique emails for Link test accounts to avoid conflicts.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -26,23 +26,10 @@ import com.stripe.android.utils.ForceNativeBankFlowTestRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 internal class TestInstantDebits : BasePlaygroundTest() {
-
-    private val testParameters = TestParameters.create(
-        paymentMethodCode = "link",
-    ) { settings ->
-        settings[MerchantSettingsDefinition] = Merchant.US
-        settings[CurrencySettingsDefinition] = Currency.USD
-        settings[AutomaticPaymentMethodsSettingsDefinition] = false
-        settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
-        settings[LinkSettingsDefinition] = true
-        settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
-            PaymentMethod.Type.Card,
-            PaymentMethod.Type.Link
-        ).joinToString(",")
-    }
 
     @get:Rule
     val forceNativeBankFlowTestRule = ForceNativeBankFlowTestRule(
@@ -51,12 +38,19 @@ internal class TestInstantDebits : BasePlaygroundTest() {
 
     @Test
     fun testInstantDebitsSuccess() {
-        val params = testParameters.copyPlaygroundSettings {
-            it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
-        }
+        val email = "email_${UUID.randomUUID()}@email.com"
 
+        // Sign up for Link by completing a card payment with the random email.
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = makeSignUpTestParameters(email),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+
+        // Re-use the Link account to confirm with instant debits.
         testDriver.confirmLinkBankPayment(
-            testParameters = params,
+            testParameters = makeLinkTestParameters(email),
             afterAuthorization = { _, _ ->
                 rules.compose.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                     rules.compose
@@ -70,8 +64,19 @@ internal class TestInstantDebits : BasePlaygroundTest() {
 
     @Test
     fun testInstantDebitsCancelAllowsUserToContinue() {
+        val email = "email_${UUID.randomUUID()}@email.com"
+
+        // Sign up for Link by completing a card payment with the random email.
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = makeSignUpTestParameters(email),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+
+        // Re-use the Link account to test cancel behavior.
         testDriver.confirmLinkBankPayment(
-            testParameters = testParameters.copy(
+            testParameters = makeLinkTestParameters(email).copy(
                 authorizationAction = AuthorizeAction.Cancel,
             ),
             afterAuthorization = { _, _ ->
@@ -79,5 +84,39 @@ internal class TestInstantDebits : BasePlaygroundTest() {
                     .waitFor(isEnabled())
             }
         )
+    }
+
+    private fun makeSignUpTestParameters(email: String): TestParameters {
+        return TestParameters.create(
+            paymentMethodCode = "card",
+            authorizationAction = null,
+            saveForFutureUseCheckboxVisible = true,
+        ) { settings ->
+            settings[MerchantSettingsDefinition] = Merchant.US
+            settings[CurrencySettingsDefinition] = Currency.USD
+            settings[AutomaticPaymentMethodsSettingsDefinition] = false
+            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
+            settings[LinkSettingsDefinition] = true
+            settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
+                PaymentMethod.Type.Card,
+                PaymentMethod.Type.Link
+            ).joinToString(",")
+        }
+    }
+
+    private fun makeLinkTestParameters(email: String): TestParameters {
+        return TestParameters.create(
+            paymentMethodCode = "link",
+        ) { settings ->
+            settings[MerchantSettingsDefinition] = Merchant.US
+            settings[CurrencySettingsDefinition] = Currency.USD
+            settings[AutomaticPaymentMethodsSettingsDefinition] = false
+            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
+            settings[LinkSettingsDefinition] = true
+            settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
+                PaymentMethod.Type.Card,
+                PaymentMethod.Type.Link
+            ).joinToString(",")
+        }
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -40,15 +40,8 @@ internal class TestInstantDebits : BasePlaygroundTest() {
     fun testInstantDebitsSuccess() {
         val email = "email_${UUID.randomUUID()}@email.com"
 
-        // Sign up for Link by completing a card payment with the random email.
-        testDriver.confirmNewOrGuestComplete(
-            testParameters = makeSignUpTestParameters(email),
-            populateCustomLpmFields = {
-                populateCardDetails()
-            },
-        )
+        testDriver.signUpForLink(makeSignUpTestParameters(email))
 
-        // Re-use the Link account to confirm with instant debits.
         testDriver.confirmLinkBankPayment(
             testParameters = makeLinkTestParameters(email),
             afterAuthorization = { _, _ ->
@@ -66,15 +59,8 @@ internal class TestInstantDebits : BasePlaygroundTest() {
     fun testInstantDebitsCancelAllowsUserToContinue() {
         val email = "email_${UUID.randomUUID()}@email.com"
 
-        // Sign up for Link by completing a card payment with the random email.
-        testDriver.confirmNewOrGuestComplete(
-            testParameters = makeSignUpTestParameters(email),
-            populateCustomLpmFields = {
-                populateCardDetails()
-            },
-        )
+        testDriver.signUpForLink(makeSignUpTestParameters(email))
 
-        // Re-use the Link account to test cancel behavior.
         testDriver.confirmLinkBankPayment(
             testParameters = makeLinkTestParameters(email).copy(
                 authorizationAction = AuthorizeAction.Cancel,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
@@ -22,15 +22,8 @@ internal class TestLink : BasePlaygroundTest() {
     fun testLinkPaymentWithBankAccountInPaymentMethodMode() {
         val email = "email_${UUID.randomUUID()}@email.com"
 
-        // Sign up for Link by completing a card payment with the random email.
-        testDriver.confirmNewOrGuestComplete(
-            testParameters = makeSignUpTestParameters(passthroughMode = false, email = email),
-            populateCustomLpmFields = {
-                populateCardDetails()
-            },
-        )
+        testDriver.signUpForLink(makeSignUpTestParameters(passthroughMode = false, email = email))
 
-        // Re-use the Link account to confirm with a bank account (triggers OTP flow).
         testDriver.confirmWithBankAccountInLink(
             makeLinkTestParameters(passthroughMode = false, email = email)
         )
@@ -40,15 +33,8 @@ internal class TestLink : BasePlaygroundTest() {
     fun testLinkPaymentWithBankAccountInPassthroughMode() {
         val email = "email_${UUID.randomUUID()}@email.com"
 
-        // Sign up for Link by completing a card payment with the random email.
-        testDriver.confirmNewOrGuestComplete(
-            testParameters = makeSignUpTestParameters(passthroughMode = true, email = email),
-            populateCustomLpmFields = {
-                populateCardDetails()
-            },
-        )
+        testDriver.signUpForLink(makeSignUpTestParameters(passthroughMode = true, email = email))
 
-        // Re-use the Link account to confirm with a bank account (triggers OTP flow).
         testDriver.confirmWithBankAccountInLink(
             makeLinkTestParameters(passthroughMode = true, email = email)
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
@@ -13,31 +13,70 @@ import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaym
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 internal class TestLink : BasePlaygroundTest() {
 
     @Test
     fun testLinkPaymentWithBankAccountInPaymentMethodMode() {
-        val testParameters = makeLinkTestParameters(passthroughMode = false)
-        testDriver.confirmWithBankAccountInLink(testParameters)
+        val email = "email_${UUID.randomUUID()}@email.com"
+
+        // Sign up for Link by completing a card payment with the random email.
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = makeSignUpTestParameters(passthroughMode = false, email = email),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+
+        // Re-use the Link account to confirm with a bank account (triggers OTP flow).
+        testDriver.confirmWithBankAccountInLink(
+            makeLinkTestParameters(passthroughMode = false, email = email)
+        )
     }
 
     @Test
     fun testLinkPaymentWithBankAccountInPassthroughMode() {
-        val testParameters = makeLinkTestParameters(passthroughMode = true)
-        testDriver.confirmWithBankAccountInLink(testParameters)
+        val email = "email_${UUID.randomUUID()}@email.com"
+
+        // Sign up for Link by completing a card payment with the random email.
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = makeSignUpTestParameters(passthroughMode = true, email = email),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+
+        // Re-use the Link account to confirm with a bank account (triggers OTP flow).
+        testDriver.confirmWithBankAccountInLink(
+            makeLinkTestParameters(passthroughMode = true, email = email)
+        )
     }
 
-    private fun makeLinkTestParameters(passthroughMode: Boolean): TestParameters {
+    private fun makeSignUpTestParameters(passthroughMode: Boolean, email: String): TestParameters {
         return TestParameters.create(
             paymentMethodCode = "card",
+            authorizationAction = null,
+            saveForFutureUseCheckboxVisible = true,
+        ) { settings ->
+            settings[SupportedPaymentMethodsSettingsDefinition] = if (passthroughMode) "card" else "card,link"
+            settings[MerchantSettingsDefinition] = Merchant.US
+            settings[LinkSettingsDefinition] = true
+            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
+        }
+    }
+
+    private fun makeLinkTestParameters(passthroughMode: Boolean, email: String): TestParameters {
+        return TestParameters.create(
+            paymentMethodCode = "card",
+            authorizationAction = null,
         ) { settings ->
             settings[SupportedPaymentMethodsSettingsDefinition] = if (passthroughMode) "card" else "card,link"
             settings[MerchantSettingsDefinition] = Merchant.US
             settings[LinkSettingsDefinition] = true
             settings[LinkTypeSettingsDefinition] = LinkType.Native
-            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
+            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
         }
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -39,15 +39,8 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
     fun testLinkCardBrandSuccess() {
         val email = "email_${UUID.randomUUID()}@email.com"
 
-        // Sign up for Link by completing a card payment with the random email.
-        testDriver.confirmNewOrGuestComplete(
-            testParameters = makeSignUpTestParameters(email),
-            populateCustomLpmFields = {
-                populateCardDetails()
-            },
-        )
+        testDriver.signUpForLink(makeSignUpTestParameters(email))
 
-        // Re-use the Link account to confirm with a bank payment.
         testDriver.confirmLinkBankPayment(
             testParameters = makeLinkTestParameters(email),
             afterAuthorization = { _, _ ->
@@ -65,15 +58,8 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
     fun testLinkCardBrandCancelAllowsUserToContinue() {
         val email = "email_${UUID.randomUUID()}@email.com"
 
-        // Sign up for Link by completing a card payment with the random email.
-        testDriver.confirmNewOrGuestComplete(
-            testParameters = makeSignUpTestParameters(email),
-            populateCustomLpmFields = {
-                populateCardDetails()
-            },
-        )
+        testDriver.signUpForLink(makeSignUpTestParameters(email))
 
-        // Re-use the Link account to test cancel behavior.
         testDriver.confirmLinkBankPayment(
             testParameters = makeLinkTestParameters(email).copy(
                 authorizationAction = AuthorizeAction.Cancel,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -25,20 +25,10 @@ import com.stripe.android.utils.ForceNativeBankFlowTestRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 internal class TestLinkCardBrand : BasePlaygroundTest() {
-
-    private val testParameters = TestParameters.create(
-        paymentMethodCode = "link",
-    ) { settings ->
-        settings[MerchantSettingsDefinition] = Merchant.US
-        settings[CurrencySettingsDefinition] = Currency.USD
-        settings[AutomaticPaymentMethodsSettingsDefinition] = false
-        settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
-        settings[LinkSettingsDefinition] = true
-        settings[SupportedPaymentMethodsSettingsDefinition] = "card"
-    }
 
     @get:Rule
     val forceNativeBankFlowTestRule = ForceNativeBankFlowTestRule(
@@ -47,12 +37,19 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
 
     @Test
     fun testLinkCardBrandSuccess() {
-        val params = testParameters.copyPlaygroundSettings {
-            it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
-        }
+        val email = "email_${UUID.randomUUID()}@email.com"
 
+        // Sign up for Link by completing a card payment with the random email.
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = makeSignUpTestParameters(email),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+
+        // Re-use the Link account to confirm with a bank payment.
         testDriver.confirmLinkBankPayment(
-            testParameters = params,
+            testParameters = makeLinkTestParameters(email),
             afterAuthorization = { _, _ ->
                 rules.compose.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                     rules.compose
@@ -66,8 +63,19 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
 
     @Test
     fun testLinkCardBrandCancelAllowsUserToContinue() {
+        val email = "email_${UUID.randomUUID()}@email.com"
+
+        // Sign up for Link by completing a card payment with the random email.
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = makeSignUpTestParameters(email),
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+
+        // Re-use the Link account to test cancel behavior.
         testDriver.confirmLinkBankPayment(
-            testParameters = testParameters.copy(
+            testParameters = makeLinkTestParameters(email).copy(
                 authorizationAction = AuthorizeAction.Cancel,
             ),
             afterAuthorization = { _, _ ->
@@ -75,5 +83,33 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
                     .waitFor(isEnabled())
             }
         )
+    }
+
+    private fun makeSignUpTestParameters(email: String): TestParameters {
+        return TestParameters.create(
+            paymentMethodCode = "card",
+            authorizationAction = null,
+            saveForFutureUseCheckboxVisible = true,
+        ) { settings ->
+            settings[MerchantSettingsDefinition] = Merchant.US
+            settings[CurrencySettingsDefinition] = Currency.USD
+            settings[AutomaticPaymentMethodsSettingsDefinition] = false
+            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
+            settings[LinkSettingsDefinition] = true
+            settings[SupportedPaymentMethodsSettingsDefinition] = "card"
+        }
+    }
+
+    private fun makeLinkTestParameters(email: String): TestParameters {
+        return TestParameters.create(
+            paymentMethodCode = "link",
+        ) { settings ->
+            settings[MerchantSettingsDefinition] = Merchant.US
+            settings[CurrencySettingsDefinition] = Currency.USD
+            settings[AutomaticPaymentMethodsSettingsDefinition] = false
+            settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
+            settings[LinkSettingsDefinition] = true
+            settings[SupportedPaymentMethodsSettingsDefinition] = "card"
+        }
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -903,6 +903,17 @@ internal class PlaygroundTestDriver(
         )
     }
 
+    fun signUpForLink(
+        testParameters: TestParameters,
+    ) {
+        confirmNewOrGuestComplete(
+            testParameters = testParameters,
+            populateCustomLpmFields = {
+                populateCardDetails()
+            },
+        )
+    }
+
     @OptIn(ExperimentalTestApi::class)
     fun confirmWithBankAccountInLink(
         testParameters: TestParameters,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
@@ -9,12 +9,24 @@ import java.util.UUID
 
 internal object DefaultBillingAddressSettingsDefinition :
     PlaygroundSettingDefinition<DefaultBillingAddress>,
-    PlaygroundSettingDefinition.Saveable<DefaultBillingAddress> by EnumSaveable(
-        key = "defaultBillingAddress",
-        values = DefaultBillingAddress.entries.toTypedArray(),
-        defaultValue = DefaultBillingAddress.On,
-    ),
+    PlaygroundSettingDefinition.Saveable<DefaultBillingAddress>,
     PlaygroundSettingDefinition.Displayable<DefaultBillingAddress> {
+
+    override val key: String = "defaultBillingAddress"
+    override val defaultValue: DefaultBillingAddress = DefaultBillingAddress.On
+
+    override fun convertToValue(value: String): DefaultBillingAddress {
+        return when (value) {
+            "on" -> DefaultBillingAddress.On
+            "on_with_random_email" -> DefaultBillingAddress.OnWithRandomEmail
+            "off" -> DefaultBillingAddress.Off
+            else -> defaultValue
+        }
+    }
+
+    override fun convertToString(value: DefaultBillingAddress): String {
+        return value.value
+    }
 
     override val displayName: String
         get() = "Default Billing Address"
@@ -87,6 +99,7 @@ internal object DefaultBillingAddressSettingsDefinition :
             DefaultBillingAddress.On -> "email@email.com"
             DefaultBillingAddress.OnWithRandomEmail -> "email_${UUID.randomUUID()}@email.com"
             DefaultBillingAddress.Off -> null
+            is DefaultBillingAddress.WithEmail -> value.email
         }
 
         return email?.let {
@@ -107,8 +120,9 @@ internal object DefaultBillingAddressSettingsDefinition :
     }
 }
 
-internal enum class DefaultBillingAddress(override val value: String) : ValueEnum {
-    On("on"),
-    OnWithRandomEmail("on_with_random_email"),
-    Off("off"),
+internal sealed class DefaultBillingAddress(val value: String) {
+    data object On : DefaultBillingAddress("on")
+    data object OnWithRandomEmail : DefaultBillingAddress("on_with_random_email")
+    data object Off : DefaultBillingAddress("off")
+    data class WithEmail(val email: String) : DefaultBillingAddress("with_email")
 }


### PR DESCRIPTION
# Summary
Modified Link-related tests to use unique email addresses for each test run, preventing conflicts from reusing the same email across tests.

# Motivation
The Link tests were using a shared email address which could cause test failures when Link accounts persisted between test runs. Using unique emails ensures each test starts with a fresh Link account state.

https://jira.corp.stripe.com/browse/MOBILESDK-4313

# Testing
- [x] Modified tests
- [x] Manually verified

# Changelog
[Fixed] - Link integration tests now use unique email addresses to prevent account conflicts between test runs.