### PR TITLE
Fix client attribution metadata for CheckoutSession flows

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ClientAttributionMetadata.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ClientAttributionMetadata.kt
@@ -13,6 +13,7 @@ data class ClientAttributionMetadata(
     @get:VisibleForTesting val elementsSessionConfigId: String?,
     @get:VisibleForTesting val paymentIntentCreationFlow: PaymentIntentCreationFlow?,
     @get:VisibleForTesting val paymentMethodSelectionFlow: PaymentMethodSelectionFlow?,
+    @get:VisibleForTesting val checkoutSessionId: String?,
     private val stripeSdkVersion: String = StripeSdkVersion.VERSION_NAME,
 ) : StripeParamsModel, Parcelable {
 
@@ -33,6 +34,10 @@ data class ClientAttributionMetadata(
         ).plus(
             elementsSessionConfigId?.let {
                 mapOf("elements_session_config_id" to it)
+            }.orEmpty()
+        ).plus(
+            checkoutSessionId?.let {
+                mapOf("checkout_session_id" to it)
             }.orEmpty()
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -297,6 +297,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                 elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
                 paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
                 paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+                checkoutSessionId = null,
             )
         )
         val REQUEST_OPTIONS = ApiRequest.Options(

--- a/payments-core/src/test/java/com/stripe/android/model/ClientAttributionMetadataTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ClientAttributionMetadataTest.kt
@@ -13,6 +13,7 @@ class ClientAttributionMetadataTest {
             elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+            checkoutSessionId = null,
         ).toParamMap()
 
         assertThat(clientAttributionMetadataParams).hasSize(7)
@@ -52,6 +53,7 @@ class ClientAttributionMetadataTest {
             elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
             paymentIntentCreationFlow = null,
+            checkoutSessionId = null,
         ).toParamMap()
 
         assertThat(clientAttributionMetadataParams).hasSize(6)
@@ -64,6 +66,7 @@ class ClientAttributionMetadataTest {
             elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = null,
+            checkoutSessionId = null,
         ).toParamMap()
 
         assertThat(clientAttributionMetadataParams).hasSize(6)
@@ -76,9 +79,34 @@ class ClientAttributionMetadataTest {
             elementsSessionConfigId = null,
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+            checkoutSessionId = null,
         ).toParamMap()
 
         assertThat(clientAttributionMetadataParams).hasSize(6)
         assertThat(clientAttributionMetadataParams).doesNotContainKey("elements_session_config_id")
+    }
+
+    @Test
+    fun `toParamMap() includes checkoutSessionId when non-null`() {
+        val clientAttributionMetadataParams = ClientAttributionMetadata(
+            elementsSessionConfigId = null,
+            paymentIntentCreationFlow = null,
+            paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = "cs_test_123",
+        ).toParamMap()
+
+        assertThat(clientAttributionMetadataParams).containsEntry("checkout_session_id", "cs_test_123")
+    }
+
+    @Test
+    fun `toParamMap() omits checkoutSessionId if null`() {
+        val clientAttributionMetadataParams = ClientAttributionMetadata(
+            elementsSessionConfigId = null,
+            paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+            paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+            checkoutSessionId = null,
+        ).toParamMap()
+
+        assertThat(clientAttributionMetadataParams).doesNotContainKey("checkout_session_id")
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -596,6 +596,7 @@ class ConfirmPaymentIntentParamsTest {
             elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = null,
         )
         val params = ConfirmPaymentIntentParams(
             clientSecret = CLIENT_SECRET,

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -257,6 +257,7 @@ class ConfirmSetupIntentParamsTest {
             elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = null,
         )
         val params = ConfirmSetupIntentParams(
             paymentMethodId = "pm_123",

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmationTokenParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmationTokenParamsTest.kt
@@ -334,6 +334,7 @@ class ConfirmationTokenParamsTest {
             elementsSessionConfigId = "elements_session_123",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = null,
         )
         val params = ConfirmationTokenParams(
             clientAttributionMetadata = clientAttributionMetadata

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -487,6 +487,7 @@ class PaymentMethodCreateParamsTest {
             elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = null,
         )
         val paymentMethodCreateParams = PaymentMethodCreateParams.createWithOverride(
             code = "card",
@@ -511,6 +512,7 @@ class PaymentMethodCreateParamsTest {
         elementsSessionConfigId = "elements_session_123",
         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
         paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+        checkoutSessionId = null,
     )
 
     private fun createFpx(): PaymentMethodCreateParams {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -135,6 +135,7 @@ class FieldValuesToParamsMapConverterTest {
                     elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
                     paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
                     paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+                    checkoutSessionId = null,
                 )
             )
 
@@ -544,6 +545,7 @@ class FieldValuesToParamsMapConverterTest {
             elementsSessionConfigId = "elements_session_123",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
@@ -13,9 +13,9 @@ internal fun ClientAttributionMetadata.Companion.create(
     val paymentIntentCreationFlow = when (initializationMode) {
         is PaymentElementLoader.InitializationMode.CryptoOnramp,
         is PaymentElementLoader.InitializationMode.DeferredIntent -> PaymentIntentCreationFlow.Deferred
-        is PaymentElementLoader.InitializationMode.CheckoutSession,
         is PaymentElementLoader.InitializationMode.PaymentIntent,
         is PaymentElementLoader.InitializationMode.SetupIntent -> PaymentIntentCreationFlow.Standard
+        is PaymentElementLoader.InitializationMode.CheckoutSession -> null
     }
 
     val paymentMethodSelectionFlow = if (automaticPaymentMethodsEnabled) {
@@ -24,9 +24,14 @@ internal fun ClientAttributionMetadata.Companion.create(
         PaymentMethodSelectionFlow.MerchantSpecified
     }
 
+    val checkoutSessionId =
+        (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
+            ?.checkoutSessionResponse?.id
+
     return ClientAttributionMetadata(
         elementsSessionConfigId = elementsSessionConfigId,
         paymentIntentCreationFlow = paymentIntentCreationFlow,
         paymentMethodSelectionFlow = paymentMethodSelectionFlow,
+        checkoutSessionId = checkoutSessionId,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -435,7 +435,6 @@ internal data class PaymentMethodMetadata(
             customerMetadata: CustomerMetadata,
             integrationMetadata: IntegrationMetadata.CustomerSheet,
         ): PaymentMethodMetadata {
-            val cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty()
             return PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
                 billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
@@ -476,11 +475,9 @@ internal data class PaymentMethodMetadata(
                 openCardScanAutomatically = configuration.opensCardScannerAutomatically,
                 clientAttributionMetadata = ClientAttributionMetadata(
                     elementsSessionConfigId = elementsSession.elementsSessionConfigId,
-                    // We omit paymentIntentCreationFlow and paymentMethodSelectionFlow in CustomerSheet, because these
-                    // fields are not meaningful for CustomerSheet (since intent creation is functionally always
-                    // deferred and only a few PMs are supported).
                     paymentMethodSelectionFlow = null,
                     paymentIntentCreationFlow = null,
+                    checkoutSessionId = null,
                 ),
                 attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
                 appearance = configuration.appearance,
@@ -493,7 +490,7 @@ internal data class PaymentMethodMetadata(
                 enableMlKitCardScan = elementsSession.enableMlKitCardScan,
                 elementsSessionId = elementsSession.elementsSessionId,
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
-                cardArts = cardArts,
+                cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -285,6 +285,7 @@ internal object TestFactory {
             elementsSessionConfigId = "elements_session_123",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+            checkoutSessionId = null,
         ),
         cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
         linkBrand = LinkBrand.Link,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtxTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import org.junit.Test
 
@@ -86,6 +87,45 @@ class ClientAttributionMetadataKtxTest {
         assertThat(clientAttributionMetadata.paymentMethodSelectionFlow).isEqualTo(
             PaymentMethodSelectionFlow.MerchantSpecified
         )
+    }
+
+    @Test
+    fun `payment intent creation flow is null for checkout session`() {
+        val initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+            instancesKey = "instances_key",
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(id = "cs_test_456"),
+        )
+
+        val clientAttributionMetadata = createClientAttributionMetadata(
+            initializationMode = initializationMode,
+        )
+
+        assertThat(clientAttributionMetadata.paymentIntentCreationFlow).isNull()
+    }
+
+    @Test
+    fun `checkout session ID is set for checkout session`() {
+        val initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+            instancesKey = "instances_key",
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(id = "cs_test_456"),
+        )
+
+        val clientAttributionMetadata = createClientAttributionMetadata(
+            initializationMode = initializationMode,
+        )
+
+        assertThat(clientAttributionMetadata.checkoutSessionId).isEqualTo("cs_test_456")
+    }
+
+    @Test
+    fun `checkout session ID is null for non-checkout-session modes`() {
+        val initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123")
+
+        val clientAttributionMetadata = createClientAttributionMetadata(
+            initializationMode = initializationMode,
+        )
+
+        assertThat(clientAttributionMetadata.checkoutSessionId).isNull()
     }
 
     private fun createClientAttributionMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFixtures.kt
@@ -27,6 +27,7 @@ internal object PaymentMethodMetadataFixtures {
         elementsSessionConfigId = "e961790f-43ed-4fcc-a534-74eeca28d042",
         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
         paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+        checkoutSessionId = null,
     )
 
     internal val CUSTOMER_SESSIONS_CUSTOMER_METADATA = CustomerMetadata.CustomerSession(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1357,6 +1357,7 @@ internal class PaymentMethodMetadataTest {
                 elementsSessionConfigId = elementsSession.elementsSessionConfigId,
                 paymentMethodSelectionFlow = null,
                 paymentIntentCreationFlow = null,
+                checkoutSessionId = null,
             ),
             attestOnIntentConfirmation = false,
             appearance = configuration.appearance,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -450,6 +450,7 @@ class CheckoutSessionConfirmationInterceptorTest {
                 elementsSessionConfigId = "test_session_id",
                 paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
                 paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+                checkoutSessionId = null,
             ),
             context = applicationContext,
             stripeRepository = stripeRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptorTest.kt
@@ -37,6 +37,7 @@ class CustomerSheetConfirmationInterceptorTest {
         elementsSessionConfigId = "test_session_id",
         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
         paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+        checkoutSessionId = null,
     )
 
     private val requestOptions = ApiRequest.Options(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptorTest.kt
@@ -28,6 +28,7 @@ class CustomerSheetSetupIntentInterceptorTest {
         elementsSessionConfigId = "test_session_id",
         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
         paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+        checkoutSessionId = null,
     )
 
     private val requestOptions = ApiRequest.Options(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParamsTest.kt
@@ -70,6 +70,7 @@ class ConfirmCheckoutSessionParamsTest {
             elementsSessionConfigId = "test_session_id",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+            checkoutSessionId = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -173,6 +173,7 @@ internal class DefaultCreateLinkStateTest {
             elementsSessionConfigId = FakeElementsSessionRepository.DEFAULT_ELEMENTS_SESSION_CONFIG_ID,
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+            checkoutSessionId = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -161,6 +161,7 @@ internal class DefaultPaymentElementLoaderTest {
                         elementsSessionConfigId = DEFAULT_ELEMENTS_SESSION_CONFIG_ID,
                         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
                         paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+                        checkoutSessionId = null,
                     ),
                     integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_1234"),
                     elementsSessionId = "session_1234",


### PR DESCRIPTION
## Summary
- Send `checkout_session_id` in `ClientAttributionMetadata` for CheckoutSession flows
- Omit `payment_intent_creation_flow` for CheckoutSession (Stripe owns intent lifecycle via CS)
- Enables proper conversion attribution in the Weave analytics pipeline

## Motivation
Fixes [MOBILESDK-4481](https://jira.corp.stripe.com/browse/MOBILESDK-4481). The proto field `checkout_session_id` (field 13) was never sent from Android, and CheckoutSession was incorrectly grouped with PI/SI as `"standard"` for `payment_intent_creation_flow`.

## Testing
- Added unit tests for `checkout_session_id` emission/omission in `ClientAttributionMetadataTest`
- Added unit tests for CheckoutSession mode in `ClientAttributionMetadataKtxTest` (null creation flow, correct session ID, null for non-CS modes)