### PR TITLE
Reduce redundancy in CI unit tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,7 +93,7 @@ workflows:
       - script@1:
           timeout: 1200
           inputs:
-            - content: ./gradlew testDebugUnitTest verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest --init-script build-configuration/unit-test-init.gradle --continue
+            - content: ./gradlew runUnitAndScreenshotTests --init-script build-configuration/unit-test-init.gradle --continue
       - bundle::export_unit_test_results:
           title: Export unit & screenshot test results
           inputs:

--- a/build.gradle
+++ b/build.gradle
@@ -159,3 +159,33 @@ subprojects {
         }
     }
 }
+
+tasks.register("runUnitAndScreenshotTests") {
+    group = "verification"
+    description =
+            "Runs verifyPaparazziDebug where Paparazzi is applied (else testDebugUnitTest or test); " +
+                    "other projects run testDebugUnitTest or plain test. Skips :stripe-test-e2e."
+}
+
+gradle.projectsEvaluated {
+    tasks.named("runUnitAndScreenshotTests").configure {
+        rootProject.subprojects.each { Project sub ->
+            if (sub.path == ":stripe-test-e2e") {
+                return
+            }
+
+            def selected = null
+
+            if (sub.plugins.hasPlugin("app.cash.paparazzi")) {
+                selected = sub.tasks.findByName("verifyPaparazziDebug")
+                    ?: sub.tasks.findByName("testDebugUnitTest")
+            } else {
+                selected = sub.tasks.findByName("testDebugUnitTest")
+            }
+
+            if (selected != null) {
+                dependsOn(selected)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Reduce redundancy in CI unit & screenshot tests by only running one of `verifyPaparazziDebug` or `testDebugUnitTest` based on the module. `verifyPaparazziDebug` runs `testDebugUnitTest` internally, causing all the unit tests to be ran again.

# Motivation
Improved CI times and less wasted operations.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
