### PR TITLE
Remove call to pay mint --enable

### DIFF
--- a/scripts/deploy/update_pay_server_docs.rb
+++ b/scripts/deploy/update_pay_server_docs.rb
@@ -16,7 +16,6 @@ def update_pay_server_docs()
     unless Dir.exist?(mint_repo)
         puts 'Mint repo not found. Cloning mint (this may take a while)...'
         execute_or_fail("cd .. && pay get mint")
-        execute_or_fail("pay mint --enable")
     end
 
     puts 'Ensuring mint repo is up-to-date.'


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Now that mint is the default, we do not need to run `pay mint --enable` anymore.
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[DEVE-6704](https://jira.corp.stripe.com/browse/DEVE-6704)
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
