### PR TITLE
Add load latency benchmark script

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -36,6 +36,10 @@ def directlyToPlayground() {
     return project.hasProperty("DIRECTLY_TO_PLAYGROUND") && project.DIRECTLY_TO_PLAYGROUND.contains("true")
 }
 
+def getLatencyExperimentIterations() {
+    return findProperty('LATENCY_EXPERIMENT_ITERATIONS') ?: "1"
+}
+
 emerge {
     // Api token is implicitly set to the EMERGE_API_TOKEN env variable
 
@@ -67,6 +71,7 @@ android {
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
         buildConfigField "boolean", "IS_BROWSERSTACK_BUILD", "$gradle.ext.isBrowserstackBuild"
         buildConfigField "boolean", "DIRECTLY_TO_PLAYGROUND", "${directlyToPlayground()}"
+        buildConfigField "int", "LATENCY_EXPERIMENT_ITERATIONS", "${getLatencyExperimentIterations()}"
         buildConfigField "String", "PROXY_IP_ADDRESS", "\"${getProxyIpAddress()}\""
 
         manifestPlaceholders = [

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -1,0 +1,224 @@
+package com.stripe.android.latency
+
+import android.util.Log
+import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.BuildConfig
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
+import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.GooglePayMode
+import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
+import com.stripe.android.test.core.TestParameters
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class TestLatency(
+    val testConfig: TestConfig,
+) : BasePlaygroundTest() {
+    @Test
+    fun testLatency() {
+        Assume.assumeFalse(BuildConfig.IS_RUNNING_IN_CI)
+        Log.d(LOG_TAG, "LATENCY_TEST_CASE_STARTED: ${testConfig.name}")
+
+        runTestWithIterations {
+            testDriver.loadComplete(
+                testParameters = TestParameters.create(
+                    paymentMethodCode = "card",
+                    playgroundSettingsBlock = testConfig.playgroundSettingsBlock,
+                ),
+                isReturningCustomer = testConfig.isReturningCustomer,
+            )
+        }
+
+        Log.d(LOG_TAG, "LATENCY_TEST_CASE_FINISHED: ${testConfig.name}")
+    }
+
+    fun runTestWithIterations(
+        block: () -> Unit,
+    ) {
+        var successfulSamples = 0
+        var failedAttempts = 0
+        var lastFailure: Throwable? = null
+
+        while (successfulSamples < BuildConfig.LATENCY_EXPERIMENT_ITERATIONS && failedAttempts < MAX_FAILED_ATTEMPTS) {
+            runCatching {
+               block()
+            }.onSuccess {
+                successfulSamples += 1
+            }.onFailure { error ->
+                failedAttempts += 1
+                lastFailure = error
+            }
+        }
+
+        if (successfulSamples < BuildConfig.LATENCY_EXPERIMENT_ITERATIONS) {
+            throw AssertionError(
+                "Collected $successfulSamples/${BuildConfig.LATENCY_EXPERIMENT_ITERATIONS} samples " +
+                    "for ${testConfig.name} after $failedAttempts failed attempts",
+                lastFailure,
+            )
+        }
+    }
+
+    class TestConfig(
+        val name: String,
+        val isReturningCustomer: Boolean,
+        val playgroundSettingsBlock: (PlaygroundSettings) -> Unit,
+    ) {
+        override fun toString() = name
+    }
+
+    companion object {
+        private const val LOG_TAG = "StripeSdk"
+        private const val MAX_FAILED_ATTEMPTS = 3
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun testConfigs(): List<Array<Any>> {
+            return listOf(
+                testConfig(
+                    testName = "test_link_off_with_no_customer",
+                    isReturningCustomer = false,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = false
+                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_off_with_ek",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = false
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = false
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_off_with_cs",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = false
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = true
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_on_with_no_customer",
+                    isReturningCustomer = false,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = true
+                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_on_with_ek",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = true
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = false
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_on_with_cs",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = true
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = true
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_on_with_ek_default_email",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = true
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = false
+                    settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_link_on_with_cs_default_email",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = true
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = true
+                    settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                },
+                testConfig(
+                    testName = "test_google_pay_on_link_off_with_no_customer",
+                    isReturningCustomer = false,
+                ) { settings: PlaygroundSettings ->
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Test
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = false
+                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
+                },
+                testConfig(
+                    testName = "test_google_pay_on_link_off_with_ek",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Test
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = false
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = false
+                },
+                testConfig(
+                    testName = "test_google_pay_on_link_off_with_cs",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Test
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = false
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = true
+                },
+                testConfig(
+                    testName = "test_google_pay_on_link_on_with_cs",
+                    isReturningCustomer = true,
+                ) { settings: PlaygroundSettings ->
+                    settings[GooglePaySettingsDefinition] = GooglePayMode.Test
+                    settings[MerchantSettingsDefinition] = Merchant.US
+                    settings[LinkSettingsDefinition] = true
+                    settings[CustomerSettingsDefinition] = CustomerType.RETURNING
+                    settings[CustomerSessionSettingsDefinition] = true
+                },
+            )
+        }
+
+        private fun testConfig(
+            testName: String,
+            isReturningCustomer: Boolean,
+            playgroundSettingsBlock: (PlaygroundSettings) -> Unit,
+        ): Array<Any> {
+            return arrayOf(
+                TestConfig(
+                    name = testName,
+                    isReturningCustomer = isReturningCustomer,
+                    playgroundSettingsBlock = playgroundSettingsBlock,
+                )
+            )
+        }
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -20,6 +20,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+/**
+ * This test is special -- it's intended to be used to measure loading latency of PaymentSheet. As such, it doesn't
+ * run in CI, but can be run locally (to test changes) and via the latency benchmarking script:
+ * scripts/measure_latency_difference.rb.
+ * */
 @RunWith(Parameterized::class)
 internal class TestLatency(
     val testConfig: TestConfig,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -58,6 +58,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.RequireCvcRec
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CHECKOUT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
@@ -426,6 +427,30 @@ internal class PlaygroundTestDriver(
 
         Espresso.onIdle()
         composeTestRule.waitForIdle()
+    }
+
+    fun loadComplete(
+        testParameters: TestParameters,
+        isReturningCustomer: Boolean,
+    ) {
+        setup(testParameters)
+        launchComplete()
+
+        if (isReturningCustomer) {
+            waitForSavedPaymentMethodScreen()
+        } else {
+            selectors.formElement.waitFor()
+        }
+
+        teardown()
+    }
+
+    private fun waitForSavedPaymentMethodScreen() {
+        selectors.composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            selectors.composeTestRule.onAllNodes(
+                hasTestTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG)
+            ).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+        }
     }
 
     /**

--- a/scripts/measure_latency_difference.rb
+++ b/scripts/measure_latency_difference.rb
@@ -1,0 +1,528 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require 'open3'
+
+PROJECT_ROOT = File.expand_path('..', __dir__)
+LOGCAT_TAG = 'StripeSdk'
+LATENCY_TEST_CLASS = 'com.stripe.android.latency.TestLatency'
+LATENCY_TEST_GRADLE_TASK = ':paymentsheet-example:connectedBaseDebugAndroidTest'
+DURATION_KEY = 'Loading'
+MAX_INVOCATION_ATTEMPTS = 3
+LOGCAT_BUFFER_SIZE = ENV.fetch('LOGCAT_BUFFER_SIZE', '16M')
+
+# ============================================================================
+# DATA COLLECTION
+# ============================================================================
+
+def merge_results(target, source)
+  target.merge!(source) { |_, old, new| old + new }
+end
+
+def run_latency_tests_for_commit(commit, sample_count)
+  puts "\n" + "=" * 80
+  puts "Testing commit: #{commit}"
+  puts '=' * 80
+
+  checkout_commit(commit)
+
+  (1..MAX_INVOCATION_ATTEMPTS).each do |attempt|
+    puts "Collecting #{sample_count} sample(s) in one Gradle invocation..."
+    puts "Attempt #{attempt}/#{MAX_INVOCATION_ATTEMPTS}"
+
+    output = run_android_latency_tests(sample_count)
+    print_raw_result_debug_summary(output)
+    results = parse_latency_results(output)
+    expected_test_count = extract_expected_test_count(output)
+
+    if valid_invocation_results?(
+      results: results,
+      sample_count: sample_count,
+      expected_test_count: expected_test_count
+    )
+      puts "\nFound #{results.length} test(s) with results"
+      return results
+    end
+
+    puts "\nInvocation did not produce a complete sample set."
+    puts "  Expected tests: #{expected_test_count || 'unknown'}"
+    puts "  Actual tests:   #{results.length}"
+    if results.any?
+      puts '  Samples per test:'
+      results.sort.each do |test_name, durations|
+        puts "    #{test_name}: #{durations.length}"
+      end
+    end
+  end
+
+  raise "Failed to collect a complete sample set for commit #{commit} after #{MAX_INVOCATION_ATTEMPTS} attempts"
+end
+
+def run_android_latency_tests(sample_count)
+  clear_logcat
+
+  command = [
+    './gradlew',
+    '--no-configuration-cache',
+    LATENCY_TEST_GRADLE_TASK,
+    "-Pandroid.testInstrumentationRunnerArguments.class=#{LATENCY_TEST_CLASS}",
+    "-PLATENCY_EXPERIMENT_ITERATIONS=#{sample_count}"
+  ]
+
+  output = +''
+
+  Dir.chdir(PROJECT_ROOT) do
+    Open3.popen2e(*command) do |stdin, stdout_stderr, wait_thread|
+      stdin.close
+
+      stdout_stderr.each_line do |line|
+        print line
+        output << line
+      end
+
+      exit_status = wait_thread.value
+      unless exit_status.success?
+        puts "\nWarning: Gradle command exited with status #{exit_status.exitstatus}"
+        puts 'Continuing to parse available logcat output...'
+      end
+    end
+  end
+
+  output + "\n" + dump_logcat
+end
+
+def clear_logcat
+  resize_logcat_buffer
+
+  stdout, status = Open3.capture2e('adb', 'logcat', '-c', chdir: PROJECT_ROOT)
+  return if status.success?
+
+  warn stdout
+  raise 'Failed to clear adb logcat. Ensure adb is installed and a device/emulator is available.'
+end
+
+def resize_logcat_buffer
+  stdout, status = Open3.capture2e('adb', 'logcat', '-G', LOGCAT_BUFFER_SIZE, chdir: PROJECT_ROOT)
+  return if status.success?
+
+  warn stdout
+  raise "Failed to resize adb logcat buffer to #{LOGCAT_BUFFER_SIZE}."
+end
+
+def dump_logcat
+  stdout, status = Open3.capture2e(
+    'adb',
+    'logcat',
+    '-d',
+    '-s',
+    "#{LOGCAT_TAG}:D",
+    '*:S',
+    chdir: PROJECT_ROOT
+  )
+
+  return stdout if status.success?
+
+  warn stdout
+  raise 'Failed to read adb logcat. Ensure adb is installed and a device/emulator is available.'
+end
+
+def parse_latency_results(output)
+  results = Hash.new { |h, k| h[k] = [] }
+  current_test_name = nil
+  start_time = nil
+
+  output.each_line do |line|
+    if line =~ /LATENCY_TEST_CASE_STARTED:\s*(.+?)\s*$/
+      current_test_name = Regexp.last_match(1).strip
+      start_time = nil
+      next
+    end
+
+    if line =~ /LATENCY_TEST_CASE_FINISHED:\s*(.+?)\s*$/
+      finished_test_name = Regexp.last_match(1).strip
+      current_test_name = nil if finished_test_name == current_test_name
+      start_time = nil
+      next
+    end
+
+    if line =~ /DURATION_STARTED:\s*#{Regexp.escape(DURATION_KEY)}:\s*(\d+)/
+      start_time = Regexp.last_match(1).to_i
+      next
+    end
+
+    next unless line =~ /DURATION_ENDED:\s*#{Regexp.escape(DURATION_KEY)}:\s*(\d+)/
+    next if current_test_name.nil? || start_time.nil?
+
+    end_time = Regexp.last_match(1).to_i
+    duration_seconds = (end_time - start_time) / 1000.0
+    results[current_test_name] << duration_seconds
+    puts "  Found result: #{current_test_name} = #{format('%.4f', duration_seconds)}s"
+    start_time = nil
+  end
+
+  results
+end
+
+def print_raw_result_debug_summary(output)
+  counts = Hash.new(0)
+
+  output.each_line do |line|
+    next unless line =~ /LATENCY_TEST_CASE_STARTED:\s*(.+?)\s*$/
+
+    test_name = Regexp.last_match(1).strip
+    counts[test_name] += 1
+  end
+
+  puts "\nRaw test start counts for this invocation:"
+  if counts.empty?
+    puts '  No LATENCY_TEST_CASE_STARTED lines found'
+    return
+  end
+
+  counts.sort.each do |test_name, count|
+    puts "  #{test_name}: #{count}"
+  end
+end
+
+def extract_expected_test_count(output)
+  match = output.match(/Starting (\d+) tests on/)
+  match && match[1].to_i
+end
+
+def valid_invocation_results?(results:, sample_count:, expected_test_count:)
+  return false if expected_test_count.nil?
+  return false unless results.length == expected_test_count
+
+  results.values.all? { |durations| durations.length == sample_count }
+end
+
+# ============================================================================
+# STATISTICS
+# ============================================================================
+
+T_CRITICAL_VALUES = {
+  1 => 12.706, 2 => 4.303, 3 => 3.182, 4 => 2.776, 5 => 2.571,
+  6 => 2.447, 7 => 2.365, 8 => 2.306, 9 => 2.262, 10 => 2.228,
+  11 => 2.201, 12 => 2.179, 13 => 2.160, 14 => 2.145, 15 => 2.131,
+  16 => 2.120, 17 => 2.110, 18 => 2.101,
+  19 => 2.093, 20 => 2.086, 21 => 2.080, 22 => 2.074, 23 => 2.069,
+  24 => 2.064, 25 => 2.060, 26 => 2.056, 27 => 2.052, 28 => 2.048,
+  29 => 2.045, 30 => 2.042,
+  32 => 2.037, 34 => 2.032, 36 => 2.028, 38 => 2.024, 40 => 2.021,
+  42 => 2.018, 44 => 2.015, 46 => 2.013, 48 => 2.011, 50 => 2.009,
+  55 => 2.004, 60 => 2.000, 65 => 1.997, 70 => 1.994, 75 => 1.992,
+  80 => 1.990, 85 => 1.989, 90 => 1.987, 95 => 1.985, 98 => 1.984
+}.freeze
+
+T_KEYS = T_CRITICAL_VALUES.keys.sort.freeze
+MIN_KEY = T_KEYS.first
+MAX_KEY = T_KEYS.last
+
+def get_t_critical(df)
+  df = df.to_f
+  return T_CRITICAL_VALUES[MIN_KEY] if df <= MIN_KEY
+  return T_CRITICAL_VALUES[MAX_KEY] if df >= MAX_KEY
+
+  lower = T_KEYS.reverse_each.find { |key| key <= df }
+  T_CRITICAL_VALUES[lower]
+end
+
+def mean(array)
+  array.sum / array.length.to_f
+end
+
+def standard_deviation(array, mean_val)
+  variance = array.map { |value| (value - mean_val)**2 }.sum / (array.length - 1).to_f
+  Math.sqrt(variance)
+end
+
+def compute_independent_statistics(base_values, new_values)
+  base_mean = mean(base_values)
+  new_mean = mean(new_values)
+  base_sd = standard_deviation(base_values, base_mean)
+  new_sd = standard_deviation(new_values, new_mean)
+  n1 = base_values.length
+  n2 = new_values.length
+
+  abs_mean = new_mean - base_mean
+  abs_se = Math.sqrt((base_sd**2 / n1) + (new_sd**2 / n2))
+
+  numerator = (base_sd**2 / n1 + new_sd**2 / n2)**2
+  denominator = ((base_sd**2 / n1)**2 / (n1 - 1)) + ((new_sd**2 / n2)**2 / (n2 - 1))
+  df = numerator / denominator
+  tcrit = get_t_critical(df)
+
+  abs_margin = tcrit * abs_se
+  abs_lo = abs_mean - abs_margin
+  abs_hi = abs_mean + abs_margin
+
+  pct_mean = abs_mean / base_mean * 100.0
+  pct_lo = abs_lo / base_mean * 100.0
+  pct_hi = abs_hi / base_mean * 100.0
+  pct_margin = (pct_hi - pct_mean).abs
+
+  {
+    abs_mean: abs_mean,
+    abs_margin: abs_margin,
+    pct_mean: pct_mean,
+    pct_margin: pct_margin,
+    significant: abs_mean.abs > abs_margin
+  }
+end
+
+def compute_statistical_report(all_results)
+  base_tests = all_results[:base]
+  new_tests = all_results[:new]
+
+  raise 'No test results found for one or both commits' if base_tests.empty? || new_tests.empty?
+
+  common_tests = base_tests.keys & new_tests.keys
+  raise 'No common tests found between commits' if common_tests.empty?
+
+  common_tests.each_with_object({}) do |test_name, test_stats|
+    test_stats[test_name] = compute_independent_statistics(
+      base_tests.fetch(test_name),
+      new_tests.fetch(test_name)
+    )
+  end
+end
+
+# ============================================================================
+# PRINTING
+# ============================================================================
+
+def print_raw_measurements(all_results, base_commit, new_commit)
+  puts "\n" + '=' * 80
+  puts 'RAW LATENCY MEASUREMENTS'
+  puts '=' * 80
+
+  puts "\nBase Commit: #{base_commit}"
+  puts '-' * 80
+  all_results[:base].each do |test_name, durations|
+    avg = durations.sum / durations.length
+    puts "  #{test_name}:"
+    puts "    Runs: #{durations.map { |duration| format('%.4fs', duration) }.join(', ')}"
+    puts "    Average: #{format('%.4fs', avg)}"
+  end
+
+  puts "\nNew Commit: #{new_commit}"
+  puts '-' * 80
+  all_results[:new].each do |test_name, durations|
+    avg = durations.sum / durations.length
+    puts "  #{test_name}:"
+    puts "    Runs: #{durations.map { |duration| format('%.4fs', duration) }.join(', ')}"
+    puts "    Average: #{format('%.4fs', avg)}"
+  end
+end
+
+def print_statistical_report(test_stats, all_results)
+  puts "\n" + '=' * 80
+  puts 'LATENCY DELTA REPORT (vs Base Commit)'
+  puts '=' * 80
+
+  max_test_name_length = [test_stats.keys.map(&:length).max, 40].max
+  base_width = 13
+  new_width = 12
+  delta_width = 45
+  significance_width = 20
+  separators = 12
+  total_width = max_test_name_length + base_width + new_width + delta_width + significance_width + separators
+
+  puts
+  puts format(
+    "%-#{max_test_name_length}s | %#{base_width}s | %#{new_width}s | %-#{delta_width}s | %s",
+    'Test',
+    'Base commit',
+    'New commit',
+    'Mean Delta (95% CI)',
+    'Significant Difference?'
+  )
+  puts '-' * total_width
+
+  test_stats.sort.each do |test_name, stats|
+    base_avg = mean(all_results[:base].fetch(test_name)) * 1000
+    new_avg = mean(all_results[:new].fetch(test_name)) * 1000
+
+    pct_str = format('Δ %+.1f%% ± %.1f%%', stats[:pct_mean], stats[:pct_margin])
+    abs_str = format('%+.0fms ± %.0fms', stats[:abs_mean] * 1000, stats[:abs_margin] * 1000)
+    delta_str = "#{pct_str}; #{abs_str}"
+    significance_str = stats[:significant] ? 'Yes (p < 0.05)' : 'No'
+
+    puts format(
+      "%-#{max_test_name_length}s | %#{base_width}s | %#{new_width}s | %-#{delta_width}s | %s",
+      test_name,
+      format('%.0fms', base_avg),
+      format('%.0fms', new_avg),
+      delta_str,
+      significance_str
+    )
+  end
+
+  puts
+end
+
+# ============================================================================
+# GIT / PRECONDITIONS
+# ============================================================================
+
+def inside_clean_worktree?
+  Dir.chdir(PROJECT_ROOT) do
+    stdout, status = Open3.capture2e('git', '-c', 'core.fsmonitor=false', 'status', '--porcelain')
+    raise stdout unless status.success?
+
+    stdout.strip.empty?
+  end
+end
+
+def checkout_commit(commit)
+  Dir.chdir(PROJECT_ROOT) do
+    success = system('git', '-c', 'core.fsmonitor=false', 'checkout', commit)
+    raise "Failed to checkout commit #{commit}" unless success
+  end
+end
+
+def current_checkout
+  Dir.chdir(PROJECT_ROOT) do
+    branch, branch_status = Open3.capture2e('git', 'rev-parse', '--abbrev-ref', 'HEAD')
+    raise branch unless branch_status.success?
+
+    commit, commit_status = Open3.capture2e('git', 'rev-parse', 'HEAD')
+    raise commit unless commit_status.success?
+
+    branch = branch.strip
+    commit = commit.strip
+
+    branch == 'HEAD' ? commit : branch
+  end
+end
+
+def restore_checkout(target)
+  puts "\nRestoring original checkout: #{target}"
+  Dir.chdir(PROJECT_ROOT) do
+    system('git', '-c', 'core.fsmonitor=false', 'checkout', target)
+  end
+end
+
+# ============================================================================
+# TEST MODE
+# ============================================================================
+
+def run_statistics_test
+  puts '=' * 80
+  puts 'STATISTICS TEST MODE'
+  puts '=' * 80
+
+  base = [1.0, 1.1, 1.2, 1.1, 1.0] * 2
+  new = [1.1, 1.2, 1.3, 1.2, 1.1] * 2
+  stats = compute_independent_statistics(base, new)
+
+  puts "\nTest data:"
+  puts "  Base mean: #{mean(base).round(3)}"
+  puts "  New mean: #{mean(new).round(3)}"
+  puts "\nComputed statistics:"
+  puts "  Percentage delta: #{stats[:pct_mean].round(1)}% ± #{stats[:pct_margin].round(1)}%"
+  puts "  Absolute delta: #{(stats[:abs_mean] * 1000).round(0)}ms ± #{(stats[:abs_margin] * 1000).round(0)}ms"
+  puts "  Statistically significant: #{stats[:significant]}"
+  puts '=' * 80
+end
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+options = {
+  iterations: 20
+}
+
+benchmark_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: measure_latency_difference.rb [options]
+
+    Measures and compares Android PaymentSheet loading latency between two git commits.
+
+    This script:
+    1. Checks out each commit and runs the TestLatency instrumentation test in ABBA order
+    2. Parses StripeSdk logcat output from DurationProvider for the Loading key
+    3. Performs Welch t-test analysis to compare latency differences
+    4. Reports mean delta with 95% confidence intervals and statistical significance
+
+    Examples:
+      ./scripts/measure_latency_difference.rb --base-commit abc123 --commit def456
+      ./scripts/measure_latency_difference.rb --base-commit abc123 --commit abc123
+
+    Options:
+  BANNER
+
+  opts.on('--base-commit COMMIT', 'Base commit to compare against (required)') do |commit|
+    options[:base_commit] = commit
+  end
+
+  opts.on('--commit COMMIT', 'New commit to compare (required)') do |commit|
+    options[:commit] = commit
+  end
+
+  opts.on('--iterations N', Integer, 'Number of total samples to collect per commit (default: 20)') do |value|
+    options[:iterations] = value
+  end
+
+  opts.on('-h', '--help', 'Prints this help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+if ENV['TEST_STATS'] == '1'
+  run_statistics_test
+  exit
+end
+
+if options[:base_commit].nil? || options[:commit].nil?
+  warn 'Error: --base-commit and --commit are required'
+  exit 1
+end
+
+if options[:iterations] < 10
+  warn "Error: Iterations must be at least 10 (got #{options[:iterations]})"
+  exit 1
+end
+
+unless inside_clean_worktree?
+  warn 'Error: stripe-android has uncommitted changes. Commit or stash them before running this script.'
+  exit 1
+end
+
+original_checkout = current_checkout
+puts 'Configuration:'
+puts "  Base commit: #{options[:base_commit]}"
+puts "  New commit:  #{options[:commit]}"
+puts "  Iterations:  #{options[:iterations]}"
+puts "  Original checkout: #{original_checkout}"
+
+all_results = { base: {}, new: {} }
+run_size = options[:iterations] / 2
+
+unless options[:iterations].even?
+  warn 'Error: Iterations must be even so ABBA ordering produces balanced samples'
+  exit 1
+end
+
+puts "\nUsing ABBA ordering (2 runs per commit, #{run_size} samples per run = #{options[:iterations]} total samples per commit)"
+
+begin
+  merge_results(all_results[:base], run_latency_tests_for_commit(options[:base_commit], run_size))
+  merge_results(all_results[:new], run_latency_tests_for_commit(options[:commit], run_size))
+  merge_results(all_results[:new], run_latency_tests_for_commit(options[:commit], run_size))
+  merge_results(all_results[:base], run_latency_tests_for_commit(options[:base_commit], run_size))
+ensure
+  restore_checkout(original_checkout)
+end
+
+test_stats = compute_statistical_report(all_results)
+print_raw_measurements(all_results, options[:base_commit], options[:commit])
+print_statistical_report(test_stats, all_results)
+
+benchmark_duration_seconds = Process.clock_gettime(Process::CLOCK_MONOTONIC) - benchmark_started_at
+puts format('BENCHMARK_DURATION: %.1fs', benchmark_duration_seconds)

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -2,6 +2,8 @@ package com.stripe.android.core.utils
 
 import android.os.SystemClock
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.BuildConfig
+import com.stripe.android.core.Logger
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
@@ -33,6 +35,7 @@ interface DurationProvider {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultDurationProvider private constructor() : DurationProvider {
+    private val logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
 
     private val store = mutableMapOf<DurationProvider.Key, Long>()
 
@@ -40,6 +43,7 @@ class DefaultDurationProvider private constructor() : DurationProvider {
         if (reset || key !in store) {
             val startTime = SystemClock.uptimeMillis()
             store[key] = startTime
+            logger.debug("DURATION_STARTED: ${key.name}: $startTime")
         }
     }
 
@@ -50,7 +54,9 @@ class DefaultDurationProvider private constructor() : DurationProvider {
 
     override fun end(key: DurationProvider.Key): Duration? {
         val startTime = store.remove(key) ?: return null
-        return (SystemClock.uptimeMillis() - startTime).milliseconds
+        val endTime = SystemClock.uptimeMillis()
+        logger.debug("DURATION_ENDED: ${key.name}: ${endTime}")
+        return (endTime - startTime).milliseconds
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -55,7 +55,7 @@ class DefaultDurationProvider private constructor() : DurationProvider {
     override fun end(key: DurationProvider.Key): Duration? {
         val startTime = store.remove(key) ?: return null
         val endTime = SystemClock.uptimeMillis()
-        logger.debug("DURATION_ENDED: ${key.name}: ${endTime}")
+        logger.debug("DURATION_ENDED: ${key.name}: $endTime")
         return (endTime - startTime).milliseconds
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add load latency benchmark script

Usage: `./scripts/measure_latency_difference.sh --commit <commit to test> --base-commit <base commit> --iterations N`

Notably this tests against a debug build. We discussed using a release build instead, but that's proving tricky. I want to get this merged as at least a starting point, as I think a debug-build latency benchmark is better than nothing.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4486

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Ran on my laptop and verified the script worked as expected