### PR TITLE
[link] Thread Link brand into financial connections Link interop

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -236,13 +236,6 @@ public final class com/stripe/android/financialconnections/features/manualentry/
 	public final fun getLambda$-1128705666$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class com/stripe/android/financialconnections/features/networkinglinkloginwarmup/ComposableSingletons$NetworkingLinkLoginWarmupScreenKt {
-	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/networkinglinkloginwarmup/ComposableSingletons$NetworkingLinkLoginWarmupScreenKt;
-	public fun <init> ()V
-	public final fun getLambda$-540276609$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1685113889$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-}
-
 public final class com/stripe/android/financialconnections/features/networkinglinkverification/ComposableSingletons$NetworkingLinkVerificationScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/networkinglinkverification/ComposableSingletons$NetworkingLinkVerificationScreenKt;
 	public fun <init> ()V

--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -18,9 +18,9 @@
   <string name="stripe_attachlinkedpaymentaccount_error_desc_manual_entry">Please enter your bank details manually or select another bank.</string>
   <string name="stripe_attachlinkedpaymentaccount_error_title">Your account number couldn’t be accessed at this time</string>
   <string name="stripe_close_dialog_networking_desc">If you cancel now, your account will be linked to %1$s but it will not be saved to Link.</string>
-  <string name="stripe_close_dialog_networking_desc_with_brand">If you cancel now, your account will be linked to %1$s but it will not be saved to %2$s.</string>
   <string name="stripe_close_dialog_networking_desc_no_business">If you cancel now, your account will be linked to this business but it will not be saved to Link.</string>
   <string name="stripe_close_dialog_networking_desc_no_business_with_brand">If you cancel now, your account will be linked to this business but it will not be saved to %1$s.</string>
+  <string name="stripe_close_dialog_networking_desc_with_brand">If you cancel now, your account will be linked to %1$s but it will not be saved to %2$s.</string>
   <string name="stripe_error_cta_close">Close</string>
   <string name="stripe_error_cta_manual_entry">Enter bank details manually</string>
   <string name="stripe_error_cta_retry">Try again</string>

--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -18,7 +18,9 @@
   <string name="stripe_attachlinkedpaymentaccount_error_desc_manual_entry">Please enter your bank details manually or select another bank.</string>
   <string name="stripe_attachlinkedpaymentaccount_error_title">Your account number couldn’t be accessed at this time</string>
   <string name="stripe_close_dialog_networking_desc">If you cancel now, your account will be linked to %1$s but it will not be saved to Link.</string>
+  <string name="stripe_close_dialog_networking_desc_with_brand">If you cancel now, your account will be linked to %1$s but it will not be saved to %2$s.</string>
   <string name="stripe_close_dialog_networking_desc_no_business">If you cancel now, your account will be linked to this business but it will not be saved to Link.</string>
+  <string name="stripe_close_dialog_networking_desc_no_business_with_brand">If you cancel now, your account will be linked to this business but it will not be saved to %1$s.</string>
   <string name="stripe_error_cta_close">Close</string>
   <string name="stripe_error_cta_manual_entry">Enter bank details manually</string>
   <string name="stripe_error_cta_retry">Try again</string>
@@ -60,10 +62,13 @@
   <string name="stripe_manualentry_title">Enter bank details</string>
   <string name="stripe_networking_link_login_warmup_cta_cancel">Cancel</string>
   <string name="stripe_networking_link_login_warmup_cta_continue">Continue with Link</string>
+  <string name="stripe_networking_link_login_warmup_cta_continue_with_brand">Continue with %1$s</string>
   <string name="stripe_networking_link_login_warmup_cta_skip">Not now</string>
   <!-- Networking warmup -->
   <string name="stripe_networking_link_login_warmup_description">Use information you previously saved with your Link account.</string>
+  <string name="stripe_networking_link_login_warmup_description_with_brand">Use information you previously saved with your %1$s account.</string>
   <string name="stripe_networking_link_login_warmup_title">Continue with Link</string>
+  <string name="stripe_networking_link_login_warmup_title_with_brand">Continue with %1$s</string>
   <string name="stripe_networking_save_to_link_verification_cta_negative">Not now</string>
   <string name="stripe_networking_save_to_link_verification_title">Confirm it\'s you</string>
   <!-- Networking signup -->
@@ -76,9 +81,13 @@
   <string name="stripe_prepane_choose_different_bank_cta">Choose a different bank</string>
   <string name="stripe_search">Search</string>
   <string name="stripe_success_pane_desc_link_error_plural">Your accounts were connected but couldn’t be saved with Link.</string>
+  <string name="stripe_success_pane_desc_link_error_plural_with_brand">Your accounts were connected but couldn’t be saved with %1$s.</string>
   <string name="stripe_success_pane_desc_link_error_singular">Your account was connected but couldn’t be saved with Link.</string>
+  <string name="stripe_success_pane_desc_link_error_singular_with_brand">Your account was connected but couldn’t be saved with %1$s.</string>
   <string name="stripe_success_pane_desc_link_success_plural">Your accounts were connected and saved with Link.</string>
+  <string name="stripe_success_pane_desc_link_success_plural_with_brand">Your accounts were connected and saved with %1$s.</string>
   <string name="stripe_success_pane_desc_link_success_singular">Your account was connected and saved with Link.</string>
