### PR TITLE
Add test autofill service for manual QA

### DIFF
--- a/paymentsheet-example/src/debug/AndroidManifest.xml
+++ b/paymentsheet-example/src/debug/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <service
+            android:name="com.stripe.android.paymentsheet.example.autofill.TestAutofillService"
+            android:exported="true"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.autofill"
+                android:resource="@xml/autofill_service_config" />
+        </service>
+    </application>
+
+</manifest>

--- a/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/README.md
+++ b/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/README.md
@@ -1,0 +1,37 @@
+# Test Autofill Service
+
+A minimal `AutofillService` for debug builds that provides hardcoded test data for autofill-enabled fields. This removes the dependency on Google Play Services or a signed-in Google account for testing autofill behavior.
+
+## Setup
+
+1. Install the debug build on a device or emulator
+2. Open autofill settings:
+   ```
+   adb shell am start -a android.settings.REQUEST_SET_AUTOFILL_SERVICE
+   ```
+3. Select **PaymentSheet Example** as the autofill provider
+
+## Usage
+
+Tap into any text field that declares a `ContentType` via Compose semantics. The service matches fields by their autofill hints and presents a suggestion with hardcoded test data (e.g. "123 Main Street", "San Francisco", "4242424242424242").
+
+## Test data
+
+| Hint | Value |
+|------|-------|
+| streetAddress | 123 Main Street |
+| extendedAddress | Apt 4B |
+| addressLocality | San Francisco |
+| addressRegion | CA |
+| addressCountry | US |
+| postalCode | 94105 |
+| personName | Jane Doe |
+| emailAddress | test@example.com |
+| phoneNational | 4155551234 |
+| creditCardNumber | 4242424242424242 |
+| creditCardSecurityCode | 123 |
+| creditCardExpirationDate | 12/28 |
+
+## Extending
+
+To support new fields, add entries to the `TEST_DATA` map in `TestAutofillService.kt`. The keys must match the hint strings from `androidx.autofill.HintConstants` (which Compose's `ContentType` maps to internally).

--- a/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/README.md
+++ b/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/README.md
@@ -5,10 +5,13 @@ A minimal `AutofillService` for debug builds that provides hardcoded test data f
 ## Setup
 
 1. Install the debug build on a device or emulator
-2. Open autofill settings:
-   ```
-   adb shell am start -a android.settings.REQUEST_SET_AUTOFILL_SERVICE
-   ```
+2. Open autofill settings via one of:
+   - **Pixel/Stock Android**: Settings > Passwords & accounts > Autofill service
+   - **Older versions (API 26-29)**: Settings > System > Languages & input > Advanced > Autofill service
+   - **adb shortcut**:
+     ```
+     adb shell am start -a android.settings.REQUEST_SET_AUTOFILL_SERVICE
+     ```
 3. Select **PaymentSheet Example** as the autofill provider
 
 ## Usage

--- a/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/TestAutofillService.kt
+++ b/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/TestAutofillService.kt
@@ -33,21 +33,19 @@ class TestAutofillService : AutofillService() {
             return
         }
 
-        val dataset = Dataset.Builder()
-        var hasField = false
+        val matchedFields = fields.filter { (hint, _) -> hint in TEST_DATA }
+        if (matchedFields.isEmpty()) {
+            callback.onSuccess(null)
+            return
+        }
 
-        for ((hint, autofillId) in fields) {
-            val value = TEST_DATA[hint] ?: continue
+        val dataset = Dataset.Builder()
+        for ((hint, autofillId) in matchedFields) {
+            val value = TEST_DATA.getValue(hint)
             val presentation = RemoteViews(packageName, android.R.layout.simple_list_item_1).apply {
                 setTextViewText(android.R.id.text1, "Test: $value")
             }
             dataset.setValue(autofillId, AutofillValue.forText(value), presentation)
-            hasField = true
-        }
-
-        if (!hasField) {
-            callback.onSuccess(null)
-            return
         }
 
         val response = FillResponse.Builder()

--- a/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/TestAutofillService.kt
+++ b/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/TestAutofillService.kt
@@ -25,7 +25,7 @@ class TestAutofillService : AutofillService() {
             return
         }
 
-        val fields = mutableMapOf<String, AutofillId>()
+        val fields = mutableListOf<Pair<String, AutofillId>>()
         parseStructure(structure, fields)
 
         if (fields.isEmpty()) {
@@ -33,15 +33,9 @@ class TestAutofillService : AutofillService() {
             return
         }
 
-        val matchedFields = fields.filter { (hint, _) -> hint in TEST_DATA }
-        if (matchedFields.isEmpty()) {
-            callback.onSuccess(null)
-            return
-        }
-
         val dataset = Dataset.Builder()
-        for ((hint, autofillId) in matchedFields) {
-            val value = TEST_DATA.getValue(hint)
+        for ((hint, autofillId) in fields) {
+            val value = TEST_DATA[hint] ?: continue
             val presentation = RemoteViews(packageName, android.R.layout.simple_list_item_1).apply {
                 setTextViewText(android.R.id.text1, "Test: $value")
             }
@@ -61,7 +55,7 @@ class TestAutofillService : AutofillService() {
 
     private fun parseStructure(
         structure: AssistStructure,
-        fields: MutableMap<String, AutofillId>
+        fields: MutableList<Pair<String, AutofillId>>
     ) {
         for (i in 0 until structure.windowNodeCount) {
             parseNode(structure.getWindowNodeAt(i).rootViewNode, fields)
@@ -70,7 +64,7 @@ class TestAutofillService : AutofillService() {
 
     private fun parseNode(
         node: AssistStructure.ViewNode,
-        fields: MutableMap<String, AutofillId>
+        fields: MutableList<Pair<String, AutofillId>>
     ) {
         val hints = node.autofillHints
         val autofillId = node.autofillId
@@ -78,7 +72,7 @@ class TestAutofillService : AutofillService() {
         if (hints != null && autofillId != null) {
             for (hint in hints) {
                 if (hint in TEST_DATA) {
-                    fields[hint] = autofillId
+                    fields.add(hint to autofillId)
                 }
             }
         }

--- a/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/TestAutofillService.kt
+++ b/paymentsheet-example/src/debug/java/com/stripe/android/paymentsheet/example/autofill/TestAutofillService.kt
@@ -1,0 +1,124 @@
+package com.stripe.android.paymentsheet.example.autofill
+
+import android.app.assist.AssistStructure
+import android.os.CancellationSignal
+import android.service.autofill.AutofillService
+import android.service.autofill.Dataset
+import android.service.autofill.FillCallback
+import android.service.autofill.FillRequest
+import android.service.autofill.FillResponse
+import android.service.autofill.SaveCallback
+import android.service.autofill.SaveRequest
+import android.view.autofill.AutofillId
+import android.view.autofill.AutofillValue
+import android.widget.RemoteViews
+
+class TestAutofillService : AutofillService() {
+
+    override fun onFillRequest(
+        request: FillRequest,
+        cancellationSignal: CancellationSignal,
+        callback: FillCallback
+    ) {
+        val structure = request.fillContexts.lastOrNull()?.structure ?: run {
+            callback.onSuccess(null)
+            return
+        }
+
+        val fields = mutableMapOf<String, AutofillId>()
+        parseStructure(structure, fields)
+
+        if (fields.isEmpty()) {
+            callback.onSuccess(null)
+            return
+        }
+
+        val dataset = Dataset.Builder()
+        var hasField = false
+
+        for ((hint, autofillId) in fields) {
+            val value = TEST_DATA[hint] ?: continue
+            val presentation = RemoteViews(packageName, android.R.layout.simple_list_item_1).apply {
+                setTextViewText(android.R.id.text1, "Test: $value")
+            }
+            dataset.setValue(autofillId, AutofillValue.forText(value), presentation)
+            hasField = true
+        }
+
+        if (!hasField) {
+            callback.onSuccess(null)
+            return
+        }
+
+        val response = FillResponse.Builder()
+            .addDataset(dataset.build())
+            .build()
+
+        callback.onSuccess(response)
+    }
+
+    override fun onSaveRequest(request: SaveRequest, callback: SaveCallback) {
+        callback.onSuccess()
+    }
+
+    private fun parseStructure(
+        structure: AssistStructure,
+        fields: MutableMap<String, AutofillId>
+    ) {
+        for (i in 0 until structure.windowNodeCount) {
+            parseNode(structure.getWindowNodeAt(i).rootViewNode, fields)
+        }
+    }
+
+    private fun parseNode(
+        node: AssistStructure.ViewNode,
+        fields: MutableMap<String, AutofillId>
+    ) {
+        val hints = node.autofillHints
+        val autofillId = node.autofillId
+
+        if (hints != null && autofillId != null) {
+            for (hint in hints) {
+                if (hint in TEST_DATA) {
+                    fields[hint] = autofillId
+                }
+            }
+        }
+
+        for (i in 0 until node.childCount) {
+            parseNode(node.getChildAt(i), fields)
+        }
+    }
+
+    companion object {
+        // Keys are the autofill hint strings that Compose ContentType maps to
+        // via androidx.autofill.HintConstants
+        private val TEST_DATA = mapOf(
+            // Address fields
+            "postalAddress" to "123 Main Street, Apt 4B, San Francisco, CA 94105",
+            "streetAddress" to "123 Main Street",
+            "extendedAddress" to "Apt 4B",
+            "addressLocality" to "San Francisco",
+            "addressRegion" to "CA",
+            "addressCountry" to "US",
+            "postalCode" to "94105",
+
+            // Person name
+            "personName" to "Jane Doe",
+            "personGivenName" to "Jane",
+            "personFamilyName" to "Doe",
+
+            // Contact
+            "emailAddress" to "test@example.com",
+            "phoneNumber" to "+14155551234",
+            "phoneNational" to "4155551234",
+
+            // Payment
+            "creditCardNumber" to "4242424242424242",
+            "creditCardSecurityCode" to "123",
+            "creditCardExpirationDate" to "12/28",
+            "creditCardExpirationMonth" to "12",
+            "creditCardExpirationYear" to "2028",
+        )
+    }
+}

--- a/paymentsheet-example/src/debug/res/xml/autofill_service_config.xml
+++ b/paymentsheet-example/src/debug/res/xml/autofill_service_config.xml
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Required by the Android autofill framework. The manifest meta-data must point to a valid
+     resource or the system won't list the service as an autofill provider. -->
 <autofill-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:settingsActivity="" />

--- a/paymentsheet-example/src/debug/res/xml/autofill_service_config.xml
+++ b/paymentsheet-example/src/debug/res/xml/autofill_service_config.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<autofill-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="" />


### PR DESCRIPTION
## Summary

Adds a lightweight in-house autofill provider for manual QA of autofill-enabled fields in debug builds. When you don't have (or don't want to use) a third-party autofill service like Google's, this provides deterministic test data for address, contact, and payment fields without requiring Google Play Services or a signed-in account.

This also serves as the foundation for verifying address autofill support as we add `ContentType` semantics to more form fields across PaymentSheet, Flow Controller, and Embedded.

## Setup
1. Install debug build
2. `adb shell am start -a android.settings.REQUEST_SET_AUTOFILL_SERVICE`
3. Select "PaymentSheet Example" as autofill provider
4. Tap into fields with autofill hints to see test suggestions

## Test plan
- [x] Verified debug build compiles
- [x] Verified service appears in system autofill picker
- [x] Verified autofill suggestions show for fields with ContentType hints (name, email, postal code, card number)
- [ ] Verify no impact on release builds (service only in debug manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)