### PR TITLE
Use Places API (New) for address autocomplete

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -8,7 +8,6 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken
-import com.google.android.libraries.places.api.model.PlaceTypes
 import com.google.android.libraries.places.api.net.FetchPlaceRequest
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.PlacesClient
@@ -104,7 +103,6 @@ internal class DefaultPlacesClientProxy(
                     .setSessionToken(token)
                     .setQuery(query)
                     .setCountries(listOf(country))
-                    .setTypesFilter(listOf(PlaceTypes.STREET_ADDRESS))
                     .build()
             ).await()
             errorReporter.report(ErrorReporter.SuccessEvent.PLACES_FIND_AUTOCOMPLETE_SUCCESS)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -48,7 +48,7 @@ interface PlacesClientProxy {
             googlePlacesApiKey: String,
             isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
             clientFactory: (Context) -> PlacesClient = { Places.createClient(context) },
-            initializer: () -> Unit = { Places.initialize(context, googlePlacesApiKey) },
+            initializer: () -> Unit = { Places.initializeWithNewPlacesApiEnabled(context, googlePlacesApiKey) },
             errorReporter: ErrorReporter
         ): PlacesClientProxy {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isPlacesAvailable()) {
@@ -104,7 +104,7 @@ internal class DefaultPlacesClientProxy(
                     .setSessionToken(token)
                     .setQuery(query)
                     .setCountries(listOf(country))
-                    .setTypesFilter(listOf(PlaceTypes.ADDRESS))
+                    .setTypesFilter(listOf(PlaceTypes.STREET_ADDRESS))
                     .build()
             ).await()
             errorReporter.report(ErrorReporter.SuccessEvent.PLACES_FIND_AUTOCOMPLETE_SUCCESS)


### PR DESCRIPTION
## Summary
- Switch from `Places.initialize` to `Places.initializeWithNewPlacesApiEnabled` to opt into the Places API (New)
- Change autocomplete types filter from `PlaceTypes.ADDRESS` to `PlaceTypes.STREET_ADDRESS` for compatibility with the new API

## Test plan
- [ ] Verify address autocomplete still returns relevant suggestions
- [ ] Confirm no regressions in the address element flow (PaymentSheet, AddressElement)
- [ ] Test with various country filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)