### PR TITLE
Use `org.gradle.test-retry` plugin for retries with unit & screenshot tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,7 +93,7 @@ workflows:
       - script@1:
           timeout: 1200
           inputs:
-            - content: ./scripts/retry.sh 3 ./gradlew testDebugUnitTest verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest --continue
+            - content: ./gradlew testDebugUnitTest verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest --continue
   build-connect-debug:
     envs:
       - BUILD_VARIANT: debug

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -5,6 +5,7 @@
  */
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
+apply plugin: "org.gradle.test-retry"
 if (project.hasProperty("enable_dokka") && project.enable_dokka) {
     apply plugin: "org.jetbrains.dokka"
 }
@@ -90,6 +91,16 @@ android {
 
         compilerOptions {
             jvmTarget.set("JVM_11")
+        }
+    }
+}
+
+tasks.withType(Test).configureEach {
+    if (gradle.ext.isCi) {
+        retry {
+            maxRetries.set(2)
+            maxFailures.set(20)
+            failOnPassedAfterRetry.set(false)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '2.2.21' apply false
     id 'com.emergetools.android' version '4.4.0' apply false
     id 'com.google.dagger.hilt.android' version '2.58' apply false
+    id 'org.gradle.test-retry' version "1.6.4" apply false
 }
 
 apply plugin: "dev.detekt"


### PR DESCRIPTION
# Summary
Use `org.gradle.test-retry` plugin for retries with unit & screenshot tests to reduce redundancy of re-running the whole test suite on a flaky test. The plugin re-runs the failed test on its own to handle flakiness and outputs all the runs in its JUnit report.

# Motivation
Improve test CI pipeline time, reduce test redundancy, and also better report flaky tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified