### PR TITLE
[fc] Show correct brand after logging in and connecting an account

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -11,10 +11,12 @@ import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.financialconnections.ElementsSessionContext
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.CreateInstantDebitsResult
+import com.stripe.android.financialconnections.domain.CurrentLinkBrand
 import com.stripe.android.financialconnections.domain.HandleError
 import com.stripe.android.financialconnections.domain.IsLinkWithStripe
 import com.stripe.android.financialconnections.domain.RealAttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.RealCreateInstantDebitsResult
+import com.stripe.android.financialconnections.domain.RealCurrentLinkBrand
 import com.stripe.android.financialconnections.domain.RealHandleError
 import com.stripe.android.financialconnections.features.networkinglinksignup.LinkSignupHandler
 import com.stripe.android.financialconnections.features.networkinglinksignup.LinkSignupHandlerForInstantDebits
@@ -75,6 +77,12 @@ internal interface FinancialConnectionsSheetNativeModule {
     fun bindsCreateInstantDebitsPaymentMethod(
         impl: RealCreateInstantDebitsResult,
     ): CreateInstantDebitsResult
+
+    @Binds
+    @ActivityRetainedScope
+    fun bindsCurrentLinkBrand(
+        impl: RealCurrentLinkBrand,
+    ): CurrentLinkBrand
 
     companion object {
         @Provides

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CurrentLinkBrand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CurrentLinkBrand.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.domain
 
-import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeState
 import com.stripe.android.financialconnections.repository.ConsumerSessionRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
@@ -10,13 +9,18 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
-@ActivityRetainedScope
-internal class CurrentLinkBrand @Inject constructor(
+internal interface CurrentLinkBrand {
+    val stateFlow: StateFlow<LinkBrand>
+
+    operator fun invoke(): LinkBrand
+}
+
+internal class RealCurrentLinkBrand @Inject constructor(
     private val initialState: FinancialConnectionsSheetNativeState,
     financialConnectionsManifestRepository: FinancialConnectionsManifestRepository,
     consumerSessionRepository: ConsumerSessionRepository,
-) {
-    val stateFlow: StateFlow<LinkBrand> =
+) : CurrentLinkBrand {
+    override val stateFlow: StateFlow<LinkBrand> =
         combineAsStateFlow(
             consumerSessionRepository.consumerSessionFlow.mapAsStateFlow { it?.linkBrand },
             financialConnectionsManifestRepository.syncFlow.mapAsStateFlow { it?.manifest?.linkBrand }
@@ -24,7 +28,7 @@ internal class CurrentLinkBrand @Inject constructor(
             consumerLinkBrand ?: manifestLinkBrand ?: initialState.linkBrand
         }
 
-    operator fun invoke(): LinkBrand {
+    override fun invoke(): LinkBrand {
         return stateFlow.value
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CurrentLinkBrand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CurrentLinkBrand.kt
@@ -3,7 +3,9 @@ package com.stripe.android.financialconnections.domain
 import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeState
 import com.stripe.android.financialconnections.repository.ConsumerSessionRepository
+import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
@@ -11,10 +13,18 @@ import javax.inject.Inject
 @ActivityRetainedScope
 internal class CurrentLinkBrand @Inject constructor(
     private val initialState: FinancialConnectionsSheetNativeState,
-    private val consumerSessionRepository: ConsumerSessionRepository,
+    financialConnectionsManifestRepository: FinancialConnectionsManifestRepository,
+    consumerSessionRepository: ConsumerSessionRepository,
 ) {
     val stateFlow: StateFlow<LinkBrand> =
-        consumerSessionRepository.consumerSessionFlow.mapAsStateFlow { consumerSession ->
-            consumerSession?.linkBrand ?: initialState.linkBrand
+        combineAsStateFlow(
+            consumerSessionRepository.consumerSessionFlow.mapAsStateFlow { it?.linkBrand },
+            financialConnectionsManifestRepository.syncFlow.mapAsStateFlow { it?.manifest?.linkBrand }
+        ) { consumerLinkBrand, manifestLinkBrand ->
+            consumerLinkBrand ?: manifestLinkBrand ?: initialState.linkBrand
         }
+
+    operator fun invoke(): LinkBrand {
+        return stateFlow.value
+    }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -194,7 +194,10 @@ private fun LazyListScope.accountPickerContent(
     item("header") {
         if (payload != null) {
             Text(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .semantics { testTagsAsResourceId = true }
+                    .testTag("loaded_picker_title")
+                    .fillMaxWidth(),
                 text = stringResource(
                     when (payload.selectionMode) {
                         SelectionMode.Single -> R.string.stripe_account_picker_singleselect_account

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -18,6 +18,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
+import com.stripe.android.financialconnections.domain.CurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
@@ -62,6 +63,7 @@ internal class AccountPickerViewModel @AssistedInject constructor(
     nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val consumerSessionProvider: ConsumerSessionProvider,
+    private val currentLinkBrand: CurrentLinkBrand,
     private val saveAccountToLink: SaveAccountToLink,
     private val selectAccounts: SelectAccounts,
     private val getOrFetchSync: GetOrFetchSync,
@@ -338,7 +340,7 @@ internal class AccountPickerViewModel @AssistedInject constructor(
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     selectedAccounts = accountsList.data.toCachedPartnerAccounts(),
                     shouldPollAccountNumbers = manifest.isDataFlow,
-                    linkBrand = manifest.linkBrand,
+                    linkBrand = currentLinkBrand(),
                 )
             }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -10,6 +10,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.domain.CachedPartnerAccount
+import com.stripe.android.financialconnections.domain.CurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.IsNetworkingRelinkSession
@@ -45,6 +46,7 @@ internal class AttachPaymentViewModel @AssistedInject constructor(
     private val getCachedAccounts: GetCachedAccounts,
     private val navigationManager: NavigationManager,
     private val getOrFetchSync: GetOrFetchSync,
+    private val currentLinkBrand: CurrentLinkBrand,
     private val logger: Logger,
     private val isNetworkingRelinkSession: IsNetworkingRelinkSession,
 ) : FinancialConnectionsViewModel<AttachPaymentState>(initialState, nativeAuthFlowCoordinator) {
@@ -94,7 +96,7 @@ internal class AttachPaymentViewModel @AssistedInject constructor(
         accounts: List<CachedPartnerAccount>,
     ) {
         if (manifest.canSetCustomLinkSuccessMessage && !isNetworkingRelinkSession()) {
-            val linkBrand = manifest.linkBrand
+            val linkBrand = currentLinkBrand()
             successContentRepository.set(
                 message = if (linkBrand == LinkBrand.Link) {
                     PluralId(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/exit/ExitViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/exit/ExitViewModel.kt
@@ -9,6 +9,7 @@ import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
+import com.stripe.android.financialconnections.domain.CurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
@@ -34,6 +35,7 @@ internal class ExitViewModel @AssistedInject constructor(
     private val coordinator: NativeAuthFlowCoordinator,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val navigationManager: NavigationManager,
+    private val currentLinkBrand: CurrentLinkBrand,
     private val logger: Logger
 ) : FinancialConnectionsViewModel<ExitState>(initialState, nativeAuthFlowCoordinator) {
 
@@ -45,7 +47,7 @@ internal class ExitViewModel @AssistedInject constructor(
             val isNetworkingSignupPane =
                 manifest?.isNetworkingUserFlow == true && stateFlow.value.referrer == Pane.NETWORKING_LINK_SIGNUP_PANE
             // Safe default: manifest is null only on fetch failure, and Link is the original brand.
-            val linkBrand = manifest?.linkBrand ?: LinkBrand.Link
+            val linkBrand = currentLinkBrand()
             val description = when {
                 isNetworkingSignupPane -> when (businessName) {
                     null -> if (linkBrand == LinkBrand.Link) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -180,7 +180,8 @@ private fun LoadedContent(
                 modifier = Modifier
                     .semantics { testTagsAsResourceId = true }
                     .testTag("loaded_picker_title")
-                    .padding(horizontal = 8.dp))
+                    .padding(horizontal = 8.dp)
+            )
         }
         item { Spacer(modifier = Modifier.height(24.dp)) }
         stickyHeader(key = "searchRow") {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -175,7 +175,13 @@ private fun LoadedContent(
         lazyListState = listState,
         bodyPadding = PaddingValues(horizontal = 16.dp),
     ) {
-        item { SearchTitle(modifier = Modifier.padding(horizontal = 8.dp)) }
+        item {
+            SearchTitle(
+                modifier = Modifier
+                    .semantics { testTagsAsResourceId = true }
+                    .testTag("loaded_picker_title")
+                    .padding(horizontal = 8.dp))
+        }
         item { Spacer(modifier = Modifier.height(24.dp)) }
         stickyHeader(key = "searchRow") {
             SearchRow(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerScreen.kt
@@ -208,6 +208,9 @@ private fun LazyListScope.loadedContent(
 ) {
     item {
         AnnotatedText(
+            modifier = Modifier
+                .semantics { testTagsAsResourceId = true }
+                .testTag("loaded_picker_title"),
             text = TextResource.Text(payload.title),
             defaultStyle = typography.headingXLarge.copy(
                 color = colors.textDefault,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -8,6 +8,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.di.APPLICATION_ID
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
+import com.stripe.android.financialconnections.domain.CurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GetOrFetchSync.RefetchCondition.Always
@@ -116,6 +117,7 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
     private val saveAccountToLink: SaveAccountToLink,
     private val eventTracker: FinancialConnectionsAnalyticsTracker,
     private val navigationManager: NavigationManager,
+    private val currentLinkBrand: CurrentLinkBrand,
     @Named(APPLICATION_ID) private val applicationId: String,
     private val logger: Logger,
 ) : LinkSignupHandler {
@@ -160,7 +162,7 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
                 phoneNumber = state.validPhone!!,
                 selectedAccounts = selectedAccounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
-                linkBrand = manifest.linkBrand,
+                linkBrand = currentLinkBrand(),
             )
         }
         return Pane.SUCCESS

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.domain.ConfirmVerification
 import com.stripe.android.financialconnections.domain.ConfirmVerification.OTPError
+import com.stripe.android.financialconnections.domain.CurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.MarkLinkVerified
@@ -55,6 +56,7 @@ internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constru
     private val getCachedAccounts: GetCachedAccounts,
     private val saveAccountToLink: SaveAccountToLink,
     private val navigationManager: NavigationManager,
+    private val currentLinkBrand: CurrentLinkBrand,
     private val logger: Logger
 ) : FinancialConnectionsViewModel<NetworkingSaveToLinkVerificationState>(initialState, nativeAuthFlowCoordinator) {
 
@@ -150,7 +152,7 @@ internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constru
                 consumerSessionClientSecret = payload.consumerSessionClientSecret,
                 selectedAccounts = accounts,
                 shouldPollAccountNumbers = manifest.isDataFlow,
-                linkBrand = manifest.linkBrand,
+                linkBrand = currentLinkBrand(),
             )
         }
             .onSuccess { eventTracker.track(VerificationSuccess(PANE)) }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -112,7 +112,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         // The first pane may choose to hide the Stripe logo. Therefore, let's hide it by default
         // on the first pane.
         get() = initialState.toTopAppBarState(
-            linkBrand = currentLinkBrand.stateFlow.value,
+            linkBrand = currentLinkBrand(),
             forceHideStripeLogo = true
         )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
@@ -20,6 +20,9 @@ import com.stripe.android.financialconnections.network.NetworkConstants
 import com.stripe.android.financialconnections.network.NetworkConstants.PARAM_SELECTED_ACCOUNTS
 import com.stripe.android.financialconnections.repository.api.ProvideApiRequestOptions
 import com.stripe.android.financialconnections.utils.filterNotNullValues
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.Date
@@ -30,6 +33,8 @@ import java.util.Locale
  * of the current flow.
  */
 internal interface FinancialConnectionsManifestRepository {
+
+    val syncFlow: StateFlow<SynchronizeSessionResponse?>
 
     /**
      * Retrieves the current cached [SynchronizeSessionResponse] instance, or fetches
@@ -210,7 +215,17 @@ private class FinancialConnectionsManifestRepositoryImpl(
      * current writes are running.
      */
     val mutex = Mutex()
-    private var cachedSynchronizeSessionResponse: SynchronizeSessionResponse? = initialSync
+
+    private val cachedSynchronizeSessionResponseFlow = MutableStateFlow(initialSync)
+
+    private var cachedSynchronizeSessionResponse: SynchronizeSessionResponse?
+        get() = cachedSynchronizeSessionResponseFlow.value
+        set(value) {
+            cachedSynchronizeSessionResponseFlow.value = value
+        }
+
+    override val syncFlow: StateFlow<SynchronizeSessionResponse?> =
+        cachedSynchronizeSessionResponseFlow.asStateFlow()
 
     override suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CurrentLinkBrandTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CurrentLinkBrandTest.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.financialconnections.domain
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetFlowType
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.networking.FakeFinancialConnectionsManifestRepository
+import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeState
+import com.stripe.android.financialconnections.presentation.WebAuthFlowState
+import com.stripe.android.financialconnections.repository.RealConsumerSessionRepository
+import com.stripe.android.financialconnections.ui.theme.Theme
+import com.stripe.android.model.LinkBrand
+import org.junit.Test
+
+internal class CurrentLinkBrandTest {
+
+    private val initialState = FinancialConnectionsSheetNativeState(
+        flowType = FinancialConnectionsSheetFlowType.ForData,
+        webAuthFlow = WebAuthFlowState.Uninitialized,
+        firstInit = true,
+        configuration = FinancialConnectionsSheetConfiguration(
+            financialConnectionsSessionClientSecret = ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
+            publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        ),
+        reducedBranding = false,
+        testMode = false,
+        viewEffect = null,
+        completed = false,
+        initialPane = FinancialConnectionsSessionManifest.Pane.CONSENT,
+        theme = Theme.LinkLight,
+        linkBrand = LinkBrand.Link,
+        isLinkWithStripe = true,
+        manualEntryUsesMicrodeposits = false,
+        elementsSessionContext = null,
+    )
+
+    private val manifestRepository = FakeFinancialConnectionsManifestRepository()
+    private val consumerSessionRepository = RealConsumerSessionRepository(SavedStateHandle())
+
+    @Test
+    fun `falls back to initial state linkBrand`() {
+        val currentLinkBrand = currentLinkBrand()
+
+        assertThat(currentLinkBrand()).isEqualTo(LinkBrand.Link)
+    }
+
+    @Test
+    fun `uses manifest linkBrand over initial state linkBrand`() {
+        manifestRepository.setSyncResponse(syncResponseWithLinkBrand(LinkBrand.Onelink))
+        val currentLinkBrand = currentLinkBrand()
+
+        assertThat(currentLinkBrand()).isEqualTo(LinkBrand.Onelink)
+    }
+
+    @Test
+    fun `uses consumer session linkBrand over manifest linkBrand`() {
+        manifestRepository.setSyncResponse(syncResponseWithLinkBrand(LinkBrand.Link))
+        consumerSessionRepository.storeNewConsumerSession(
+            consumerSession = ApiKeyFixtures.verifiedConsumerSession().copy(linkBrand = LinkBrand.Onelink),
+            publishableKey = "pk_123",
+        )
+        val currentLinkBrand = currentLinkBrand()
+
+        assertThat(currentLinkBrand()).isEqualTo(LinkBrand.Onelink)
+    }
+
+    @Test
+    fun `updates when repositories change`() {
+        val currentLinkBrand = currentLinkBrand()
+
+        assertThat(currentLinkBrand.stateFlow.value).isEqualTo(LinkBrand.Link)
+
+        manifestRepository.setSyncResponse(syncResponseWithLinkBrand(LinkBrand.Onelink))
+        assertThat(currentLinkBrand.stateFlow.value).isEqualTo(LinkBrand.Onelink)
+
+        consumerSessionRepository.storeNewConsumerSession(
+            consumerSession = ApiKeyFixtures.verifiedConsumerSession().copy(linkBrand = LinkBrand.Link),
+            publishableKey = "pk_123",
+        )
+        assertThat(currentLinkBrand.stateFlow.value).isEqualTo(LinkBrand.Link)
+    }
+
+    private fun currentLinkBrand(): CurrentLinkBrand {
+        return RealCurrentLinkBrand(
+            initialState = initialState,
+            financialConnectionsManifestRepository = manifestRepository,
+            consumerSessionRepository = consumerSessionRepository,
+        )
+    }
+
+    private fun syncResponseWithLinkBrand(linkBrand: LinkBrand) = ApiKeyFixtures.syncResponse(
+        manifest = ApiKeyFixtures.sessionManifest().copy(rawLinkBrand = linkBrand),
+    )
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/FakeCurrentLinkBrand.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/FakeCurrentLinkBrand.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.financialconnections.domain
+
+import com.stripe.android.model.LinkBrand
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class FakeCurrentLinkBrand(
+    initialLinkBrand: LinkBrand = LinkBrand.Link,
+) : CurrentLinkBrand {
+    private val _stateFlow = MutableStateFlow(initialLinkBrand)
+
+    override val stateFlow: StateFlow<LinkBrand> = _stateFlow.asStateFlow()
+
+    override fun invoke(): LinkBrand {
+        return stateFlow.value
+    }
+
+    fun set(linkBrand: LinkBrand) {
+        _stateFlow.value = linkBrand
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.domain.CachedPartnerAccount
+import com.stripe.android.financialconnections.domain.FakeCurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
@@ -64,6 +65,7 @@ internal class AccountPickerViewModelTest {
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
         saveAccountToLink = saveAccountToLink,
         consumerSessionProvider = { cachedConsumerSession() },
+        currentLinkBrand = FakeCurrentLinkBrand(),
         presentSheet = mock(),
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.domain.CachedPartnerAccount
+import com.stripe.android.financialconnections.domain.FakeCurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.RequestIntegrityToken
@@ -53,6 +54,7 @@ class LinkSignupHandlerForNetworkingTest {
             saveAccountToLink,
             eventTracker,
             navigationManager,
+            FakeCurrentLinkBrand(),
             "applicationId",
             logger
         )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.ElementsSessionContext
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.ConsentAgree.analyticsValue
+import com.stripe.android.financialconnections.domain.FakeCurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.LookupAccount
@@ -747,6 +748,7 @@ class NetworkingLinkSignupViewModelTest {
             eventTracker = eventTracker,
             navigationManager = navigationManager,
             requestIntegrityToken = mock(),
+            currentLinkBrand = FakeCurrentLinkBrand(),
             applicationId = "test",
             logger = Logger.noop(),
         )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.CoroutineTestRule
 import com.stripe.android.financialconnections.TestFinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.domain.ConfirmVerification
+import com.stripe.android.financialconnections.domain.FakeCurrentLinkBrand
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.MarkLinkVerified
@@ -67,6 +68,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
         initialState = state,
         attachedPaymentAccountRepository = attachedPaymentAccountRepository,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
+        currentLinkBrand = FakeCurrentLinkBrand(),
     )
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
@@ -7,9 +7,13 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsInstitu
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import java.util.Date
 
 internal abstract class AbsFinancialConnectionsManifestRepository : FinancialConnectionsManifestRepository {
+
+    override val syncFlow: StateFlow<SynchronizeSessionResponse?> = MutableStateFlow(null)
 
     override suspend fun markConsentAcquired(clientSecret: String): FinancialConnectionsSessionManifest {
         TODO("Not yet implemented")

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -8,9 +8,15 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsInstitu
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import java.util.Date
 
 internal class FakeFinancialConnectionsManifestRepository : FinancialConnectionsManifestRepository {
+
+    private val _syncFlow = MutableStateFlow<SynchronizeSessionResponse?>(null)
+    override val syncFlow: StateFlow<SynchronizeSessionResponse?> = _syncFlow.asStateFlow()
 
     var getSynchronizeSessionResponseProvider: () -> SynchronizeSessionResponse =
         { ApiKeyFixtures.syncResponse() }
@@ -105,7 +111,14 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
 
     override fun updateLocalManifest(
         block: (FinancialConnectionsSessionManifest) -> FinancialConnectionsSessionManifest
-    ) = Unit
+    ) {
+        val currentSync = syncFlow.value ?: return
+        _syncFlow.value = currentSync.copy(manifest = block(currentSync.manifest))
+    }
+
+    fun setSyncResponse(syncResponse: SynchronizeSessionResponse?) {
+        _syncFlow.value = syncResponse
+    }
 
     override suspend fun selectInstitution(
         clientSecret: String,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.CreateInstantDebitsResult
 import com.stripe.android.financialconnections.domain.CurrentLinkBrand
+import com.stripe.android.financialconnections.domain.FakeCurrentLinkBrand
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete.EarlyTerminationCause
@@ -37,7 +38,6 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession.StatusDetails.Cancelled.Reason
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.Finish
-import com.stripe.android.financialconnections.repository.RealConsumerSessionRepository
 import com.stripe.android.financialconnections.ui.theme.Theme
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.financialconnections.utils.UriUtils
@@ -504,60 +504,40 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
     }
 
     @Test
-    fun `topAppBarState uses consumer session linkBrand over state linkBrand`() = runTest {
-        val repository = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
-
-        repository.storeNewConsumerSession(
-            consumerSession = ApiKeyFixtures.verifiedConsumerSession().copy(linkBrand = LinkBrand.Onelink),
-            publishableKey = "pk_123",
-        )
-
+    fun `topAppBarState uses current linkBrand over state linkBrand`() = runTest {
         val initialState = stateWithLinkBrand(LinkBrand.Link)
         val viewModel = createViewModel(
             initialState = initialState,
-            currentLinkBrand = CurrentLinkBrand(initialState, repository),
+            currentLinkBrand = FakeCurrentLinkBrand(LinkBrand.Onelink),
         )
 
-        // Consumer session's Onelink should override the state's Link
         assertThat(viewModel.topAppBarState.value.linkBrand).isEqualTo(LinkBrand.Onelink)
     }
 
     @Test
-    fun `topAppBarState falls back to state linkBrand when consumer session has no linkBrand`() = runTest {
-        val repository = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
-
-        repository.storeNewConsumerSession(
-            consumerSession = ApiKeyFixtures.verifiedConsumerSession(),
-            publishableKey = "pk_123",
-        )
-
+    fun `topAppBarState falls back to state linkBrand`() = runTest {
         val initialState = stateWithLinkBrand(LinkBrand.Onelink)
         val viewModel = createViewModel(
             initialState = initialState,
-            currentLinkBrand = CurrentLinkBrand(initialState, repository),
+            currentLinkBrand = FakeCurrentLinkBrand(LinkBrand.Onelink),
         )
 
-        // Should fall back to state's Onelink since consumer session has no linkBrand
         assertThat(viewModel.topAppBarState.value.linkBrand).isEqualTo(LinkBrand.Onelink)
     }
 
     @Test
-    fun `topAppBarState updates reactively when consumer session changes`() = runTest {
-        val repository = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
-
+    fun `topAppBarState updates reactively when current linkBrand changes`() = runTest {
         val initialState = stateWithLinkBrand(LinkBrand.Link)
+        val currentLinkBrand = FakeCurrentLinkBrand(LinkBrand.Link)
         val viewModel = createViewModel(
             initialState = initialState,
-            currentLinkBrand = CurrentLinkBrand(initialState, repository),
+            currentLinkBrand = currentLinkBrand,
         )
 
         viewModel.topAppBarState.test {
             assertThat(awaitItem().linkBrand).isEqualTo(LinkBrand.Link)
 
-            repository.storeNewConsumerSession(
-                consumerSession = ApiKeyFixtures.verifiedConsumerSession().copy(linkBrand = LinkBrand.Onelink),
-                publishableKey = "pk_123",
-            )
+            currentLinkBrand.set(LinkBrand.Onelink)
 
             assertThat(awaitItem().linkBrand).isEqualTo(LinkBrand.Onelink)
         }
@@ -600,7 +580,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             error("Unexpected call to create InstantDebitsResult")
         },
         currentLinkBrand: CurrentLinkBrand =
-            CurrentLinkBrand(initialState, RealConsumerSessionRepository(SavedStateHandle())),
+            FakeCurrentLinkBrand(initialState.linkBrand),
     ) = FinancialConnectionsSheetNativeViewModel(
         eventTracker = mock(),
         activityRetainedComponent = mock(),

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
@@ -20,6 +21,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.lifecycle.lifecycleScope
 import androidx.test.core.app.ActivityScenario
@@ -1640,8 +1642,9 @@ internal class PlaygroundTestDriver(
         }
 
         clickButtonWithTag("consent_cta")
+        waitUntilTag("loaded_picker_title")
         // TODO: Replace with institution ID tag when available
-        clickButton("Test (Non-OAuth)")
+        scrollToAndClick("Test (Non-OAuth)")
 
         // Verifies bank in web view so Compose hierarchy can detach. Button should be available
         // after web view verification.
@@ -1667,8 +1670,9 @@ internal class PlaygroundTestDriver(
         clickButtonWithTag("existing_email-button")
         clickButtonWithTag("test_mode_fill_button")
 
+        waitUntilTag("loaded_picker_title")
         // TODO: Replace with institution ID tag when available
-        clickButton("Success")
+        scrollToAndClick("Success")
 
         clickButtonWithTag("link_account_picker_cta")
         clickButtonWithTag("done_button")
@@ -1725,15 +1729,20 @@ internal class PlaygroundTestDriver(
         }
     }
 
-    private fun clickButton(text: String, composeCanDetach: Boolean = false) {
+    private fun waitUntilTag(tag: String) {
         composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
-                .onAllNodesWithText(text)
-                .fetchSemanticsNodes(atLeastOneRootRequired = !composeCanDetach)
+                .onAllNodesWithTag(tag)
+                .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+    }
 
-        composeTestRule.onNodeWithText(text).performClick()
+    private fun scrollToAndClick(text: String) {
+        composeTestRule.onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText(text))
+        composeTestRule.onNodeWithText(text)
+            .performClick()
     }
 
     private fun clickButtonWithTag(tag: String, composeCanDetach: Boolean = false) {


### PR DESCRIPTION
# Summary
Keep Financial Connections Link branding in sync with the latest consumer session or manifest state, so FC flows use the correct brand after updates.

## Notable changes
- Add reactive manifest sync state and combine it with consumer session state in `CurrentLinkBrand`.
- Use `CurrentLinkBrand` across FC panes and save-to-Link flows instead of stale manifest/state values.
- Make `CurrentLinkBrand` fakeable through DI and add focused tests for brand precedence and updates.

# Motivation
[LINK_MOBILE-872](https://go/jira/LINK_MOBILE-872)

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/27d517f8-83a1-4bbd-8752-66400d21d5a4