### PR TITLE
[link] Thread Link brand into LinkTerms

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/model/LinkBrand.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/LinkBrand.kt
@@ -29,7 +29,7 @@ enum class LinkBrand(val value: String) {
 
     fun privacyUrl(): String = "${baseUrl()}/privacy"
 
-    fun achAuthorizationUrl(): String = "${baseUrl()}/terms/ach-authorization"
+    fun achAuthorizationTermsUrl(): String = "${baseUrl()}/terms/ach-authorization"
 
     internal object Serializer :
         EnumIgnoreUnknownSerializer<LinkBrand>(entries.toTypedArray(), Link)

--- a/payments-model/src/main/java/com/stripe/android/model/LinkBrand.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/LinkBrand.kt
@@ -20,6 +20,17 @@ enum class LinkBrand(val value: String) {
         Notlink -> "Notlink"
     }
 
+    fun baseUrl(): String = when (this) {
+        Link -> "https://link.com"
+        Notlink -> "https://onelink.com"
+    }
+
+    fun termsUrl(): String = "${baseUrl()}/terms"
+
+    fun privacyUrl(): String = "${baseUrl()}/privacy"
+
+    fun achAuthorizationUrl(): String = "${baseUrl()}/terms/ach-authorization"
+
     internal object Serializer :
         EnumIgnoreUnknownSerializer<LinkBrand>(entries.toTypedArray(), Link)
 }

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -259,16 +259,16 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_sign_up_terms"><![CDATA[By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
   <string name="stripe_sign_up_terms_alternative"><![CDATA[By providing your email, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a Link account with a phone number in the alternative flow. -->
-  <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a Link account in the alternative flow. -->
-  <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a non-Link branded account. -->
-  <string name="stripe_sign_up_terms_branded"><![CDATA[By joining %1$s, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a non-Link branded account in the alternative flow. -->
   <string name="stripe_sign_up_terms_alternative_branded"><![CDATA[By providing your email, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a Link account with a phone number in the alternative flow. -->
+  <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a non-Link branded account with a phone number in the alternative flow. -->
   <string name="stripe_sign_up_terms_alternative_with_phone_number_branded"><![CDATA[By providing your phone number, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a non-Link branded account. -->
+  <string name="stripe_sign_up_terms_branded"><![CDATA[By joining %1$s, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a Link account in the alternative flow. -->
+  <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a non-Link branded account in the alternative flow. -->
   <string name="stripe_sign_up_terms_default_opt_in_branded"><![CDATA[By providing phone number and email, you agree to create a %1$s account subject to the %1$s <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Message for a deactivated account in the signup flow. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -137,11 +137,13 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_off">By continuing, you agree to save your information for future purchases with %s.</string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link>. You also agree to %2$s\'s <terms>Terms</terms> and <privacy>Privacy</privacy>.]]></string>
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link>. You also agree to Link\'s <terms>Terms</terms> and <privacy>Privacy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> according to %2$s <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
+  <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> according to %2$s <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->
   <string name="stripe_paymentsheet_card_updates_failed_error_message">Card was not updated. Please try again.</string>
   <!-- Title shown above a carousel containing available payment methods -->
@@ -254,13 +256,21 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. Pay faster at {Merchant Name} and thousands of merchants. e.g, 'Pay faster at Example, Inc. and thousands of merchants.' -->
   <string name="stripe_sign_up_message">Pay faster at %s and thousands of businesses.</string>
   <!-- Legal text shown when creating a Link account. -->
-  <string name="stripe_sign_up_terms"><![CDATA[By joining %1$s, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms"><![CDATA[By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
-  <string name="stripe_sign_up_terms_alternative"><![CDATA[By providing your email, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms_alternative"><![CDATA[By providing your email, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account with a phone number in the alternative flow. -->
-  <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
-  <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a %1$s account subject to the %1$s <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a non-Link branded account. -->
+  <string name="stripe_sign_up_terms_branded"><![CDATA[By joining %1$s, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a non-Link branded account in the alternative flow. -->
+  <string name="stripe_sign_up_terms_alternative_branded"><![CDATA[By providing your email, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a non-Link branded account with a phone number in the alternative flow. -->
+  <string name="stripe_sign_up_terms_alternative_with_phone_number_branded"><![CDATA[By providing your phone number, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Legal text shown when creating a non-Link branded account in the alternative flow. -->
+  <string name="stripe_sign_up_terms_default_opt_in_branded"><![CDATA[By providing phone number and email, you agree to create a %1$s account subject to the %1$s <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Message for a deactivated account in the signup flow. -->
   <string name="stripe_signup_deactivated_account_message">Your account has been deactivated</string>
   <!-- Generic failure message -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -137,11 +137,11 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_off">By continuing, you agree to save your information for future purchases with %s.</string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link>. You also agree to Link\'s <terms>Terms</terms> and <privacy>Privacy</privacy>.]]></string>
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link>. You also agree to %2$s\'s <terms>Terms</terms> and <privacy>Privacy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
+  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> according to %2$s <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->
   <string name="stripe_paymentsheet_card_updates_failed_error_message">Card was not updated. Please try again.</string>
   <!-- Title shown above a carousel containing available payment methods -->
@@ -254,13 +254,13 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. Pay faster at {Merchant Name} and thousands of merchants. e.g, 'Pay faster at Example, Inc. and thousands of merchants.' -->
   <string name="stripe_sign_up_message">Pay faster at %s and thousands of businesses.</string>
   <!-- Legal text shown when creating a Link account. -->
-  <string name="stripe_sign_up_terms"><![CDATA[By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms"><![CDATA[By joining %1$s, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
-  <string name="stripe_sign_up_terms_alternative"><![CDATA[By providing your email, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms_alternative"><![CDATA[By providing your email, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account with a phone number in the alternative flow. -->
-  <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
-  <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a %1$s account subject to the %1$s <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Message for a deactivated account in the signup flow. -->
   <string name="stripe_signup_deactivated_account_message">Your account has been deactivated</string>
   <!-- Generic failure message -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -142,7 +142,7 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
-  <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
+  <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link, where a different brand name is supplied for Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> according to %2$s <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->
   <string name="stripe_paymentsheet_card_updates_failed_error_message">Card was not updated. Please try again.</string>
@@ -259,17 +259,17 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_sign_up_terms"><![CDATA[By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
   <string name="stripe_sign_up_terms_alternative"><![CDATA[By providing your email, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a non-Link branded account in the alternative flow. -->
+  <!-- Legal text shown when creating a Link account in the alternative flow, where a different brand name for Link is supplied. -->
   <string name="stripe_sign_up_terms_alternative_branded"><![CDATA[By providing your email, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account with a phone number in the alternative flow. -->
   <string name="stripe_sign_up_terms_alternative_with_phone_number"><![CDATA[By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the <terms>Link Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a non-Link branded account with a phone number in the alternative flow. -->
+  <!-- Legal text shown when creating a Link account with a phone number in the alternative flow, where a different brand name for Link is supplied. -->
   <string name="stripe_sign_up_terms_alternative_with_phone_number_branded"><![CDATA[By providing your phone number, you agree to create a %1$s account and save your payment info to %1$s, according to the <terms>%1$s Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a non-Link branded account. -->
+  <!-- Legal text shown when creating a Link account, where a different brand name for Link is supplied. -->
   <string name="stripe_sign_up_terms_branded"><![CDATA[By joining %1$s, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Legal text shown when creating a Link account in the alternative flow. -->
   <string name="stripe_sign_up_terms_default_opt_in"><![CDATA[By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
-  <!-- Legal text shown when creating a non-Link branded account in the alternative flow. -->
+  <!-- Legal text shown when creating a Link account in the alternative flow, where a different brand name for Link is supplied. -->
   <string name="stripe_sign_up_terms_default_opt_in_branded"><![CDATA[By providing phone number and email, you agree to create a %1$s account subject to the %1$s <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Message for a deactivated account in the signup flow. -->
   <string name="stripe_signup_deactivated_account_message">Your account has been deactivated</string>

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -34,16 +34,33 @@ internal fun LinkTerms(
     val brandName = linkBrand.brandName()
     val text = when (type) {
         LinkTermsType.InlineOptionalWithPhoneFirst -> {
-            stringResource(R.string.stripe_sign_up_terms_alternative_with_phone_number, brandName)
+            if (linkBrand == LinkBrand.Link) {
+                stringResource(R.string.stripe_sign_up_terms_alternative_with_phone_number)
+            } else {
+                stringResource(R.string.stripe_sign_up_terms_alternative_with_phone_number_branded, brandName)
+            }
         }
         LinkTermsType.InlineOptional -> {
-            stringResource(R.string.stripe_sign_up_terms_alternative, brandName)
+            if (linkBrand == LinkBrand.Link) {
+                stringResource(R.string.stripe_sign_up_terms_alternative)
+            } else {
+                stringResource(R.string.stripe_sign_up_terms_alternative_branded, brandName)
+            }
         }
         LinkTermsType.Inline -> {
-            stringResource(R.string.stripe_sign_up_terms, brandName)
+            if (linkBrand == LinkBrand.Link) {
+                stringResource(R.string.stripe_sign_up_terms)
+            } else {
+                stringResource(R.string.stripe_sign_up_terms_branded, brandName)
+            }
         }
         LinkTermsType.InlineWithDefaultOptIn -> {
-            "<img src=\"link_logo\"> • " + stringResource(R.string.stripe_sign_up_terms_default_opt_in, brandName)
+            val terms = if (linkBrand == LinkBrand.Link) {
+                stringResource(R.string.stripe_sign_up_terms_default_opt_in)
+            } else {
+                stringResource(R.string.stripe_sign_up_terms_default_opt_in_branded, brandName)
+            }
+            "<img src=\"link_logo\"> • $terms"
         }
         LinkTermsType.Full -> {
             stringResource(R.string.stripe_link_sign_up_terms)

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -31,18 +31,19 @@ internal fun LinkTerms(
     modifier: Modifier = Modifier,
     textAlign: TextAlign = TextAlign.Center,
 ) {
+    val brandName = linkBrand.brandName()
     val text = when (type) {
         LinkTermsType.InlineOptionalWithPhoneFirst -> {
-            stringResource(R.string.stripe_sign_up_terms_alternative_with_phone_number)
+            stringResource(R.string.stripe_sign_up_terms_alternative_with_phone_number, brandName)
         }
         LinkTermsType.InlineOptional -> {
-            stringResource(R.string.stripe_sign_up_terms_alternative)
+            stringResource(R.string.stripe_sign_up_terms_alternative, brandName)
         }
         LinkTermsType.Inline -> {
-            stringResource(R.string.stripe_sign_up_terms)
+            stringResource(R.string.stripe_sign_up_terms, brandName)
         }
         LinkTermsType.InlineWithDefaultOptIn -> {
-            "<img src=\"link_logo\"> • " + stringResource(R.string.stripe_sign_up_terms_default_opt_in)
+            "<img src=\"link_logo\"> • " + stringResource(R.string.stripe_sign_up_terms_default_opt_in, brandName)
         }
         LinkTermsType.Full -> {
             stringResource(R.string.stripe_link_sign_up_terms)
@@ -69,7 +70,7 @@ internal fun LinkTerms(
     }
 
     Mandate(
-        mandateText = text.replaceHyperlinks(),
+        mandateText = text.replaceHyperlinks(linkBrand),
         modifier = modifier,
         textAlign = textAlign,
         imageAlign = PlaceholderVerticalAlign.TextCenter,
@@ -77,15 +78,15 @@ internal fun LinkTerms(
     )
 }
 
-internal fun String.replaceHyperlinks() = this.replace(
+internal fun String.replaceHyperlinks(linkBrand: LinkBrand) = this.replace(
     "<terms>",
-    "<a href=\"https://link.com/terms\">"
+    "<a href=\"${linkBrand.termsUrl()}\">"
 ).replace("</terms>", "</a>").replace(
     "<privacy>",
-    "<a href=\"https://link.com/privacy\">"
+    "<a href=\"${linkBrand.privacyUrl()}\">"
 ).replace("</privacy>", "</a>").replace(
     "<link>",
-    "<a href=\"https://link.com\">"
+    "<a href=\"${linkBrand.baseUrl()}\">"
 ).replace("</link>", "</a>")
 
 @Preview

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -31,8 +31,40 @@ internal fun LinkTerms(
     modifier: Modifier = Modifier,
     textAlign: TextAlign = TextAlign.Center,
 ) {
+    val text = linkTermsText(type, linkBrand)
+
+    val imageLoader = buildMap {
+        if (type == LinkTermsType.InlineWithDefaultOptIn) {
+            put(
+                "link_logo",
+                EmbeddableImage.Drawable(
+                    id = if (MaterialTheme.stripeColors.component.shouldUseDarkDynamicColor()) {
+                        linkBrand.logoRes(LinkLogoStyle.TermsKnockoutBlack)
+                    } else {
+                        linkBrand.logoRes(LinkLogoStyle.TermsKnockoutWhite)
+                    },
+                    contentDescription = when (linkBrand) {
+                        LinkBrand.Link -> com.stripe.android.R.string.stripe_link
+                        LinkBrand.Notlink -> com.stripe.android.R.string.stripe_notlink
+                    },
+                )
+            )
+        }
+    }
+
+    Mandate(
+        mandateText = text.replaceHyperlinks(linkBrand),
+        modifier = modifier,
+        textAlign = textAlign,
+        imageAlign = PlaceholderVerticalAlign.TextCenter,
+        imageLoader = imageLoader,
+    )
+}
+
+@Composable
+private fun linkTermsText(type: LinkTermsType, linkBrand: LinkBrand): String {
     val brandName = linkBrand.brandName()
-    val text = when (type) {
+    return when (type) {
         LinkTermsType.InlineOptionalWithPhoneFirst -> {
             if (linkBrand == LinkBrand.Link) {
                 stringResource(R.string.stripe_sign_up_terms_alternative_with_phone_number)
@@ -62,37 +94,8 @@ internal fun LinkTerms(
             }
             "<img src=\"link_logo\"> • $terms"
         }
-        LinkTermsType.Full -> {
-            stringResource(R.string.stripe_link_sign_up_terms)
-        }
+        LinkTermsType.Full -> stringResource(R.string.stripe_link_sign_up_terms)
     }
-
-    val imageLoader = buildMap {
-        if (type == LinkTermsType.InlineWithDefaultOptIn) {
-            put(
-                "link_logo",
-                EmbeddableImage.Drawable(
-                    id = if (MaterialTheme.stripeColors.component.shouldUseDarkDynamicColor()) {
-                        linkBrand.logoRes(LinkLogoStyle.TermsKnockoutBlack)
-                    } else {
-                        linkBrand.logoRes(LinkLogoStyle.TermsKnockoutWhite)
-                    },
-                    contentDescription = when (linkBrand) {
-                        LinkBrand.Link -> com.stripe.android.R.string.stripe_link
-                        LinkBrand.Notlink -> com.stripe.android.R.string.stripe_notlink
-                    },
-                )
-            )
-        }
-    }
-
-    Mandate(
-        mandateText = text.replaceHyperlinks(linkBrand),
-        modifier = modifier,
-        textAlign = textAlign,
-        imageAlign = PlaceholderVerticalAlign.TextCenter,
-        imageLoader = imageLoader,
-    )
 }
 
 internal fun String.replaceHyperlinks(linkBrand: LinkBrand) = this.replace(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -68,6 +68,7 @@ import com.stripe.android.link.ui.ScrollableTopLevelColumn
 import com.stripe.android.link.ui.SecondaryButton
 import com.stripe.android.link.utils.LinkScreenTransition
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.payments.financialconnections.getIntentBuilder
 import com.stripe.android.paymentsheet.R
@@ -269,7 +270,7 @@ private fun PaymentDetailsSection(
 
         AnimatedVisibility(visible = state.mandate != null) {
             state.mandate?.let { mandate ->
-                LinkMandate(mandate.resolve())
+                LinkMandate(mandate.resolve(), state.linkBrand)
             }
         }
 
@@ -766,9 +767,9 @@ private fun AddPaymentMethodRow(
 }
 
 @Composable
-private fun LinkMandate(text: String) {
+private fun LinkMandate(text: String, linkBrand: LinkBrand) {
     Html(
-        html = text.replaceHyperlinks(),
+        html = text.replaceHyperlinks(linkBrand),
         color = LinkTheme.colors.textTertiary,
         style = LinkTheme.typography.caption.copy(
             textAlign = TextAlign.Center,
@@ -892,9 +893,9 @@ private fun rememberFinancialConnectionsSheetInternal(
     }
 }
 
-private fun String.replaceHyperlinks() = this.replace(
+private fun String.replaceHyperlinks(linkBrand: LinkBrand) = this.replace(
     "<terms>",
-    "<a href=\"https://link.com/terms/ach-authorization\">"
+    "<a href=\"${linkBrand.achAuthorizationUrl()}\">"
 ).replace("</terms>", "</a>")
 
 private const val CHEVRON_ICON_ROTATION = 180f

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -895,7 +895,7 @@ private fun rememberFinancialConnectionsSheetInternal(
 
 private fun String.replaceHyperlinks(linkBrand: LinkBrand) = this.replace(
     "<terms>",
-    "<a href=\"${linkBrand.achAuthorizationUrl()}\">"
+    "<a href=\"${linkBrand.achAuthorizationTermsUrl()}\">"
 ).replace("</terms>", "</a>")
 
 private const val CHEVRON_ICON_ROTATION = 180f

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -40,6 +41,7 @@ internal data class WalletUiState(
     val paymentSelectionHint: ResolvableString? = null,
     val signupToggleEnabled: Boolean,
     val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
+    val linkBrand: LinkBrand,
     val isValidating: Boolean = false,
 ) {
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -95,6 +95,7 @@ internal class WalletViewModel(
             paymentSelectionHint = paymentSelectionHint,
             signupToggleEnabled = configuration.linkSignUpOptInFeatureEnabled,
             billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
+            linkBrand = configuration.linkBrand,
         )
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -21,6 +21,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.lpmfoundations.paymentmethod.link.LinkFormElement
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
@@ -179,10 +180,12 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
 
             val mandateAllowed = metadata.mandateAllowed(CardDefinition.type)
             if (metadata.forceSetupFutureUseBehaviorAndNewMandate) {
+                val linkBrand = metadata.linkState?.configuration?.linkBrand ?: return@buildList
                 add(
                     CombinedLinkMandateElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),
                         merchantName = metadata.merchantName,
+                        linkBrand = linkBrand,
                         signupMode = signupMode,
                         isLinkUI = arguments.isLinkUI,
                         canChangeSaveForFutureUse = canChangeSaveForFutureUsage,
@@ -298,6 +301,7 @@ internal class CombinedLinkMandateElement(
     signupMode: LinkSignupMode?,
     canChangeSaveForFutureUse: Boolean,
     private val merchantName: String,
+    private val linkBrand: LinkBrand,
     private val linkSignupStateFlow: StateFlow<InlineSignupViewState?>,
     private val isLinkUI: Boolean,
 ) : RenderableFormElement(
@@ -326,13 +330,13 @@ internal class CombinedLinkMandateElement(
             mandateText = if (linkState?.isExpanded == true && isLinkUI.not()) {
                 stringResource(
                     id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3,
-                    formatArgs = arrayOf(merchantName)
-                ).replaceHyperlinks()
+                    formatArgs = arrayOf(merchantName, linkBrand.brandName())
+                ).replaceHyperlinks(linkBrand)
             } else {
                 stringResource(
                     id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_off,
                     formatArgs = arrayOf(merchantName)
-                ).replaceHyperlinks()
+                ).replaceHyperlinks(linkBrand)
             },
             textAlign = if (isLinkUI) TextAlign.Center else TextAlign.Start,
             modifier = Modifier.padding(top = topPadding)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -328,10 +328,17 @@ internal class CombinedLinkMandateElement(
             // when displaying the mandate from Link UI (add card to Link) we always want the
             // non-signup version of the mandate text.
             mandateText = if (linkState?.isExpanded == true && isLinkUI.not()) {
-                stringResource(
-                    id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3,
-                    formatArgs = arrayOf(merchantName, linkBrand.brandName())
-                ).replaceHyperlinks(linkBrand)
+                if (linkBrand == LinkBrand.Link) {
+                    stringResource(
+                        id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3,
+                        formatArgs = arrayOf(merchantName)
+                    )
+                } else {
+                    stringResource(
+                        id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded,
+                        formatArgs = arrayOf(merchantName, linkBrand.brandName())
+                    )
+                }.replaceHyperlinks(linkBrand)
             } else {
                 stringResource(
                     id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_off,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.screenshottesting.Orientation
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -272,6 +273,7 @@ internal class WalletScreenScreenshotTest {
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             signupToggleEnabled = signupToggleEnabled,
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+            linkBrand = LinkBrand.Link,
             isValidating = isValidating,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -46,6 +46,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
@@ -770,6 +771,7 @@ internal class WalletScreenTest {
                 collectMissingBillingDetailsForExistingPaymentMethods = true,
                 signupToggleEnabled = false,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                linkBrand = LinkBrand.Link,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             ),
             onItemSelected = {},

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -358,6 +359,7 @@ class WalletUiStateTest {
             collectMissingBillingDetailsForExistingPaymentMethods,
             signupToggleEnabled = signupToggleEnabled,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+            linkBrand = LinkBrand.Link,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.link.utils.TestNavigationManager
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
@@ -99,6 +100,7 @@ class WalletViewModelTest {
                 collectMissingBillingDetailsForExistingPaymentMethods = true,
                 signupToggleEnabled = false,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                linkBrand = LinkBrand.Link,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             )
         )


### PR DESCRIPTION
# Summary
Add new strings that interpolate Link brand terms / privacy policy to display the right things (and link to the right place)

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-801

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
- manually verified by forcing Notlink and clicking through signup screen links for terms and privacy policy
- Terms are updated here, the "Save your information for faster checkout" is updated in #13057

<img width=300 alt="image" src="https://github.com/user-attachments/assets/4f439dee-62a9-4b61-bb65-03a37ddf844e" />

# Changelog
n/a
