### PR TITLE
Clean up instrumentation test naming

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ConfirmWithAttestationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ConfirmWithAttestationTest.kt
@@ -53,7 +53,7 @@ internal class ConfirmWithAttestationTest {
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,
             builder = {
-                ConfirmationType.DeferredClientSideConfirmation().createIntentCallback?.let {
+                ConfirmationType.DeferredClientSideConfirmation.createIntentCallback?.let {
                     createIntentCallback(it)
                 }
             }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
@@ -45,7 +45,7 @@ internal class DefaultPaymentMethodsConfirmationTest {
     lateinit var paymentMethodType: PaymentMethodType
 
     // Confirmation behavior between horizontal and vertical doesn't differ, so we're testing with vertical mode only.
-    private val layoutType: PaymentSheetLayoutType = PaymentSheetLayoutType.Vertical()
+    private val layoutType: PaymentSheetLayoutType = PaymentSheetLayoutType.Vertical
 
     @Test
     fun setNewPMAsDefault_withSavedPaymentMethods_sendsSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsDeferredServerSideConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsDeferredServerSideConfirmationTest.kt
@@ -28,7 +28,7 @@ internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest {
     lateinit var integrationType: ProductIntegrationType
 
     // Confirmation behavior between horizontal and vertical doesn't differ, so we're testing with vertical mode only.
-    private val layoutType = PaymentSheetLayoutType.Vertical()
+    private val layoutType = PaymentSheetLayoutType.Vertical
 
     @Test
     fun setNewCardAsDefault_withSavedPaymentMethods_failsInTestMode() = runProductIntegrationTest(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
@@ -39,7 +39,7 @@ internal class DefaultPaymentMethodsFlowControllerConfirmationTest {
     lateinit var paymentMethodType: PaymentMethodType
 
     // Confirmation behavior between horizontal and vertical doesn't differ, so we're testing with vertical mode only.
-    private val layoutType: PaymentSheetLayoutType = PaymentSheetLayoutType.Vertical()
+    private val layoutType: PaymentSheetLayoutType = PaymentSheetLayoutType.Vertical
 
     @Test
     fun relaunchesIntoFormPageWithSaveForFutureUseChecked() = relaunchIntoFormPage(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.utils.ActivityLaunchObserver
 import com.stripe.android.paymentsheet.utils.IntegrationType
+import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.MultipleInstancesTestType
 import com.stripe.android.paymentsheet.utils.MultipleInstancesTestTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -76,7 +77,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testSuccessfulCardPayment(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -115,7 +116,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testSuccessfulCardPaymentWithVerticalMode(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -157,7 +158,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testCardRelaunchesIntoFormPage(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
             networkRule = networkRule,
@@ -199,7 +200,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testCashappRelaunchesIntoListPageWithCashappSelected(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
             networkRule = networkRule,
@@ -243,7 +244,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testCorrectMandatesDisplayedAfterNavigation(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
             networkRule = networkRule,
@@ -298,7 +299,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testFailedElementsSessionCall(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -386,7 +387,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testFailedConfirmCall(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
             networkRule = networkRule,
@@ -554,7 +555,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testDeferredIntentCardPayment(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -687,7 +688,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testDeferredIntentFailedCardPayment(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -747,7 +748,7 @@ internal class FlowControllerTest {
     @OptIn(DelicatePaymentSheetApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithForcedSuccess(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -800,7 +801,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testDeferredIntentCardPaymentWithInvalidStripeIntent(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -867,7 +868,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testCvcRecollection(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -932,7 +933,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testSavedCardsInVerticalMode(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -1008,7 +1009,7 @@ internal class FlowControllerTest {
      */
     @Test
     fun testDefaultPaymentMethodOrderWithFailedSession(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -1227,7 +1228,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testFlowControllerConfigurationBuilderWithTermsDisplayNever(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
@@ -1273,7 +1274,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testOBO_PassedToElementsSessionCall(
-        @TestParameter integrationType: IntegrationType,
+        @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
@@ -47,7 +47,7 @@ internal class HCaptchaTokenTest {
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,
             builder = {
-                ConfirmationType.DeferredClientSideConfirmation().createIntentCallback?.let {
+                ConfirmationType.DeferredClientSideConfirmation.createIntentCallback?.let {
                     createIntentCallback(it)
                 }
             }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ConfirmationType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ConfirmationType.kt
@@ -24,7 +24,7 @@ internal sealed class ConfirmationType(
         networkRule: NetworkRule,
     )
 
-    class IntentFirst : ConfirmationType(
+    data object IntentFirst : ConfirmationType(
         createIntentCallback = null,
         isDeferredIntent = false,
     ) {
@@ -86,7 +86,7 @@ internal sealed class ConfirmationType(
         }
     }
 
-    class DeferredClientSideConfirmation : ConfirmationType(
+    data object DeferredClientSideConfirmation : ConfirmationType(
         createIntentCallback = { _, _ ->
             CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
         },
@@ -193,8 +193,8 @@ internal sealed class ConfirmationType(
 internal object ConfirmationTypeProvider : TestParameterValuesProvider() {
     override fun provideValues(context: Context?): List<ConfirmationType> {
         return listOf(
-            ConfirmationType.IntentFirst(),
-            ConfirmationType.DeferredClientSideConfirmation(),
+            ConfirmationType.IntentFirst,
+            ConfirmationType.DeferredClientSideConfirmation,
         )
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestType.kt
@@ -2,10 +2,10 @@ package com.stripe.android.paymentsheet.utils
 
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
 
-internal enum class CustomerSheetTestType {
-    AttachToCustomer,
-    AttachToSetupIntent,
-    CustomerSession,
+internal sealed interface CustomerSheetTestType {
+    data object AttachToCustomer : CustomerSheetTestType
+    data object AttachToSetupIntent : CustomerSheetTestType
+    data object CustomerSession : CustomerSheetTestType
 }
 
 internal object CustomerSheetTestTypeProvider : TestParameterValuesProvider() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/IntegrationType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/IntegrationType.kt
@@ -2,13 +2,16 @@ package com.stripe.android.paymentsheet.utils
 
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
 
-internal enum class IntegrationType {
-    Activity,
-    Compose,
+internal sealed interface IntegrationType {
+    data object Activity : IntegrationType
+    data object Compose : IntegrationType
 }
 
 internal object IntegrationTypeProvider : TestParameterValuesProvider() {
     override fun provideValues(context: Context?): List<IntegrationType> {
-        return IntegrationType.entries
+        return listOf(
+            IntegrationType.Activity,
+            IntegrationType.Compose,
+        )
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetLayoutType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetLayoutType.kt
@@ -48,7 +48,9 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
         composeTestRule: ComposeTestRule,
     )
 
-    class Horizontal : PaymentSheetLayoutType(paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal) {
+    data object Horizontal : PaymentSheetLayoutType(
+        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal
+    ) {
         override fun assertHasSelectedPaymentMethod(
             composeTestRule: ComposeTestRule,
             context: Context,
@@ -129,7 +131,7 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
         }
     }
 
-    class Vertical : PaymentSheetLayoutType(paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical) {
+    data object Vertical : PaymentSheetLayoutType(paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical) {
         override fun assertHasSelectedPaymentMethod(
             composeTestRule: ComposeTestRule,
             context: Context,
@@ -243,6 +245,6 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
 
 internal object PaymentSheetLayoutTypeProvider : TestParameterValuesProvider() {
     override fun provideValues(context: Context?): List<PaymentSheetLayoutType> {
-       return listOf(PaymentSheetLayoutType.Vertical(), PaymentSheetLayoutType.Horizontal())
+       return listOf(PaymentSheetLayoutType.Vertical, PaymentSheetLayoutType.Horizontal)
     }
 }


### PR DESCRIPTION
# Summary
Clean up instrumentation test naming so that instance IDs are not included and no enum numbering prefixes the test name.

# Motivation
Helps ensure quarantining tests are possible since the names are now reproducible.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified