### PR TITLE
Rename UnmatchedRequest.describe() to toString()

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -99,7 +99,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     }
 
     private fun extraRequestDescriptions(): String {
-        return unmatchedRequests.joinToString(separator = "\n\n") { it.describe() }
+        return unmatchedRequests.joinToString(separator = "\n\n")
     }
 
     override fun dispatch(request: RecordedRequest): MockResponse {
@@ -162,7 +162,7 @@ private class UnmatchedRequest(
     val bodyParams: Map<String, String>,
     val diagnostics: String,
 ) {
-    fun describe(): String {
+    override fun toString(): String {
         val lines = mutableListOf("$method $url")
         if (bodyParams.isNotEmpty()) {
             lines.add("  Body params: $bodyParams")


### PR DESCRIPTION
## Summary
- Renames `UnmatchedRequest.describe()` to `override fun toString()` for more idiomatic Kotlin
- Simplifies the `joinToString` call site since `toString()` is used by default

Addresses review feedback from #13007: https://github.com/stripe/stripe-android/pull/13007#discussion_r3191057141

## Motivation
`UnmatchedRequest` is a small private class whose sole purpose is to render itself as a diagnostic string. Overriding `toString()` is the idiomatic way to express this in Kotlin.

## Testing
No behavior change — the output is identical.