### PR TITLE
Fix flaky `TapToAdd` tests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -112,6 +112,8 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
                 )
 
                 context.flowController.confirm()
+
+                context.consumeNullPaymentOptionEventForFlowController()
             }
 
             override fun markTestSucceeded() {
@@ -168,6 +170,8 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
             assertThat(paymentOption?.paymentMethodType).isEqualTo("card")
 
             context.confirm()
+
+            assertThat(context.paymentOptionTurbine.awaitItem()).isNull()
         }
 
         protected fun hasPrimaryButton(): Boolean {


### PR DESCRIPTION
# Summary
Fix flaky `TapToAdd` tests by consuming the null payment option emitted at the end of `Embedded` and `FlowController` after confirming.

# Motivation
Stabilizes TTA tests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified