### PR TITLE
Fix elements/sessions URL not respecting API_HOST_OVERRIDE

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -183,7 +183,8 @@ internal class RealElementsSessionRepository @Inject constructor(
     }
 
     private companion object {
-        private val ELEMENTS_SESSIONS_URL = "${ApiRequest.API_HOST}/v1/elements/sessions"
+        private val ELEMENTS_SESSIONS_URL: String
+            get() = "${ApiRequest.API_HOST}/v1/elements/sessions"
     }
 }
 


### PR DESCRIPTION
## Summary
- `ELEMENTS_SESSIONS_URL` was a `val` in a companion object, meaning it was evaluated once at class-load time and permanently baked `https://api.stripe.com`
- Changed to a computed property (`get()`) so it reads `ApiRequest.API_HOST` (and thus `API_HOST_OVERRIDE`) fresh on every call
- This makes the playground's "Custom Stripe API" setting work for elements/sessions requests (e.g. devbox tunnel testing)

## Motivation
When using the playground with a custom Stripe API (e.g. a devbox tunnel endpoint for local testing), all other API requests correctly use the tunnel URL, but the elements/sessions request still went to `api.stripe.com`. This is because `ELEMENTS_SESSIONS_URL` was eagerly evaluated before `API_HOST_OVERRIDE` was set.

## Testing
Verified locally with playground pointing to a devbox tunnel — elements/sessions now correctly routes through the custom API host.