### PR TITLE
Increase timeouts in OnrampFlowTest for test stability.

### DIFF
--- a/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
+++ b/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
@@ -43,7 +43,7 @@ class OnrampFlowTest {
         .around(RetryRule(3))
         .around(activityRule)
 
-    private val defaultTimeout: Duration = 15.seconds
+    private val defaultTimeout: Duration = 30.seconds
 
     private fun clearPrefs() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -97,11 +97,11 @@ class OnrampFlowTest {
         performClickOnNode("PrimaryButtonTag")
         performClickOnNode(CREATE_CRYPTO_TOKEN_BUTTON_TAG)
         performClickOnNode(CREATE_SESSION_BUTTON_TAG)
-        performClickOnNode(CHECKOUT_BUTTON_TAG, timeoutMs = 30.seconds.inWholeMilliseconds)
+        performClickOnNode(CHECKOUT_BUTTON_TAG, timeoutMs = 60.seconds.inWholeMilliseconds)
 
         composeRule.waitUntilExactlyOneExists(
             hasText("Checkout completed successfully!"),
-            timeoutMillis = 30.seconds.inWholeMilliseconds
+            timeoutMillis = 60.seconds.inWholeMilliseconds
         )
     }
 


### PR DESCRIPTION
# Summary
Increased timeout values in OnrampFlowTest to improve test reliability and reduce flakiness.

# Motivation
The OnrampFlowTest was experiencing intermittent failures due to insufficient timeout durations. The test involves creating crypto tokens and sessions which can take longer depending on network conditions and server response times. Increasing the timeouts from 15-30 seconds and 30-60 seconds helps ensure tests complete successfully even under slower conditions.

# Testing
- [x] Modified tests
- [x] Manually verified

# Changelog