### PR TITLE
Prototype: Connect support for CheckoutSession

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -21,6 +21,10 @@ class CheckoutRequest private constructor(
     val mode: String?,
     @SerialName("on_behalf_of")
     val onBehalfOf: String?,
+    @SerialName("transfer_data_destination")
+    val transferDataDestination: String?,
+    @SerialName("application_fee_amount")
+    val applicationFeeAmount: Long?,
     @SerialName("set_shipping_address")
     val setShippingAddress: Boolean?,
     @SerialName("automatic_payment_methods")
@@ -101,6 +105,8 @@ class CheckoutRequest private constructor(
         private var amount: Long? = null
         private var mode: String? = null
         private var onBehalfOf: String? = null
+        private var transferDataDestination: String? = null
+        private var applicationFeeAmount: Long? = null
         private var setShippingAddress: Boolean? = null
         private var automaticPaymentMethods: Boolean? = null
         private var useLink: Boolean? = null
@@ -237,6 +243,14 @@ class CheckoutRequest private constructor(
             this.onBehalfOf = onBehalfOf
         }
 
+        fun transferDataDestination(destination: String?) = apply {
+            this.transferDataDestination = destination
+        }
+
+        fun applicationFeeAmount(amount: Long?) = apply {
+            this.applicationFeeAmount = amount
+        }
+
         fun customStripeApi(customStripeApi: String?) = apply {
             this.customStripeApi = customStripeApi
         }
@@ -298,6 +312,8 @@ class CheckoutRequest private constructor(
                 amount = amount,
                 mode = mode,
                 onBehalfOf = onBehalfOf,
+                transferDataDestination = transferDataDestination,
+                applicationFeeAmount = applicationFeeAmount,
                 setShippingAddress = setShippingAddress,
                 automaticPaymentMethods = automaticPaymentMethods,
                 useLink = useLink,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -25,6 +25,8 @@ class CheckoutRequest private constructor(
     val transferDataDestination: String?,
     @SerialName("application_fee_amount")
     val applicationFeeAmount: Long?,
+    @SerialName("stripe_account_id")
+    val stripeAccountId: String?,
     @SerialName("set_shipping_address")
     val setShippingAddress: Boolean?,
     @SerialName("automatic_payment_methods")
@@ -107,6 +109,7 @@ class CheckoutRequest private constructor(
         private var onBehalfOf: String? = null
         private var transferDataDestination: String? = null
         private var applicationFeeAmount: Long? = null
+        private var stripeAccountId: String? = null
         private var setShippingAddress: Boolean? = null
         private var automaticPaymentMethods: Boolean? = null
         private var useLink: Boolean? = null
@@ -251,6 +254,10 @@ class CheckoutRequest private constructor(
             this.applicationFeeAmount = amount
         }
 
+        fun stripeAccountId(stripeAccountId: String?) = apply {
+            this.stripeAccountId = stripeAccountId
+        }
+
         fun customStripeApi(customStripeApi: String?) = apply {
             this.customStripeApi = customStripeApi
         }
@@ -314,6 +321,7 @@ class CheckoutRequest private constructor(
                 onBehalfOf = onBehalfOf,
                 transferDataDestination = transferDataDestination,
                 applicationFeeAmount = applicationFeeAmount,
+                stripeAccountId = stripeAccountId,
                 setShippingAddress = setShippingAddress,
                 automaticPaymentMethods = automaticPaymentMethods,
                 useLink = useLink,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState.Companion.asPlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
+import com.stripe.android.paymentsheet.example.playground.settings.CheckoutSessionConnectSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
@@ -47,10 +48,17 @@ internal class PlaygroundRequester(
 
                 // Init PaymentConfiguration with the publishable key returned from the backend,
                 // which will be used on all Stripe API calls
+                val connectMode = playgroundSettings[CheckoutSessionConnectSettingsDefinition]
+                val stripeAccountId = when (connectMode) {
+                    CheckoutSessionConnectSettingsDefinition.ConnectMode.DIRECT ->
+                        CheckoutSessionConnectSettingsDefinition.CONNECTED_ACCOUNT_ID
+                    else -> null
+                }
                 withContext(Dispatchers.IO) {
                     PaymentConfiguration.init(
                         applicationContext,
                         checkoutResponse.publishableKey,
+                        stripeAccountId,
                     )
                 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionConnectSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionConnectSettingsDefinition.kt
@@ -7,7 +7,7 @@ internal object CheckoutSessionConnectSettingsDefinition :
     PlaygroundSettingDefinition.Saveable<CheckoutSessionConnectSettingsDefinition.ConnectMode>,
     PlaygroundSettingDefinition.Displayable<CheckoutSessionConnectSettingsDefinition.ConnectMode> {
 
-    private const val US_CONNECTED_ACCOUNT_ID = "acct_1SG4B2LapbQGsfjG"
+    private const val CONNECTED_ACCOUNT_ID = "acct_1SGP1sPvdtoA7EjP"
     private const val APPLICATION_FEE_AMOUNT = 400L
 
     override val key: String = "checkoutSessionConnectMode"
@@ -30,10 +30,10 @@ internal object CheckoutSessionConnectSettingsDefinition :
         when (value) {
             ConnectMode.NONE -> { }
             ConnectMode.ON_BEHALF_OF -> {
-                checkoutRequestBuilder.onBehalfOf(US_CONNECTED_ACCOUNT_ID)
+                checkoutRequestBuilder.onBehalfOf(CONNECTED_ACCOUNT_ID)
             }
             ConnectMode.DESTINATION -> {
-                checkoutRequestBuilder.transferDataDestination(US_CONNECTED_ACCOUNT_ID)
+                checkoutRequestBuilder.transferDataDestination(CONNECTED_ACCOUNT_ID)
                 checkoutRequestBuilder.applicationFeeAmount(APPLICATION_FEE_AMOUNT)
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionConnectSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionConnectSettingsDefinition.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+
+internal object CheckoutSessionConnectSettingsDefinition :
+    PlaygroundSettingDefinition<CheckoutSessionConnectSettingsDefinition.ConnectMode>,
+    PlaygroundSettingDefinition.Saveable<CheckoutSessionConnectSettingsDefinition.ConnectMode>,
+    PlaygroundSettingDefinition.Displayable<CheckoutSessionConnectSettingsDefinition.ConnectMode> {
+
+    private const val US_CONNECTED_ACCOUNT_ID = "acct_1SG4B2LapbQGsfjG"
+    private const val APPLICATION_FEE_AMOUNT = 400L
+
+    override val key: String = "checkoutSessionConnectMode"
+    override val defaultValue: ConnectMode = ConnectMode.NONE
+
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession
+    }
+
+    override fun convertToString(value: ConnectMode): String = value.value
+
+    override fun convertToValue(value: String): ConnectMode {
+        return ConnectMode.entries.firstOrNull { it.value == value } ?: ConnectMode.NONE
+    }
+
+    override fun configure(value: ConnectMode, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        when (value) {
+            ConnectMode.NONE -> { }
+            ConnectMode.ON_BEHALF_OF -> {
+                checkoutRequestBuilder.onBehalfOf(US_CONNECTED_ACCOUNT_ID)
+            }
+            ConnectMode.DESTINATION -> {
+                checkoutRequestBuilder.transferDataDestination(US_CONNECTED_ACCOUNT_ID)
+                checkoutRequestBuilder.applicationFeeAmount(APPLICATION_FEE_AMOUNT)
+            }
+        }
+    }
+
+    override val displayName: String = "Checkout Connect Mode"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData,
+    ): List<PlaygroundSettingDefinition.Displayable.Option<ConnectMode>> {
+        return listOf(
+            PlaygroundSettingDefinition.Displayable.Option("None", ConnectMode.NONE),
+            PlaygroundSettingDefinition.Displayable.Option("On Behalf Of", ConnectMode.ON_BEHALF_OF),
+            PlaygroundSettingDefinition.Displayable.Option("Destination", ConnectMode.DESTINATION),
+        )
+    }
+
+    enum class ConnectMode(override val value: String) : ValueEnum {
+        NONE("none"),
+        ON_BEHALF_OF("on_behalf_of"),
+        DESTINATION("destination"),
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionConnectSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionConnectSettingsDefinition.kt
@@ -7,7 +7,7 @@ internal object CheckoutSessionConnectSettingsDefinition :
     PlaygroundSettingDefinition.Saveable<CheckoutSessionConnectSettingsDefinition.ConnectMode>,
     PlaygroundSettingDefinition.Displayable<CheckoutSessionConnectSettingsDefinition.ConnectMode> {
 
-    private const val CONNECTED_ACCOUNT_ID = "acct_1SGP1sPvdtoA7EjP"
+    const val CONNECTED_ACCOUNT_ID = "acct_1SGP1sPvdtoA7EjP"
     private const val APPLICATION_FEE_AMOUNT = 400L
 
     override val key: String = "checkoutSessionConnectMode"
@@ -36,6 +36,9 @@ internal object CheckoutSessionConnectSettingsDefinition :
                 checkoutRequestBuilder.transferDataDestination(CONNECTED_ACCOUNT_ID)
                 checkoutRequestBuilder.applicationFeeAmount(APPLICATION_FEE_AMOUNT)
             }
+            ConnectMode.DIRECT -> {
+                checkoutRequestBuilder.stripeAccountId(CONNECTED_ACCOUNT_ID)
+            }
         }
     }
 
@@ -48,6 +51,7 @@ internal object CheckoutSessionConnectSettingsDefinition :
             PlaygroundSettingDefinition.Displayable.Option("None", ConnectMode.NONE),
             PlaygroundSettingDefinition.Displayable.Option("On Behalf Of", ConnectMode.ON_BEHALF_OF),
             PlaygroundSettingDefinition.Displayable.Option("Destination", ConnectMode.DESTINATION),
+            PlaygroundSettingDefinition.Displayable.Option("Direct", ConnectMode.DIRECT),
         )
     }
 
@@ -55,5 +59,6 @@ internal object CheckoutSessionConnectSettingsDefinition :
         NONE("none"),
         ON_BEHALF_OF("on_behalf_of"),
         DESTINATION("destination"),
+        DIRECT("direct"),
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -505,6 +505,7 @@ internal class PlaygroundSettings private constructor(
             CheckoutSessionAutomaticTaxSettingsDefinition,
             CheckoutSessionAdaptivePricingSettingsDefinition,
             CheckoutSessionDisplayShippingRatesSettingsDefinition,
+            CheckoutSessionConnectSettingsDefinition,
             AllowPromotionCodesSettingsDefinition,
             CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -2,12 +2,17 @@ package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
+import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.model.PaymentIntentCreationFlow
+import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.header
 import com.stripe.android.networktesting.testBodyFromFile
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -31,6 +36,15 @@ class CheckoutSessionRepositoryTest {
         stripeNetworkClient = DefaultStripeNetworkClient(),
         publishableKeyProvider = { "pk_test_123" },
         stripeAccountIdProvider = { null },
+    )
+
+    private val connectedAccountId = "acct_connected123"
+
+    private val connectRepository = CheckoutSessionRepository(
+        clientParams = clientParams,
+        stripeNetworkClient = DefaultStripeNetworkClient(),
+        publishableKeyProvider = { "pk_test_123" },
+        stripeAccountIdProvider = { connectedAccountId },
     )
 
     @Test
@@ -82,5 +96,62 @@ class CheckoutSessionRepositoryTest {
         )
 
         assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
+    fun `init sends Stripe-Account header when stripeAccountId is set`() = runTest {
+        networkRule.checkoutInit(
+            header("Stripe-Account", connectedAccountId),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-init.json")
+        }
+
+        val result = connectRepository.init(
+            sessionId = DEFAULT_CHECKOUT_SESSION_ID,
+            adaptivePricingAllowed = true,
+        )
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `confirm sends Stripe-Account header when stripeAccountId is set`() = runTest {
+        networkRule.checkoutConfirm(
+            header("Stripe-Account", connectedAccountId),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        val result = connectRepository.confirm(
+            id = DEFAULT_CHECKOUT_SESSION_ID,
+            params = ConfirmCheckoutSessionParams(
+                paymentMethodId = "pm_123",
+                clientAttributionMetadata = ClientAttributionMetadata(
+                    elementsSessionConfigId = "test_session",
+                    paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+                    paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+                    checkoutSessionId = null,
+                ),
+                returnUrl = "stripesdk://return_url",
+            ),
+        )
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `update sends Stripe-Account header when stripeAccountId is set`() = runTest {
+        networkRule.checkoutUpdate(
+            header("Stripe-Account", connectedAccountId),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-init.json")
+        }
+
+        val result = connectRepository.updateCurrency(
+            sessionId = DEFAULT_CHECKOUT_SESSION_ID,
+            currencyCode = "eur",
+        )
+
+        assertThat(result.isSuccess).isTrue()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1111,4 +1111,79 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result).isNotNull()
         assertThat(result?.taxStatus).isEqualTo(CheckoutSessionResponse.TaxStatus.UNKNOWN)
     }
+
+    @Test
+    fun `parse succeeds with on_behalf_of in server_built_elements_session_params`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_connect123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "mode": "payment",
+                "total_summary": { "due": 7000, "subtotal": 7000, "total": 7000 },
+                "server_built_elements_session_params": {
+                    "type": "deferred_intent",
+                    "locale": "en-US",
+                    "deferred_intent": {
+                        "mode": "payment",
+                        "amount": 7000,
+                        "currency": "usd",
+                        "payment_method_types": ["card"],
+                        "on_behalf_of": "acct_connected123"
+                    }
+                },
+                "elements_session": ${CheckoutSessionFixtures.MINIMAL_ELEMENTS_SESSION_JSON}
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.elementsSession).isNotNull()
+    }
+
+    @Test
+    fun `parse succeeds with on_behalf_of and accountId set for Connect OBO`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_connect123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "mode": "payment",
+                "total_summary": { "due": 7000, "subtotal": 7000, "total": 7000 },
+                "server_built_elements_session_params": {
+                    "type": "deferred_intent",
+                    "locale": "en-US",
+                    "deferred_intent": {
+                        "mode": "payment",
+                        "amount": 7000,
+                        "currency": "usd",
+                        "payment_method_types": ["card"],
+                        "on_behalf_of": "acct_connected123"
+                    }
+                },
+                "elements_session": {
+                    "session_id": "es_123",
+                    "merchant_country": "US",
+                    "account_id": "acct_connected123",
+                    "merchant_id": "acct_platform456",
+                    "google_pay_preference": "enabled",
+                    "payment_method_preference": {
+                        "object": "payment_method_preference",
+                        "country_code": "US",
+                        "ordered_payment_method_types": ["card"],
+                        "type": "deferred_intent"
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.elementsSession).isNotNull()
+        assertThat(result?.elementsSession?.onBehalfOf).isEqualTo("acct_connected123")
+    }
 }


### PR DESCRIPTION
## Summary
Prototype verifying that the Android SDK supports all three Connect charge types for CheckoutSession with **zero production code changes**.

### What was tested E2E
| Connect Flow | How it works | SDK changes needed | Status |
|---|---|---|---|
| **On Behalf Of** | `payment_intent_data.on_behalf_of` on session | None | Verified working |
| **Destination** | `payment_intent_data.transfer_data` + `application_fee_amount` | None | Verified working |
| **Direct** | `Stripe-Account` header on all API calls | None (wiring already exists via `PaymentConfiguration.stripeAccountId`) | Verified working |

### Key finding
The SDK already wires `stripeAccount` through all CheckoutSession API calls (init, confirm, update) via `ApiRequest.Options`. The `on_behalf_of` field is parsed from `server_built_elements_session_params` and propagated to `ElementsSession.onBehalfOf`. No production code changes were required.

### Changes in this PR (all playground/test only)
- **Playground UI**: New "Checkout Connect Mode" dropdown (None / OBO / Destination / Direct), visible when CheckoutSession is selected
- **`PlaygroundCheckoutModel.kt`**: Added `transferDataDestination`, `applicationFeeAmount`, `stripeAccountId` fields to `CheckoutRequest`
- **`PlaygroundRequester.kt`**: Pass `stripeAccountId` to `PaymentConfiguration.init` for direct charges
- **`CheckoutSessionRepositoryTest.kt`**: 3 new tests verifying `Stripe-Account` header flows through init, confirm, and update API calls
- **`CheckoutSessionResponseJsonParserTest.kt`**: 2 new tests verifying `on_behalf_of` parsing and `ElementsSession.onBehalfOf` for Connect OBO

### Notes
- Uses France connected account (`acct_1SGP1sPvdtoA7EjP`) since the US one (`acct_1SG4B2LapbQGsfjG`) was deleted
- Backend changes (playground backend) are on a separate branch
- The `payment_intent_data.transfer_data` and `application_fee_amount` are server-side params not visible in the `payment_pages` confirm response, but confirmed present on the underlying PaymentIntent via Dashboard

## Test plan
- [x] Unit tests pass (64/64: 6 repository + 58 parser)
- [x] E2E: OBO flow completes payment successfully
- [x] E2E: Destination flow completes payment, transfer_data on PI confirmed in Dashboard
- [x] E2E: Direct flow completes payment on connected account

🤖 Generated with [Claude Code](https://claude.com/claude-code)