### PR TITLE
Disable passive captcha in latency tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
@@ -11,7 +11,7 @@ import org.junit.Rule
 
 internal open class BasePlaygroundTest(disableAnimations: Boolean = true) {
     @get:Rule
-    val rules = TestRules.create(disableAnimations = disableAnimations)
+    open val rules = TestRules.create(disableAnimations = disableAnimations)
 
     lateinit var device: UiDevice
     lateinit var testDriver: PlaygroundTestDriver

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -2,6 +2,7 @@ package com.stripe.android.latency
 
 import android.util.Log
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.example.BuildConfig
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
@@ -15,7 +16,10 @@ import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.test.core.TestParameters
+import com.stripe.android.testing.FeatureFlagTestRule
+import com.stripe.android.utils.TestRules
 import org.junit.Assume
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -28,7 +32,19 @@ import org.junit.runners.Parameterized
 @RunWith(Parameterized::class)
 internal class TestLatency(
     val testConfig: TestConfig,
-) : BasePlaygroundTest() {
+): BasePlaygroundTest() {
+
+    @get:Rule
+    val disablePassiveCaptchaWarmupRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.disablePassiveCaptchaWarmup,
+        isEnabled = true,
+    )
+
+    @get:Rule
+    override val rules = TestRules.create(disableAnimations = true) {
+        around(disablePassiveCaptchaWarmupRule)
+    }
+
     @Test
     fun testLatency() {
         Assume.assumeFalse(BuildConfig.IS_RUNNING_IN_CI)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -7,6 +7,7 @@ import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.RadarOptions
@@ -38,6 +39,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
     }
 
     override fun bootstrap(paymentMethodMetadata: PaymentMethodMetadata) {
+        if (FeatureFlags.disablePassiveCaptchaWarmup.isEnabled) return
         val passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams ?: return
         passiveChallengeWarmer.start(
             passiveCaptchaParams = passiveCaptchaParams,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -7,8 +7,8 @@ import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.RadarOptions
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.challenge.passive.PassiveChallengeActivityContract
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.AndroidVerificationObject
@@ -27,12 +28,19 @@ import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.utils.FakeActivityResultLauncher
 import com.stripe.android.utils.FakePassiveChallengeWarmer
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 
 internal class PassiveChallengeConfirmationDefinitionTest {
+    @get:Rule
+    val disablePassiveCaptchaWarmupRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.disablePassiveCaptchaWarmup,
+        isEnabled = false
+    )
 
     @Test
     fun `'key' should be 'ChallengePassive'`() {
@@ -450,6 +458,24 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             passiveCaptchaParams = null
+        )
+
+        definition.bootstrap(paymentMethodMetadata)
+
+        fakePassiveChallengeWarmer.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `'bootstrap' should not start warmer if passive captcha warm-up is disabled`() {
+        disablePassiveCaptchaWarmupRule.setEnabled(true)
+
+        val fakePassiveChallengeWarmer = FakePassiveChallengeWarmer()
+        val definition = createPassiveChallengeConfirmationDefinition(
+            passiveChallengeWarmer = fakePassiveChallengeWarmer
+        )
+
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS
         )
 
         definition.bootstrap(paymentMethodMetadata)

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -18,6 +18,7 @@ object FeatureFlags {
     val forceNotlinkConsumer = FeatureFlag("Link: Force Notlink consumer")
     val enableKlarnaFormRemoval = FeatureFlag("Remove forms from Klarna")
     val paymentMethodMessagePromotions = FeatureFlag("Use BNPL Promotions")
+    val disablePassiveCaptchaWarmup = FeatureFlag("Disable Passive Captcha Warm-Up")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Disable passive captcha in latency tests

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Passive captcha doesn't affect latency so it's ok to disable it here. I noticed a case where it seems like it may have made the test fail (specific to the test infra) so I'm hoping this will de-flake that test case.