### PR TITLE
Make LinkSettingsDefinition applicable for all payment flows

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
@@ -14,14 +14,7 @@ internal object LinkSettingsDefinition : BooleanSettingsDefinition(
         configurationData: PlaygroundConfigurationData,
         settings: Map<PlaygroundSettingDefinition<*>, Any?>,
     ): Boolean {
-        if (!configurationData.integrationType.isPaymentFlow()) {
-            return false
-        }
-
-        return (settings[MerchantSettingsDefinition] as? Merchant) in listOf(
-            Merchant.US,
-            Merchant.StripeShop,
-        )
+        return configurationData.integrationType.isPaymentFlow()
     }
 
     override fun configure(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make LinkSettingsDefinition applicable for all payment flows

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- This setting was set to be non-applicable for a bunch of merchants that do support Link
- This led to an issue where in playground tests, if you set LinkSettingsDefinition to false, Link would still show up. This is because we set the merchant to GB by default, which meant the Link setting was not applicable, but then we'd always use the default Link settings value which was "true". 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Ran TestCard and verified that Link is no longer shown. 