### PR TITLE
Add Bitrise workflow for latency synthetics

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -366,6 +366,33 @@ workflows:
           title: Export PaymentSheet E2E test results
           inputs:
             - test_title: PaymentSheet E2E tests
+  run-paymentsheet-latency-synthetics:
+    before_run:
+      - start_emulator
+      - prepare_all
+    after_run:
+      - conclude_all
+    steps:
+      - script@1:
+          title: Install Ruby via asdf
+          inputs:
+            - content: asdf install ruby 3.2.4
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
+      - script@1:
+          title: Report PaymentSheet latency synthetics
+          timeout: 2400
+          inputs:
+            - content: ruby scripts/report_latency_synthetics.rb
+      - bundle::export_instrumentation_test_results:
+          title: Export PaymentSheet latency test results
+          inputs:
+            - test_title: PaymentSheet latency synthetics
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
   run-crypto-onramp-example-e2e-tests:
     before_run:
       - start_emulator

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -36,6 +36,10 @@ def directlyToPlayground() {
     return project.hasProperty("DIRECTLY_TO_PLAYGROUND") && project.DIRECTLY_TO_PLAYGROUND.contains("true")
 }
 
+def runLatencyTestsInCi() {
+    return project.hasProperty("RUN_LATENCY_TESTS_IN_CI") && project.RUN_LATENCY_TESTS_IN_CI.contains("true")
+}
+
 def getLatencyExperimentIterations() {
     return findProperty('LATENCY_EXPERIMENT_ITERATIONS') ?: "1"
 }
@@ -71,6 +75,7 @@ android {
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
         buildConfigField "boolean", "IS_BROWSERSTACK_BUILD", "$gradle.ext.isBrowserstackBuild"
         buildConfigField "boolean", "DIRECTLY_TO_PLAYGROUND", "${directlyToPlayground()}"
+        buildConfigField "boolean", "RUN_LATENCY_TESTS_IN_CI", "${runLatencyTestsInCi()}"
         buildConfigField "int", "LATENCY_EXPERIMENT_ITERATIONS", "${getLatencyExperimentIterations()}"
         buildConfigField "String", "PROXY_IP_ADDRESS", "\"${getProxyIpAddress()}\""
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -26,8 +26,8 @@ import org.junit.runners.Parameterized
 
 /**
  * This test is special -- it's intended to be used to measure loading latency of PaymentSheet. As such, it doesn't
- * run in CI, but can be run locally (to test changes) and via the latency benchmarking script:
- * scripts/measure_latency_difference.rb.
+ * run in regular CI, but can be run locally (to test changes) and via the latency benchmarking scripts:
+ * scripts/measure_latency_difference.rb and scripts/report_latency_synthetics.rb.
  * */
 @RunWith(Parameterized::class)
 internal class TestLatency(
@@ -47,7 +47,7 @@ internal class TestLatency(
 
     @Test
     fun testLatency() {
-        Assume.assumeFalse(BuildConfig.IS_RUNNING_IN_CI)
+        Assume.assumeFalse(BuildConfig.IS_RUNNING_IN_CI && !BuildConfig.RUN_LATENCY_TESTS_IN_CI)
         Log.d(LOG_TAG, "LATENCY_TEST_CASE_STARTED: ${testConfig.name}")
 
         runTestWithIterations {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
@@ -47,7 +47,7 @@ class TestRules private constructor(
                         chain
                     }
                 }.let { chain ->
-                    if (BuildConfig.IS_RUNNING_IN_CI) {
+                    if (BuildConfig.IS_RUNNING_IN_CI && !BuildConfig.RUN_LATENCY_TESTS_IN_CI) {
                         chain.around(RetryRule(retryCount))
                     } else {
                         chain

--- a/scripts/latency_test_utils.rb
+++ b/scripts/latency_test_utils.rb
@@ -69,6 +69,7 @@ module LatencyTestUtils
       '--no-configuration-cache',
       gradle_task,
       "-Pandroid.testInstrumentationRunnerArguments.class=#{latency_test_class}",
+      '-PRUN_LATENCY_TESTS_IN_CI=true',
       "-PLATENCY_EXPERIMENT_ITERATIONS=#{sample_count}"
     ]
 


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Add Bitrise workflow for latency synthetics

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I'll set up the workflow to run hourly so that we can report synthetic events on a regular basis, as iOS does.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Ran the bitrise workflow manually, here's the run: https://app.bitrise.io/app/f5b7f5379a28eb07/build/0fafa21d-d10b-4743-bf4e-26df26cf472d
Analytics events were sent (not all shown here bc logscale samples heavily): https://logscale.corp.stripe.com/main-view/search?live=false&query=%23repo%3Dnginx%20%23service%3Dprimary-nginx%20(analytics_ua%3Danalytics.stripe_android-1.0%20or%20analytics_ua%3Danalytics.stripeios-1.0)%0A%7C%20event%3D%22mpe.synthetic_latency%22&start=15m&tz=UTC 