### PR TITLE
Fix checkout test cleanup to await deferred instead of canceling.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -776,7 +776,7 @@ class CheckoutTest {
             .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
 
         latch.countDown()
-        deferred.cancel()
+        deferred.await()
     }
 
     @Test
@@ -801,7 +801,7 @@ class CheckoutTest {
             .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
 
         latch.countDown()
-        deferred.cancel()
+        deferred.await()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Changed test cleanup in CheckoutTest to properly await async operations instead of canceling them.

# Motivation
The tests were canceling deferred operations during cleanup, which could potentially leave coroutines in an inconsistent state. Awaiting the deferred ensures proper completion of async operations before the test ends.

# Testing
- [x] Modified tests
- [ ] Added tests
- [ ] Manually verified