### PR TITLE
Swap currency selector order to show local currency first.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
@@ -44,8 +44,8 @@ internal object CurrencySelectorOptionsFactory {
         }
 
         return CurrencySelectorOptions(
-            first = integrationCurrencyOption,
-            second = localCurrencyOption,
+            first = localCurrencyOption,
+            second = integrationCurrencyOption,
             selectedCode = selectedCode,
             exchangeRateText = exchangeRateText,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactoryTest.kt
@@ -27,8 +27,8 @@ class CurrencySelectorOptionsFactoryTest {
 
         assertThat(result).isEqualTo(
             CurrencySelectorOptions(
-                first = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €50.99"),
-                second = CurrencyOption(code = "USD", displayableText = "🇺🇸 $61.06"),
+                first = CurrencyOption(code = "USD", displayableText = "🇺🇸 $61.06"),
+                second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €50.99"),
                 selectedCode = "USD",
                 exchangeRateText = "1 EUR = 1.19749 USD",
             )
@@ -110,8 +110,8 @@ class CurrencySelectorOptionsFactoryTest {
 
         val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
 
-        assertThat(result?.first).isEqualTo(CurrencyOption(code = "JPY", displayableText = "🇯🇵 ¥5,000"))
-        assertThat(result?.second).isEqualTo(CurrencyOption(code = "USD", displayableText = "🇺🇸 $35.00"))
+        assertThat(result?.first).isEqualTo(CurrencyOption(code = "USD", displayableText = "🇺🇸 $35.00"))
+        assertThat(result?.second).isEqualTo(CurrencyOption(code = "JPY", displayableText = "🇯🇵 ¥5,000"))
         assertThat(result?.exchangeRateText).isEqualTo("1 JPY = 0.00680 USD")
     }
 
@@ -155,8 +155,8 @@ class CurrencySelectorOptionsFactoryTest {
 
         val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
 
-        assertThat(result?.first?.displayableText).isEqualTo("FCFA1,000")
-        assertThat(result?.second?.displayableText).isEqualTo("🇺🇸 $15.00")
+        assertThat(result?.first?.displayableText).isEqualTo("🇺🇸 $15.00")
+        assertThat(result?.second?.displayableText).isEqualTo("FCFA1,000")
     }
 
     @Test
@@ -177,8 +177,8 @@ class CurrencySelectorOptionsFactoryTest {
 
         val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
 
-        assertThat(result?.first?.displayableText).isEqualTo("CFPF500")
-        assertThat(result?.second?.displayableText).isEqualTo("🇪🇺 €6.00")
+        assertThat(result?.first?.displayableText).isEqualTo("🇪🇺 €6.00")
+        assertThat(result?.second?.displayableText).isEqualTo("CFPF500")
     }
 
     @Test
@@ -199,8 +199,8 @@ class CurrencySelectorOptionsFactoryTest {
 
         val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
 
-        assertThat(result?.first?.code).isEqualTo("EUR")
-        assertThat(result?.second?.code).isEqualTo("USD")
+        assertThat(result?.first?.code).isEqualTo("USD")
+        assertThat(result?.second?.code).isEqualTo("EUR")
         assertThat(result?.selectedCode).isEqualTo("USD")
         assertThat(result?.exchangeRateText).isEqualTo("1 EUR = 1.10000 USD")
     }


### PR DESCRIPTION
# Summary
Swapped the order of currency options in the currency selector to display the local currency first and the integration currency second.

# Motivation
This change improves the user experience by presenting the local currency as the primary option, which is typically more familiar and relevant to users when making payment decisions.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
[Changed] Currency selector now displays local currency as the first option instead of integration currency.