### PR TITLE
[link] Thread correct Link brand in remaining strings

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -26,14 +26,11 @@
   <string name="stripe_confirm_close_form_title">Do you want to close this form?</string>
   <!-- Label for a checkbox that when checked allows the payment information to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header">Save your info for secure 1-click checkout with Link</string>
-  <!-- Label for a checkbox that when checked allows the payment information
-to be saved and used in future checkout sessions. -->
+  <!-- Label for a checkbox that when checked allows the payment information to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in">Save my info for faster checkout with Link</string>
-  <!-- Label for a checkbox that when checked allows the payment information
-to be saved and used in future checkout sessions. '%s' is a Stripe brand name such as 'Link'. -->
+  <!-- Label for a checkbox that when checked allows the payment information to be saved and used in future checkout sessions. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Save my info for faster checkout with %s</string>
-  <!-- Label for a checkbox that when checked allows the payment information
-to be saved and used in future checkout sessions. -->
+  <!-- Label for a checkbox that when checked allows the payment information to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_toggle">Create an account with Link for faster checkout across the web</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. '%s' is a Stripe brand name such as 'Link'. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -30,8 +30,14 @@
 to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in">Save my info for faster checkout with Link</string>
   <!-- Label for a checkbox that when checked allows the payment information
+to be saved and used in future checkout sessions. '%s' is a Stripe brand name such as 'Link'. -->
+  <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Save my info for faster checkout with %s</string>
+  <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_toggle">Create an account with Link for faster checkout across the web</string>
+  <!-- Label for a checkbox that when checked allows the payment information
+to be saved and used in future checkout sessions. '%s' is a Stripe brand name such as 'Link'. -->
+  <string name="stripe_inline_sign_up_toggle_with_brand">Create an account with %s for faster checkout across the web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
   <!-- Label a debit funding source. E.g. 'Visa Debit' -->
@@ -70,6 +76,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_link_sign_up_message">Save your payment information with Link, and securely check out in 1-click on Link-supported sites.</string>
   <!-- Subtitle for the Link signup screen -->
   <string name="stripe_link_sign_up_message_v2">Pay faster everywhere Link is accepted.</string>
