### PR TITLE
Add wait conditions to Financial Connections Maestro tests.

### DIFF
--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
@@ -13,6 +13,10 @@ tags:
     &merchant=networking\
     &financial_connections_test_mode=true\
     &stripe_account_id=acct_1PnnD9CY58qxxwvr"
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
@@ -13,13 +13,10 @@ tags:
     &merchant=networking\
     &financial_connections_test_mode=true\
     &stripe_account_id=acct_1PnnD9CY58qxxwvr"
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"
+    timeout: 30000
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -7,13 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=testmode&financial_connections_test_mode=true
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"
+    timeout: 30000
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -7,6 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-data-testoauthinstitution-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Data&financial_connections_override_native=native&merchant=testmode&financial_connections_test_mode=true
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
@@ -7,6 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-instantdebits-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=InstantDebits&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=false
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "Customer email setting"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
@@ -7,13 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-instantdebits-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=InstantDebits&flow=PaymentIntent&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=transactions,payment_method&financial_connections_confirm_intent=false
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "Customer email setting"
+    timeout: 30000
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -7,6 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=payment_method
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -7,13 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-networking-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=payment_method
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"
+    timeout: 30000
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -7,6 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -7,13 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-paymentintent-testinstitution-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=PaymentIntent&financial_connections_override_native=native&merchant=testmode&permissions=payment_method&financial_connections_test_mode=true&financial_connections_confirm_intent=true
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"
+    timeout: 30000
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -7,13 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Token&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=balances,payment_method
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"
+    timeout: 30000
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -7,6 +7,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-token_manualentry-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?integration_type=Standalone&experience=FinancialConnections&flow=Token&financial_connections_override_native=native&financial_connections_test_mode=true&merchant=testmode&permissions=balances,payment_method
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Token-NME.yaml
+++ b/maestro/financial-connections/Testmode-Token-NME.yaml
@@ -10,6 +10,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-nme-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Token&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=payment_method&financial_connections_confirm_intent=true
+- extendedWaitUntil:
+    visible:
+      id: "connect_accounts"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"

--- a/maestro/financial-connections/Testmode-Token-NME.yaml
+++ b/maestro/financial-connections/Testmode-Token-NME.yaml
@@ -10,13 +10,10 @@ tags:
 - startRecording: ${'/tmp/test_results/testmode-nme-' + new Date().getTime()}
 - clearState
 - openLink: stripeconnectionsexample://playground?experience=FinancialConnections&flow=Token&financial_connections_override_native=native&merchant=networking&financial_connections_test_mode=true&permissions=payment_method&financial_connections_confirm_intent=true
-- extendedWaitUntil:
-    visible:
-      id: "connect_accounts"
-    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "connect_accounts"
+    timeout: 30000
 - tapOn:
     id: "Customer email setting"
 - inputRandomEmail


### PR DESCRIPTION
# Summary
Added `extendedWaitUntil` conditions to Financial Connections Maestro test files to wait for the "connect_accounts" element to be visible before proceeding with test execution.

# Motivation
The tests were likely experiencing flakiness or failures due to timing issues where the "connect_accounts" element wasn't fully loaded before the test tried to interact with it. Adding explicit wait conditions ensures the element is visible before scrolling to it, improving test reliability.

# Testing
- [x] Modified tests
- [x] Manually verified

# Changelog
No changes needed - this is an internal test improvement that doesn't affect SDK users.