### PR TITLE
Split release flow into propose and deploy scripts

### DIFF
--- a/scripts/deploy/common.rb
+++ b/scripts/deploy/common.rb
@@ -78,6 +78,32 @@ def switch_to_new_branch(branch_to_create, main_branch, repo: ".")
     execute_or_fail("git -C #{repo} branch -u #{main_branch}")
 end
 
+def local_git_tag_exists?(tag, repo: ".")
+    system("git -C #{repo} show-ref --verify --quiet refs/tags/#{tag}")
+end
+
+def remote_git_tag_exists?(tag, repo: ".", remote: "origin")
+    stdout, stderr, status = Open3.capture3("git -C #{repo} ls-remote --tags #{remote} refs/tags/#{tag}")
+    raise("Failed to query #{remote} for tag #{tag}: #{stderr}") unless status.success?
+
+    !stdout.empty?
+end
+
+def git_commit_for_ref(ref, repo: ".")
+    stdout, stderr, status = Open3.capture3("git", "-C", repo, "rev-list", "-n", "1", ref)
+    raise("Failed to resolve #{ref}: #{stderr}") unless status.success?
+
+    stdout.strip
+end
+
+def git_commit_exists?(commit, repo: ".")
+    system("git", "-C", repo, "cat-file", "-e", "#{commit}^{commit}")
+end
+
+def release_tag_name
+    "v#{@version}"
+end
+
 def create_pr(
     pr_branch,
     pr_title,

--- a/scripts/deploy/common.rb
+++ b/scripts/deploy/common.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'octokit'
 require 'open3'
 
 def fetch_password(password)
@@ -124,6 +125,17 @@ def create_pr(
 
     rputs user_message
     wait_for_user
+end
+
+private def octokit_client
+  @octokit_client ||= begin
+    token = fetch_password("bindings/gh-tokens/#{ENV['USER']}")
+    if token.nil? || token == ""
+      raise "Got empty Github token from password-vault"
+    end
+
+    Octokit::Client.new(access_token: token)
+  end
 end
 
 private def github_login

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -1,25 +1,20 @@
 #!/usr/bin/env ruby
 
 require 'octokit'
-require 'subprocess'
 
 require_relative 'common'
-require_relative 'gnupg_utils'
 
 @release_url = nil
 
 def create_github_release
-    # Must be run on the deploy branch, because it depends on changes made in
-    # create_version_bump_pr (updating CHANGELOG.md)
-    execute_or_fail("git checkout #{@deploy_branch}")
-    execute_or_fail("git pull")
-
-    tag_release
+    unless local_git_tag_exists?(release_tag_name)
+        raise "Release tag #{release_tag_name} does not exist locally. Run `git fetch origin --tags` before creating the GitHub release."
+    end
 
     begin
         release_response = octokit_client.create_release(
           "stripe/stripe-android",
-          "v#{@version}",
+          release_tag_name,
           name: "stripe-android v#{@version}",
           body: release_description,
           draft: @is_dry_run
@@ -31,20 +26,16 @@ def create_github_release
         open_url(release_response.html_url)
 
         if (@is_dry_run)
-            rputs "Please verify that the release was opened + created properly. It should contain a changelog of the changes for this release."
-            rputs "Since this is a dry run, you should see the release as a draft. It will be missing a tag + source code attachments."
+            rputs "Please verify that deploy release created a draft GitHub release for #{release_tag_name}. It should contain the changelog entries and point at the existing signed tag."
             wait_for_user
         end
     rescue StandardError => e
-        rputs "Failed to create GitHub release for #{tag_name}: #{e.class}: #{e.message}"
-        delete_release_tag
+        rputs "Failed to create GitHub release for #{release_tag_name}: #{e.class}: #{e.message}"
         raise
     end
 end
 
 def delete_github_release
-   delete_release_tag
-
    if (@release_url != nil)
        puts "Deleting release..."
        deleting_release_succeeded = octokit_client.delete_release("#{@release_url}__")
@@ -52,25 +43,6 @@ def delete_github_release
            rputs "Deleting release failed! Please manually delete release."
        end
    end
-end
-
-private def tag_name
-    "v#{@version}"
-end
-
-private def tag_release
-    gnupg_env do |env|
-        Subprocess.check_call(["git", "tag", "-s", "-u", "#{gnupg_key_id}", "#{tag_name}", "-m", "\"Version #{@version}\""], env: env)
-    end
-
-    # There's no way to create a "draft" tag, so we skip pushing tags if this is a dry run.
-    if(!@is_dry_run)
-        execute_or_fail("git push origin #{tag_name}")
-    end
-end
-
-private def delete_release_tag
-    execute("git tag -d #{tag_name}")
 end
 
 private def release_description
@@ -123,9 +95,4 @@ private def octokit_client
 
     Octokit::Client.new(access_token: token)
   end
-end
-
-# Gets the GnuPG key ID used to sign tagged commits.
-private def gnupg_key_id
-  fetch_password("bindings/gnupg/fingerprint").strip
 end

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'octokit'
-
 require_relative 'common'
 
 @release_url = nil
@@ -83,16 +81,4 @@ private def changelog_entries_for_version
     end
 
     raise ArgumentError.new("Version #{@version} not found in changelog. Have you finished merging the version bump PR?")
-end
-
-private def octokit_client
-  @octokit_client ||= begin
-    # Fetch the per-user secret from password-vault
-    token = fetch_password("bindings/gh-tokens/#{ENV['USER']}")
-    if token.nil? || token == ""
-      raise "Got empty Github token from password-vault"
-    end
-
-    Octokit::Client.new(access_token: token)
-  end
 end

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -5,8 +5,14 @@ require_relative 'common'
 @release_url = nil
 
 def create_github_release
-    unless local_git_tag_exists?(release_tag_name)
+    tag_exists_locally = local_git_tag_exists?(release_tag_name)
+
+    unless tag_exists_locally || @is_dry_run
         raise "Release tag #{release_tag_name} does not exist locally. Run `git fetch origin --tags` before creating the GitHub release."
+    end
+
+    if @is_dry_run && !tag_exists_locally
+        rputs "Dry run: local release tag #{release_tag_name} is unavailable. Creating a draft GitHub release without validating a checked-out tag first."
     end
 
     begin
@@ -24,7 +30,11 @@ def create_github_release
         open_url(release_response.html_url)
 
         if (@is_dry_run)
-            rputs "Please verify that deploy release created a draft GitHub release for #{release_tag_name}. It should contain the changelog entries and point at the existing signed tag."
+            if tag_exists_locally
+                rputs "Please verify that deploy release created a draft GitHub release for #{release_tag_name}. It should contain the changelog entries and point at the existing signed tag."
+            else
+                rputs "Please verify that deploy release created a draft GitHub release for #{release_tag_name}. Because the release source was unavailable, it may be missing tag or source attachments."
+            end
             wait_for_user
         end
     rescue StandardError => e
@@ -48,6 +58,16 @@ private def release_description
 
     release_body = <<~EOS
         #{changelog_entries}
+
+        See [the changelog for more details](https://github.com/stripe/stripe-android/blob/master/CHANGELOG.md).
+    EOS
+rescue ArgumentError => e
+    raise unless @is_dry_run
+
+    rputs "Dry run: #{e.message}"
+
+    <<~EOS
+        Dry run: changelog entries for #{@version} are not available in the current checkout.
 
         See [the changelog for more details](https://github.com/stripe/stripe-android/blob/master/CHANGELOG.md).
     EOS

--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -1,100 +1,12 @@
 #!/usr/bin/env ruby
 
-require 'colorize'
-require 'optparse'
+abort <<~EOS
+`scripts/deploy/deploy.rb` no longer runs the release end-to-end.
 
-require_relative 'common'
-require_relative 'create_github_release'
-require_relative 'permissions_check'
-require_relative 'publish_to_sonatype'
-require_relative 'translations'
-require_relative 'update_pay_server_docs'
-require_relative 'update_version_numbers'
-require_relative 'validate_version_number'
-require_relative 'version_bump_pr_steps'
+Use:
+  `./scripts/deploy/propose_release.rb`
+  `./scripts/deploy/deploy_release.rb`
 
-@step_index = 1
-@is_dry_run = false
-@deploy_branch = 'master'
-@is_older_version = false
-
-def execute_steps(steps, step_index)
-  step_count = steps.length
-
-  if step_index > 1
-    steps = steps.drop(step_index - 1)
-    rputs "Continuing from step #{step_index}: #{steps.first.name}"
-  end
-
-  begin
-    steps.each do |step|
-      rputs "# #{step.name} (step #{step_index}/#{step_count})"
-      step.call
-      step_index += 1
-    end
-  rescue Exception => e
-    rputs "Restart with --continue-from #{step_index} --version #{@version} to re-run from this step."
-    raise
-  end
-end
-
-OptionParser.new do |opts|
-  opts.on('--version VERSION',
-          'Version to release (e.g. 21.2.0)') do |t|
-    @version = t
-  end
-
-  opts.on('--continue-from NUMBER',
-          'Continue from a specified step') do |t|
-    @step_index = t.to_i
-  end
-
-  opts.on('--dry-run', "Don't do a real deployment, but test what would happen if you did") do |t|
-      @is_dry_run = t
-  end
-
-  opts.on('--branch BRANCH', "Branch to deploy from") do |t|
-      @deploy_branch = t
-  end
-
-  opts.on('--release-older-version', "Indicates you are not releasing the newest version of stripe-android.") do |t|
-      @is_older_version = t
-  end
-
-end.parse!
-
-if @version.nil?
-  @version = infer_version_from_changelog()
-end
-
-steps = [
-    # Prep for making changes
-    method(:check_permissions),
-    method(:validate_translations_merged),
-    method(:validate_version_number),
-    method(:ensure_clean_repo),
-    method(:pull_latest),
-
-    # Update version number
-    method(:create_version_bump_pr),
-
-    # Actually release a new SDK version
-    method(:publish_to_sonatype),
-
-    # Create a Github release
-    method(:create_github_release),
-
-    # Do docs updates
-    method(:update_pay_server_docs),
-]
-
-execute_steps(steps, @step_index)
-
-if (@is_dry_run)
-    rputs "Press enter to revert all changes made during the dry run."
-    wait_for_user()
-
-    delete_github_release()
-    revert_version_bump_changes()
-    delete_pay_server_branch()
-end
+`propose release` creates the version bump branch, signed tag, and PR handoff.
+`deploy release` publishes from the existing signed tag after the version bump PR is merged.
+EOS

--- a/scripts/deploy/deploy_release.rb
+++ b/scripts/deploy/deploy_release.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require_relative 'create_github_release'
+require_relative 'permissions_check'
+require_relative 'publish_to_sonatype'
+require_relative 'release_cli'
+require_relative 'release_tag_steps'
+require_relative 'update_pay_server_docs'
+require_relative 'version_bump_pr_steps'
+
+def cleanup_deploy_release(success:)
+    delete_github_release if @is_dry_run
+    execute("git checkout #{@deploy_branch}") if success && @checked_out_release_tag
+end
+
+def prepare_deploy_release_resume(step_index)
+    return if step_index < 4
+
+    checkout_release_source
+end
+
+parse_release_options!(flow_name: 'deploy release')
+
+steps = [
+    method(:check_permissions),
+    method(:ensure_clean_repo),
+    method(:checkout_release_source),
+    method(:publish_to_sonatype),
+    method(:create_github_release),
+    method(:update_pay_server_docs),
+]
+
+@deploy_release_succeeded = false
+
+begin
+    execute_steps(steps, before_resume: method(:prepare_deploy_release_resume))
+    @deploy_release_succeeded = true
+ensure
+    cleanup_deploy_release(success: @deploy_release_succeeded)
+end

--- a/scripts/deploy/propose_release.rb
+++ b/scripts/deploy/propose_release.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+require_relative 'permissions_check'
+require_relative 'release_cli'
+require_relative 'release_tag_steps'
+require_relative 'translations'
+require_relative 'update_version_numbers'
+require_relative 'validate_version_number'
+require_relative 'version_bump_pr_steps'
+
+def print_propose_release_handoff
+    rputs "propose release complete"
+    puts "Version: #{@version}"
+    puts "Branch: #{release_branch}"
+    puts "Tag: #{release_tag_name}"
+
+    if @is_dry_run
+        rputs "Dry run: the signed tag was created locally but not pushed. Use deploy release only after a real propose release has created the final remote tag."
+    else
+        rputs "Hand off #{release_tag_name} to deploy release."
+    end
+end
+
+def cleanup_propose_release_dry_run
+    delete_release_tag
+    delete_git_branch(release_branch, @deploy_branch)
+end
+
+parse_release_options!(flow_name: 'propose release')
+
+steps = [
+    method(:check_permissions),
+    method(:validate_translations_merged),
+    method(:validate_version_number),
+    method(:ensure_clean_repo),
+    method(:pull_latest),
+    method(:create_version_bump_pr),
+    method(:create_release_tag),
+    method(:print_propose_release_handoff),
+]
+
+@propose_release_succeeded = false
+
+begin
+    execute_steps(steps)
+    @propose_release_succeeded = true
+ensure
+    if @is_dry_run && @propose_release_succeeded
+        rputs "Press enter to clean up the dry run branch and tag."
+        wait_for_user
+        cleanup_propose_release_dry_run
+    end
+end

--- a/scripts/deploy/publish_to_sonatype.rb
+++ b/scripts/deploy/publish_to_sonatype.rb
@@ -6,11 +6,6 @@ require_relative 'common'
 require_relative 'gnupg_utils'
 
 def publish_to_sonatype
-    # Must be run on the deploy branch, because it depends on changes made in
-    # create_version_bump_pr (updating the VERSION file)
-    execute_or_fail("git checkout #{@deploy_branch}")
-    execute_or_fail("git pull")
-
     set_gpg_location()
 
     begin
@@ -81,7 +76,7 @@ private def set_gpg_location
 end
 
 private def reset_gradle_properties
-    execute_or_fail("git checkout origin/#{@deploy_branch} gradle.properties")
+    execute_or_fail("git checkout -- gradle.properties")
 end
 
 # Gets the contents of the PATH environment variable, but before it does

--- a/scripts/deploy/release_cli.rb
+++ b/scripts/deploy/release_cli.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+require_relative 'common'
+require_relative 'validate_version_number'
+
+def parse_release_options!(flow_name:)
+    @flow_name = flow_name
+    @step_index = 1
+    @is_dry_run = false
+    @deploy_branch = 'master'
+    @is_older_version = false
+
+    OptionParser.new do |opts|
+        opts.on('--version VERSION',
+                'Version to release (e.g. 21.2.0)') do |t|
+            @version = t
+        end
+
+        opts.on('--continue-from NUMBER',
+                'Continue from a specified step within this release flow') do |t|
+            @step_index = t.to_i
+        end
+
+        opts.on('--dry-run', "Don't do a real deployment, but test what would happen if you did") do |t|
+            @is_dry_run = t
+        end
+
+        opts.on('--branch BRANCH', "Branch to deploy from") do |t|
+            @deploy_branch = t
+        end
+
+        opts.on('--release-older-version', "Indicates you are not releasing the newest version of stripe-android.") do |t|
+            @is_older_version = t
+        end
+    end.parse!
+
+    if @version.nil?
+        @version = infer_version_from_changelog()
+    end
+end
+
+def execute_steps(steps, before_resume: nil)
+    step_count = steps.length
+    step_index = @step_index
+
+    if step_index < 1 || step_index > step_count
+        raise ArgumentError, "--continue-from must be between 1 and #{step_count}"
+    end
+
+    begin
+        if step_index > 1
+            before_resume.call(step_index) if before_resume
+            steps = steps.drop(step_index - 1)
+            rputs "Continuing #{@flow_name} from step #{step_index}: #{steps.first.name}"
+        end
+
+        steps.each do |step|
+            rputs "# #{step.name} (step #{step_index}/#{step_count})"
+            step.call
+            step_index += 1
+        end
+    rescue Exception
+        command = "./scripts/deploy/#{File.basename($PROGRAM_NAME)}"
+        rputs "Restart #{@flow_name} with `#{command} --continue-from #{step_index} --version #{@version}` to re-run from this step."
+        raise
+    end
+end

--- a/scripts/deploy/release_tag_steps.rb
+++ b/scripts/deploy/release_tag_steps.rb
@@ -1,0 +1,142 @@
+#!/usr/bin/env ruby
+
+require 'subprocess'
+
+require_relative 'common'
+require_relative 'gnupg_utils'
+
+def fetch_origin_and_tags
+    execute_or_fail("git fetch --tags origin #{@deploy_branch}")
+end
+
+def verify_release_pr_merged
+    pr = fetch_release_pr
+    if pr.nil?
+        raise "Could not find a version bump PR for #{release_branch} targeting #{@deploy_branch}. Run `propose release` first."
+    end
+
+    if pr.merged_at.nil?
+        raise "Version bump PR for #{release_branch} is not merged yet: #{pr.html_url}"
+    end
+
+    if pr.merge_commit_sha.nil? || pr.merge_commit_sha.empty?
+        raise "Version bump PR for #{release_branch} is merged, but GitHub did not return a merge commit sha."
+    end
+
+    @release_source_sha = pr.merge_commit_sha
+    puts "Verified merged version bump PR: #{pr.html_url}".green
+    pr
+end
+
+def prepare_release_source_from_merged_pr
+    verify_release_pr_merged
+    fetch_origin_and_tags
+
+    unless git_commit_exists?(@release_source_sha)
+        raise "Merged PR commit #{@release_source_sha} is not available locally after fetching #{@deploy_branch}."
+    end
+end
+
+def verify_release_tag_exists
+    unless local_git_tag_exists?(release_tag_name)
+        raise "Release tag #{release_tag_name} does not exist locally. Run `git fetch origin --tags` or confirm `propose release` completed."
+    end
+end
+
+def create_release_tag
+    if @is_dry_run
+        pr = fetch_release_pr
+        if pr.nil?
+            raise "Could not find a version bump PR for #{release_branch} targeting #{@deploy_branch}. Run `propose release` first."
+        end
+
+        if pr.head.sha.nil? || pr.head.sha.empty?
+            raise "Could not determine the release branch head for dry-run tag creation."
+        end
+
+        @release_source_sha = pr.head.sha
+        rputs "Dry run: using release branch head #{@release_source_sha} as a stand-in for the merged PR revision."
+    else
+        prepare_release_source_from_merged_pr
+    end
+
+    if local_git_tag_exists?(release_tag_name)
+        verify_release_tag_matches_release_source
+    elsif remote_git_tag_exists?(release_tag_name)
+        fetch_origin_and_tags
+        verify_release_tag_matches_release_source
+    else
+        create_local_release_tag
+    end
+
+    if @is_dry_run
+        rputs "Dry run: verified local signed tag #{release_tag_name} at #{@release_source_sha} without pushing it to origin."
+        return
+    end
+
+    unless remote_git_tag_exists?(release_tag_name)
+        execute_or_fail("git push origin #{release_tag_name}")
+    end
+end
+
+def checkout_release_source
+    prepare_release_source_from_merged_pr
+    verify_release_tag_matches_release_source
+    checkout_release_tag
+end
+
+def verify_release_tag_matches_release_source
+    verify_release_tag_exists
+    tag_commit = git_commit_for_ref("refs/tags/#{release_tag_name}")
+
+    if tag_commit != @release_source_sha
+        raise "Release tag #{release_tag_name} points to #{tag_commit}, but the merged PR revision is #{@release_source_sha}."
+    end
+
+    puts "Verified release tag #{release_tag_name} points to #{@release_source_sha}".green
+end
+
+def checkout_release_tag
+    verify_release_tag_exists
+    execute_or_fail("git checkout --detach refs/tags/#{release_tag_name}")
+    @checked_out_release_tag = true
+end
+
+def delete_release_tag(delete_remote: false, delete_local: true)
+    if delete_remote && remote_git_tag_exists?(release_tag_name)
+        execute("git push origin :refs/tags/#{release_tag_name}")
+    end
+
+    if delete_local && local_git_tag_exists?(release_tag_name)
+        execute("git tag -d #{release_tag_name}")
+    end
+end
+
+private def create_local_release_tag
+    gnupg_env do |env|
+        Subprocess.check_call(
+            ["git", "tag", "-s", "-u", gnupg_key_id, "-m", "Version #{@version}", release_tag_name, @release_source_sha],
+            env: env
+        )
+    end
+end
+
+private def fetch_release_pr
+    octokit_client.auto_paginate = true
+    pull_requests = octokit_client.pull_requests(
+        "stripe/stripe-android",
+        state: "all",
+        head: "stripe:#{release_branch}",
+        base: @deploy_branch,
+    )
+
+    matching_prs = pull_requests.select do |pr|
+        pr.head.ref == release_branch && pr.base.ref == @deploy_branch
+    end
+
+    matching_prs.max_by { |pr| pr.updated_at || pr.created_at }
+end
+
+private def gnupg_key_id
+    fetch_password("bindings/gnupg/fingerprint").strip
+end

--- a/scripts/deploy/release_tag_steps.rb
+++ b/scripts/deploy/release_tag_steps.rb
@@ -80,9 +80,16 @@ def create_release_tag
 end
 
 def checkout_release_source
-    prepare_release_source_from_merged_pr
-    verify_release_tag_matches_release_source
-    checkout_release_tag
+    begin
+        prepare_release_source_from_merged_pr
+        verify_release_tag_matches_release_source
+        checkout_release_tag
+    rescue StandardError => e
+        raise unless @is_dry_run
+
+        rputs "Dry run: continuing without checked-out release source: #{e.message}"
+        rputs "Dry run: remaining deploy release steps will run from the current checkout instead of #{release_tag_name}."
+    end
 end
 
 def verify_release_tag_matches_release_source

--- a/scripts/deploy/translations.rb
+++ b/scripts/deploy/translations.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'octokit'
-
 require_relative 'common'
 
 def validate_translations_merged


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Split release flow into propose and deploy scripts

We now have two scripts:
- propose_release.rb
- deploy_release.rb

Propose release does everything up through the version bump PR in the current deploy.rb, then it generates the release tag.
The deploy release script pulls the release tag and does the rest of the release based on that.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Match iOS + RN, full discussion here: [slack](https://stripe.slack.com/archives/CFA2HJ99A/p1778185792176729?thread_ts=1777580604.053499&cid=CFA2HJ99A)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Used `--dry-run` to verify as much as possible