### PR TITLE
Temporarily disable WeChat Pay tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestWeChatPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestWeChatPay.kt
@@ -3,18 +3,20 @@ package com.stripe.android.lpm
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.example.playground.settings.Merchant
-import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
+@Ignore("ir-alabaster-elude")
 internal class TestWeChatPay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "wechat_pay",


### PR DESCRIPTION
CI is blocked by the failing test. Temporarily disable the test to unblock CI.
