### PR TITLE
Add explicit waits to connections E2E tests to reduce flakiness

### DIFF
--- a/maestro/common/subflow-skip-chrome-welcome.yaml
+++ b/maestro/common/subflow-skip-chrome-welcome.yaml
@@ -1,16 +1,20 @@
 appId: ${APP_ID}
 ---
 ####### Bypass Chrome on-boarding screen #######
+- waitForAnimationToEnd
 # USE CHROME WITHOUT AN ACCOUNT
 - tapOn:
     id: com.android.chrome:id/signin_fre_dismiss_button
     optional: true
+- waitForAnimationToEnd
 # ACCEPT TERMS
 - tapOn:
     id: "com.android.chrome:id/terms_accept"
     optional: true
+- waitForAnimationToEnd
 # REJECT TURN ON SYNC
 - tapOn:
     id: "com.android.chrome:id/negative_button"
     optional: true
+- waitForAnimationToEnd
 ###############################################

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution-Connected.yaml
@@ -27,8 +27,16 @@ tags:
 # Common: web AuthFlow - connect OAuth institution
 - tapOn: "Agree and continue"
 # SELECT OAUTH INSTITUTION
+- extendedWaitUntil:
+    visible:
+      id: "bcinst_LLQZzmKZMjl0j0"
+    timeout: 30000
 - tapOn:
     id: "bcinst_LLQZzmKZMjl0j0"
+- extendedWaitUntil:
+    visible:
+      id: "prepane_cta"
+    timeout: 30000
 - tapOn:
     id: "prepane_cta"
 ####### Bypass Chrome on-boarding screen #######
@@ -41,9 +49,16 @@ tags:
     timeout: 60000
 - tapOn: "Connect accounts" # select all accounts
 # SKIP NETWORKING
+- extendedWaitUntil:
+    visible:
+      id: "skip_cta"
+    timeout: 30000
 - tapOn:
     id: "skip_cta"
 # CONFIRM AND COMPLETE
+- extendedWaitUntil:
+    visible: "Your accounts were connected"
+    timeout: 30000
 - assertVisible: "Your accounts were connected"
 - tapOn:
     id: "done_button"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -21,8 +21,16 @@ tags:
 # Common: web AuthFlow - connect OAuth institution
 - tapOn: "Agree and continue"
 # SELECT OAUTH INSTITUTION
+- extendedWaitUntil:
+    visible:
+      id: "bcinst_LLQZzmKZMjl0j0"
+    timeout: 30000
 - tapOn:
     id: "bcinst_LLQZzmKZMjl0j0"
+- extendedWaitUntil:
+    visible:
+      id: "prepane_cta"
+    timeout: 30000
 - tapOn:
     id: "prepane_cta"
 ####### Bypass Chrome on-boarding screen #######
@@ -35,9 +43,16 @@ tags:
     timeout: 60000
 - tapOn: "Connect accounts" # select all accounts
 # SKIP NETWORKING
+- extendedWaitUntil:
+    visible:
+      id: "skip_cta"
+    timeout: 30000
 - tapOn:
     id: "skip_cta"
 # CONFIRM AND COMPLETE
+- extendedWaitUntil:
+    visible: "Your accounts were connected"
+    timeout: 30000
 - assertVisible: "Your accounts were connected"
 - tapOn:
     id: "done_button"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-InstantDebits.yaml
@@ -35,6 +35,10 @@ tags:
 - inputText: "6223115555"
 - tapOn: "Continue with Link"
 # Select "Payment Success" institution
+- extendedWaitUntil:
+    visible:
+      id: "bcinst_QsDedeogZ5PA7V"
+    timeout: 30000
 - tapOn:
     id: "bcinst_QsDedeogZ5PA7V"
 # Bypass Chrome on-boarding screen
@@ -49,6 +53,9 @@ tags:
     timeout: 60000
 - tapOn: "Success"
 - tapOn: "Connect account"
+- extendedWaitUntil:
+    visible: "Your account was connected"
+    timeout: 30000
 - assertVisible: "Your account was connected"
 - tapOn:
     id: "done_button"
@@ -65,14 +72,28 @@ tags:
 - tapOn:
     id: "consent_cta"
 # Continue with existing account
+- extendedWaitUntil:
+    visible:
+      id: "existing_email-button"
+    timeout: 30000
 - tapOn:
     id: "existing_email-button"
+- extendedWaitUntil:
+    visible:
+      id: "OTP-0"
+    timeout: 30000
 - assertVisible:
     id: "OTP-0"
 - inputText: "111111"
 # Select previously networked account and complete
+- extendedWaitUntil:
+    visible: "Success"
+    timeout: 30000
 - tapOn: "Success"
 - tapOn: "Connect account"
