### PR TITLE
Require --version for deploy_release to prevent inferring wrong version

### DIFF
--- a/scripts/deploy/deploy_release.rb
+++ b/scripts/deploy/deploy_release.rb
@@ -19,7 +19,7 @@ def prepare_deploy_release_resume(step_index)
     checkout_release_source
 end
 
-parse_release_options!(flow_name: 'deploy release')
+parse_release_options!(flow_name: 'deploy release', version_required: true)
 
 steps = [
     method(:check_permissions),

--- a/scripts/deploy/release_cli.rb
+++ b/scripts/deploy/release_cli.rb
@@ -5,7 +5,7 @@ require 'optparse'
 require_relative 'common'
 require_relative 'validate_version_number'
 
-def parse_release_options!(flow_name:)
+def parse_release_options!(flow_name:, version_required: false)
     @flow_name = flow_name
     @step_index = 1
     @is_dry_run = false
@@ -37,6 +37,9 @@ def parse_release_options!(flow_name:)
     end.parse!
 
     if @version.nil?
+        if version_required
+            raise ArgumentError, "--version is required for #{flow_name}"
+        end
         @version = infer_version_from_changelog()
     end
 end


### PR DESCRIPTION
Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->
Require --version for deploy_release to prevent inferring wrong version

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
After propose_release bumps the version, the changelog reflects the next version, causing deploy_release to infer a newer version than intended.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified