### PR TITLE
Refactor test to use @Before setup for mock initialization.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.atMost
@@ -42,7 +43,12 @@ import org.robolectric.RobolectricTestRunner
 internal class PaymentIntentFlowResultProcessorTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val mockStripeRepository: StripeRepository = mock()
+    private lateinit var mockStripeRepository: StripeRepository
+
+    @Before
+    fun setUp() {
+        mockStripeRepository = mock()
+    }
 
     @Test
     fun `processPaymentIntent() when shouldCancelSource=true should return canceled PaymentIntent`() =


### PR DESCRIPTION
# Summary
Refactored `PaymentIntentFlowResultProcessorTest` to initialize the mock repository in a `@Before` setup method instead of at field declaration.

# Motivation
This change improves test reliability by ensuring the mock is freshly initialized before each test method runs, preventing potential state leakage between tests and following JUnit best practices for test setup.

# Testing
- [x] Modified tests
- [ ] Added tests
- [ ] Manually verified

# Changelog