+- extendedWaitUntil:
+    visible: "Your account was connected"
+    timeout: 30000
 - assertVisible: "Your account was connected"
 - tapOn:
     id: "done_button"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -21,12 +21,24 @@ tags:
 - tapOn:
     id: "consent_cta"
 # Select Down institution
+- extendedWaitUntil:
+    visible: "Down (Unscheduled)"
+    timeout: 30000
 - tapOn: "Down (Unscheduled)"
 # Selecting another bank resets the flow
+- extendedWaitUntil:
+    visible: "Select another bank"
+    timeout: 30000
 - tapOn: "Select another bank"
 # Assert flow correctly returns to institution picker
+- extendedWaitUntil:
+    visible: "Down (Unscheduled)"
+    timeout: 30000
 - tapOn: "Down (Unscheduled)"
 # Close flow from error page
+- extendedWaitUntil:
+    visible: "Close icon"
+    timeout: 30000
 - tapOn: "Close icon"
 - scrollUntilVisible:
     element:

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -21,6 +21,9 @@ tags:
 - tapOn:
     id: "consent_cta"
 # SELECT LEGACY INSTITUTION
+- extendedWaitUntil:
+    visible: "Test (Non-OAuth)"
+    timeout: 30000
 - tapOn: "Test (Non-OAuth)"
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
@@ -36,10 +39,18 @@ tags:
     text: "Connect account"
     retryTapIfNoChange: false
 # SKIP NETWORKING
+- extendedWaitUntil:
+    visible:
+      id: "skip_cta"
+    timeout: 30000
 - tapOn:
     id: "skip_cta"
     optional: true # Networking might not be enabled
 # CONFIRM AND COMPLETE
+- extendedWaitUntil:
+    visible:
+      id: "done_button"
+    timeout: 30000
 - tapOn:
     id: "done_button"
 - scrollUntilVisible:

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -38,10 +38,18 @@ tags:
     text: "Submit"
     retryTapIfNoChange: false
 # SKIP NETWORKING
+- extendedWaitUntil:
+    visible:
+      id: "skip_cta"
+    timeout: 30000
 - tapOn:
     id: "skip_cta"
     optional: true # Networking might not be enabled
 # CONFIRM AND COMPLETE
+- extendedWaitUntil:
+    visible:
+      id: "done_button"
+    timeout: 30000
 - tapOn:
     id: "done_button"
 - scrollUntilVisible:

--- a/maestro/financial-connections/Testmode-Token-NME.yaml
+++ b/maestro/financial-connections/Testmode-Token-NME.yaml
@@ -33,6 +33,9 @@ tags:
     # Maestro does not yet support tapping on annotated strings.
     # https://github.com/mobile-dev-inc/maestro/issues/389
     point: "50%,93%"
+- extendedWaitUntil:
+    visible: "Use test account"
+    timeout: 30000
 - tapOn: "Use test account"
 ## ENTER PHONE FOR NEW NETWORKED USER
 - waitForAnimationToEnd
@@ -42,6 +45,10 @@ tags:
 - inputText: "6223115555"
 - tapOn: "Save with Link"
 # CONFIRM AND COMPLETE
+- extendedWaitUntil:
+    visible:
+      id: "done_button"
+    timeout: 30000
 - tapOn:
     id: "done_button"
 - scrollUntilVisible:
@@ -60,16 +67,31 @@ tags:
 - tapOn:
     id: "consent_cta"
 ## LOGIN TO NETWORKING
+- extendedWaitUntil:
+    visible:
+      id: "existing_email-button"
+    timeout: 30000
 - tapOn:
     id: "existing_email-button"
 ## 2FA
+- extendedWaitUntil:
+    visible:
+      id: "OTP-0"
+    timeout: 30000
 - assertVisible:
     id: "OTP-0"
 - inputText: "111111"
 ## SELECT NETWORKED ACCOUNT
 # First institution should be auto selected.
+- extendedWaitUntil:
+    visible: "Connect account"
+    timeout: 30000
 - tapOn: "Connect account"
 # CONFIRM AND COMPLETE
+- extendedWaitUntil:
+    visible:
+      id: "done_button"
+    timeout: 30000
 - tapOn:
     id: "done_button"
 - scrollUntilVisible:


### PR DESCRIPTION
Adds extendedWaitUntil before taps that follow screen transitions (network-dependent) and waitForAnimationToEnd in the Chrome onboarding subflow. This ensures elements are visible before interaction rather than relying on Maestro's default timing.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->
Add explicit waits to connections E2E tests to reduce flakiness

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Reduce flakiness of FC maestro tests