+  <string name="stripe_success_pane_desc_link_success_singular_with_brand">Your account was connected and saved with %1$s.</string>
   <string name="stripe_success_pane_desc_microdeposits">You can expect micro-deposits to account ••••%1$s in 1–2 days and an email with further instructions.</string>
   <string name="stripe_success_pane_desc_plural">Your accounts were connected</string>
   <string name="stripe_success_pane_desc_singular">Your account was connected</string>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetOrFetchSync.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetOrFetchSync.kt
@@ -34,7 +34,7 @@ internal class GetOrFetchSync @Inject constructor(
 
     private fun SynchronizeSessionResponse.maybeOverrideLinkBrand(): SynchronizeSessionResponse {
         if (debugConfiguration.forceNotlink) {
-            return copy(manifest = manifest.copy(linkBrand = LinkBrand.Notlink))
+            return copy(manifest = manifest.copy(rawLinkBrand = LinkBrand.Notlink))
         }
         return this
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
@@ -4,7 +4,6 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheetConfigur
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.PaymentAccountParams.BankAccount
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
@@ -13,6 +12,7 @@ import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.utils.PollTimingOptions
 import com.stripe.android.financialconnections.utils.retryOnException
 import com.stripe.android.financialconnections.utils.shouldRetry
+import com.stripe.android.model.LinkBrand
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.max

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SaveAccountToLink.kt
@@ -4,6 +4,7 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheetConfigur
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.PaymentAccountParams.BankAccount
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
@@ -33,8 +34,9 @@ internal class SaveAccountToLink @Inject constructor(
         selectedAccounts: List<CachedPartnerAccount>,
         country: String,
         shouldPollAccountNumbers: Boolean,
+        linkBrand: LinkBrand,
     ): FinancialConnectionsSessionManifest {
-        return ensureReadyAccounts(shouldPollAccountNumbers, selectedAccounts) { selectedAccountIds ->
+        return ensureReadyAccounts(shouldPollAccountNumbers, selectedAccounts, linkBrand) { selectedAccountIds ->
             repository.postSaveAccountsToLink(
                 clientSecret = configuration.financialConnectionsSessionClientSecret,
                 email = email,
@@ -51,8 +53,9 @@ internal class SaveAccountToLink @Inject constructor(
         consumerSessionClientSecret: String,
         selectedAccounts: List<CachedPartnerAccount>?,
         shouldPollAccountNumbers: Boolean,
+        linkBrand: LinkBrand,
     ): FinancialConnectionsSessionManifest {
-        return ensureReadyAccounts(shouldPollAccountNumbers, selectedAccounts) { selectedAccountIds ->
+        return ensureReadyAccounts(shouldPollAccountNumbers, selectedAccounts, linkBrand) { selectedAccountIds ->
             repository.postSaveAccountsToLink(
                 clientSecret = configuration.financialConnectionsSessionClientSecret,
                 email = null,
@@ -68,6 +71,7 @@ internal class SaveAccountToLink @Inject constructor(
     private suspend fun ensureReadyAccounts(
         shouldPollAccountNumbers: Boolean,
         partnerAccounts: List<CachedPartnerAccount>?,
+        linkBrand: LinkBrand,
         action: suspend (Set<String>?) -> FinancialConnectionsSessionManifest,
     ): FinancialConnectionsSessionManifest {
         val selectedAccountIds = partnerAccounts?.map { it.id }?.toSet() ?: emptySet()
@@ -92,11 +96,11 @@ internal class SaveAccountToLink @Inject constructor(
             action(selectedAccountIds)
         }.onSuccess { manifest ->
             if (!isNetworkingRelinkSession()) {
-                storeSavedToLinkMessage(manifest, selectedAccountIds.size)
+                storeSavedToLinkMessage(manifest, selectedAccountIds.size, linkBrand)
             }
         }.onFailure {
             if (!isNetworkingRelinkSession()) {
-                storeFailedToSaveToLinkMessage(selectedAccountIds.size)
+                storeFailedToSaveToLinkMessage(selectedAccountIds.size, linkBrand)
             }
         }.getOrThrow()
     }
@@ -128,6 +132,7 @@ internal class SaveAccountToLink @Inject constructor(
     private fun storeSavedToLinkMessage(
         manifest: FinancialConnectionsSessionManifest,
         selectedAccounts: Int,
+        linkBrand: LinkBrand,
     ) {
         successContentRepository.set(
             heading = manifest.displayText?.successPane?.caption
@@ -135,24 +140,42 @@ internal class SaveAccountToLink @Inject constructor(
             message = manifest.displayText?.successPane?.subCaption
                 // If backend returns a custom success message, use it
                 ?.let { TextResource.Text(it) }
-                // If not, build a Link success message locally
-                ?: TextResource.PluralId(
-                    singular = R.string.stripe_success_pane_desc_link_success_singular,
-                    plural = R.string.stripe_success_pane_desc_link_success_plural,
-                    // No selected accounts means a manually entered account was already attached.
-                    count = max(1, selectedAccounts),
-                )
+                // If not, build a success message locally with the correct brand
+                ?: if (linkBrand == LinkBrand.Link) {
+                    TextResource.PluralId(
+                        singular = R.string.stripe_success_pane_desc_link_success_singular,
+                        plural = R.string.stripe_success_pane_desc_link_success_plural,
+                        // No selected accounts means a manually entered account was already attached.
+                        count = max(1, selectedAccounts),
+                    )
+                } else {
+                    TextResource.PluralId(
+                        singular = R.string.stripe_success_pane_desc_link_success_singular_with_brand,
+                        plural = R.string.stripe_success_pane_desc_link_success_plural_with_brand,
+                        count = max(1, selectedAccounts),
+                        args = listOf(linkBrand.brandName()),
+                    )
+                }
         )
     }
 
-    private fun storeFailedToSaveToLinkMessage(selectedAccounts: Int) {
+    private fun storeFailedToSaveToLinkMessage(selectedAccounts: Int, linkBrand: LinkBrand) {
         successContentRepository.set(
-            message = TextResource.PluralId(
-                singular = R.string.stripe_success_pane_desc_link_error_singular,
-                plural = R.string.stripe_success_pane_desc_link_error_plural,
-                // No selected accounts means a manually entered account was already attached.
-                count = max(1, selectedAccounts),
-            )
+            message = if (linkBrand == LinkBrand.Link) {
+                TextResource.PluralId(
+                    singular = R.string.stripe_success_pane_desc_link_error_singular,
+                    plural = R.string.stripe_success_pane_desc_link_error_plural,
+                    // No selected accounts means a manually entered account was already attached.
+                    count = max(1, selectedAccounts),
+                )
+            } else {
+                TextResource.PluralId(
+                    singular = R.string.stripe_success_pane_desc_link_error_singular_with_brand,
+                    plural = R.string.stripe_success_pane_desc_link_error_plural_with_brand,
+                    count = max(1, selectedAccounts),
+                    args = listOf(linkBrand.brandName()),
+                )
+            }
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -55,7 +55,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.launch
-import com.stripe.android.model.LinkBrand
 import java.util.Date
 
 internal class AccountPickerViewModel @AssistedInject constructor(
@@ -339,8 +338,7 @@ internal class AccountPickerViewModel @AssistedInject constructor(
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     selectedAccounts = accountsList.data.toCachedPartnerAccounts(),
                     shouldPollAccountNumbers = manifest.isDataFlow,
-                    // linkBrand is null when the backend doesn't specify one; Link is the default brand.
-                    linkBrand = manifest.linkBrand ?: LinkBrand.Link,
+                    linkBrand = manifest.linkBrand,
                 )
             }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -55,6 +55,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.launch
+import com.stripe.android.model.LinkBrand
 import java.util.Date
 
 internal class AccountPickerViewModel @AssistedInject constructor(
@@ -338,6 +339,8 @@ internal class AccountPickerViewModel @AssistedInject constructor(
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     selectedAccounts = accountsList.data.toCachedPartnerAccounts(),
                     shouldPollAccountNumbers = manifest.isDataFlow,
+                    // linkBrand is null when the backend doesn't specify one; Link is the default brand.
+                    linkBrand = manifest.linkBrand ?: LinkBrand.Link,
                 )
             }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -30,6 +30,7 @@ import com.stripe.android.financialconnections.repository.SuccessContentReposito
 import com.stripe.android.financialconnections.ui.TextResource.PluralId
 import com.stripe.android.financialconnections.utils.error
 import com.stripe.android.financialconnections.utils.measureTimeMillis
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.navigation.NavigationManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -93,12 +94,23 @@ internal class AttachPaymentViewModel @AssistedInject constructor(
         accounts: List<CachedPartnerAccount>,
     ) {
         if (manifest.canSetCustomLinkSuccessMessage && !isNetworkingRelinkSession()) {
+            // linkBrand is null when the backend doesn't specify one; Link is the default brand.
+            val linkBrand = manifest.linkBrand ?: LinkBrand.Link
             successContentRepository.set(
-                message = PluralId(
-                    singular = R.string.stripe_success_pane_desc_link_success_singular,
-                    plural = R.string.stripe_success_pane_desc_link_success_plural,
-                    count = accounts.size
-                )
+                message = if (linkBrand == LinkBrand.Link) {
+                    PluralId(
+                        singular = R.string.stripe_success_pane_desc_link_success_singular,
+                        plural = R.string.stripe_success_pane_desc_link_success_plural,
+                        count = accounts.size,
+                    )
+                } else {
+                    PluralId(
+                        singular = R.string.stripe_success_pane_desc_link_success_singular_with_brand,
+                        plural = R.string.stripe_success_pane_desc_link_success_plural_with_brand,
+                        count = accounts.size,
+                        args = listOf(linkBrand.brandName()),
+                    )
+                }
             )
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -94,8 +94,7 @@ internal class AttachPaymentViewModel @AssistedInject constructor(
         accounts: List<CachedPartnerAccount>,
     ) {
         if (manifest.canSetCustomLinkSuccessMessage && !isNetworkingRelinkSession()) {
-            // linkBrand is null when the backend doesn't specify one; Link is the default brand.
-            val linkBrand = manifest.linkBrand ?: LinkBrand.Link
+            val linkBrand = manifest.linkBrand
             successContentRepository.set(
                 message = if (linkBrand == LinkBrand.Link) {
                     PluralId(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/exit/ExitViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/exit/ExitViewModel.kt
@@ -14,13 +14,13 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
 import com.stripe.android.financialconnections.features.common.getBusinessName
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarStateUpdate
 import com.stripe.android.financialconnections.presentation.Async
 import com.stripe.android.financialconnections.presentation.Async.Uninitialized
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsViewModel
 import com.stripe.android.financialconnections.ui.TextResource
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.navigation.NavigationManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/exit/ExitViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/exit/ExitViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
 import com.stripe.android.financialconnections.features.common.getBusinessName
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarStateUpdate
 import com.stripe.android.financialconnections.presentation.Async
@@ -43,13 +44,29 @@ internal class ExitViewModel @AssistedInject constructor(
             val businessName = manifest?.getBusinessName()
             val isNetworkingSignupPane =
                 manifest?.isNetworkingUserFlow == true && stateFlow.value.referrer == Pane.NETWORKING_LINK_SIGNUP_PANE
+            // Safe default: manifest is null only on fetch failure, and Link is the original brand.
+            val linkBrand = manifest?.linkBrand ?: LinkBrand.Link
             val description = when {
                 isNetworkingSignupPane -> when (businessName) {
-                    null -> TextResource.StringId(R.string.stripe_close_dialog_networking_desc_no_business)
-                    else -> TextResource.StringId(
-                        value = R.string.stripe_close_dialog_networking_desc,
-                        args = listOf(businessName)
-                    )
+                    null -> if (linkBrand == LinkBrand.Link) {
+                        TextResource.StringId(R.string.stripe_close_dialog_networking_desc_no_business)
+                    } else {
+                        TextResource.StringId(
+                            value = R.string.stripe_close_dialog_networking_desc_no_business_with_brand,
+                            args = listOf(linkBrand.brandName())
+                        )
+                    }
+                    else -> if (linkBrand == LinkBrand.Link) {
+                        TextResource.StringId(
+                            value = R.string.stripe_close_dialog_networking_desc,
+                            args = listOf(businessName)
+                        )
+                    } else {
+                        TextResource.StringId(
+                            value = R.string.stripe_close_dialog_networking_desc_with_brand,
+                            args = listOf(businessName, linkBrand.brandName())
+                        )
+                    }
                 }
 
                 else -> when (businessName) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupPreviewParameterProvider.kt
@@ -5,6 +5,7 @@ import com.stripe.android.financialconnections.presentation.Async.Fail
 import com.stripe.android.financialconnections.presentation.Async.Loading
 import com.stripe.android.financialconnections.presentation.Async.Success
 import com.stripe.android.financialconnections.presentation.Async.Uninitialized
+import com.stripe.android.model.LinkBrand
 
 internal class NetworkingLinkLoginWarmupPreviewParameterProvider :
     PreviewParameterProvider<NetworkingLinkLoginWarmupState> {
@@ -29,18 +30,21 @@ internal class NetworkingLinkLoginWarmupPreviewParameterProvider :
         ),
         disableNetworkingAsync = Uninitialized,
         isInstantDebits = false,
+        linkBrand = LinkBrand.Link,
     )
 
     private fun loading() = NetworkingLinkLoginWarmupState(
         payload = Loading(),
         disableNetworkingAsync = Uninitialized,
         isInstantDebits = false,
+        linkBrand = LinkBrand.Link,
     )
 
     private fun payloadError() = NetworkingLinkLoginWarmupState(
         payload = Fail(Exception("Error")),
         disableNetworkingAsync = Uninitialized,
         isInstantDebits = false,
+        linkBrand = LinkBrand.Link,
     )
 
     private fun disablingError() = NetworkingLinkLoginWarmupState(
@@ -55,6 +59,7 @@ internal class NetworkingLinkLoginWarmupPreviewParameterProvider :
         ),
         disableNetworkingAsync = Fail(Exception("Error")),
         isInstantDebits = false,
+        linkBrand = LinkBrand.Link,
     )
 
     private fun disablingNetworking() = NetworkingLinkLoginWarmupState(
@@ -69,6 +74,7 @@ internal class NetworkingLinkLoginWarmupPreviewParameterProvider :
         ),
         disableNetworkingAsync = Loading(),
         isInstantDebits = false,
+        linkBrand = LinkBrand.Link,
     )
 
     private fun instantDebits() = NetworkingLinkLoginWarmupState(
@@ -83,5 +89,6 @@ internal class NetworkingLinkLoginWarmupPreviewParameterProvider :
         ),
         disableNetworkingAsync = Uninitialized,
         isInstantDebits = true,
+        linkBrand = LinkBrand.Link,
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavBackStackEntry
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.ShapedIcon
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.presentation.Async.Loading
 import com.stripe.android.financialconnections.presentation.paneViewModel
 import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
@@ -78,7 +79,7 @@ private fun NetworkingLinkLoginWarmupContent(
         verticalArrangement = Arrangement.spacedBy(24.dp),
         lazyListState = lazyListState,
         body = {
-            item { HeaderSection() }
+            item { HeaderSection(linkBrand = state.linkBrand) }
             item { ExistingEmailSection(email = state.payload()?.redactedEmail ?: "") }
         },
         footer = {
@@ -86,6 +87,7 @@ private fun NetworkingLinkLoginWarmupContent(
                 primaryButtonLoading = state.continueAsync is Loading,
                 secondaryButtonLoading = state.disableNetworkingAsync is Loading,
                 secondaryButtonLabel = state.secondaryButtonLabel,
+                linkBrand = state.linkBrand,
                 onContinueClick = onContinueClick,
                 onSkipClicked = onSkipClicked,
             )
@@ -94,21 +96,31 @@ private fun NetworkingLinkLoginWarmupContent(
 }
 
 @Composable
-private fun HeaderSection() {
+private fun HeaderSection(linkBrand: LinkBrand) {
+    val title = if (linkBrand == LinkBrand.Link) {
+        stringResource(R.string.stripe_networking_link_login_warmup_title)
+    } else {
+        stringResource(R.string.stripe_networking_link_login_warmup_title_with_brand, linkBrand.brandName())
+    }
+    val description = if (linkBrand == LinkBrand.Link) {
+        stringResource(R.string.stripe_networking_link_login_warmup_description)
+    } else {
+        stringResource(R.string.stripe_networking_link_login_warmup_description_with_brand, linkBrand.brandName())
+    }
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         ShapedIcon(
             painter = painterResource(id = R.drawable.stripe_ic_person),
-            contentDescription = stringResource(R.string.stripe_networking_link_login_warmup_title)
+            contentDescription = title
         )
         Text(
-            text = stringResource(R.string.stripe_networking_link_login_warmup_title),
+            text = title,
             style = typography.headingLarge,
             color = colors.textDefault,
         )
         Text(
-            text = stringResource(R.string.stripe_networking_link_login_warmup_description),
+            text = description,
             style = typography.bodyMedium,
             color = colors.textDefault,
         )
@@ -121,10 +133,16 @@ private fun Footer(
     primaryButtonLoading: Boolean,
     secondaryButtonLoading: Boolean,
     secondaryButtonLabel: Int,
+    linkBrand: LinkBrand,
     onContinueClick: () -> Unit,
     onSkipClicked: () -> Unit
 ) {
     val enableButtons = !primaryButtonLoading && !secondaryButtonLoading
+    val ctaContinue = if (linkBrand == LinkBrand.Link) {
+        stringResource(id = R.string.stripe_networking_link_login_warmup_cta_continue)
+    } else {
+        stringResource(id = R.string.stripe_networking_link_login_warmup_cta_continue_with_brand, linkBrand.brandName())
+    }
 
     Column {
         FinancialConnectionsButton(
@@ -137,7 +155,7 @@ private fun Footer(
                 .testTag("existing_email-button")
                 .fillMaxWidth()
         ) {
-            Text(text = stringResource(id = R.string.stripe_networking_link_login_warmup_cta_continue))
+            Text(text = ctaContinue)
         }
         Spacer(modifier = Modifier.size(16.dp))
         FinancialConnectionsButton(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavBackStackEntry
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.ShapedIcon
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.presentation.Async.Loading
 import com.stripe.android.financialconnections.presentation.paneViewModel
 import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
@@ -47,6 +46,7 @@ import com.stripe.android.financialconnections.ui.theme.LazyLayout
 import com.stripe.android.financialconnections.ui.theme.LinkGreen200
 import com.stripe.android.financialconnections.ui.theme.LinkGreen900
 import com.stripe.android.financialconnections.ui.theme.Theme
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -18,6 +18,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.features.common.getBusinessName
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.Destination.Companion.KEY_NEXT_PANE_ON_DISABLE_NETWORKING
 import com.stripe.android.financialconnections.navigation.destination
@@ -207,6 +208,7 @@ internal data class NetworkingLinkLoginWarmupState(
     val disableNetworkingAsync: Async<FinancialConnectionsSessionManifest> = Uninitialized,
     val continueAsync: Async<Unit> = Uninitialized,
     val isInstantDebits: Boolean = false,
+    val linkBrand: LinkBrand,
 ) {
 
     val secondaryButtonLabel: Int
@@ -225,6 +227,7 @@ internal data class NetworkingLinkLoginWarmupState(
         payload = Uninitialized,
         disableNetworkingAsync = Uninitialized,
         isInstantDebits = state.isLinkWithStripe,
+        linkBrand = state.linkBrand,
     )
 
     data class Payload(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -18,7 +18,6 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.features.common.getBusinessName
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.Destination.Companion.KEY_NEXT_PANE_ON_DISABLE_NETWORKING
 import com.stripe.android.financialconnections.navigation.destination
@@ -29,6 +28,7 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsViewModel
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.model.EmailSource
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.navigation.NavigationManager
 import com.stripe.android.uicore.navigation.PopUpToBehavior
 import dagger.assisted.Assisted

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -208,7 +208,8 @@ internal data class NetworkingLinkLoginWarmupState(
     val disableNetworkingAsync: Async<FinancialConnectionsSessionManifest> = Uninitialized,
     val continueAsync: Async<Unit> = Uninitialized,
     val isInstantDebits: Boolean = false,
-    val linkBrand: LinkBrand,
+    // Defaults to Link so tests that don't exercise branding can omit this parameter.
+    val linkBrand: LinkBrand = LinkBrand.Link,
 ) {
 
     val secondaryButtonLabel: Int

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -23,6 +23,7 @@ import com.stripe.android.financialconnections.navigation.Destination.Networking
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
 import com.stripe.android.financialconnections.navigation.Destination.Success
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.navigation.NavigationManager
 import javax.inject.Inject
 import javax.inject.Named
@@ -148,6 +149,8 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
                 consumerSessionClientSecret = signup.consumerSession.clientSecret,
                 selectedAccounts = selectedAccounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
+                // linkBrand is null when the backend doesn't specify one; Link is the default brand.
+                linkBrand = manifest.linkBrand ?: LinkBrand.Link,
             )
         } else {
             // ** Legacy signup endpoint on unverified flows: 1 request **
@@ -159,6 +162,8 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
                 phoneNumber = state.validPhone!!,
                 selectedAccounts = selectedAccounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
+                // linkBrand is null when the backend doesn't specify one; Link is the default brand.
+                linkBrand = manifest.linkBrand ?: LinkBrand.Link,
             )
         }
         return Pane.SUCCESS

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -23,7 +23,6 @@ import com.stripe.android.financialconnections.navigation.Destination.Networking
 import com.stripe.android.financialconnections.navigation.Destination.NetworkingSaveToLinkVerification
 import com.stripe.android.financialconnections.navigation.Destination.Success
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.navigation.NavigationManager
 import javax.inject.Inject
 import javax.inject.Named
@@ -149,8 +148,7 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
                 consumerSessionClientSecret = signup.consumerSession.clientSecret,
                 selectedAccounts = selectedAccounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
-                // linkBrand is null when the backend doesn't specify one; Link is the default brand.
-                linkBrand = manifest.linkBrand ?: LinkBrand.Link,
+                linkBrand = manifest.linkBrand,
             )
         } else {
             // ** Legacy signup endpoint on unverified flows: 1 request **
@@ -162,8 +160,7 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
                 phoneNumber = state.validPhone!!,
                 selectedAccounts = selectedAccounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
-                // linkBrand is null when the backend doesn't specify one; Link is the default brand.
-                linkBrand = manifest.linkBrand ?: LinkBrand.Link,
+                linkBrand = manifest.linkBrand,
             )
         }
         return Pane.SUCCESS

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -40,7 +40,6 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.navigation.Destination.Success as SuccessDestination
 
 internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constructor(
@@ -151,8 +150,7 @@ internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constru
                 consumerSessionClientSecret = payload.consumerSessionClientSecret,
                 selectedAccounts = accounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
-                // linkBrand is null when the backend doesn't specify one; Link is the default brand.
-                linkBrand = manifest.linkBrand ?: LinkBrand.Link,
+                linkBrand = manifest.linkBrand,
             )
         }
             .onSuccess { eventTracker.track(VerificationSuccess(PANE)) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -40,6 +40,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.financialconnections.navigation.Destination.Success as SuccessDestination
 
 internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constructor(
@@ -150,6 +151,8 @@ internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constru
                 consumerSessionClientSecret = payload.consumerSessionClientSecret,
                 selectedAccounts = accounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
+                // linkBrand is null when the backend doesn't specify one; Link is the default brand.
+                linkBrand = manifest.linkBrand ?: LinkBrand.Link,
             )
         }
             .onSuccess { eventTracker.track(VerificationSuccess(PANE)) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -142,14 +142,14 @@ internal data class FinancialConnectionsSessionManifest(
     @SerialName("theme")
     val theme: Theme? = null,
     @SerialName("link_brand")
-    private val _linkBrand: LinkBrand? = null,
+    private val rawLinkBrand: LinkBrand? = null,
 ) : Parcelable {
 
     val consentAcquired: Boolean
         get() = !consentRequired || consentAcquiredAt != null
 
     val linkBrand: LinkBrand
-        get() = _linkBrand ?: LinkBrand.Link
+        get() = rawLinkBrand ?: LinkBrand.Link
 
     /**
      *

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -142,11 +142,14 @@ internal data class FinancialConnectionsSessionManifest(
     @SerialName("theme")
     val theme: Theme? = null,
     @SerialName("link_brand")
-    val linkBrand: LinkBrand? = null,
+    private val _linkBrand: LinkBrand? = null,
 ) : Parcelable {
 
     val consentAcquired: Boolean
         get() = !consentRequired || consentAcquiredAt != null
+
+    val linkBrand: LinkBrand
+        get() = _linkBrand ?: LinkBrand.Link
 
     /**
      *

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -556,7 +556,7 @@ internal data class FinancialConnectionsSheetNativeState(
         initialPane = args.initialSyncResponse.manifest.nextPane,
         configuration = args.configuration,
         theme = args.initialSyncResponse.manifest.theme?.toLocalTheme() ?: Theme.default,
-        linkBrand = args.initialSyncResponse.manifest.linkBrand ?: LinkBrand.Link,
+        linkBrand = args.initialSyncResponse.manifest.linkBrand,
         viewEffect = null,
         isLinkWithStripe = args.initialSyncResponse.manifest.isLinkWithStripe ?: false,
         manualEntryUsesMicrodeposits = args.initialSyncResponse.manifest.manualEntryUsesMicrodeposits,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsAc
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.ui.TextResource
+import com.stripe.android.model.LinkBrand
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -52,6 +53,7 @@ internal class SaveAccountToLinkTest {
             selectedAccounts = partnerAccounts,
             country = "US",
             shouldPollAccountNumbers = true,
+            linkBrand = LinkBrand.Link,
         )
 
         assertThat(polledClientSecret).isEqualTo(ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET)
@@ -78,6 +80,7 @@ internal class SaveAccountToLinkTest {
             selectedAccounts = partnerAccounts,
             country = "US",
             shouldPollAccountNumbers = false,
+            linkBrand = LinkBrand.Link,
         )
 
         assertThat(polledAccountIds).isEmpty()
@@ -109,6 +112,7 @@ internal class SaveAccountToLinkTest {
                 selectedAccounts = partnerAccounts,
                 country = "US",
                 shouldPollAccountNumbers = true,
+                linkBrand = LinkBrand.Link,
             )
         }
 
@@ -137,6 +141,7 @@ internal class SaveAccountToLinkTest {
                 selectedAccounts = partnerAccounts,
                 country = "US",
                 shouldPollAccountNumbers = true,
+                linkBrand = LinkBrand.Link,
             )
         }
 
@@ -145,6 +150,42 @@ internal class SaveAccountToLinkTest {
                 singular = R.string.stripe_success_pane_desc_link_error_singular,
                 plural = R.string.stripe_success_pane_desc_link_error_plural,
                 count = 2,
+            )
+        )
+    }
+
+    @Test
+    fun `Sets branded error message if polling account numbers fails with non-Link brand`() = runTest(testDispatcher) {
+        val partnerAccounts = ApiKeyFixtures.cachedPartnerAccounts()
+
+        val accountsRepository = mockAccountsRepository(
+            onPollAccountNumbers = { _, _ -> error("This is failing") },
+        )
+
+        val successRepository = SuccessContentRepository(SavedStateHandle())
+
+        val saveAccountToLink = makeSaveAccountToLink(
+            accountsRepository = accountsRepository,
+            successRepository = successRepository,
+        )
+
+        assertFails {
+            saveAccountToLink.new(
+                email = "email@email.com",
+                phoneNumber = "+15555555555",
+                selectedAccounts = partnerAccounts,
+                country = "US",
+                shouldPollAccountNumbers = true,
+                linkBrand = LinkBrand.Notlink,
+            )
+        }
+
+        assertThat(successRepository.get()?.message).isEqualTo(
+            TextResource.PluralId(
+                singular = R.string.stripe_success_pane_desc_link_error_singular_with_brand,
+                plural = R.string.stripe_success_pane_desc_link_error_plural_with_brand,
+                count = 2,
+                args = listOf(LinkBrand.Notlink.brandName()),
             )
         )
     }
@@ -177,6 +218,7 @@ internal class SaveAccountToLinkTest {
                 selectedAccounts = emptyList(),
                 country = "US",
                 shouldPollAccountNumbers = true,
+                linkBrand = LinkBrand.Link,
             )
 
             assertThat(successRepository.get()?.message).isEqualTo(
@@ -214,6 +256,7 @@ internal class SaveAccountToLinkTest {
             consumerSessionClientSecret = "cscs_123",
             selectedAccounts = emptyList(),
             shouldPollAccountNumbers = true,
+            linkBrand = LinkBrand.Link,
         )
 
         assertThat(successRepository.get()).isNull()

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.presentation.withState
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.model.LinkBrand
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -233,6 +234,7 @@ internal class AccountPickerViewModelTest {
             consumerSessionClientSecret = any(),
             selectedAccounts = any(),
             shouldPollAccountNumbers = any(),
+            linkBrand = any(),
         )
 
         navigationManager.assertNavigatedTo(
@@ -265,6 +267,7 @@ internal class AccountPickerViewModelTest {
             consumerSessionClientSecret = any(),
             selectedAccounts = any(),
             shouldPollAccountNumbers = any(),
+            linkBrand = any(),
         )
 
         navigationManager.assertNavigatedTo(
@@ -306,6 +309,7 @@ internal class AccountPickerViewModelTest {
             consumerSessionClientSecret = consumerSession.clientSecret,
             selectedAccounts = accounts.data.map { CachedPartnerAccount(it.id, it.linkedAccountId) },
             shouldPollAccountNumbers = true,
+            linkBrand = LinkBrand.Link,
         )
 
         navigationManager.assertNavigatedTo(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.presentation.Async
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.model.LinkBrand
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.mockito.kotlin.any
@@ -104,7 +105,7 @@ class LinkSignupHandlerForNetworkingTest {
             verificationToken = eq(expectedToken),
             appId = eq("applicationId")
         )
-        verify(saveAccountToLink).existing(any(), any(), any())
+        verify(saveAccountToLink).existing(any(), any(), any(), any())
         assertEquals(expectedPane, result)
     }
 
@@ -158,7 +159,8 @@ class LinkSignupHandlerForNetworkingTest {
             phoneNumber = eq("+1987654321"),
             selectedAccounts = eq(cachedAccounts),
             country = eq("US"),
-            shouldPollAccountNumbers = eq(true)
+            shouldPollAccountNumbers = eq(true),
+            linkBrand = eq(LinkBrand.Link),
         )
         assertEquals(expectedPane, result)
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -731,11 +731,11 @@ class NetworkingLinkSignupViewModelTest {
 
         val saveAccountToLink = mock<SaveAccountToLink> {
             if (failOnSignup) {
-                on { new(any(), any(), any(), any(), any()) } doAnswer {
+                on { new(any(), any(), any(), any(), any(), any()) } doAnswer {
                     throw APIConnectionException()
                 }
             } else {
-                on { new(any(), any(), any(), any(), any()) } doReturn manifest
+                on { new(any(), any(), any(), any(), any(), any()) } doReturn manifest
             }
         }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.financialconnections.model.PaymentAccountParams
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.model.LinkBrand
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -103,6 +104,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
                 eq(state.payload()!!.consumerSessionClientSecret),
                 eq(listOf(selectedAccount)),
                 eq(true),
+                eq(LinkBrand.Link),
             )
             verify(confirmVerification).sms(
                 consumerSessionClientSecret = cachedConsumerSession.clientSecret,
@@ -148,6 +150,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
                 eq(state.payload()!!.consumerSessionClientSecret),
                 eq(emptyList()),
                 eq(true),
+                eq(LinkBrand.Link),
             )
             verify(confirmVerification).sms(
                 consumerSessionClientSecret = cachedConsumerSession.clientSecret,
@@ -171,7 +174,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
             whenever(getOrFetchSync()).thenReturn(syncResponse(sessionManifest()))
             whenever(markLinkVerified()).thenReturn(linkVerifiedManifest)
             whenever(getCachedAccounts()).thenReturn(listOf(selectedAccount))
-            whenever(saveAccountToLink.existing(any(), any(), any())).thenThrow(RuntimeException("error"))
+            whenever(saveAccountToLink.existing(any(), any(), any(), any())).thenThrow(RuntimeException("error"))
 
             val viewModel = buildViewModel()
 
@@ -187,6 +190,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
                 eq(state.payload()!!.consumerSessionClientSecret),
                 eq(listOf(selectedAccount)),
                 eq(true),
+                eq(LinkBrand.Link),
             )
             verify(confirmVerification).sms(
                 consumerSessionClientSecret = cachedConsumerSession.clientSecret,

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -50,6 +50,12 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_link_email_suggestion_update">Yes, update</string>
   <!-- Title for a button that indicates a user can log in or sign up. -->
   <string name="stripe_link_log_in_or_sign_up">Log in or sign up</string>
+  <!-- Text displayed on a confirmation button on the CRS CARF declaration screen -->
+  <string name="stripe_link_onramp_carf_declaration_accept_button_text">Accept</string>
+  <!-- Text displayed on a cancel button on the CRS CARF declaration screen -->
+  <string name="stripe_link_onramp_carf_declaration_cancel_button_text">Cancel</string>
+  <!-- Title of the screen responsible for accepting CRS CARF declarations -->
+  <string name="stripe_link_onramp_carf_declaration_screen_title">Declarations</string>
   <!-- Title for the address field on the KYC verification screen -->
   <string name="stripe_link_onramp_kyc_verification_address_field_title">Address</string>
   <!-- Text displayed in a confirmation button when gathering kyc information -->
@@ -62,12 +68,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_link_onramp_kyc_verification_screen_title">Confirm your information</string>
   <!-- Title for the SSN field on the KYC verification screen -->
   <string name="stripe_link_onramp_kyc_verification_ssn_field_title">Last 4 digits of SSN</string>
-  <!-- Title of the screen responsible for accepting CRS CARF declarations -->
-  <string name="stripe_link_onramp_carf_declaration_screen_title">Declarations</string>
-  <!-- Text displayed on a cancel button on the CRS CARF declaration screen -->
-  <string name="stripe_link_onramp_carf_declaration_cancel_button_text">Cancel</string>
-  <!-- Text displayed on a confirmation button on the CRS CARF declaration screen -->
-  <string name="stripe_link_onramp_carf_declaration_accept_button_text">Accept</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->
   <string name="stripe_link_sign_up">Agree and continue</string>
   <!-- Title for the Link signup screen -->


### PR DESCRIPTION
# Summary
Make sure correct Link brand is threaded into Financial Connections Link signup / interop.

# Motivation
Bug bashing bank account connection

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Payment sheet --> US bank account --> existing customer email
<img width="300" alt="Screenshot_20260513_121637" src="https://github.com/user-attachments/assets/1fcf8470-1112-40f9-a05d-6e6358b1909b" />

Financial connections --> Networking merchant --> connect account to Link (`Save account with Link` comes from the backend)
<img width="300" alt="Screenshot_20260513_124224" src="https://github.com/user-attachments/assets/24f7bddb-9088-435c-a1d8-bee8d958836b" />

<img width="300" alt="Screenshot_20260513_124530" src="https://github.com/user-attachments/assets/3ee5cc34-ff2e-49fc-909b-d34f17b1e62d" />

# Changelog
n/a