### PR TITLE
Use shallow fetch for mint repo in deploy script

### DIFF
--- a/scripts/deploy/update_pay_server_docs.rb
+++ b/scripts/deploy/update_pay_server_docs.rb
@@ -18,10 +18,12 @@ def update_pay_server_docs()
         execute_or_fail("cd .. && pay get mint")
     end
 
-    puts 'Ensuring mint repo is up-to-date.'
+    mint_base_ref = "origin/green-pay-server"
+
+    puts 'Fetching latest pay-server...'
     begin
-        execute_or_fail("git -C #{mint_repo} checkout master")
-        execute_or_fail("git -C #{mint_repo} pull")
+        execute_or_fail("git -C #{mint_repo} fetch --depth=1 origin green-pay-server")
+        execute_or_fail("git -C #{mint_repo} checkout #{mint_base_ref}")
 
         puts '> Updating android SDK version in pay-server for latest release.'
         replace_in_file("#{mint_repo}/#{constants_file}",
@@ -29,7 +31,7 @@ def update_pay_server_docs()
           "sdk-version: #{@version}",
         )
         execute_or_fail("git -C #{mint_repo} add #{constants_file}")
-        switch_to_new_branch(pay_server_branch, "master", repo: mint_repo)
+        switch_to_new_branch(pay_server_branch, mint_base_ref, repo: mint_repo)
         execute_or_fail("git -C #{mint_repo} add #{constants_file}")
         execute_or_fail("git -C #{mint_repo} commit -m \"Update Android Payments SDK version to #{@version}\"")
     rescue
@@ -55,7 +57,7 @@ def update_pay_server_docs()
 end
 
 def delete_pay_server_branch
-    delete_git_branch(pay_server_branch, "master", repo: "../mint")
+    delete_git_branch(pay_server_branch, "origin/green-pay-server", repo: "../mint")
 end
 
 private def pay_server_branch

--- a/scripts/deploy/update_pay_server_docs.rb
+++ b/scripts/deploy/update_pay_server_docs.rb
@@ -22,7 +22,7 @@ def update_pay_server_docs()
 
     puts 'Fetching latest pay-server...'
     begin
-        execute_or_fail("git -C #{mint_repo} fetch --depth=1 origin green-pay-server")
+        execute_or_fail("git -C #{mint_repo} fetch --depth=1 --no-tags origin green-pay-server")
         execute_or_fail("git -C #{mint_repo} checkout #{mint_base_ref}")
 
         puts '> Updating android SDK version in pay-server for latest release.'
@@ -40,7 +40,7 @@ def update_pay_server_docs()
     end
 
     begin
-        execute_or_fail("git -C #{mint_repo} push -u origin")
+        execute_or_fail("git -C #{mint_repo} push -u origin #{pay_server_branch}")
     rescue
         delete_pay_server_branch
         raise


### PR DESCRIPTION
## Summary
- Replace `git checkout master && git pull` with `git fetch --depth=1 origin green-pay-server` in the deploy script's mint repo step
- This is fast regardless of how stale the local mint clone is (only fetches the latest commit)
- Uses detached HEAD on `origin/green-pay-server` so it doesn't modify any local branches

## Motivation
`git pull` on a stale mint clone can be extremely slow due to the repo's size. The deploy script only needs the latest `constants.yaml` to update the SDK version, so a shallow fetch is sufficient.

## Test plan
- [ ] Run `pay get mint` to get mint locally
- [ ] Run deploy with `--dry-run --version 99.99.99 --continue-from 6` to validate the mint update step
- [ ] Verify the branch is created and pushed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)