### PR TITLE
Remove unused refresh method from Checkout class.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -118,7 +118,6 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
                     )
                     billingAddressLauncher.present(publishableKey, configuration)
                 },
-                refresh = viewModel::refresh,
             )
         }
     }
@@ -147,7 +146,6 @@ private fun CheckoutScreen(
     lastBillingAddressDetails: StateFlow<AddressDetails?>,
     clearBillingAddress: () -> Unit,
     updateBillingAddress: () -> Unit,
-    refresh: () -> Unit,
 ) {
     val checkoutSession by checkout.checkoutSession.collectAsState()
     val loading by checkout.isLoading.collectAsState()
@@ -183,11 +181,6 @@ private fun CheckoutScreen(
                 TaxIdSection(updateTaxId = updateTaxId)
                 ShippingOptionsSection(checkoutSession, selectShippingRate)
                 PromotionCodeInput(promotionCode, { promotionCode = it }, applyPromotionCode)
-                Button(
-                    onClick = refresh,
-                ) {
-                    Text("Refresh")
-                }
             },
             bottomBarContent = {
                 TotalSummary(checkoutSession, removePromotionCode)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
@@ -104,10 +104,6 @@ internal class CheckoutPlaygroundViewModel(
         checkout.updateTaxId(type, value)
     }
 
-    fun refresh() = performWhileLoading {
-        checkout.refresh()
-    }
-
     private fun performWhileLoading(block: suspend () -> Result<Unit>) {
         viewModelScope.launch {
             block().onSuccess {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -300,16 +300,6 @@ class Checkout private constructor(
         }
     }
 
-    /**
-     * Re-fetches the checkout session from the server, replacing the local state.
-     */
-    suspend fun refresh(): Result<Unit> = withInternalState { sessionId ->
-        component.checkoutSessionRepository.init(
-            sessionId = sessionId,
-            adaptivePricingAllowed = configuration.adaptivePricingAllowed
-        )
-    }
-
     internal suspend fun updateCurrency(currency: String): Result<Unit> {
         val result = withInternalState { sessionId ->
             component.checkoutSessionRepository.updateCurrency(sessionId, currency)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.checkout
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -104,7 +103,7 @@ class CheckoutInstancesTest {
         val requestArrived = CountDownLatch(1)
         val holdResponse = CountDownLatch(1)
 
-        networkRule.checkoutInit { response ->
+        networkRule.checkoutUpdate { response ->
             requestArrived.countDown()
             holdResponse.await()
             response.setBody("{}")
@@ -112,7 +111,7 @@ class CheckoutInstancesTest {
 
         runBlocking {
             val job = launch(Dispatchers.IO) {
-                checkout.refresh()
+                checkout.removePromotionCode()
             }
 
             assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -153,36 +153,6 @@ class CheckoutTest {
     }
 
     @Test
-    fun `refresh updates checkoutSession on success`() = runCreateWithStateScenario {
-        networkRule.checkoutInit { response ->
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-
-        assertThat(checkoutSessionTurbine.awaitItem().totalSummary).isNull()
-
-        val result = checkout.refresh()
-
-        val updated = checkoutSessionTurbine.awaitItem()
-        result.getOrThrow()
-        assertThat(updated.totalSummary).isNotNull()
-    }
-
-    @Test
-    fun `refresh returns failure on error response`() = runCreateWithStateScenario {
-        networkRule.checkoutInit { response ->
-            response.setResponseCode(500)
-            response.setBody("""{"error": {"message": "Internal server error"}}""")
-        }
-
-        val initial = checkoutSessionTurbine.awaitItem()
-
-        val result = checkout.refresh()
-        assertThat(result.isFailure).isTrue()
-
-        assertThat(checkout.checkoutSession.value).isEqualTo(initial)
-    }
-
-    @Test
     fun `updateLineItemQuantity updates checkoutSession on success`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
             bodyPart("updated_line_item_quantity[line_item_id]", "li_1"),


### PR DESCRIPTION
# Summary
Removed the unused `refresh()` method from the Checkout class and its associated tests.

# Motivation
The `refresh()` method was not being used anywhere in the codebase and represented dead code that could be safely removed to simplify the API surface. Merchants should use `runServerUpdate` instead.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified