### PR TITLE
Move Google Pay fix to Payments section in CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ NEXT_VERSION_BUMP: PATCH
 ### PaymentSheet
 * [FIXED][13020](https://github.com/stripe/stripe-android/pull/13020) `CustomerSheet` now correctly filters out unsupported payment method types.
 
+### Payments
+* [FIXED][12983](https://github.com/stripe/stripe-android/pull/12983) Fixed an issue where `additionalEnabledNetworks` would not be respected for Google Pay payments.
+
 ## 23.7.0 - 2026-05-04
 
 ### PaymentSheet
 * [FIXED][12965](https://github.com/stripe/stripe-android/issues/12965) Fixed an issue where a white screen would briefly appear during payment confirmation, hiding the bottom sheet.
 * [FIXED][12973](https://github.com/stripe/stripe-android/pull/12973) Fixed an issue where `FlowController` would bypass mandate display when `setupFutureUsage` was added via `configureWithIntentConfiguration()` after the user had already entered card details.
-* [FIXED][12983](https://github.com/stripe/stripe-android/pull/12983) Fixed an issue where `additionalEnabledNetworks` would not be respected for Google Pay payments.
 * [CHANGED][12975](https://github.com/stripe/stripe-android/pull/12975) When `paymentMethodLayout` is set to `Automatic`, the layout is now horizontal when there are 2 or fewer payment methods available.
 
 ## 23.6.0 - 2026-04-27


### PR DESCRIPTION
# Summary
Moved the Google Pay `additionalEnabledNetworks` fix entry from the PaymentSheet section to the Payments section in CHANGELOG.md.

# Motivation
The fix for `additionalEnabledNetworks` not being respected for Google Pay payments is more appropriately categorized under the Payments section rather than PaymentSheet, as it affects Google Pay functionality broadly rather than being specific to PaymentSheet.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
No new changes - this is a documentation reorganization only.