### PR TITLE
Handle SecurityException when launching custom tabs.

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.connect
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.RestrictTo
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 
 /**
@@ -34,8 +36,17 @@ class StripeConnectRedirectActivity : Activity() {
             //  - this activity having launchMode="singleTask"
             //  - intent flags FLAG_ACTIVITY_SINGLE_TOP and FLAG_ACTIVITY_CLEAR_TOP
             // With the task cleared, the activity finishes in `onNewIntent()`
-            val customTabsIntent = CustomTabsIntent.Builder().build()
-            customTabsIntent.launchUrl(this, Uri.parse(customTabUrl))
+            try {
+                val customTabsIntent = CustomTabsIntent.Builder().build()
+                CustomTabsClient.getPackageName(this, null)?.let { browserPackage ->
+                    customTabsIntent.intent.setPackage(browserPackage)
+                }
+                customTabsIntent.launchUrl(this, Uri.parse(customTabUrl))
+            } catch (_: ActivityNotFoundException) {
+                finish()
+            } catch (_: SecurityException) {
+                finish()
+            }
         } else {
             // Shouldn't happen under normal circumstances -- just finish.
             finish()

--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections.lite
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -17,6 +18,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.annotation.RestrictTo
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
@@ -156,12 +158,21 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
     }
 
     private fun openCustomTab(uri: String) {
-        CustomTabsIntent.Builder()
-            .setShowTitle(true)
-            .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
-            .setBookmarksButtonEnabled(false)
-            .build()
-            .launchUrl(this, uri.toUri())
+        try {
+            val customTabsIntent = CustomTabsIntent.Builder()
+                .setShowTitle(true)
+                .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+                .setBookmarksButtonEnabled(false)
+                .build()
+            CustomTabsClient.getPackageName(this, null)?.let { browserPackage ->
+                customTabsIntent.intent.setPackage(browserPackage)
+            }
+            customTabsIntent.launchUrl(this, uri.toUri())
+        } catch (_: ActivityNotFoundException) {
+            finish()
+        } catch (_: SecurityException) {
+            finish()
+        }
     }
 
     private fun handleUrl(uri: Uri?): Boolean {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -131,11 +132,17 @@ internal class FinancialConnectionsSheetActivity : AppCompatActivity() {
     ) {
         when (viewEffect) {
             is OpenAuthFlowWithUrl -> {
-                startBrowserForResult.launch(
-                    browserManager.createBrowserIntentForUrl(
-                        uri = Uri.parse(viewEffect.url)
+                try {
+                    startBrowserForResult.launch(
+                        browserManager.createBrowserIntentForUrl(
+                            uri = Uri.parse(viewEffect.url)
+                        )
                     )
-                )
+                } catch (_: ActivityNotFoundException) {
+                    // No browser available on the device.
+                } catch (_: SecurityException) {
+                    // A non-exported activity on the device matched the URL intent filter.
+                }
             }
 
             is FinishWithResult -> {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/browser/BrowserManager.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/browser/BrowserManager.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import javax.inject.Inject
 
@@ -51,7 +52,12 @@ internal class BrowserManager @Inject constructor(
     private fun createCustomTabIntent(uri: Uri): Intent = CustomTabsIntent.Builder()
         .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
         .build()
-        .also { it.intent.data = uri }
+        .also { customTabsIntent ->
+            customTabsIntent.intent.data = uri
+            CustomTabsClient.getPackageName(context, null)?.let { browserPackage ->
+                customTabsIntent.intent.setPackage(browserPackage)
+            }
+        }
         .intent
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/CustomTabUriHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/CustomTabUriHandler.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.ui
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.net.Uri
 import androidx.compose.ui.platform.UriHandler
@@ -14,8 +15,14 @@ internal class CustomTabUriHandler(
     private val browserManager: BrowserManager
 ) : UriHandler {
     override fun openUri(uri: String) {
-        context.startActivity(
-            browserManager.createBrowserIntentForUrl(uri = Uri.parse(uri))
-        )
+        try {
+            context.startActivity(
+                browserManager.createBrowserIntentForUrl(uri = Uri.parse(uri))
+            )
+        } catch (_: ActivityNotFoundException) {
+            // No browser available on the device.
+        } catch (_: SecurityException) {
+            // A non-exported activity on the device matched the URL intent filter.
+        }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.ui
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -133,9 +134,15 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity() {
                 .filterNotNull()
                 .collect { viewEffect ->
                     when (viewEffect) {
-                        is OpenUrl -> startActivity(
-                            browserManager.createBrowserIntentForUrl(uri = Uri.parse(viewEffect.url))
-                        )
+                        is OpenUrl -> try {
+                            startActivity(
+                                browserManager.createBrowserIntentForUrl(uri = Uri.parse(viewEffect.url))
+                            )
+                        } catch (_: ActivityNotFoundException) {
+                            // No browser available on the device.
+                        } catch (_: SecurityException) {
+                            // A non-exported activity on the device matched the URL intent filter.
+                        }
 
                         is Finish -> {
                             setResult(

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -76,6 +76,13 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
                     stripeException = StripeException.create(e),
                 )
             finishWithFailure(args)
+        } catch (e: SecurityException) {
+            ErrorReporter.createFallbackInstance(applicationContext)
+                .report(
+                    errorEvent = ErrorReporter.ExpectedErrorEvent.BROWSER_LAUNCHER_ACTIVITY_NOT_FOUND,
+                    stripeException = StripeException.create(e),
+                )
+            finishWithFailure(args)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -3,6 +3,7 @@ package com.stripe.android.payments
 import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -26,6 +27,7 @@ internal class StripeBrowserLauncherViewModel(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     private val browserCapabilities: BrowserCapabilities,
+    private val customTabsPackage: String?,
     private val resolveErrorMessage: String,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -75,6 +77,7 @@ internal class StripeBrowserLauncherViewModel(
             .build()
             .apply {
                 intent.data = url
+                customTabsPackage?.let { intent.setPackage(it) }
             }
     }
 
@@ -136,6 +139,7 @@ internal class StripeBrowserLauncherViewModel(
                     publishableKey = config.publishableKey,
                 ),
                 browserCapabilities = browserCapabilitiesSupplier.get(),
+                customTabsPackage = CustomTabsClient.getPackageName(application, null),
                 resolveErrorMessage = application.getString(R.string.stripe_failure_reason_authentication),
                 savedStateHandle = savedStateHandle,
             ) as T

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -100,6 +100,7 @@ class StripeBrowserLauncherViewModelTest {
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = analyticsRequestFactory,
             browserCapabilities = browserCapabilities,
+            customTabsPackage = null,
             resolveErrorMessage = "Unable to resolve things",
             savedStateHandle = savedStateHandle,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkForegroundActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkForegroundActivity.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
 
@@ -84,11 +85,17 @@ internal class LinkForegroundActivity : AppCompatActivity() {
             return
         }
         try {
-            CustomTabsIntent.Builder()
+            val customTabsIntent = CustomTabsIntent.Builder()
                 .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
                 .build()
-                .launchUrl(this, popupUri)
+            CustomTabsClient.getPackageName(this, null)?.let { browserPackage ->
+                customTabsIntent.intent.setPackage(browserPackage)
+            }
+            customTabsIntent.launchUrl(this, popupUri)
         } catch (e: ActivityNotFoundException) {
+            setResult(RESULT_FAILURE, Intent().putExtra(EXTRA_FAILURE, e))
+            finish()
+        } catch (e: SecurityException) {
             setResult(RESULT_FAILURE, Intent().putExtra(EXTRA_FAILURE, e))
             finish()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkForegroundActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkForegroundActivityTest.kt
@@ -61,6 +61,22 @@ internal class LinkForegroundActivityTest {
     }
 
     @Test
+    fun `finishes with a failure result when security exception is thrown`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        intending(anyIntent()).respondWithFunction {
+            throw SecurityException("Permission Denial: activity not exported")
+        }
+
+        val scenario = ActivityScenario.launchActivityForResult<LinkForegroundActivity>(intent)
+        assertThat(scenario.result.resultCode)
+            .isEqualTo(LinkForegroundActivity.RESULT_FAILURE)
+    }
+
+    @Test
     fun `launches chrome custom tabs with url onResume`() {
         val intent = LinkForegroundActivity.createIntent(
             context = ApplicationProvider.getApplicationContext(),


### PR DESCRIPTION
# Summary
Added SecurityException handling when launching custom tabs across multiple SDK components to prevent crashes when a non-exported activity matches the URL intent filter.

# Motivation
When launching custom tabs, the SDK can crash with a SecurityException if a non-exported activity on the device matches the URL intent filter. This adds proper exception handling to gracefully handle these cases and prevent app crashes.

Fixes https://github.com/stripe/stripe-android/issues/13041

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
[Fixed] Fixed potential crash when launching custom tabs if a non-exported activity matches the URL intent filter.