### PR TITLE
Extract currency selector logic into dedicated ViewModel.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -5,23 +5,18 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.stripe.android.checkout.Checkout.Companion.configure
 import com.stripe.android.checkout.Checkout.Companion.createWithState
 import com.stripe.android.checkout.injection.CheckoutComponent
 import com.stripe.android.checkout.injection.DaggerCheckoutComponent
-import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorToggle
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
@@ -373,30 +368,25 @@ class Checkout private constructor(
      */
     @Composable
     fun CurrencySelectorContent() {
-        val context = LocalContext.current
-        val scope = rememberCoroutineScope()
+        val viewModel: CurrencySelectorViewModel = viewModel(
+            factory = CurrencySelectorViewModel.Factory(
+                checkoutSession = checkoutSession,
+                updateCurrency = ::updateCurrency,
+                analyticsRequestExecutor = component.analyticsRequestExecutor,
+                paymentAnalyticsRequestFactory = component.paymentAnalyticsRequestFactory,
+            )
+        )
         val isLoading by isLoading.collectAsState()
         val checkoutSession by checkoutSession.collectAsState()
         val currencySelectorOptions = checkoutSession.currencySelectorOptions ?: return
-        var errorMessage by rememberSaveable { mutableStateOf<String?>(null) }
-        LaunchedEffect(checkoutSession) {
-            errorMessage = null
-        }
-        LaunchedEffect(Unit) {
-            fireEvent(PaymentSheetEvent.AdaptivePricingCurrencySelectorInit())
-        }
+        val errorMessage by viewModel.errorMessage.collectAsState()
         CurrencySelectorToggle(
             options = currencySelectorOptions,
             onCurrencySelected = { currencyOption ->
-                scope.launch(Dispatchers.Main.immediate) {
-                    updateCurrency(currencyOption.code)
-                        .onFailure { throwable ->
-                            errorMessage = throwable.stripeErrorMessage(context)
-                        }
-                }
+                viewModel.onCurrencySelected(currencyOption.code)
             },
             isEnabled = !isLoading,
-            errorMessage = errorMessage,
+            errorMessage = errorMessage?.resolve(),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorViewModel.kt
@@ -1,0 +1,94 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@CheckoutSessionPreview
+internal class CurrencySelectorViewModel(
+    private val checkoutSession: StateFlow<CheckoutSession>,
+    private val updateCurrency: suspend (String) -> Result<Unit>,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val _errorMessage = MutableStateFlow<ResolvableString?>(null)
+    val errorMessage: StateFlow<ResolvableString?> = _errorMessage.asStateFlow()
+
+    init {
+        val previouslyInitialized: Boolean? = savedStateHandle[KEY_INITIALIZED]
+        if (previouslyInitialized == null) {
+            savedStateHandle[KEY_INITIALIZED] = true
+            fireEvent(PaymentSheetEvent.AdaptivePricingCurrencySelectorInit())
+        }
+
+        viewModelScope.launch {
+            checkoutSession.collect {
+                _errorMessage.value = null
+            }
+        }
+    }
+
+    fun onCurrencySelected(currencyCode: String) {
+        viewModelScope.launch {
+            updateCurrency(currencyCode)
+                .onFailure { throwable ->
+                    _errorMessage.value = throwable.stripeErrorMessage()
+                }
+        }
+    }
+
+    private fun fireEvent(event: PaymentSheetEvent) {
+        viewModelScope.launch {
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(
+                    event = event,
+                    additionalParams = event.params,
+                )
+            )
+        }
+    }
+
+    companion object {
+        private const val KEY_INITIALIZED = "currency_selector_initialized"
+    }
+
+    internal class Factory(
+        private val checkoutSession: StateFlow<CheckoutSession>,
+        private val updateCurrency: suspend (String) -> Result<Unit>,
+        private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+        private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            throw UnsupportedOperationException("Use create(modelClass, extras) instead")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(
+            modelClass: Class<T>,
+            extras: androidx.lifecycle.viewmodel.CreationExtras
+        ): T {
+            return CurrencySelectorViewModel(
+                checkoutSession = checkoutSession,
+                updateCurrency = updateCurrency,
+                analyticsRequestExecutor = analyticsRequestExecutor,
+                paymentAnalyticsRequestFactory = paymentAnalyticsRequestFactory,
+                savedStateHandle = extras.createSavedStateHandle(),
+            ) as T
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
@@ -1,0 +1,152 @@
+package com.stripe.android.checkout
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.Turbine
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CurrencySelectorViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @Test
+    fun `init fires currency selector init analytics event`() = runScenario {
+        val requests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+        assertThat(requests).hasSize(1)
+        assertThat(requests.first().params["event"])
+            .isEqualTo("elements.adaptive_pricing.currency_selector_init")
+    }
+
+    @Test
+    fun `init only fires analytics event once across config changes`() = runScenario(
+        savedStateHandle = SavedStateHandle(mapOf("currency_selector_initialized" to true)),
+    ) {
+        val requests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+        assertThat(requests).isEmpty()
+    }
+
+    @Test
+    fun `onCurrencySelected calls updateCurrency with correct code`() = runScenario {
+        viewModel.onCurrencySelected("eur")
+
+        assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
+    }
+
+    @Test
+    fun `onCurrencySelected sets error message on failure`() = runScenario {
+        updateCurrencyResult = Result.failure(RuntimeException("Something went wrong"))
+
+        viewModel.errorMessage.test {
+            assertThat(awaitItem()).isNull()
+
+            viewModel.onCurrencySelected("eur")
+            assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
+
+            assertThat(awaitItem()).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+        }
+    }
+
+    @Test
+    fun `errorMessage is cleared when checkout session changes`() = runScenario {
+        updateCurrencyResult = Result.failure(RuntimeException("fail"))
+        viewModel.onCurrencySelected("eur")
+        assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
+
+        viewModel.errorMessage.test {
+            assertThat(awaitItem()).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
+
+            checkoutSessionFlow.value = CheckoutSessionResponseFactory.create(currency = "eur").asCheckoutSession()
+
+            assertThat(awaitItem()).isNull()
+        }
+    }
+
+    @Test
+    fun `onCurrencySelected does not set error on success`() = runScenario {
+        viewModel.onCurrencySelected("gbp")
+        assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("gbp")
+
+        assertThat(viewModel.errorMessage.value).isNull()
+    }
+
+    @Test
+    fun `multiple currency selections track all calls`() = runScenario {
+        viewModel.onCurrencySelected("eur")
+        viewModel.onCurrencySelected("gbp")
+        viewModel.onCurrencySelected("jpy")
+
+        assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
+        assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("gbp")
+        assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("jpy")
+    }
+
+    private fun runScenario(
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest(dispatcher) {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val fakeAnalyticsRequestExecutor = FakeAnalyticsRequestExecutor()
+        val checkoutSessionFlow = MutableStateFlow(
+            CheckoutSessionResponseFactory.create().asCheckoutSession()
+        )
+        val updateCurrencyCalls = Turbine<String>()
+        var updateCurrencyResult: Result<Unit> = Result.success(Unit)
+
+        val viewModel = CurrencySelectorViewModel(
+            checkoutSession = checkoutSessionFlow,
+            updateCurrency = { code ->
+                updateCurrencyCalls.add(code)
+                updateCurrencyResult
+            },
+            analyticsRequestExecutor = fakeAnalyticsRequestExecutor,
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = application,
+                publishableKey = "pk_test_123",
+            ),
+            savedStateHandle = savedStateHandle,
+        )
+
+        Scenario(
+            viewModel = viewModel,
+            fakeAnalyticsRequestExecutor = fakeAnalyticsRequestExecutor,
+            checkoutSessionFlow = checkoutSessionFlow,
+            updateCurrencyCalls = updateCurrencyCalls,
+            updateCurrencyResultSetter = { updateCurrencyResult = it },
+        ).apply { block() }
+
+        updateCurrencyCalls.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val viewModel: CurrencySelectorViewModel,
+        val fakeAnalyticsRequestExecutor: FakeAnalyticsRequestExecutor,
+        val checkoutSessionFlow: MutableStateFlow<CheckoutSession>,
+        val updateCurrencyCalls: Turbine<String>,
+        private val updateCurrencyResultSetter: (Result<Unit>) -> Unit,
+    ) {
+        var updateCurrencyResult: Result<Unit>
+            get() = error("Write-only property")
+            set(value) = updateCurrencyResultSetter(value)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
@@ -48,6 +48,8 @@ internal class CurrencySelectorViewModelTest {
 
     @Test
     fun `onCurrencySelected calls updateCurrency with correct code`() = runScenario {
+        updateCurrencyResult.add(Result.success(Unit))
+
         viewModel.onCurrencySelected("eur")
 
         assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
@@ -55,8 +57,7 @@ internal class CurrencySelectorViewModelTest {
 
     @Test
     fun `onCurrencySelected sets error message on failure`() = runScenario {
-        updateCurrencyResult = Result.failure(RuntimeException("Something went wrong"))
-
+        updateCurrencyResult.add(Result.failure(RuntimeException("Something went wrong")))
         viewModel.errorMessage.test {
             assertThat(awaitItem()).isNull()
 
@@ -69,7 +70,8 @@ internal class CurrencySelectorViewModelTest {
 
     @Test
     fun `errorMessage is cleared when checkout session changes`() = runScenario {
-        updateCurrencyResult = Result.failure(RuntimeException("fail"))
+        updateCurrencyResult.add(Result.failure(RuntimeException("fail")))
+
         viewModel.onCurrencySelected("eur")
         assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
 
@@ -84,6 +86,8 @@ internal class CurrencySelectorViewModelTest {
 
     @Test
     fun `onCurrencySelected does not set error on success`() = runScenario {
+        updateCurrencyResult.add(Result.success(Unit))
+
         viewModel.onCurrencySelected("gbp")
         assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("gbp")
 
@@ -92,12 +96,16 @@ internal class CurrencySelectorViewModelTest {
 
     @Test
     fun `multiple currency selections track all calls`() = runScenario {
+        updateCurrencyResult.add(Result.success(Unit))
         viewModel.onCurrencySelected("eur")
-        viewModel.onCurrencySelected("gbp")
-        viewModel.onCurrencySelected("jpy")
-
         assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("eur")
+
+        updateCurrencyResult.add(Result.success(Unit))
+        viewModel.onCurrencySelected("gbp")
         assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("gbp")
+
+        updateCurrencyResult.add(Result.success(Unit))
+        viewModel.onCurrencySelected("jpy")
         assertThat(updateCurrencyCalls.awaitItem()).isEqualTo("jpy")
     }
 
@@ -111,13 +119,13 @@ internal class CurrencySelectorViewModelTest {
             CheckoutSessionResponseFactory.create().asCheckoutSession()
         )
         val updateCurrencyCalls = Turbine<String>()
-        var updateCurrencyResult: Result<Unit> = Result.success(Unit)
+        val updateCurrencyResult = Turbine<Result<Unit>>()
 
         val viewModel = CurrencySelectorViewModel(
             checkoutSession = checkoutSessionFlow,
             updateCurrency = { code ->
                 updateCurrencyCalls.add(code)
-                updateCurrencyResult
+                updateCurrencyResult.awaitItem()
             },
             analyticsRequestExecutor = fakeAnalyticsRequestExecutor,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
@@ -128,25 +136,22 @@ internal class CurrencySelectorViewModelTest {
         )
 
         Scenario(
-            viewModel = viewModel,
             fakeAnalyticsRequestExecutor = fakeAnalyticsRequestExecutor,
             checkoutSessionFlow = checkoutSessionFlow,
             updateCurrencyCalls = updateCurrencyCalls,
-            updateCurrencyResultSetter = { updateCurrencyResult = it },
-        ).apply { block() }
+            updateCurrencyResult = updateCurrencyResult,
+            viewModel = viewModel,
+        ).block()
 
         updateCurrencyCalls.ensureAllEventsConsumed()
+        updateCurrencyResult.ensureAllEventsConsumed()
     }
 
     private class Scenario(
-        val viewModel: CurrencySelectorViewModel,
         val fakeAnalyticsRequestExecutor: FakeAnalyticsRequestExecutor,
         val checkoutSessionFlow: MutableStateFlow<CheckoutSession>,
         val updateCurrencyCalls: Turbine<String>,
-        private val updateCurrencyResultSetter: (Result<Unit>) -> Unit,
-    ) {
-        var updateCurrencyResult: Result<Unit>
-            get() = error("Write-only property")
-            set(value) = updateCurrencyResultSetter(value)
-    }
+        val updateCurrencyResult: Turbine<Result<Unit>>,
+        val viewModel: CurrencySelectorViewModel,
+    )
 }


### PR DESCRIPTION
# Summary
Refactored the currency selector functionality in the Checkout component to use a dedicated ViewModel, improving separation of concerns and testability.

# Motivation
The currency selector logic was previously embedded directly in the Composable function, making it difficult to test and violating MVVM architecture principles. By extracting this logic into a ViewModel, we can properly unit test the business logic, handle configuration changes correctly, and maintain cleaner separation between UI and business logic.

# Testing
- [x] Added tests
- [x] Manually verified

# Changelog
[Changed] Improved internal architecture of currency selector component for better maintainability and testability.