### PR TITLE
[link] Thread Link brand to PaymentOptionsItem

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -27,6 +27,7 @@ import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.R
@@ -152,6 +153,7 @@ internal fun SelectPaymentMethod(
             paymentMethods = viewState.savedPaymentMethods,
             showGooglePay = viewState.showGooglePay,
             showLink = false,
+            linkBrand = LinkBrand.Link,
             currentSelection = viewState.paymentSelection,
             nameProvider = paymentMethodNameProvider,
             isCbcEligible = viewState.isCbcEligible,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -19,7 +20,9 @@ sealed class PaymentOptionsItem {
         override val isEnabledDuringEditing: Boolean = false
     }
 
-    internal object Link : PaymentOptionsItem() {
+    internal data class Link(
+        val linkBrand: LinkBrand,
+    ) : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.Link
         override val isEnabledDuringEditing: Boolean = false
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -100,15 +100,11 @@ private fun List<PaymentOptionsItem>.findSelectedItem(paymentSelection: PaymentS
     }
 }
 
-internal fun PaymentOptionsItem.toPaymentSelection(linkBrand: LinkBrand?): PaymentSelection? {
+internal fun PaymentOptionsItem.toPaymentSelection(): PaymentSelection? {
     return when (this) {
         is PaymentOptionsItem.AddCard -> null
         is PaymentOptionsItem.GooglePay -> PaymentSelection.GooglePay
-        is PaymentOptionsItem.Link -> linkBrand?.let { PaymentSelection.Link(it) }
+        is PaymentOptionsItem.Link -> PaymentSelection.Link(linkBrand)
         is PaymentOptionsItem.SavedPaymentMethod -> PaymentSelection.Saved(paymentMethod)
     }
-}
-
-internal fun PaymentOptionsItem.Link.toPaymentSelection(linkBrand: LinkBrand): PaymentSelection.Link {
-    return PaymentSelection.Link(brand = linkBrand)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -17,6 +17,7 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
+        linkBrand: LinkBrand,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         isCbcEligible: Boolean,
         defaultPaymentMethodId: String?,
@@ -24,7 +25,7 @@ internal object PaymentOptionsStateFactory {
         return listOfNotNull(
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay.takeIf { showGooglePay },
-            PaymentOptionsItem.Link.takeIf { showLink }
+            PaymentOptionsItem.Link(linkBrand).takeIf { showLink }
         ) + paymentMethods.map {
             PaymentOptionsItem.SavedPaymentMethod(
                 DisplayableSavedPaymentMethod.create(
@@ -50,6 +51,7 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
+        linkBrand: LinkBrand,
         currentSelection: PaymentSelection?,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         isCbcEligible: Boolean,
@@ -59,6 +61,7 @@ internal object PaymentOptionsStateFactory {
             paymentMethods = paymentMethods,
             showGooglePay = showGooglePay,
             showLink = showLink,
+            linkBrand = linkBrand,
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible,
             defaultPaymentMethodId = defaultPaymentMethodId

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -74,6 +74,7 @@ internal class SavedPaymentMethodMutator(
             customerState = customerStateHolder.customer,
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
             isLinkEnabled = isLinkEnabled,
+            linkBrand = paymentMethodMetadataFlow.mapAsStateFlow { it?.linkState?.configuration?.linkBrand },
             isNotPaymentFlow = isNotPaymentFlow,
             nameProvider = { paymentMethodMetadataFlow.value?.displayNameForCode(it).orEmpty() },
             isCbcEligible = { paymentMethodMetadataFlow.value?.cbcEligibility is CardBrandChoiceEligibility.Eligible },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -182,7 +182,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
 
 private val PREVIEW_PAYMENT_OPTION_ITEMS = listOf(
     PaymentOptionsItem.AddCard,
-    PaymentOptionsItem.Link,
+    PaymentOptionsItem.Link(LinkBrand.Link),
     PaymentOptionsItem.GooglePay,
     PaymentOptionsItem.SavedPaymentMethod(
         DisplayableSavedPaymentMethod.create(
@@ -310,7 +310,7 @@ private fun SavedPaymentMethodTab(
                 width = width,
                 isEnabled = isEnabled,
                 isSelected = isSelected,
-                linkBrand = requireNotNull(linkBrand), // non-null: Link tab only shown when linkState != null
+                linkBrand = item.linkBrand,
                 onItemSelected = onItemSelected,
                 modifier = modifier,
             )
@@ -399,9 +399,9 @@ private fun LinkTab(
         isEnabled = isEnabled,
         iconRes = getLinkIcon(showNightIcon = !MaterialTheme.stripeColors.component.shouldUseDarkDynamicColor()),
         iconTint = null,
-        labelText = stringResource(StripeR.string.stripe_link),
-        description = stringResource(StripeR.string.stripe_link),
-        onItemSelectedListener = { onItemSelected(PaymentOptionsItem.Link.toPaymentSelection(linkBrand)) },
+        labelText = linkBrand.brandName(),
+        description = linkBrand.brandName(),
+        onItemSelectedListener = { onItemSelected(PaymentSelection.Link(brand = linkBrand)) },
         cardArtUrl = null,
         modifier = modifier,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -318,7 +318,6 @@ private fun SavedPaymentMethodTab(
         is PaymentOptionsItem.SavedPaymentMethod -> {
             SavedPaymentMethodTab(
                 paymentMethod = item,
-                linkBrand = linkBrand,
                 width = width,
                 isEnabled = isEnabled,
                 isEditing = isEditing,
@@ -410,7 +409,6 @@ private fun LinkTab(
 @Composable
 private fun SavedPaymentMethodTab(
     paymentMethod: PaymentOptionsItem.SavedPaymentMethod,
-    linkBrand: LinkBrand?,
     width: Dp,
     isEnabled: Boolean,
     isEditing: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -459,7 +459,7 @@ private fun SavedPaymentMethodTab(
                 .resolve()
                 .readNumbersAsIndividualDigits(),
             onItemSelectedListener = {
-                onItemSelected(paymentMethod.toPaymentSelection(linkBrand))
+                onItemSelected(paymentMethod.toPaymentSelection())
             },
             modifier = modifier,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.viewmodels
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -15,6 +16,7 @@ internal class PaymentOptionsItemsMapper(
     private val customerState: StateFlow<CustomerState?>,
     private val isGooglePayReady: StateFlow<Boolean>,
     private val isLinkEnabled: StateFlow<Boolean?>,
+    private val linkBrand: StateFlow<LinkBrand?>,
     private val nameProvider: (PaymentMethodCode?) -> ResolvableString,
     private val isNotPaymentFlow: Boolean,
     private val isCbcEligible: () -> Boolean
@@ -26,11 +28,13 @@ internal class PaymentOptionsItemsMapper(
             isLinkEnabled,
             isGooglePayReady,
             customerMetadata,
-        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata ->
+            linkBrand,
+        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata, linkBrand ->
             createPaymentOptionsItems(
                 paymentMethods = customerState?.paymentMethods ?: listOf(),
                 isLinkEnabled = isLinkEnabled,
                 isGooglePayReady = isGooglePayReady,
+                linkBrand = linkBrand,
                 defaultPaymentMethodId = if (customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
                     customerState?.defaultPaymentMethodId
                 } else {
@@ -45,6 +49,7 @@ internal class PaymentOptionsItemsMapper(
         paymentMethods: List<PaymentMethod>,
         isLinkEnabled: Boolean?,
         isGooglePayReady: Boolean,
+        linkBrand: LinkBrand?,
         defaultPaymentMethodId: String?,
     ): List<PaymentOptionsItem>? {
         if (isLinkEnabled == null) return null
@@ -53,6 +58,8 @@ internal class PaymentOptionsItemsMapper(
             paymentMethods = paymentMethods,
             showGooglePay = isGooglePayReady && isNotPaymentFlow,
             showLink = isLinkEnabled && isNotPaymentFlow,
+            // linkBrand is non-null whenever showLink=true (Link is enabled only when LinkState is available)
+            linkBrand = linkBrand ?: LinkBrand.Link,
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible(),
             defaultPaymentMethodId = defaultPaymentMethodId,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -14,9 +14,9 @@ class PaymentOptionsStateFactoryTest {
     fun `non-Link payment options convert without LinkBrand`() {
         val savedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
-        assertThat(PaymentOptionsItem.AddCard.toPaymentSelection(linkBrand = null)).isNull()
+        assertThat(PaymentOptionsItem.AddCard.toPaymentSelection()).isNull()
         assertThat(
-            PaymentOptionsItem.GooglePay.toPaymentSelection(linkBrand = null)
+            PaymentOptionsItem.GooglePay.toPaymentSelection()
         ).isEqualTo(PaymentSelection.GooglePay)
         assertThat(
             PaymentOptionsItem.SavedPaymentMethod(
@@ -24,13 +24,13 @@ class PaymentOptionsStateFactoryTest {
                     displayName = "Card".resolvableString,
                     paymentMethod = savedPaymentMethod,
                 )
-            ).toPaymentSelection(linkBrand = null)
+            ).toPaymentSelection()
         ).isEqualTo(PaymentSelection.Saved(savedPaymentMethod))
     }
 
     @Test
     fun `Link payment option conversion requires LinkBrand`() {
-        assertThat(PaymentOptionsItem.Link.toPaymentSelection(LinkBrand.Notlink))
+        assertThat(PaymentOptionsItem.Link(linkBrand = LinkBrand.Notlink).toPaymentSelection())
             .isEqualTo(PaymentSelection.Link(brand = LinkBrand.Notlink))
     }
 
@@ -43,6 +43,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = true,
             showLink = true,
+            linkBrand = LinkBrand.Link,
             currentSelection = PaymentSelection.Saved(paymentMethod),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
@@ -61,6 +62,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
+            linkBrand = LinkBrand.Link,
             currentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
@@ -124,6 +126,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
+            linkBrand = LinkBrand.Link,
             currentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = isCbcEligible,
@@ -174,6 +177,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = true,
             showLink = true,
+            linkBrand = LinkBrand.Link,
             currentSelection = PaymentSelection.Saved(defaultPaymentMethod),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
@@ -195,6 +199,7 @@ class PaymentOptionsStateFactoryTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
+            linkBrand = LinkBrand.Link,
             currentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -193,13 +193,13 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(
                     paymentMethods = PaymentMethodFixtures.createCards(2),
-                ).plus(PaymentOptionsItem.Link)
+                ).plus(PaymentOptionsItem.Link(LinkBrand.Link))
             ),
             currentSelection = currentSelectionFlow,
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link(LinkBrand.Link))
                 }
             }
         }
@@ -214,13 +214,13 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(
                     paymentMethods = PaymentMethodFixtures.createCards(2),
-                ).plus(PaymentOptionsItem.Link).plus(PaymentOptionsItem.GooglePay)
+                ).plus(PaymentOptionsItem.Link(LinkBrand.Link)).plus(PaymentOptionsItem.GooglePay)
             ),
             currentSelection = currentSelectionFlow,
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link(LinkBrand.Link))
                 }
             }
 
@@ -243,13 +243,13 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(
                     paymentMethods = PaymentMethodFixtures.createCards(2),
-                ).plus(PaymentOptionsItem.Link)
+                ).plus(PaymentOptionsItem.Link(LinkBrand.Link))
             ),
             currentSelection = currentSelectionFlow,
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link(LinkBrand.Link))
                 }
             }
 
@@ -257,7 +257,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link)
+                    assertThat(selectedPaymentOptionsItem).isEqualTo(PaymentOptionsItem.Link(LinkBrand.Link))
                 }
             }
         }
@@ -379,7 +379,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
         runScenario(
             paymentOptionsItems = MutableStateFlow(
                 createPaymentOptionsItems(paymentMethods = paymentMethods).plus(
-                    PaymentOptionsItem.Link
+                    PaymentOptionsItem.Link(LinkBrand.Link)
                 )
             ),
             currentSelection = currentSelectionFlow,
@@ -400,7 +400,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             interactor.state.test {
                 awaitItem().run {
                     assertThat(selectedPaymentOptionsItem).isEqualTo(
-                        PaymentOptionsItem.Link
+                        PaymentOptionsItem.Link(LinkBrand.Link)
                     )
                 }
             }
@@ -469,6 +469,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             paymentMethods = paymentMethods,
             showGooglePay = false,
             showLink = false,
+            linkBrand = LinkBrand.Link,
             currentSelection = PaymentSelection.Saved(paymentMethods[0]),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreenshotTest.kt
@@ -22,9 +22,9 @@ class PaymentOptionsScreenshotTest {
         createSavedPaymentMethodTabLayoutUiScreenshot(
             paymentOptionsItems = listOf(
                 PaymentOptionsItem.AddCard,
-                PaymentOptionsItem.Link,
+                PaymentOptionsItem.Link(LinkBrand.Link),
             ),
-            selectedPaymentOptionsItem = PaymentOptionsItem.Link,
+            selectedPaymentOptionsItem = PaymentOptionsItem.Link(LinkBrand.Link),
             isEditing = false,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.getDefaultCustomerMetadataFlow
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -22,6 +23,7 @@ class PaymentOptionsItemsMapperTest {
     private val customerStateFlow = MutableStateFlow<CustomerState?>(null)
     private val isGooglePayReadyFlow = MutableStateFlow(false)
     private val isLinkEnabledFlow = MutableStateFlow<Boolean?>(null)
+    private val linkBrandFlow = MutableStateFlow<LinkBrand?>(null)
 
     @Test
     fun `Only emits value if required flows have emitted values`() = runTest {
@@ -29,6 +31,7 @@ class PaymentOptionsItemsMapperTest {
             customerState = customerStateFlow,
             isGooglePayReady = isGooglePayReadyFlow,
             isLinkEnabled = isLinkEnabledFlow,
+            linkBrand = linkBrandFlow,
             isNotPaymentFlow = true,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },
@@ -43,6 +46,7 @@ class PaymentOptionsItemsMapperTest {
             )
             isGooglePayReadyFlow.value = true
             isLinkEnabledFlow.value = true
+            linkBrandFlow.value = LinkBrand.Link
 
             val state = awaitItem()
             assertThat(state).hasSize(5)
@@ -60,6 +64,7 @@ class PaymentOptionsItemsMapperTest {
             customerState = customerStateFlow,
             isGooglePayReady = isGooglePayReadyFlow,
             isLinkEnabled = isLinkEnabledFlow,
+            linkBrand = linkBrandFlow,
             isNotPaymentFlow = false,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },
@@ -77,7 +82,7 @@ class PaymentOptionsItemsMapperTest {
 
             assertThat(awaitItem()).containsNoneOf(
                 PaymentOptionsItem.GooglePay,
-                PaymentOptionsItem.Link,
+                PaymentOptionsItem.Link(LinkBrand.Link),
             )
         }
     }
@@ -110,6 +115,7 @@ class PaymentOptionsItemsMapperTest {
             customerState = customerStateFlow,
             isGooglePayReady = isGooglePayReadyFlow,
             isLinkEnabled = isLinkEnabledFlow,
+            linkBrand = linkBrandFlow,
             isNotPaymentFlow = false,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },


### PR DESCRIPTION
# Summary
Fix `SavedPaymentMethodTabLayoutUI` to use dynamic brand name, which requires adding `linkBrand` to `PaymentOptionsItem`. This helps eliminate some of the `requireNotNull` riffraff from the previous PR.

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-812

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

Flow controller - now shows Notlink when selected payment method
<img width=400 alt="image" src="https://github.com/user-attachments/assets/524e72ba-eef1-421a-ad77-fec953054e1f" />

# Changelog
n/a