### PR TITLE
Document nullable field default convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Multi-module Android library for payment processing and financial services.
 - Dagger/Hilt DI in some modules; binary-compatibility-validator for API compat
 - Gradle with shared deps (dependencies.gradle), AGP 8.13.x, Kotlin 2.3.x
 - Detekt for static analysis, Paparazzi for screenshot testing
+- Nullable field defaults: public models give nullable fields `= null` for ergonomic construction; non-public models (`internal` or `@RestrictTo`) omit defaults to force explicit decisions at each call site
 
 **Testing** — MUST invoke the relevant skill before writing any test code:
 - `write-unit-tests` — unit test structure, runScenario pattern, Turbine Flow testing, Truth assertions


### PR DESCRIPTION
## Summary
- Adds a convention note to CLAUDE.md: public models give nullable fields `= null` defaults for ergonomic construction, while internal models (`@RestrictTo`) omit defaults to force explicit decisions at each call site.
- Based on analysis of existing `StripeParamsModel` data classes in payments-core (Address, ConfirmPaymentIntentParams, ClientAttributionMetadata, RadarOptions, etc.)

## Motivation
No detekt/lint rule enforces this, but the codebase already follows this pattern consistently. Documenting it helps maintain consistency for future contributions.

## Test plan
- [ ] N/A — documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)