### PR TITLE
Fix PaymentMethodMessagingElement test cleanup and idle sync.

### DIFF
--- a/payment-method-messaging/src/androidTest/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingElementTest.kt
+++ b/payment-method-messaging/src/androidTest/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingElementTest.kt
@@ -39,7 +39,7 @@ class PaymentMethodMessagingElementTest {
     )
 
     @Test
-    fun testNoContent() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testNoContent() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         networkRule.enqueue(getConfigRequestMatcher) { response ->
             response.testBodyFromFile("no-content.json")
         }
@@ -50,7 +50,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testSinglePartner() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testSinglePartner() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         networkRule.enqueue(getConfigRequestMatcher) { response ->
             response.testBodyFromFile("single-partner.json")
         }
@@ -63,7 +63,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testMultiPartner() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testMultiPartner() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         networkRule.enqueue(getConfigRequestMatcher) { response ->
             response.testBodyFromFile("multi-partner.json")
         }
@@ -77,7 +77,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testError() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testError() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         networkRule.enqueue(getConfigRequestMatcher) { response ->
             response.setResponseCode(400)
             response.testBodyFromFile("error-invalid-currency.json")
@@ -93,7 +93,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testUpdatesContentOnConfigChange() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testUpdatesContentOnConfigChange() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         networkRule.enqueue(getConfigRequestMatcher) { response ->
             response.testBodyFromFile("single-partner.json")
         }
@@ -117,7 +117,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testMalformedResponse() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testMalformedResponse() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         networkRule.enqueue(getConfigRequestMatcher) { response ->
             response.setBody("{}")
         }
@@ -129,7 +129,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testMultiPartnerLegalDisclosure() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testMultiPartnerLegalDisclosure() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         val replacement = ResponseReplacement(
             original = """
                 "legal_disclosure": null
@@ -152,7 +152,7 @@ class PaymentMethodMessagingElementTest {
     }
 
     @Test
-    fun testSinglePartnerLegalDisclosure() = runPaymentMethodMessagingElementTest { testContext ->
+    fun testSinglePartnerLegalDisclosure() = runPaymentMethodMessagingElementTest(composeTestRule) { testContext ->
         val replacement = ResponseReplacement(
             original = """
                 "legal_disclosure": null

--- a/payment-method-messaging/src/androidTest/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingTestRunner.kt
+++ b/payment-method-messaging/src/androidTest/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingTestRunner.kt
@@ -5,6 +5,7 @@ package com.stripe.android.paymentmethodmessaging.element
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import com.stripe.android.PaymentConfiguration
@@ -31,6 +32,7 @@ internal class PaymentMethodMessagingElementTestRunnerContext(
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal fun runPaymentMethodMessagingElementTest(
+    composeTestRule: ComposeTestRule,
     block: suspend (PaymentMethodMessagingElementTestRunnerContext) -> Unit
 ) {
     val factory: (ComponentActivity) -> PaymentMethodMessagingElement = {
@@ -62,5 +64,8 @@ internal fun runPaymentMethodMessagingElementTest(
         runTest {
             block(testContext)
         }
+
+        composeTestRule.waitForIdle()
+        scenario.moveToState(Lifecycle.State.CREATED)
     }
 }


### PR DESCRIPTION
# Summary
Added proper test cleanup and idle synchronization to PaymentMethodMessagingElement tests by passing ComposeTestRule and ensuring tests wait for idle state before teardown.

# Motivation
The tests were not properly waiting for Compose to finish rendering and cleaning up resources, which could lead to flaky tests or resource leaks. This change ensures proper synchronization and lifecycle management.

# Testing
- [x] Modified tests
- [x] Manually verified