+  <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
+  <string name="stripe_link_sign_up_message_v2_with_brand">Pay faster everywhere %s is accepted.</string>
   <!-- Legal text shown when creating a Link account. -->
   <string name="stripe_link_sign_up_terms"><![CDATA[By continuing you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
   <!-- Confirm CTA for the update card screen in Link native -->
@@ -86,12 +94,16 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_link_wallet_menu_action_update_card">Update card</string>
   <!-- Title of the logout action. -->
   <string name="stripe_log_out">Log out of Link</string>
+  <!-- Title of the logout action. '%s' is a Stripe brand name such as 'Link'. -->
+  <string name="stripe_log_out_with_brand">Log out of %s</string>
   <!-- Text that is displayed when a network error occurs -->
   <string name="stripe_network_error_message">An error occurred. Check your connection and try again.</string>
   <!-- Text for separator within a separator that separates a button to tap to add a card and the card form -->
   <string name="stripe_or_enter_manually">or enter manually</string>
   <!-- Text for the 'Pay with Link' button. 'Link' is a Stripe brand, please do not translate the word 'Link'. -->
   <string name="stripe_pay_with_link">Pay with Link</string>
+  <!-- Text for the branded pay button. '%s' is a Stripe brand name such as 'Link'. -->
+  <string name="stripe_pay_with_link_with_brand">Pay with %s</string>
   <!-- Accessibility label for the 'Pay with Link' button. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_pay_with_link_format">Pay with %s</string>
   <!-- Text providing link to terms for ACH payments -->

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/BrandTextUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/BrandTextUtils.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.link.ui
+
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+
+internal fun String.buildBrandIconAnnotatedString(
+    brandToken: String,
+    inlineContentId: String,
+    alternateText: String = "[icon]",
+): AnnotatedString = buildAnnotatedString {
+    val brandIndex = indexOf(brandToken)
+
+    if (brandToken.isEmpty() || brandIndex < 0) {
+        append(this@buildBrandIconAnnotatedString)
+        return@buildAnnotatedString
+    }
+
+    append(substring(0, brandIndex))
+    appendInlineContent(id = inlineContentId, alternateText = alternateText)
+    append(substring(brandIndex + brandToken.length))
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarMenu.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarMenu.kt
@@ -5,14 +5,16 @@ import androidx.compose.runtime.remember
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.menu.LinkMenu
 import com.stripe.android.link.ui.menu.LinkMenuItem
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.R
 
 @Composable
 internal fun LinkAppBarMenu(
+    linkBrand: LinkBrand,
     onLogoutClicked: () -> Unit
 ) {
-    val items = remember {
-        listOf(LogoutMenuItem)
+    val items = remember(linkBrand) {
+        listOf(LogoutMenuItem(linkBrand))
     }
 
     LinkMenu(
@@ -22,8 +24,14 @@ internal fun LinkAppBarMenu(
     }
 }
 
-internal data object LogoutMenuItem : LinkMenuItem {
-    override val text = R.string.stripe_log_out.resolvableString
+internal data class LogoutMenuItem(
+    private val linkBrand: LinkBrand,
+) : LinkMenuItem {
+    override val text = if (linkBrand == LinkBrand.Link) {
+        R.string.stripe_log_out.resolvableString
+    } else {
+        resolvableString(R.string.stripe_log_out_with_brand, linkBrand.brandName())
+    }
     override val testTag = LOGOUT_MENU_ROW_TAG
     override val isDestructive = true
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkButton.kt
@@ -135,7 +135,6 @@ private val LinkButtonShape: RoundedCornerShape
         StripeTheme.primaryButtonStyle.shape.cornerRadius.dp
     )
 
-private const val LINK_BRAND_NAME = "Link"
 private const val LINK_ICON_ID = "LinkIcon"
 private const val LINK_DIVIDER_SPACER_ID = "LinkDividerSpacer"
 private const val LINK_DIVIDER_ID = "LinkDivider"
@@ -325,17 +324,17 @@ private fun SignedInButtonContent(
 @Suppress("UnusedReceiverParameter")
 @Composable
 private fun RowScope.SignedOutButtonContent(theme: LinkButtonTheme, linkBrand: LinkBrand) {
-    val text = stringResource(R.string.stripe_pay_with_link)
-    val contentDescription = stringResource(R.string.stripe_pay_with_link_format, linkBrand.brandName())
-
-    val iconizedText = buildAnnotatedString {
-        append(text.substringBefore(LINK_BRAND_NAME))
-        appendInlineContent(
-            id = LINK_ICON_ID,
-            alternateText = "[icon]"
-        )
-        append(text.substringAfter(LINK_BRAND_NAME))
+    val brandName = linkBrand.brandName()
+    val text = if (linkBrand == LinkBrand.Link) {
+        stringResource(R.string.stripe_pay_with_link)
+    } else {
+        stringResource(R.string.stripe_pay_with_link_with_brand, brandName)
     }
+    val contentDescription = stringResource(R.string.stripe_pay_with_link_format, brandName)
+    val iconizedText = text.buildBrandIconAnnotatedString(
+        brandToken = brandName,
+        inlineContentId = LINK_ICON_ID,
+    )
 
     Text(
         text = iconizedText,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -61,6 +61,7 @@ import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.LinkLogoStyle
 import com.stripe.android.link.ui.LinkTerms
 import com.stripe.android.link.ui.LinkTermsType
+import com.stripe.android.link.ui.buildBrandIconAnnotatedString
 import com.stripe.android.link.ui.logoRes
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.link.ui.signup.SignUpState.InputtingRemainingFields
@@ -83,6 +84,7 @@ import com.stripe.android.uicore.R as StripeUiCoreR
 
 internal const val ProgressIndicatorTestTag = "CircularProgressIndicator"
 private const val LINK_LOGO_SCALE = 0.95f
+private const val LINK_LOGO_INLINE_CONTENT_ID = "link_logo"
 
 @Composable
 internal fun LinkInlineSignup(
@@ -355,7 +357,14 @@ private fun LinkCheckbox(
     toggleExpanded: () -> Unit,
     useLinkLogoInCheckboxText: Boolean,
 ) {
-    val label = stringResource(id = R.string.stripe_inline_sign_up_header_default_opt_in)
+    val label = if (linkBrand == LinkBrand.Link) {
+        stringResource(id = R.string.stripe_inline_sign_up_header_default_opt_in)
+    } else {
+        stringResource(
+            id = R.string.stripe_inline_sign_up_header_default_opt_in_with_brand,
+            linkBrand.brandName(),
+        )
+    }
 
     val sublabel = if (!simplifiedCheckbox) {
         stringResource(R.string.stripe_sign_up_message, merchantName)
@@ -409,17 +418,25 @@ private fun TextWithLinkLogo(
     color: Color,
     linkBrand: LinkBrand,
 ) {
-    val label = stringResource(R.string.stripe_inline_sign_up_toggle)
+    val brandName = linkBrand.brandName()
+    val label = if (linkBrand == LinkBrand.Link) {
+        stringResource(R.string.stripe_inline_sign_up_toggle)
+    } else {
+        stringResource(R.string.stripe_inline_sign_up_toggle_with_brand, brandName)
+    }
     val painter = painterResource(linkBrand.logoRes(LinkLogoStyle.InlineKnockout))
     // Slightly smaller Link logo for better visual balance
     val logoHeight = style.fontSize * LINK_LOGO_SCALE
     val logoWidth = logoHeight * (painter.intrinsicSize.width / painter.intrinsicSize.height)
     Text(
-        text = label.buildLinkLogoAnnotatedString(),
+        text = label.buildBrandIconAnnotatedString(
+            brandToken = brandName,
+            inlineContentId = LINK_LOGO_INLINE_CONTENT_ID,
+        ),
         style = style,
         color = color,
         inlineContent = mapOf(
-            "link_logo" to InlineTextContent(
+            LINK_LOGO_INLINE_CONTENT_ID to InlineTextContent(
                 placeholder = Placeholder(
                     width = logoWidth,
                     height = logoHeight,
@@ -435,21 +452,6 @@ private fun TextWithLinkLogo(
             }
         )
     )
-}
-
-@Composable
-private fun String.buildLinkLogoAnnotatedString(): AnnotatedString = buildAnnotatedString {
-    val parts = split("Link")
-    val preLinkText = parts.getOrNull(0)
-    val postLinkText = parts.getOrNull(1)
-    if (preLinkText == null || postLinkText == null) {
-        // "Link" not found, just show the label as-is
-        append(this@buildLinkLogoAnnotatedString)
-    } else {
-        append(preLinkText)
-        appendInlineContent(id = "link_logo")
-        append(postLinkText)
-    }
 }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -47,11 +46,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -106,7 +106,7 @@ internal fun SignUpBody(
     }
 
     ScrollableTopLevelColumn {
-        SignUpHeader()
+        SignUpHeader(linkBrand = signUpScreenState.linkBrand)
         StripeThemeForLink(sectionStyle = SectionStyle.Bordered) {
             EmailCollectionSection(
                 canEditForm = signUpScreenState.canEditForm,
@@ -270,7 +270,7 @@ private fun SecondaryFields(
 }
 
 @Composable
-private fun ColumnScope.SignUpHeader() {
+private fun ColumnScope.SignUpHeader(linkBrand: LinkBrand) {
     Text(
         text = stringResource(R.string.stripe_link_sign_up_header_v2),
         modifier = Modifier
@@ -281,7 +281,14 @@ private fun ColumnScope.SignUpHeader() {
         color = LinkTheme.colors.textPrimary
     )
     Text(
-        text = stringResource(R.string.stripe_link_sign_up_message_v2),
+        text = if (linkBrand == LinkBrand.Link) {
+            stringResource(R.string.stripe_link_sign_up_message_v2)
+        } else {
+            stringResource(
+                R.string.stripe_link_sign_up_message_v2_with_brand,
+                linkBrand.brandName(),
+            )
+        },
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 4.dp, bottom = 30.dp),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -68,6 +68,7 @@ import com.stripe.android.link.ui.ScrollableTopLevelColumn
 import com.stripe.android.link.ui.SecondaryButton
 import com.stripe.android.link.utils.LinkScreenTransition
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.payments.financialconnections.getIntentBuilder
 import com.stripe.android.paymentsheet.R
@@ -118,6 +119,7 @@ internal fun WalletScreen(
 
     WalletBody(
         state = state,
+        linkBrand = viewModel.linkBrand,
         expiryDateController = viewModel.expiryDateController,
         cvcController = viewModel.cvcController,
         onItemSelected = viewModel::onItemSelected,
@@ -139,6 +141,7 @@ internal fun WalletScreen(
 @Composable
 internal fun WalletBody(
     state: WalletUiState,
+    linkBrand: LinkBrand,
     expiryDateController: TextFieldController,
     cvcController: CvcController,
     onItemSelected: (ConsumerPaymentDetails.PaymentDetails) -> Unit,
@@ -182,6 +185,7 @@ internal fun WalletBody(
                 PaymentDetailsSection(
                     modifier = Modifier,
                     state = state,
+                    linkBrand = linkBrand,
                     isExpanded = state.isExpanded,
                     expiryDateController = expiryDateController,
                     cvcController = cvcController,
@@ -230,6 +234,7 @@ internal fun WalletBody(
 private fun PaymentDetailsSection(
     modifier: Modifier,
     state: WalletUiState,
+    linkBrand: LinkBrand,
     isExpanded: Boolean,
     expiryDateController: TextFieldController,
     cvcController: CvcController,
@@ -248,6 +253,7 @@ private fun PaymentDetailsSection(
     ) {
         PaymentMethodSection(
             state = state,
+            linkBrand = linkBrand,
             isExpanded = isExpanded,
             onItemSelected = onItemSelected,
             onExpandedChanged = onExpandedChanged,
@@ -418,6 +424,7 @@ private fun ActionSection(
 @Composable
 private fun PaymentMethodSection(
     state: WalletUiState,
+    linkBrand: LinkBrand,
     isExpanded: Boolean,
     onItemSelected: (ConsumerPaymentDetails.PaymentDetails) -> Unit,
     onExpandedChanged: (Boolean) -> Unit,
@@ -445,7 +452,10 @@ private fun PaymentMethodSection(
         labelMaxWidth = labelMaxWidthDp,
         onAccountMenuClicked = {
             showBottomSheetContent {
-                LinkAppBarMenu(onLogoutClicked)
+                LinkAppBarMenu(
+                    linkBrand = linkBrand,
+                    onLogoutClicked = onLogoutClicked,
+                )
             }
         },
         expandedContent = {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -124,6 +124,7 @@ internal class WalletViewModel(
     val uiState: StateFlow<WalletUiState> = _uiState.asStateFlow()
 
     val allowLogOut: Boolean = configuration.allowLogOut
+    val linkBrand = configuration.linkBrand
 
     val expiryDateController = SimpleTextFieldController(
         textFieldConfig = DateConfig()

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/BrandTextUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/BrandTextUtilsTest.kt
@@ -6,7 +6,10 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.R
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 internal class BrandTextUtilsTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/BrandTextUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/BrandTextUtilsTest.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.link.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentsheet.R
+import org.junit.Test
+
+internal class BrandTextUtilsTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `inline signup text replaces Link with inline brand icon`() {
+        assertThat(
+            context.getString(
+                R.string.stripe_inline_sign_up_toggle,
+            ).buildBrandIconAnnotatedString(
+                brandToken = LinkBrand.Link.brandName(),
+                inlineContentId = "brand_icon",
+            ).text
+        ).isEqualTo("Create an account with [icon] for faster checkout across the web")
+    }
+
+    @Test
+    fun `inline signup text replaces Notlink with inline brand icon`() {
+        assertThat(
+            context.getString(
+                R.string.stripe_inline_sign_up_toggle_with_brand,
+                LinkBrand.Notlink.brandName(),
+            ).buildBrandIconAnnotatedString(
+                brandToken = LinkBrand.Notlink.brandName(),
+                inlineContentId = "brand_icon",
+            ).text
+        ).isEqualTo("Create an account with [icon] for faster checkout across the web")
+    }
+
+    @Test
+    fun `pay button text replaces Link with inline brand icon`() {
+        assertThat(
+            context.getString(
+                R.string.stripe_pay_with_link,
+            ).buildBrandIconAnnotatedString(
+                brandToken = LinkBrand.Link.brandName(),
+                inlineContentId = "brand_icon",
+            ).text
+        ).isEqualTo("Pay with [icon]")
+    }
+
+    @Test
+    fun `pay button text replaces Notlink with inline brand icon`() {
+        assertThat(
+            context.getString(
+                R.string.stripe_pay_with_link_with_brand,
+                LinkBrand.Notlink.brandName(),
+            ).buildBrandIconAnnotatedString(
+                brandToken = LinkBrand.Notlink.brandName(),
+                inlineContentId = "brand_icon",
+            ).text
+        ).isEqualTo("Pay with [icon]")
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarMenuScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarMenuScreenshotTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.link.theme.DefaultLinkTheme
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
@@ -26,6 +27,7 @@ internal class LinkAppBarMenuScreenshotTest {
         paparazziRule.snapshot {
             DefaultLinkTheme {
                 LinkAppBarMenu(
+                    linkBrand = LinkBrand.Link,
                     onLogoutClicked = {}
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarMenuTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkAppBarMenuTest.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.link.ui
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.link.theme.DefaultLinkTheme
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.testing.createComposeCleanupRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LinkAppBarMenuTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @Test
+    fun logout_label_uses_link_brand_name() {
+        setContent(LinkBrand.Link)
+
+        composeRule.onNodeWithTag(LOGOUT_MENU_ROW_TAG).assertTextEquals("Log out of Link")
+    }
+
+    @Test
+    fun logout_label_uses_notlink_brand_name() {
+        setContent(LinkBrand.Notlink)
+
+        composeRule.onNodeWithTag(LOGOUT_MENU_ROW_TAG).assertTextEquals("Log out of Notlink")
+    }
+
+    private fun setContent(linkBrand: LinkBrand) {
+        composeRule.setContent {
+            DefaultLinkTheme {
+                LinkAppBarMenu(
+                    linkBrand = linkBrand,
+                    onLogoutClicked = {},
+                )
+            }
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
@@ -136,6 +136,32 @@ internal class LinkInlineSignupViewTest {
     }
 
     @Test
+    fun checkbox_label_uses_link_brand_name_for_default_opt_in() {
+        setContent(
+            expanded = false,
+            allowsDefaultOptIn = true,
+            linkBrand = LinkBrand.Link,
+        )
+
+        composeTestRule
+            .onNodeWithText("Save my info for faster checkout with Link")
+            .assertExists()
+    }
+
+    @Test
+    fun checkbox_label_uses_notlink_brand_name_for_default_opt_in() {
+        setContent(
+            expanded = false,
+            allowsDefaultOptIn = true,
+            linkBrand = LinkBrand.Notlink,
+        )
+
+        composeTestRule
+            .onNodeWithText("Save my info for faster checkout with Notlink")
+            .assertExists()
+    }
+
+    @Test
     fun inline_logo_content_description_uses_dynamic_brand_name() {
         setContent(
             expanded = true,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpBodyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpBodyTest.kt
@@ -115,12 +115,31 @@ internal class SignUpBodyTest {
         onEmailField().assertIsNotEnabled()
     }
 
+    @Test
+    fun `signup subtitle uses Link brand name`() {
+        setContent(SignUpState.InputtingPrimaryField, linkBrand = LinkBrand.Link)
+
+        composeTestRule
+            .onNodeWithText("Pay faster everywhere Link is accepted.")
+            .assertExists()
+    }
+
+    @Test
+    fun `signup subtitle uses Notlink brand name`() {
+        setContent(SignUpState.InputtingPrimaryField, linkBrand = LinkBrand.Notlink)
+
+        composeTestRule
+            .onNodeWithText("Pay faster everywhere Notlink is accepted.")
+            .assertExists()
+    }
+
     private fun setContent(
         signUpState: SignUpState,
         isReadyToSignUp: Boolean = true,
         requiresNameCollection: Boolean = false,
         errorMessage: ResolvableString? = null,
-        canEditEmail: Boolean = true
+        canEditEmail: Boolean = true,
+        linkBrand: LinkBrand = LinkBrand.Link,
     ) = composeTestRule.setContent {
         DefaultLinkTheme {
             SignUpBody(
@@ -134,7 +153,7 @@ internal class SignUpBodyTest {
                     signUpEnabled = isReadyToSignUp,
                     requiresNameCollection = requiresNameCollection,
                     canEditEmail = canEditEmail,
-                    linkBrand = LinkBrand.Link,
+                    linkBrand = linkBrand,
                     errorMessage = errorMessage,
                     signUpState = signUpState,
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.screenshottesting.Orientation
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -282,6 +283,7 @@ internal class WalletScreenScreenshotTest {
             LinkScreenshotSurface {
                 WalletBody(
                     state = state,
+                    linkBrand = LinkBrand.Link,
                     onItemSelected = {},
                     onExpandedChanged = {},
                     onPrimaryButtonClick = {},

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -46,6 +46,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
@@ -772,6 +773,7 @@ internal class WalletScreenTest {
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             ),
+            linkBrand = LinkBrand.Link,
             onItemSelected = {},
             onExpandedChanged = {},
             onPrimaryButtonClick = {},


### PR DESCRIPTION
# Summary
There's a few more strings that still require Link brand interpolation. This patches up the remaining ones for sign up / log in / log out states.

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-864

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
<img width=300 alt="Screenshot_20260507_162735" src="https://github.com/user-attachments/assets/40335b85-696f-460f-a04a-f1370b12e53a" />
<img width=300 alt="Screenshot_20260507_163113" src="https://github.com/user-attachments/assets/dfdeef04-2f68-410f-ab9d-65ecd51d3a93" />
<img width=300 alt="Screenshot_20260507_165237" src="https://github.com/user-attachments/assets/e5d1509a-1154-4b52-8d08-949bb7d1e95b" />
<img width=300 alt="Screenshot_20260507_170408" src="https://github.com/user-attachments/assets/0645aca2-8c37-41f7-be07-1a8e6d3cd89a" />

Note - Terms will be fixed in #13050
<img width=300 alt="Screenshot_20260507_163113" src="https://github.com/user-attachments/assets/47eb2bef-4da4-46c3-8414-2c0ad09c6633" />

# Changelog
n/a