### PR TITLE
Fix activity tests

### DIFF
--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -46,7 +46,6 @@ dependencies {
 
     // Terminal
     compileOnly libs.terminal.core
-    compileOnly libs.terminal.tapToPay
 
     // Other
     implementation libs.playServicesWallet
@@ -90,7 +89,6 @@ dependencies {
     testImplementation testLibs.turbine
     testImplementation testLibs.espresso.intents
     testImplementation libs.terminal.core
-    testImplementation libs.terminal.tapToPay
 
     // temporary fix for running compose test in RobolectricTestRunner, see https://github.com/robolectric/robolectric/issues/6593
     testImplementation testLibs.espresso.core

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.common.taptoadd
 
-import androidx.annotation.VisibleForTesting
+import com.stripe.android.core.utils.FeatureFlags.forceTapToAddWithTerminal
 import javax.inject.Inject
 
 internal fun interface IsStripeTerminalSdkAvailable {
@@ -25,24 +25,19 @@ internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor(
     private val hasStripeTerminalTapToPayLibrary: HasStripeTerminalTapToPayLibrary,
 ) : IsStripeTerminalSdkAvailable {
     override fun invoke(): Boolean {
-        return IsStripeTerminalSdkAvailableOverride.override ?: run {
-            try {
-                val versionName = hasStripeTerminalCoreLibrary()
-                hasStripeTerminalTapToPayLibrary()
+        if (forceTapToAddWithTerminal.isEnabled) {
+            return true
+        }
 
-                versionValidator(versionName)
-            } catch (_: Exception) {
-                false
-            }
+        return try {
+            val versionName = hasStripeTerminalCoreLibrary()
+            hasStripeTerminalTapToPayLibrary()
+
+            versionValidator(versionName)
+        } catch (_: Exception) {
+            false
         }
     }
-}
-
-@VisibleForTesting
-internal object IsStripeTerminalSdkAvailableOverride {
-    @VisibleForTesting
-    @Volatile
-    var override: Boolean? = null
 }
 
 internal class DefaultHasStripeTerminalCoreLibrary @Inject constructor() :

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
@@ -1,9 +1,18 @@
 package com.stripe.android.common.taptoadd
 
+import androidx.annotation.VisibleForTesting
 import javax.inject.Inject
 
 internal fun interface IsStripeTerminalSdkAvailable {
     operator fun invoke(): Boolean
+}
+
+internal fun interface HasStripeTerminalCoreLibrary {
+    operator fun invoke(): String
+}
+
+internal fun interface HasStripeTerminalTapToPayLibrary {
+    operator fun invoke()
 }
 
 internal fun interface StripeTerminalVersionValidator {
@@ -12,18 +21,43 @@ internal fun interface StripeTerminalVersionValidator {
 
 internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor(
     private val versionValidator: StripeTerminalVersionValidator,
+    private val hasStripeTerminalCoreLibrary: HasStripeTerminalCoreLibrary,
+    private val hasStripeTerminalTapToPayLibrary: HasStripeTerminalTapToPayLibrary,
 ) : IsStripeTerminalSdkAvailable {
     override fun invoke(): Boolean {
-        return try {
-            // If found, 'core' library was imported
-            Class.forName("com.stripe.stripeterminal.TerminalApplicationDelegate")
-            // If found, 'taptopay' library was imported
-            Class.forName("com.stripe.stripeterminal.taptopay.TapToPay")
+        return IsStripeTerminalSdkAvailableOverride.override ?: run {
+            try {
+                val versionName = hasStripeTerminalCoreLibrary()
+                hasStripeTerminalTapToPayLibrary()
 
-            versionValidator(versionName = com.stripe.stripeterminal.BuildConfig.SDK_VERSION_NAME)
-        } catch (_: Exception) {
-            false
+                versionValidator(versionName)
+            } catch (_: Exception) {
+                false
+            }
         }
+    }
+}
+
+@VisibleForTesting
+internal object IsStripeTerminalSdkAvailableOverride {
+    @VisibleForTesting
+    @Volatile
+    var override: Boolean? = null
+}
+
+internal class DefaultHasStripeTerminalCoreLibrary @Inject constructor() :
+    HasStripeTerminalCoreLibrary {
+    override operator fun invoke(): String {
+        Class.forName("com.stripe.stripeterminal.TerminalApplicationDelegate")
+
+        return com.stripe.stripeterminal.BuildConfig.SDK_VERSION_NAME
+    }
+}
+
+internal class DefaultHasStripeTerminalTapToPayLibrary @Inject constructor() :
+    HasStripeTerminalTapToPayLibrary {
+    override operator fun invoke() {
+        Class.forName("com.stripe.stripeterminal.taptopay.TapToPay")
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -24,6 +24,16 @@ internal interface TapToAddConnectionModule {
     ): StripeTerminalVersionValidator
 
     @Binds
+    fun bindsHasStripeTerminalCoreLibrary(
+        hasStripeTerminalCoreLibrary: DefaultHasStripeTerminalCoreLibrary
+    ): HasStripeTerminalCoreLibrary
+
+    @Binds
+    fun bindsHasStripeTerminalTapToPayLibrary(
+        hasStripeTerminalTapToPayLibrary: DefaultHasStripeTerminalTapToPayLibrary
+    ): HasStripeTerminalTapToPayLibrary
+
+    @Binds
     fun bindsIsSimulatedProvider(
         isSimulatedProvider: DefaultTapToAddIsSimulatedProvider
     ): TapToAddIsSimulatedProvider

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultIsStripeTerminalSdkAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultIsStripeTerminalSdkAvailableTest.kt
@@ -65,6 +65,14 @@ class DefaultIsStripeTerminalSdkAvailableTest {
         assertThat(validatorCalls.awaitItem()).isEqualTo("5.4.1")
     }
 
+    @Test
+    fun `checking Terminal Core library returns version name from library`() {
+        val coreSdk = DefaultHasStripeTerminalCoreLibrary()
+
+        assertThat(coreSdk.invoke())
+            .isEqualTo(com.stripe.stripeterminal.BuildConfig.SDK_VERSION_NAME)
+    }
+
     private fun runScenario(
         validatorResult: Boolean,
         versionName: String,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultIsStripeTerminalSdkAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultIsStripeTerminalSdkAvailableTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.common.taptoadd
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.stripeterminal.BuildConfig
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -11,48 +10,148 @@ class DefaultIsStripeTerminalSdkAvailableTest {
     @Test
     fun `returns true when terminal SDK classes are on classpath & valid Terminal version`() = runScenario(
         validatorResult = true,
+        versionName = "5.4.1",
     ) {
         assertThat(isStripeTerminalSdkAvailable()).isTrue()
-        assertThat(validatorCalls.awaitItem()).isEqualTo(BuildConfig.SDK_VERSION_NAME)
+        assertThat(coreLibraryCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(tapToPayCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(validatorCalls.awaitItem()).isEqualTo("5.4.1")
     }
 
     @Test
     fun `returns false when version validator rejects SDK version`() = runScenario(
         validatorResult = false,
+        versionName = "5.4.1",
     ) {
         assertThat(isStripeTerminalSdkAvailable()).isFalse()
-        assertThat(validatorCalls.awaitItem()).isEqualTo(BuildConfig.SDK_VERSION_NAME)
+        assertThat(coreLibraryCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(tapToPayCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(validatorCalls.awaitItem()).isEqualTo("5.4.1")
+    }
+
+    @Test
+    fun `returns false when core library is not on classpath`() = runScenario(
+        validatorResult = true,
+        versionName = "5.4.1",
+        shouldFailTerminalCoreLibraryCheck = true,
+    ) {
+        assertThat(isStripeTerminalSdkAvailable()).isFalse()
+        assertThat(coreLibraryCalls.awaitItem()).isEqualTo(Unit)
+        tapToPayCalls.expectNoEvents()
+        validatorCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `returns false when tap to pay library is not on classpath`() = runScenario(
+        validatorResult = true,
+        versionName = "5.4.1",
+        shouldFailTerminalTapToPayLibraryCheck = true,
+    ) {
+        assertThat(isStripeTerminalSdkAvailable()).isFalse()
+        assertThat(coreLibraryCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(tapToPayCalls.awaitItem()).isEqualTo(Unit)
+        validatorCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `returns false when version validator throws`() = runScenario(
+        validatorResult = true,
+        versionName = "5.4.1",
+        validatorError = IllegalStateException("validator failed"),
+    ) {
+        assertThat(isStripeTerminalSdkAvailable()).isFalse()
+        assertThat(coreLibraryCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(tapToPayCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(validatorCalls.awaitItem()).isEqualTo("5.4.1")
     }
 
     private fun runScenario(
         validatorResult: Boolean,
+        versionName: String,
+        shouldFailTerminalCoreLibraryCheck: Boolean = false,
+        shouldFailTerminalTapToPayLibraryCheck: Boolean = false,
+        validatorError: Exception? = null,
         block: suspend Scenario.() -> Unit
     ) = runTest {
-        val versionValidator = FakeStripeTerminalVersionValidator(validatorResult)
-        val isAvailable = DefaultIsStripeTerminalSdkAvailable(versionValidator)
+        val versionValidator = FakeStripeTerminalVersionValidator(
+            result = validatorResult,
+            error = validatorError,
+        )
+        val hasStripeTerminalCoreLibrary = FakeHasStripeTerminalCoreLibrary(
+            versionName = versionName,
+            shouldFail = shouldFailTerminalCoreLibraryCheck
+        )
+        val hasStripeTerminalTapToPayLibrary = FakeHasStripeTerminalTapToPayLibrary(
+            shouldFail = shouldFailTerminalTapToPayLibraryCheck
+        )
+        val isAvailable = DefaultIsStripeTerminalSdkAvailable(
+            versionValidator = versionValidator,
+            hasStripeTerminalCoreLibrary = hasStripeTerminalCoreLibrary,
+            hasStripeTerminalTapToPayLibrary = hasStripeTerminalTapToPayLibrary,
+        )
 
         block(
             Scenario(
                 isStripeTerminalSdkAvailable = isAvailable,
+                coreLibraryCalls = hasStripeTerminalCoreLibrary.calls,
+                tapToPayCalls = hasStripeTerminalTapToPayLibrary.calls,
                 validatorCalls = versionValidator.calls,
             )
         )
 
+        hasStripeTerminalCoreLibrary.calls.ensureAllEventsConsumed()
+        hasStripeTerminalTapToPayLibrary.calls.ensureAllEventsConsumed()
         versionValidator.calls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
+        val coreLibraryCalls: ReceiveTurbine<Unit>,
+        val tapToPayCalls: ReceiveTurbine<Unit>,
         val validatorCalls: ReceiveTurbine<String>,
     )
 
+    private class FakeHasStripeTerminalCoreLibrary(
+        val versionName: String,
+        val shouldFail: Boolean,
+    ) : HasStripeTerminalCoreLibrary {
+        val calls = Turbine<Unit>()
+
+        override fun invoke(): String {
+            calls.add(Unit)
+
+            if (shouldFail) {
+                throw ClassNotFoundException("com.stripe.stripeterminal.TerminalApplicationDelegate")
+            }
+
+            return versionName
+        }
+    }
+
+    private class FakeHasStripeTerminalTapToPayLibrary(
+        val shouldFail: Boolean,
+    ) : HasStripeTerminalTapToPayLibrary {
+        val calls = Turbine<Unit>()
+
+        override fun invoke() {
+            calls.add(Unit)
+
+            if (shouldFail) {
+                throw ClassNotFoundException("com.stripe.stripeterminal.taptopay.TapToPay")
+            }
+        }
+    }
+
     private class FakeStripeTerminalVersionValidator(
         val result: Boolean,
+        val error: Exception? = null,
     ) : StripeTerminalVersionValidator {
         val calls = Turbine<String>()
 
         override fun invoke(versionName: String): Boolean {
             calls.add(versionName)
+
+            error?.let { throw it }
 
             return result
         }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -44,6 +44,8 @@ import com.stripe.android.view.ActivityStarter
 import com.stripe.stripeterminal.external.models.TerminalErrorCode
 import com.stripe.stripeterminal.external.models.TerminalException
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
@@ -86,6 +88,16 @@ class TapToAddActivityTest {
     private val confirmationPage = TapToAddConfirmationPage(composeTestRule)
     private val delayPage = TapToAddDelayPage(composeTestRule)
     private val errorPage = TapToAddErrorPage(composeTestRule)
+
+    @Before
+    fun setup() {
+        IsStripeTerminalSdkAvailableOverride.override = true
+    }
+
+    @After
+    fun teardown() {
+        IsStripeTerminalSdkAvailableOverride.override = null
+    }
 
     @Test
     fun successInContinueMode() = runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -9,6 +9,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.LocalStripeException
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -27,6 +28,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkSignupModeResult
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.RetryRule
 import com.stripe.android.testing.createComposeCleanupRule
@@ -44,8 +46,6 @@ import com.stripe.android.view.ActivityStarter
 import com.stripe.stripeterminal.external.models.TerminalErrorCode
 import com.stripe.stripeterminal.external.models.TerminalException
 import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
@@ -74,6 +74,7 @@ class TapToAddActivityTest {
         .around(terminalWrapperTestRule)
         .around(paymentElementCallbackTestRule)
         .around(imageLoaderTestRule)
+        .around(FeatureFlagTestRule(FeatureFlags.forceTapToAddWithTerminal, isEnabled = true))
         .around(PaymentConfigurationTestRule(applicationContext))
         .around(RetryRule(3))
         .around(intentsRule)
@@ -88,16 +89,6 @@ class TapToAddActivityTest {
     private val confirmationPage = TapToAddConfirmationPage(composeTestRule)
     private val delayPage = TapToAddDelayPage(composeTestRule)
     private val errorPage = TapToAddErrorPage(composeTestRule)
-
-    @Before
-    fun setup() {
-        IsStripeTerminalSdkAvailableOverride.override = true
-    }
-
-    @After
-    fun teardown() {
-        IsStripeTerminalSdkAvailableOverride.override = null
-    }
 
     @Test
     fun successInContinueMode() = runScenario(

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -18,6 +18,7 @@ object FeatureFlags {
     val forceNotlinkConsumer = FeatureFlag("Link: Force Notlink consumer")
     val enableKlarnaFormRemoval = FeatureFlag("Remove forms from Klarna")
     val paymentMethodMessagePromotions = FeatureFlag("Use BNPL Promotions")
+    val forceTapToAddWithTerminal = FeatureFlag("Tap to Add: Force Terminal integration to be available")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/tap-to-add-testing/build.gradle
+++ b/tap-to-add-testing/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     implementation project(":network-testing")
 
     implementation libs.terminal.core
-    implementation libs.terminal.tapToPay
     implementation testLibs.espresso.intents
     implementation testLibs.androidx.composeUi
     implementation testLibs.mockito.core


### PR DESCRIPTION
# Summary
Fix local activity tests by removing Tap to Pay SDK and allowing for an override in testing.

# Motivation
Allows activity tests to be ran properly locally.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified