### PR TITLE
Skip Link OTP dialog if user has saved PMs

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.attestation.LinkAttestationCheck
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.state.LinkState
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -35,12 +36,21 @@ internal class LinkHandler @Inject constructor(
         linkConfigurationCoordinator.getComponent(state.configuration)
     }
 
-    suspend fun setupLinkWithEagerLaunch(state: LinkState?): Boolean {
+    suspend fun setupLinkWithEagerLaunch(
+        state: LinkState?,
+        customerPaymentMethods: List<PaymentMethod>,
+    ): Boolean {
         setupLink(state)
 
         val configuration = state?.configuration ?: return false
         val linkGate = linkConfigurationCoordinator.linkGate(configuration)
         if (linkGate.suppress2faModal) return false
+
+        if (customerPaymentMethods.isNotEmpty()) {
+            // Allow the user to check out in a single click if they already have
+            // saved payment methods.
+            return false
+        }
 
         return when (state.loginState) {
             LinkState.LoginState.LoggedIn,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -328,7 +328,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private suspend fun initializeWithState(state: PaymentSheetState.Full) {
         withContext(Dispatchers.Main.immediate) {
-            val shouldLaunchEagerly = linkHandler.setupLinkWithEagerLaunch(state.paymentMethodMetadata.linkState)
+            val shouldLaunchEagerly = linkHandler.setupLinkWithEagerLaunch(
+                state = state.paymentMethodMetadata.linkState,
+                customerPaymentMethods = state.customer?.paymentMethods.orEmpty(),
+            )
             if (shouldLaunchEagerly) {
                 checkoutWithLinkExpress(state.paymentMethodMetadata)
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -15,8 +15,10 @@ import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.state.LinkState.LoginState
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_SELECTION
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.FakeLinkStore
@@ -129,8 +131,18 @@ class LinkHandlerTest {
     }
 
     @Test
+    fun `setupLinkWithEagerLaunch returns false when customer has saved payment methods`() = runLinkTest {
+        val shouldLaunchEagerly = handler.setupLinkWithEagerLaunch(
+            state = createLinkState(loginState = LoginState.NeedsVerification),
+            customerPaymentMethods = listOf(PaymentMethodFixtures.createCard()),
+        )
+
+        assertThat(shouldLaunchEagerly).isFalse()
+    }
+
+    @Test
     fun `setupLinkWithEagerLaunch returns false when state is null`() = runLinkTest {
-        val shouldLaunchEagerly = handler.setupLinkWithEagerLaunch(state = null)
+        val shouldLaunchEagerly = handler.setupLinkWithEagerLaunch(state = null, customerPaymentMethods = emptyList())
 
         assertThat(shouldLaunchEagerly).isFalse()
     }
@@ -155,7 +167,8 @@ class LinkHandlerTest {
                 state = createLinkState(
                     loginState = loginState,
                     signupMode = LinkSignupMode.AlongsideSaveForFutureUse
-                )
+                ),
+                customerPaymentMethods = emptyList(),
             )
 
             assertThat(shouldLaunchEagerly).isEqualTo(expectedResult)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -621,6 +621,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Link Express is launched when viewmodel is started with logged in link account`() = confirmationTest {
         createViewModel(
+            customer = EMPTY_CUSTOMER_STATE,
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
                 loginState = LinkState.LoginState.LoggedIn,
@@ -1473,6 +1474,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Does not show processing WalletsProcessingState when using Link Express`() = confirmationTest {
         val viewModel = createViewModel(
+            customer = EMPTY_CUSTOMER_STATE,
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
                 loginState = LinkState.LoginState.NeedsVerification,
@@ -2668,6 +2670,7 @@ internal class PaymentSheetViewModelTest {
 
         createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
+            customer = EMPTY_CUSTOMER_STATE,
             linkState = LinkState(
                 configuration = LINK_CONFIG,
                 loginState = LinkState.LoginState.LoggedIn,
@@ -2709,6 +2712,7 @@ internal class PaymentSheetViewModelTest {
 
         createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
+            customer = EMPTY_CUSTOMER_STATE,
             linkState = LinkState(
                 configuration = LINK_CONFIG,
                 loginState = LinkState.LoginState.LoggedIn,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request skips the Link OTP dialog if the provided `customer` has saved payment methods. Instead of prompting them to sign into Link via the SMS code, they can now simply check out with a single click.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
