### PR TITLE
Add 20-second timeout to Checkout.runServerUpdate().

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -29,8 +29,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
 import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 
 /**
  * Manages a Checkout Session, providing methods to observe and mutate its state.
@@ -200,16 +204,19 @@ class Checkout private constructor(
     }
 
     /**
-     * Wraps an asynchronous function that communicates with your server to modify the
-     * Checkout Session. After the function completes, the session is re-fetched from the server.
+     * Runs an async function that calls your server to update the Checkout Session,
+     * then automatically refreshes [checkoutSession] with the latest session data.
      *
-     * @param serverUpdate A suspend function responsible for making a server request that updates
+     * A 20-second timeout is enforced. If [serverUpdate] doesn't complete within 20 seconds,
+     * this method returns a [Result.failure] with a timeout exception.
+     *
+     * @param serverUpdate A suspend function that makes a request to your server to update
      * the Checkout Session.
      */
     suspend fun runServerUpdate(
         serverUpdate: suspend () -> Result<Unit>,
     ): Result<Unit> = withInternalState { sessionId ->
-        serverUpdate().fold(
+        withTimeout(SERVER_UPDATE_TIMEOUT_MS) { serverUpdate() }.fold(
             onSuccess = {
                 component.checkoutSessionRepository.init(
                     sessionId = sessionId,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -19,8 +19,10 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -1041,6 +1043,19 @@ class CheckoutTest {
         assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
         assertThat(result.exceptionOrNull()).hasMessageThat()
             .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when serverUpdate exceeds timeout`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        val result = checkout.runServerUpdate {
+            delay(21_000)
+            Result.success(Unit)
+        }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(TimeoutCancellationException::class.java)
     }
 
     @Test


### PR DESCRIPTION
# Summary
Added a 20-second timeout to the `Checkout.runServerUpdate()` method to prevent indefinite waiting for server responses.

# Motivation
Server update operations could potentially hang indefinitely if the network request doesn't complete, leaving the SDK in an unresponsive state. This change ensures that `runServerUpdate()` will fail gracefully with a `TimeoutCancellationException` if the operation takes longer than 20 seconds.

https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?disco=AAAB6GJs19c

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
[Added] - Added a 20-second timeout to `Checkout.runServerUpdate()` to prevent indefinite waiting for server operations.