### PR TITLE
Make Tap to Add only available when callback is implemented

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
@@ -3,6 +3,9 @@ package com.stripe.android.paymentsheet.state
 import com.stripe.android.common.taptoadd.TapToAddConnectionManager
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.paymentelement.TapToAddPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import javax.inject.Inject
 
 internal interface TapToAddAvailabilityFactory {
@@ -12,8 +15,11 @@ internal interface TapToAddAvailabilityFactory {
     ): Boolean
 }
 
+@OptIn(TapToAddPreview::class)
 internal class DefaultTapToAddAvailabilityFactory @Inject constructor(
     private val connectionManager: TapToAddConnectionManager,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+
 ) : TapToAddAvailabilityFactory {
     override fun isAvailable(
         elementsSession: ElementsSession,
@@ -21,6 +27,8 @@ internal class DefaultTapToAddAvailabilityFactory @Inject constructor(
     ): Boolean {
         return connectionManager.isSupported &&
             elementsSession.isTapToAddEnabled &&
-            customerMetadata != null
+            customerMetadata != null &&
+            PaymentElementCallbackReferences[paymentElementCallbackIdentifier]
+                ?.createCardPresentSetupIntentCallback != null
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -5,18 +5,33 @@ import com.stripe.android.common.taptoadd.FakeTapToAddConnectionManager
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentelement.TapToAddPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
+import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.utils.FakeElementsSessionRepository.Companion.DEFAULT_ELEMENTS_SESSION_CONFIG_ID
 import com.stripe.android.utils.FakeElementsSessionRepository.Companion.DEFAULT_ELEMENTS_SESSION_ID
+import com.stripe.android.utils.PaymentElementCallbackTestRule
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(TapToAddPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultTapToAddAvailabilityFactoryTest {
+    @get:Rule
+    val paymentElementCallbackTestRule = PaymentElementCallbackTestRule()
+
     @Test
     fun `isAvailable is true when supported by connection manager, session flag on, and customer metadata present`() {
+        PaymentElementCallbackReferences[CALLBACK_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createCardPresentSetupIntentCallback { CreateIntentResult.Success("seti_test_secret") }
+            .build()
+
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -35,6 +50,7 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
     fun `isAvailable is false when unsupported by connection manager`() {
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = false),
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -53,6 +69,7 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
     fun `isAvailable is false when elements session disables tap to add`() {
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -71,6 +88,7 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
     fun `isAvailable is false when customer metadata is null`() {
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -81,6 +99,25 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `isAvailable is false when createCardPresentSetupIntentCallback is not registered`() {
+        val factory = DefaultTapToAddAvailabilityFactory(
+            connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+        )
+
+        assertThat(
+            factory.isAvailable(
+                elementsSession = elementsSession(
+                    flags = mapOf(
+                        ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to true,
+                    ),
+                ),
+                customerMetadata = DEFAULT_CUSTOMER_METADATA,
             )
         ).isFalse()
     }
@@ -109,5 +146,9 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
             accountId = "acct_test",
             merchantId = "acct_test",
         )
+    }
+
+    private companion object {
+        private const val CALLBACK_IDENTIFIER = "DefaultTapToAddAvailabilityFactoryTest"
     }
 }


### PR DESCRIPTION
# Summary
Make Tap to Add only available when callback is implemented, following behavior of deferred intent integration metadata.

# Motivation
Ensures Tap to Add integrations have all required parameters.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified