### PR TITLE
[link] Pass Link brand to PaymentOptionLabelsFactory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -618,7 +618,7 @@ class CustomerSheet internal constructor(
             return when (this) {
                 is PaymentSelection.GooglePay -> {
                     PaymentOptionSelection.GooglePay(
-                        paymentOption = paymentOptionFactory.create(this),
+                        paymentOption = paymentOptionFactory.create(this, null),
                     ).takeIf {
                         canUseGooglePay
                     }
@@ -626,7 +626,7 @@ class CustomerSheet internal constructor(
                 is PaymentSelection.Saved -> {
                     PaymentOptionSelection.PaymentMethod(
                         paymentMethod = this.paymentMethod,
-                        paymentOption = paymentOptionFactory.create(this)
+                        paymentOption = paymentOptionFactory.create(this, null)
                     )
                 }
                 else -> null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -265,7 +265,7 @@ internal class DefaultFlowController @Inject internal constructor(
 
     override fun getPaymentOption(): PaymentOption? {
         return viewModel.paymentSelection?.let {
-            paymentOptionFactory.create(it)
+            paymentOptionFactory.create(it, viewModel.state?.linkConfiguration?.linkBrand)
         }
     }
 
@@ -435,7 +435,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 viewModel.paymentSelection = selection
                 paymentOptionResultCallback.onPaymentOptionResult(
                     PaymentOptionResult(
-                        paymentOption = paymentOptionFactory.create(selection),
+                        paymentOption = paymentOptionFactory.create(selection, linkConfiguration.linkBrand),
                         didCancel = false,
                     )
                 )
@@ -492,7 +492,9 @@ internal class DefaultFlowController @Inject internal constructor(
                 viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
             }
             viewModel.paymentSelection = newSelection
-            val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }
+            val paymentOption = newSelection?.let {
+                paymentOptionFactory.create(it, viewModel.state?.linkConfiguration?.linkBrand)
+            }
             val result = PaymentOptionResult(
                 paymentOption = paymentOption,
                 didCancel = canceled,
@@ -631,7 +633,9 @@ internal class DefaultFlowController @Inject internal constructor(
 
     private fun onPaymentSelection(canceled: Boolean) {
         val paymentSelection = viewModel.paymentSelection
-        val paymentOption = paymentSelection?.let { paymentOptionFactory.create(it) }
+        val paymentOption = paymentSelection?.let {
+            paymentOptionFactory.create(it, viewModel.state?.linkConfiguration?.linkBrand)
+        }
 
         paymentOptionResultCallback.onPaymentOptionResult(
             PaymentOptionResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import android.content.Context
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -11,7 +12,7 @@ internal class PaymentOptionFactory @Inject constructor(
     private val cardArtDrawableLoader: PaymentOptionCardArtDrawableLoader,
     private val context: Context,
 ) {
-    fun create(selection: PaymentSelection): PaymentOption {
+    fun create(selection: PaymentSelection, linkBrand: LinkBrand?): PaymentOption {
         val drawableResourceId = selection.drawableResourceId
         val lightThemeIconUrl = selection.lightThemeIconUrl
         val darkThemeIconUrl = selection.darkThemeIconUrl
@@ -20,7 +21,7 @@ internal class PaymentOptionFactory @Inject constructor(
             drawableResourceId = drawableResourceId,
             label = selection.label.resolve(context),
             paymentMethodType = selection.paymentMethodType,
-            _labels = PaymentOptionLabelsFactory.create(context, selection),
+            _labels = PaymentOptionLabelsFactory.create(context, selection, linkBrand),
             billingDetails = selection.billingDetails?.toPaymentSheetBillingDetails(),
             _shippingDetails = selection.shippingDetails,
             imageLoader = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.wallet.paymentOptionLabel
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ui.createCardLabel
@@ -15,6 +16,7 @@ internal object PaymentOptionLabelsFactory {
     fun create(
         context: Context,
         selection: PaymentSelection,
+        linkBrand: LinkBrand?,
     ): PaymentOption.Labels {
         val label = selection.label.resolve(context)
         val fallback = PaymentOption.Labels(
@@ -38,7 +40,7 @@ internal object PaymentOptionLabelsFactory {
             }
             is PaymentSelection.Saved -> {
                 selection.paymentMethod.run {
-                    linkPaymentDetails?.let { savedLink(context, it) }
+                    linkPaymentDetails?.let { savedLink(context, it, linkBrand) }
                         ?: card?.let { savedCard(context, it) }
                         ?: usBankAccount?.let { savedUSBankAccount(it, label) }
                         ?: fallback
@@ -75,9 +77,10 @@ internal object PaymentOptionLabelsFactory {
     private fun savedLink(
         context: Context,
         linkDetails: LinkPaymentDetails,
+        linkBrand: LinkBrand?,
     ): PaymentOption.Labels {
         return PaymentOption.Labels(
-            label = R.string.stripe_link.resolvableString.resolve(context),
+            label = linkBrand?.brandName() ?: R.string.stripe_link.resolvableString.resolve(context),
             sublabel = linkDetails.paymentOptionLabel.resolve(context),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -33,7 +33,7 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with GooglePay should return expected object`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.GooglePay)
+        val paymentOption = factory.create(PaymentSelection.GooglePay, null)
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_google_pay_mark)
         assertThat(paymentOption.label).isEqualTo("Google Pay")
         assertThat(paymentOption.paymentMethodType).isEqualTo("google_pay")
@@ -48,7 +48,8 @@ class PaymentOptionFactoryTest {
                 PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
                     billingDetails = PAYMENT_METHOD_BILLING_DETAILS
                 )
-            )
+            ),
+            null,
         )
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
         assertThat(paymentOption.label).isEqualTo("···· 4242")
@@ -66,7 +67,8 @@ class PaymentOptionFactoryTest {
                 ),
                 brand = CardBrand.Visa,
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
-            )
+            ),
+            null,
         )
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
         assertThat(paymentOption.label).isEqualTo("···· 4242")
@@ -91,7 +93,8 @@ class PaymentOptionFactoryTest {
                     name = null,
                     consentAction = SignUpConsentAction.Checkbox,
                 )
-            )
+            ),
+            null,
         )
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
         assertThat(paymentOption.label).isEqualTo("···· 4242")
@@ -110,7 +113,7 @@ class PaymentOptionFactoryTest {
             .setCard(PaymentMethod.Card(last4 = "4242", brand = CardBrand.Visa, displayBrand = "visa"))
             .build()
 
-        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod))
+        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null)
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
     }
@@ -125,7 +128,7 @@ class PaymentOptionFactoryTest {
             .setCard(PaymentMethod.Card(last4 = "4242", brand = CardBrand.Visa, displayBrand = "visa"))
             .build()
 
-        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod))
+        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null)
 
         assertThat(paymentOption.billingDetails).isNull()
     }
@@ -144,7 +147,8 @@ class PaymentOptionFactoryTest {
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null
-            )
+            ),
+            null,
         )
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
@@ -153,7 +157,7 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with Google Pay should not include billing details`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.GooglePay)
+        val paymentOption = factory.create(PaymentSelection.GooglePay, null)
 
         assertThat(paymentOption.billingDetails).isNull()
     }
@@ -161,7 +165,7 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with Link should not include billing details`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.Link(brand = LinkBrand.Link))
+        val paymentOption = factory.create(PaymentSelection.Link(brand = LinkBrand.Link), null)
 
         assertThat(paymentOption.billingDetails).isNull()
     }
@@ -176,7 +180,8 @@ class PaymentOptionFactoryTest {
                 label = "CPM".resolvableString,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
-            )
+            ),
+            null,
         )
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
@@ -193,7 +198,8 @@ class PaymentOptionFactoryTest {
                 iconResource = 0,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
-            )
+            ),
+            null,
         )
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
@@ -215,7 +221,7 @@ class PaymentOptionFactoryTest {
             .setCard(PaymentMethod.Card(last4 = "4242", brand = CardBrand.Visa, displayBrand = "visa"))
             .build()
 
-        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod))
+        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null)
 
         assertThat(paymentOption.billingDetails).isEqualTo(
             PaymentSheet.BillingDetails(
@@ -241,7 +247,7 @@ class PaymentOptionFactoryTest {
             cardArtDrawableLoader = { cardArtDrawable },
         )
 
-        val option = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+        val option = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD), null)
         val icon = option.icon()
 
         assertThat(icon.current).isEqualTo(cardArtDrawable)
@@ -253,7 +259,7 @@ class PaymentOptionFactoryTest {
             cardArtDrawableLoader = { null },
         )
 
-        val option = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+        val option = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD), null)
         val icon = option.icon()
 
         assertThat(icon.current).isNotInstanceOf(ShapeDrawable::class.java)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionLabelsFactoryTest.kt
@@ -21,7 +21,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with card payment selection returns correct labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Visa")
@@ -32,7 +33,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with generic payment selection returns correct labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentMethodFixtures.GENERIC_PAYMENT_SELECTION
+            selection = PaymentMethodFixtures.GENERIC_PAYMENT_SELECTION,
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("PayPal")
@@ -43,7 +45,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with US Bank Account payment selection returns correct labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION
+            selection = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION,
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Stripe Bank")
@@ -54,7 +57,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with US Bank Account payment selection without bank name returns correct labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION_WITHOUT_BANK_NAME
+            selection = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION_WITHOUT_BANK_NAME,
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Bank")
@@ -65,7 +69,8 @@ class PaymentOptionLabelsFactoryTest {
     fun `create with Link Inline payment selection returns correct labels`() {
         val labels = PaymentOptionLabelsFactory.create(
             context = context,
-            selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION_WITH_LINK
+            selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION_WITH_LINK,
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Visa")
@@ -78,7 +83,36 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentSelection.Saved(
                 paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD
-            )
+            ),
+            linkBrand = LinkBrand.Link,
+        )
+
+        assertThat(labels.label).isEqualTo("Link")
+        assertThat(labels.sublabel).isEqualTo("Visa Credit •••• 4242")
+    }
+
+    @Test
+    fun `create with saved Link payment method and Notlink brand returns correct labels`() {
+        val labels = PaymentOptionLabelsFactory.create(
+            context = context,
+            selection = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD
+            ),
+            linkBrand = LinkBrand.Notlink,
+        )
+
+        assertThat(labels.label).isEqualTo("Notlink")
+        assertThat(labels.sublabel).isEqualTo("Visa Credit •••• 4242")
+    }
+
+    @Test
+    fun `create with saved Link payment method and null brand falls back to Link string`() {
+        val labels = PaymentOptionLabelsFactory.create(
+            context = context,
+            selection = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.LINK_PAYMENT_METHOD
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Link")
@@ -91,7 +125,8 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentSelection.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-            )
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Visa")
@@ -104,7 +139,8 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentSelection.Saved(
                 paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT
-            )
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("STRIPE TEST BANK")
@@ -123,7 +159,8 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentSelection.Saved(
                 paymentMethod = cardWithoutBrand
-            )
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("···· 4242")
@@ -142,7 +179,8 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentSelection.Saved(
                 paymentMethod = bankAccountWithoutName
-            )
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isNotEmpty()
@@ -161,6 +199,7 @@ class PaymentOptionLabelsFactoryTest {
                     billingPhone = null,
                 ),
             ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("Notlink")
@@ -173,7 +212,8 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentMethodFixtures.createExternalPaymentMethod(
                 PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC
-            )
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("external_paypal")
@@ -186,7 +226,8 @@ class PaymentOptionLabelsFactoryTest {
             context = context,
             selection = PaymentMethodFixtures.createCustomPaymentMethod(
                 PaymentMethodFixtures.PAYPAL_CUSTOM_PAYMENT_METHOD
-            )
+            ),
+            linkBrand = null,
         )
 
         assertThat(labels.label).isEqualTo("PayPal")


### PR DESCRIPTION
# Summary
Thread Link brand (right now it's nullable) to PaymentOptionLabelsFactory so that saved Link payment methods have the right branding.

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-815

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
Manually test by saving a Link PM and then using the FlowController (asset will be updated by #13052)

<img width=300 alt="Screenshot_20260508_091852" src="https://github.com/user-attachments/assets/753b9632-0b95-4be3-9295-bce911be7912" />

# Changelog
n/a