### PR TITLE
Parallelize payment methods fetch with elements session for legacy ep…

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementnetwork/NetworkRuleExtensions.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementnetwork/NetworkRuleExtensions.kt
@@ -10,18 +10,11 @@ import org.json.JSONArray
 
 fun NetworkRule.setupV1PaymentMethodsResponse(
     vararg paymentMethodDetails: PaymentMethodDetails,
-    type: String = paymentMethodDetails.first().type,
 ) {
-    for (paymentMethodDetail in paymentMethodDetails) {
-        // All types must match.
-        assertThat(type).isEqualTo(paymentMethodDetail.type)
-    }
-
     enqueue(
         host("api.stripe.com"),
         method("GET"),
         path("/v1/payment_methods"),
-        query("type", type),
     ) { response ->
         val paymentMethodsArray = JSONArray()
 

--- a/payments-core/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
@@ -10,7 +10,7 @@ import kotlinx.parcelize.Parcelize
 @Poko
 class ListPaymentMethodsParams(
     private val customerId: String,
-    internal val paymentMethodType: PaymentMethod.Type,
+    internal val paymentMethodType: PaymentMethod.Type?,
     private val limit: Int? = null,
     private val endingBefore: String? = null,
     private val startingAfter: String? = null
@@ -18,7 +18,7 @@ class ListPaymentMethodsParams(
     override fun toParamMap(): Map<String, Any> {
         return listOf(
             PARAM_CUSTOMER to customerId,
-            PARAM_TYPE to paymentMethodType.code,
+            PARAM_TYPE to paymentMethodType?.code,
             PARAM_LIMIT to limit,
             PARAM_ENDING_BEFORE to endingBefore,
             PARAM_STARTING_AFTER to startingAfter

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1258,6 +1258,56 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun getPaymentMethods_whenTypeNotSpecified_omitsTypeQueryParam() = runTest {
+        val responseBody =
+            """
+            {
+                "object": "list",
+                "data": [],
+                "has_more": false,
+                "url": "/v1/payment_methods"
+            }
+            """.trimIndent()
+        val stripeResponse = StripeResponse(200, responseBody)
+        val queryParams = mapOf(
+            "customer" to "cus_123"
+        )
+
+        val options = ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
+        val url = DEFAULT_API_REQUEST_FACTORY.createGet(
+            StripeApiRepository.paymentMethodsUrl,
+            options,
+            queryParams
+        ).url
+
+        whenever(
+            stripeNetworkClient.executeRequest(
+                argThat<ApiRequest> {
+                    ApiRequestMatcher(StripeRequest.Method.GET, url, options, queryParams)
+                        .matches(this)
+                }
+            )
+        ).thenReturn(stripeResponse)
+        val stripeApiRepository = create()
+        val paymentMethods = stripeApiRepository
+            .getPaymentMethods(
+                listPaymentMethodsParams = ListPaymentMethodsParams(
+                    "cus_123",
+                    null
+                ),
+                productUsageTokens = emptySet(),
+                requestOptions = ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
+            ).getOrThrow()
+
+        assertThat(paymentMethods).isEmpty()
+
+        verifyAnalyticsRequest(
+            PaymentAnalyticsEvent.CustomerRetrievePaymentMethods,
+            null
+        )
+    }
+
+    @Test
     fun getPaymentMethods_whenNotPopulated_returnsEmptyList() = runTest {
         val responseBody =
             """

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
@@ -181,7 +181,6 @@ internal class PaymentSheetDeferredTest {
         networkRule.enqueue(
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
             query("customer", "cus_foobar"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
@@ -238,7 +237,6 @@ internal class PaymentSheetDeferredTest {
         networkRule.enqueue(
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
             query("customer", "cus_foobar"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success-empty.json")
@@ -320,7 +318,6 @@ internal class PaymentSheetDeferredTest {
         networkRule.enqueue(
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
             query("customer", "cus_foobar"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
@@ -380,7 +377,6 @@ internal class PaymentSheetDeferredTest {
         networkRule.enqueue(
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
             query("customer", "cus_foobar"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success-empty.json")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -580,16 +580,6 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/payment_methods"),
-            query("type", "us_bank_account"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success-us-bank.json")
         }
@@ -643,16 +633,6 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/payment_methods"),
-            query("type", "us_bank_account"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success-us-bank.json")
         }
@@ -702,18 +682,8 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
-        }
-
-        networkRule.enqueue(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/payment_methods"),
-            query("type", "us_bank_account"),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
         }
 
         testContext.presentPaymentSheet {
@@ -935,7 +905,6 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
-            query("type", "card"),
             header("Authorization", "Bearer uk_12345"),
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -53,16 +53,20 @@ internal class CustomerApiRepository @Inject constructor(
     override suspend fun getPaymentMethods(
         customerId: String,
         ephemeralKeySecret: String,
-        types: List<PaymentMethod.Type>,
+        types: List<PaymentMethod.Type>?,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>> = withContext(workContext) {
-        val requests = types.filter { paymentMethodType ->
+        val filteredTypes = types?.filter { paymentMethodType ->
             paymentMethodType in setOf(
                 PaymentMethod.Type.Card,
                 PaymentMethod.Type.USBankAccount,
                 PaymentMethod.Type.SepaDebit,
             )
-        }.map { paymentMethodType ->
+        }
+
+        val requestTypes = filteredTypes ?: listOf(null)
+
+        val requests = requestTypes.map { paymentMethodType ->
             async {
                 stripeRepository.getPaymentMethods(
                     listPaymentMethodsParams = ListPaymentMethodsParams(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -18,13 +18,14 @@ internal interface CustomerRepository {
 
     /**
      * Retrieve a Customer's payment methods of all types requested.
+     * If [types] is null, retrieve payment methods without filtering by type.
      * @param silentlyFail Silently handle failures by returning an empty list for the payment method
      * types that failed.
      */
     suspend fun getPaymentMethods(
         customerId: String,
         ephemeralKeySecret: String,
-        types: List<PaymentMethod.Type>,
+        types: List<PaymentMethod.Type>?,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>>
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.Deferred
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
-internal typealias PrefetchedPaymentMethods = Deferred<Result<List<PaymentMethod>>>?
-
 @Parcelize
 internal data class CustomerState(
     val paymentMethods: List<PaymentMethod>,
@@ -29,7 +27,7 @@ internal class CreateCustomerState @Inject constructor(
         elementsSession: ElementsSession,
         metadata: PaymentMethodMetadata,
         savedSelection: Deferred<SavedSelection>,
-        prefetchedPaymentMethods: PrefetchedPaymentMethods = null,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
     ): CustomerState? {
         val customerMetadata = metadata.customerMetadata
         val customerState = when (customerMetadata) {
@@ -115,20 +113,17 @@ internal class CreateCustomerState @Inject constructor(
     private suspend fun retrieveCustomerPaymentMethods(
         metadata: PaymentMethodMetadata,
         customerMetadata: CustomerMetadata.LegacyEphemeralKey,
-        prefetchedPaymentMethods: PrefetchedPaymentMethods = null,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
     ): List<PaymentMethod> {
         val paymentMethodTypes = metadata.supportedSavedPaymentMethodTypes()
 
-        val paymentMethods = if (prefetchedPaymentMethods != null) {
-            prefetchedPaymentMethods.await().getOrThrow()
-        } else {
-            customerRepository.getPaymentMethods(
+        val paymentMethods = prefetchedPaymentMethods?.await()?.getOrThrow()
+            ?: customerRepository.getPaymentMethods(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 types = paymentMethodTypes,
                 silentlyFail = metadata.stripeIntent.isLiveMode,
             ).getOrThrow()
-        }
 
         return paymentMethods.filter { paymentMethod ->
             paymentMethod.hasExpectedDetails() &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.Deferred
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
+internal typealias PrefetchedPaymentMethods = Deferred<Result<List<PaymentMethod>>>?
+
 @Parcelize
 internal data class CustomerState(
     val paymentMethods: List<PaymentMethod>,
@@ -27,6 +29,7 @@ internal class CreateCustomerState @Inject constructor(
         elementsSession: ElementsSession,
         metadata: PaymentMethodMetadata,
         savedSelection: Deferred<SavedSelection>,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods = null,
     ): CustomerState? {
         val customerMetadata = metadata.customerMetadata
         val customerState = when (customerMetadata) {
@@ -52,6 +55,7 @@ internal class CreateCustomerState @Inject constructor(
                     paymentMethods = retrieveCustomerPaymentMethods(
                         metadata = metadata,
                         customerMetadata = customerMetadata,
+                        prefetchedPaymentMethods = prefetchedPaymentMethods,
                     )
                 )
             }
@@ -111,18 +115,24 @@ internal class CreateCustomerState @Inject constructor(
     private suspend fun retrieveCustomerPaymentMethods(
         metadata: PaymentMethodMetadata,
         customerMetadata: CustomerMetadata.LegacyEphemeralKey,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods = null,
     ): List<PaymentMethod> {
         val paymentMethodTypes = metadata.supportedSavedPaymentMethodTypes()
 
-        val paymentMethods = customerRepository.getPaymentMethods(
-            customerId = customerMetadata.id,
-            ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
-            types = paymentMethodTypes,
-            silentlyFail = metadata.stripeIntent.isLiveMode,
-        ).getOrThrow()
+        val paymentMethods = if (prefetchedPaymentMethods != null) {
+            prefetchedPaymentMethods.await().getOrThrow()
+        } else {
+            customerRepository.getPaymentMethods(
+                customerId = customerMetadata.id,
+                ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
+                types = paymentMethodTypes,
+                silentlyFail = metadata.stripeIntent.isLiveMode,
+            ).getOrThrow()
+        }
 
         return paymentMethods.filter { paymentMethod ->
-            paymentMethod.hasExpectedDetails()
+            paymentMethod.hasExpectedDetails() &&
+                paymentMethodTypes.contains(paymentMethod.type)
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -421,11 +421,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             customerRepository.getPaymentMethods(
                 customerId = customer.id,
                 ephemeralKeySecret = accessType.ephemeralKeySecret,
-                types = listOf(
-                    PaymentMethod.Type.Card,
-                    PaymentMethod.Type.USBankAccount,
-                    PaymentMethod.Type.SepaDebit,
-                ),
+                types = null,
                 silentlyFail = paymentConfiguration.get().isLiveMode(),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -44,10 +44,12 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository
 import com.stripe.attestation.IntegrityRequestManager
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
@@ -231,6 +233,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val paymentConfiguration: Provider<PaymentConfiguration>,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val analyticsMetadataFactory: AnalyticsMetadataFactory,
+    private val customerRepository: CustomerRepository,
     private val createCustomerState: CreateCustomerState,
     private val checkoutSessionLoader: CheckoutSessionLoader,
     private val elementsSessionLoader: ElementsSessionLoader,
@@ -276,6 +279,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val isGooglePaySupportedByConfiguration = async {
             configuration.isGooglePayReady()
         }
+
+        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
         val elementsSession = loadSession(
@@ -350,6 +355,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 elementsSession = elementsSession,
                 metadata = paymentMethodMetadata.await(),
                 savedSelection = savedSelection,
+                prefetchedPaymentMethods = prefetchedPaymentMethods,
             )
         }
 
@@ -402,6 +408,27 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         )
 
         return@runCatching state
+    }
+
+    private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
+        configuration: CommonConfiguration,
+    ): Deferred<Result<List<PaymentMethod>>>? {
+        val customer = configuration.customer ?: return null
+        val accessType = customer.accessType
+        if (accessType !is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey) return null
+
+        return async {
+            customerRepository.getPaymentMethods(
+                customerId = customer.id,
+                ephemeralKeySecret = accessType.ephemeralKeySecret,
+                types = listOf(
+                    PaymentMethod.Type.Card,
+                    PaymentMethod.Type.USBankAccount,
+                    PaymentMethod.Type.SepaDebit,
+                ),
+                silentlyFail = paymentConfiguration.get().isLiveMode(),
+            )
+        }
     }
 
     private suspend fun loadSession(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethods.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethods.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.paymentsheet.state
+
+import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.Deferred
+
+internal typealias PrefetchedPaymentMethods = Deferred<Result<List<PaymentMethod>>>

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,6 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -240,7 +241,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `retrievePaymentMethods requests US Bank Account payment methods`() = runTest {
+    fun `retrievePaymentMethods does not filter payment methods when paymentMethodTypes are not specified`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
         val adapter = createAdapter(
@@ -252,12 +253,7 @@ class CustomerAdapterTest {
         verify(customerRepository).getPaymentMethods(
             customerId = any(),
             ephemeralKeySecret = any(),
-            types = eq(
-                listOf(
-                    PaymentMethod.Type.Card,
-                    PaymentMethod.Type.USBankAccount,
-                )
-            ),
+            types = isNull(),
             silentlyFail = eq(false),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,7 +30,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -241,7 +240,7 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `retrievePaymentMethods does not filter payment methods when paymentMethodTypes are not specified`() = runTest {
+    fun `retrievePaymentMethods requests US Bank Account payment methods`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
         val adapter = createAdapter(
@@ -253,7 +252,12 @@ class CustomerAdapterTest {
         verify(customerRepository).getPaymentMethods(
             customerId = any(),
             ephemeralKeySecret = any(),
-            types = isNull(),
+            types = eq(
+                listOf(
+                    PaymentMethod.Type.Card,
+                    PaymentMethod.Type.USBankAccount,
+                )
+            ),
             silentlyFail = eq(false),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
@@ -121,7 +121,7 @@ internal class VerticalModePaymentSheetActivityTest {
         initialLoadWaiter = { formPage.waitUntilVisible() },
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card"))
-            networkRule.setupV1PaymentMethodsResponse(type = "card")
+            networkRule.setupV1PaymentMethodsResponse()
         },
     ) {
         verticalModePage.assertIsNotVisible()
@@ -361,8 +361,7 @@ internal class VerticalModePaymentSheetActivityTest {
         customer = PaymentSheet.CustomerConfiguration(id = "cus_1", ephemeralKeySecret = "ek_test"),
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card", "us_bank_account"))
-            networkRule.setupV1PaymentMethodsResponse(usBankAccount1)
-            networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(card1, card2, usBankAccount1)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -397,7 +396,6 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card", "us_bank_account"))
             networkRule.setupV1PaymentMethodsResponse(usBankAccount1)
-            networkRule.setupV1PaymentMethodsResponse(type = "card")
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -412,7 +410,6 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card", "us_bank_account"))
             networkRule.setupV1PaymentMethodsResponse(usBankAccount1, usBankAccount2)
-            networkRule.setupV1PaymentMethodsResponse(type = "card")
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -78,6 +78,33 @@ internal class CustomerRepositoryTest {
             )
         }
 
+    @Test
+    fun `getPaymentMethods() should omit payment method type when types are not specified`() =
+        runTest {
+            givenGetPaymentMethodsReturns(
+                Result.success(emptyList())
+            )
+
+            repository.getPaymentMethods(
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
+                types = null,
+                silentlyFail = true,
+            )
+
+            verify(stripeRepository).getPaymentMethods(
+                listPaymentMethodsParams = eq(
+                    ListPaymentMethodsParams(
+                        customerId = "customer_id",
+                        paymentMethodType = null,
+                        limit = 100,
+                    )
+                ),
+                productUsageTokens = any(),
+                requestOptions = any()
+            )
+        }
+
     // PayPal isn't supported as a saved payment method due to issues with on-session.
     // See: https://docs.google.com/document/d/1_bCPJXxhV4Kdgy7LX7HPwpZfElN3a2DcYUooiWC9SgM
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -763,38 +763,6 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `load() with customer should fetch only supported payment method types`() =
-        runScenario {
-            val paymentMethodTypes = listOf(
-                "card", // valid and supported
-                "fpx", // valid but not supported
-                "invalid_type" // unknown type
-            )
-
-            val loader = createPaymentElementLoader(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    paymentMethodTypes = paymentMethodTypes
-                ),
-            )
-
-            loader.load(
-                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                ),
-                PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                metadata = PaymentElementLoader.Metadata(
-                    initializedViaCompose = false,
-                ),
-            )
-
-            val request = customerRepository.getPaymentMethodsRequests.awaitItem()
-            assertThat(request.types).containsExactly(PaymentMethod.Type.Card)
-
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
-            assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
-        }
-
-    @Test
     fun `when allowsDelayedPaymentMethods is false then delayed payment methods are filtered out`() =
         runScenario {
             val loader = createPaymentElementLoader(
@@ -817,8 +785,7 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             )
 
-            val request = customerRepository.getPaymentMethodsRequests.awaitItem()
-            assertThat(request.types).containsExactly(PaymentMethod.Type.Card)
+            customerRepository.getPaymentMethodsRequests.awaitItem()
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -915,16 +882,14 @@ internal class DefaultPaymentElementLoaderTest {
 
     @Test
     fun `load() with customer should allow sepa`() = runScenario {
-        var requestPaymentMethodTypes: List<PaymentMethod.Type>? = null
         val result = createPaymentElementLoader(
             customerRepo = object : FakeCustomerRepository() {
                 override suspend fun getPaymentMethods(
                     customerId: String,
                     ephemeralKeySecret: String,
-                    types: List<PaymentMethod.Type>,
+                    types: List<PaymentMethod.Type>?,
                     silentlyFail: Boolean,
                 ): Result<List<PaymentMethod>> {
-                    requestPaymentMethodTypes = types
                     return Result.success(
                         listOf(
                             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -953,8 +918,6 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
             )
-        assertThat(requestPaymentMethodTypes)
-            .containsExactly(PaymentMethod.Type.Card, PaymentMethod.Type.SepaDebit)
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -4656,6 +4656,7 @@ internal class DefaultPaymentElementLoaderTest {
             analyticsMetadataFactory = analyticsMetadataFactory,
             tapToAddConnectionStarter = tapToAddConnectionStarter,
             paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
+            customerRepository = customerRepo,
             createCustomerState = CreateCustomerState(
                 customerRepository = customerRepo,
                 paymentMethodFilter = paymentMethodFilter,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -74,7 +74,7 @@ internal open class FakeCustomerRepository(
     override suspend fun getPaymentMethods(
         customerId: String,
         ephemeralKeySecret: String,
-        types: List<PaymentMethod.Type>,
+        types: List<PaymentMethod.Type>?,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>> {
         _getPaymentMethodsRequests.add(
@@ -177,7 +177,7 @@ internal open class FakeCustomerRepository(
     data class GetPaymentMethodsRequest(
         val customerId: String,
         val ephemeralKeySecret: String,
-        val types: List<PaymentMethod.Type>,
+        val types: List<PaymentMethod.Type>?,
         val silentlyFail: Boolean,
     )
 


### PR DESCRIPTION
…hemeral key path

Kicks off the payment methods network request concurrently with the elements session fetch when using the legacy ephemeral key path. This reduces latency by removing the sequential dependency between these two independent network calls.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
