### PR TITLE
Fix semantics node fetching to handle empty root cases.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1156,7 +1156,7 @@ internal class PlaygroundTestDriver(
         composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
                 .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT))
-                .fetchSemanticsNodes()
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }
 
@@ -1789,9 +1789,13 @@ internal class PlaygroundTestDriver(
         return composeTestRule.onNodeWithTag(ADD_PAYMENT_METHOD_NODE_TAG)
     }
 
-    @OptIn(ExperimentalTestApi::class)
     private fun waitForAddPaymentMethodNode() {
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag(ADD_PAYMENT_METHOD_NODE_TAG), 5000L)
+        composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            composeTestRule
+                .onAllNodesWithTag(ADD_PAYMENT_METHOD_NODE_TAG)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
     }
 
     @OptIn(ExperimentalTestApi::class)

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -372,8 +372,8 @@ internal class Selectors(
     }
 
     private fun ComposeTestRule.onNodeWithTextAfterWaiting(text: String): SemanticsNodeInteraction {
-        this.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
-            this.onAllNodes(hasText(text)).fetchSemanticsNodes().isNotEmpty()
+        waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            onAllNodes(hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
         }
         return this.onNodeWithText(
             text


### PR DESCRIPTION
# Summary
Updates the `fetchNodeWithTextAfterWaiting` function to handle cases where no root semantics nodes exist by setting `atLeastOneRootRequired = false` when fetching nodes.

# Motivation
The test was failing when attempting to fetch nodes in scenarios where the compose UI tree might be empty or in transition. By allowing the fetch to proceed without requiring at least one root, the test becomes more robust and handles edge cases gracthe UI is still initializing.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
[Fixed] Fixed test flakiness in UI tests when waiting for nodes with specific text.