### PR TITLE
[link] Reactively update Link selection brand when wallet state changes

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -354,6 +354,20 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 }
             }
         }
+
+        coroutineScope.launch(mainDispatcher) {
+            walletsState.collect { currentWalletsState ->
+                val currentSelection = verticalModeScreenSelection.value
+                if (currentSelection is PaymentSelection.Link) {
+                    val newLinkBrand = currentWalletsState?.link(WalletLocation.INLINE)?.linkBrand
+                    if (newLinkBrand != null && newLinkBrand != currentSelection.brand) {
+                        val updatedSelection = currentSelection.copy(brand = newLinkBrand)
+                        _verticalModeScreenSelection.value = updatedSelection
+                        updateSelection(updatedSelection, false)
+                    }
+                }
+            }
+        }
     }
 
     private fun getDisplayablePaymentMethods(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -607,6 +607,71 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun linkSelection_brandUpdates_whenWalletsStateLinkBrandChanges() {
+        runScenario(paymentMethodMetadata = metadataWithOnlyPaymentMethodTypes) {
+            walletsState.value = linkAndGooglePayWalletState.copy(
+                walletsAllowedInHeader = emptyList()
+            )
+            interactor.state.value.displayablePaymentMethods.first { it.code == "link" }.onClick()
+            assertThat(selection.value).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
+            assertThat(updateSelectionTurbine.awaitItem()).isFalse()
+
+            walletsState.value = linkAndGooglePayWalletState.copy(
+                link = WalletsState.Link(
+                    state = LinkButtonState.Email("email@email.com"),
+                    linkBrand = LinkBrand.Onelink,
+                ),
+                walletsAllowedInHeader = emptyList(),
+            )
+
+            assertThat(selection.value).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Onelink))
+            assertThat(updateSelectionTurbine.awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun linkSelection_brandNotUpdated_whenWalletsStateBrandUnchanged() {
+        runScenario(paymentMethodMetadata = metadataWithOnlyPaymentMethodTypes) {
+            walletsState.value = linkAndGooglePayWalletState.copy(
+                walletsAllowedInHeader = emptyList()
+            )
+            interactor.state.value.displayablePaymentMethods.first { it.code == "link" }.onClick()
+            assertThat(selection.value).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
+            assertThat(updateSelectionTurbine.awaitItem()).isFalse()
+
+            walletsState.value = linkAndGooglePayWalletState.copy(
+                walletsAllowedInHeader = emptyList(),
+            )
+
+            // Brand unchanged — no new selection event.
+            assertThat(selection.value).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
+        }
+    }
+
+    @Test
+    fun nonLinkSelection_notAffected_whenWalletsStateLinkBrandChanges() {
+        runScenario(paymentMethodMetadata = metadataWithOnlyPaymentMethodTypes) {
+            walletsState.value = linkAndGooglePayWalletState.copy(
+                walletsAllowedInHeader = emptyList()
+            )
+            interactor.state.value.displayablePaymentMethods.first { it.code == "google_pay" }.onClick()
+            assertThat(selection.value).isEqualTo(PaymentSelection.GooglePay)
+            assertThat(updateSelectionTurbine.awaitItem()).isFalse()
+
+            walletsState.value = linkAndGooglePayWalletState.copy(
+                link = WalletsState.Link(
+                    state = LinkButtonState.Email("email@email.com"),
+                    linkBrand = LinkBrand.Onelink,
+                ),
+                walletsAllowedInHeader = emptyList(),
+            )
+
+            // Google Pay selection is unaffected.
+            assertThat(selection.value).isEqualTo(PaymentSelection.GooglePay)
+        }
+    }
+
+    @Test
     fun walletDisplayablePaymentMethodsLink_invokesRowSelectionCallback() {
         var rowSelectionCallbackInvoked = false
         runScenario(


### PR DESCRIPTION
# Summary
Reactively update Link selection brand when wallet state changes.

This change adds a `walletsState` collector to `DefaultPaymentMethodVerticalLayoutInteractor.init` that automatically updates `PaymentSelection.Link.brand` whenever the wallet state's inline link brand changes and Link is the current selection. 

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-881

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Three unit tests cover the fix, the no-op case (brand unchanged), and safety for non-Link selections.

Manual testing
1. Open the embedded integration with a UK IP and a US account (OR US IP and UK account)
2. Tap the Link payment option and log in
3. Inside the Link wallet, tap "Pay another way"
4. Observe that the selected payment method at the bottom now correctly shows logged-in brand without needing to re-tap the row

# Screenshots
US IP, UK account:

https://github.com/user-attachments/assets/a6d38af8-6bc1-4452-8954-3514d8d2c87c

UK IP, US account:

https://github.com/user-attachments/assets/735bd5d5-1087-4324-b699-77b6125e2e91

# Changelog
n/a