### PR TITLE
Add Google Pay display items support for line item breakdown.

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -17,6 +17,7 @@
     <ID>LargeClass:CardMultilineWidget.kt:CardMultilineWidget : LinearLayoutCardWidget</ID>
     <ID>LargeClass:CardMultilineWidgetTest.kt:CardMultilineWidgetTest</ID>
     <ID>LargeClass:CardNumberEditTextTest.kt:CardNumberEditTextTest</ID>
+    <ID>LargeClass:GooglePayJsonFactoryTest.kt:GooglePayJsonFactoryTest</ID>
     <ID>LargeClass:PaymentIntentFixtures.kt:PaymentIntentFixtures</ID>
     <ID>LargeClass:PaymentIntentFlowResultProcessorTest.kt:PaymentIntentFlowResultProcessorTest</ID>
     <ID>LargeClass:SetupIntentFixtures.kt:SetupIntentFixtures</ID>

--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -156,6 +156,8 @@
   <string name="stripe_fpx_bank_offline">%s - Offline</string>
   <!-- Error message when a payment method gets declined. -->
   <string name="stripe_generic_decline">Your payment method was declined.</string>
+  <!-- Label for the total price in Google Pay -->
+  <string name="stripe_google_pay_total">Total</string>
   <!-- An error message displayed when the customer has not enough funds for payment. -->
   <string name="stripe_insufficient_funds">Your card has insufficient funds.</string>
   <!-- When an internal error is reported when a google pay payment is started. -->

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -279,6 +279,27 @@ class GooglePayJsonFactory internal constructor(
                 transactionInfo.checkoutOption?.let {
                     put("checkoutOption", it.code)
                 }
+
+                if (transactionInfo.displayItems.isNotEmpty()) {
+                    val displayItemsArray = JSONArray()
+                    for (item in transactionInfo.displayItems) {
+                        displayItemsArray.put(
+                            JSONObject()
+                                .put("label", item.label)
+                                .put("type", item.type.code)
+                                .put(
+                                    "price",
+                                    PayWithGoogleUtils.getPriceString(
+                                        item.price,
+                                        Currency.getInstance(
+                                            transactionInfo.currencyCode.uppercase()
+                                        )
+                                    )
+                                )
+                        )
+                    }
+                    put("displayItems", displayItemsArray)
+                }
             }
     }
 
@@ -393,6 +414,7 @@ class GooglePayJsonFactory internal constructor(
         internal val totalPrice: Long?,
         internal val totalPriceLabel: String?,
         internal val checkoutOption: CheckoutOption?,
+        internal val displayItems: List<DisplayItem> = emptyList(),
     ) : Parcelable {
 
         /**
@@ -429,6 +451,7 @@ class GooglePayJsonFactory internal constructor(
             totalPrice = totalPrice?.toLong(),
             totalPriceLabel = totalPriceLabel,
             checkoutOption = checkoutOption,
+            displayItems = emptyList(),
         )
 
         /**
@@ -469,6 +492,31 @@ class GooglePayJsonFactory internal constructor(
              * selections. This option is only available when totalPriceStatus is set to FINAL.
              */
             CompleteImmediatePurchase("COMPLETE_IMMEDIATE_PURCHASE")
+        }
+    }
+
+    /**
+     * A display line item for the Google Pay payment sheet.
+     *
+     * [DisplayLineItem](https://developers.google.com/pay/api/android/reference/request-objects#DisplayLineItem)
+     */
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Poko
+    class DisplayItem(
+        val label: String,
+        val type: Type,
+        val price: Long,
+    ) : Parcelable {
+        /**
+         * The type of display line item.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        enum class Type(val code: String) {
+            LINE_ITEM("LINE_ITEM"),
+            SUBTOTAL("SUBTOTAL"),
+            TAX("TAX"),
+            DISCOUNT("DISCOUNT"),
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -258,7 +258,8 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         transactionId: String? = null,
         label: String? = null,
         isElements: Boolean = false,
-        publishableKey: String? = null
+        publishableKey: String? = null,
+        displayItems: List<com.stripe.android.GooglePayJsonFactory.DisplayItem> = emptyList(),
     ) {
         check(skipReadyCheck || isReady) {
             "present() may only be called when Google Pay is available on this device."
@@ -275,7 +276,8 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
                 cardFundingFilter = cardFundingFilter,
                 clientAttributionMetadata = clientAttributionMetadata,
                 isElements = isElements,
-                publishableKey = publishableKey
+                publishableKey = publishableKey,
+                displayItems = displayItems,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -10,6 +10,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
@@ -56,7 +57,8 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
         internal val clientAttributionMetadata: ClientAttributionMetadata? = null,
         internal val isElements: Boolean = false,
-        internal val publishableKey: String? = null
+        internal val publishableKey: String? = null,
+        internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
     ) : Parcelable {
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.googlepaylauncher
 
+import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -13,6 +14,7 @@ import com.google.android.gms.wallet.PaymentsClient
 import com.stripe.android.BuildConfig
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.R
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
@@ -28,6 +30,7 @@ import java.util.Locale
 import javax.inject.Inject
 
 internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
+    private val context: Context,
     private val paymentsClient: PaymentsClient,
     private val requestOptions: ApiRequest.Options,
     private val args: GooglePayPaymentMethodLauncherContractV2.Args,
@@ -82,7 +85,11 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
         args: GooglePayPaymentMethodLauncherContractV2.Args
     ): GooglePayJsonFactory.TransactionInfo {
         // Google Pay requires totalPriceLabel when displayItems are present.
-        val label = args.label ?: if (args.displayItems.isNotEmpty()) "Total" else null
+        val label = args.label ?: if (args.displayItems.isNotEmpty()) {
+            context.getString(R.string.stripe_google_pay_total)
+        } else {
+            null
+        }
         return if (shouldHidePrice(args)) {
             GooglePayJsonFactory.TransactionInfo(
                 currencyCode = args.currencyCode,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -81,14 +81,18 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
     internal fun createTransactionInfo(
         args: GooglePayPaymentMethodLauncherContractV2.Args
     ): GooglePayJsonFactory.TransactionInfo {
+        // Google Pay requires totalPriceLabel when displayItems are present.
+        val label = args.label ?: if (args.displayItems.isNotEmpty()) "Total" else null
         return if (shouldHidePrice(args)) {
             GooglePayJsonFactory.TransactionInfo(
                 currencyCode = args.currencyCode,
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.NotCurrentlyKnown,
                 countryCode = args.config.merchantCountryCode,
                 transactionId = args.transactionId,
-                totalPriceLabel = args.label,
-                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
+                totalPrice = null,
+                totalPriceLabel = label,
+                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
+                displayItems = args.displayItems,
             )
         } else {
             GooglePayJsonFactory.TransactionInfo(
@@ -97,8 +101,9 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
                 countryCode = args.config.merchantCountryCode,
                 transactionId = args.transactionId,
                 totalPrice = args.amount,
-                totalPriceLabel = args.label,
-                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
+                totalPriceLabel = label,
+                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
+                displayItems = args.displayItems,
             )
         }
     }

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -736,6 +736,133 @@ class GooglePayJsonFactoryTest {
 
         assertThat(softwareInfo.getString("id")).isEqualTo("android/stripe-elements")
     }
+
+    @Test
+    fun `'transactionInfo' should include displayItems when provided`() {
+        val factory = GooglePayJsonFactory(
+            googlePayConfig = googlePayConfig,
+        )
+
+        val transactionInfo = GooglePayJsonFactory.TransactionInfo(
+            currencyCode = "USD",
+            totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
+            countryCode = "US",
+            transactionId = null,
+            totalPrice = 2500L,
+            totalPriceLabel = null,
+            checkoutOption = null,
+            displayItems = listOf(
+                GooglePayJsonFactory.DisplayItem(
+                    label = "Widget",
+                    type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                    price = 2000L,
+                ),
+                GooglePayJsonFactory.DisplayItem(
+                    label = "Tax",
+                    type = GooglePayJsonFactory.DisplayItem.Type.TAX,
+                    price = 500L,
+                ),
+            ),
+        )
+
+        val json = factory.createPaymentDataRequest(
+            transactionInfo = transactionInfo,
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(),
+        )
+
+        val transactionInfoJson = json.getJSONObject("transactionInfo")
+        assertThat(transactionInfoJson.getString("currencyCode")).isEqualTo("USD")
+        assertThat(transactionInfoJson.getString("totalPrice")).isEqualTo("25.00")
+
+        val displayItemsArray = transactionInfoJson.getJSONArray("displayItems")
+        assertThat(displayItemsArray.length()).isEqualTo(2)
+
+        val item0 = displayItemsArray.getJSONObject(0)
+        assertThat(item0.getString("label")).isEqualTo("Widget")
+        assertThat(item0.getString("type")).isEqualTo("LINE_ITEM")
+        assertThat(item0.getString("price")).isEqualTo("20.00")
+
+        val item1 = displayItemsArray.getJSONObject(1)
+        assertThat(item1.getString("label")).isEqualTo("Tax")
+        assertThat(item1.getString("type")).isEqualTo("TAX")
+        assertThat(item1.getString("price")).isEqualTo("5.00")
+    }
+
+    @Test
+    fun `'transactionInfo' should not include displayItems when list is empty`() {
+        val factory = GooglePayJsonFactory(
+            googlePayConfig = googlePayConfig,
+        )
+
+        val transactionInfo = GooglePayJsonFactory.TransactionInfo(
+            currencyCode = "USD",
+            totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
+            countryCode = "US",
+            transactionId = null,
+            totalPrice = 1000L,
+            totalPriceLabel = null,
+            checkoutOption = null,
+            displayItems = emptyList(),
+        )
+
+        val json = factory.createPaymentDataRequest(
+            transactionInfo = transactionInfo,
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(),
+        )
+
+        val transactionInfoJson = json.getJSONObject("transactionInfo")
+        assertThat(transactionInfoJson.has("displayItems")).isFalse()
+    }
+
+    @Test
+    fun `'transactionInfo' displayItems should format zero-decimal currencies correctly`() {
+        val factory = GooglePayJsonFactory(
+            googlePayConfig = googlePayConfig,
+        )
+
+        val transactionInfo = GooglePayJsonFactory.TransactionInfo(
+            currencyCode = "JPY",
+            totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
+            countryCode = "JP",
+            transactionId = null,
+            totalPrice = 1000L,
+            totalPriceLabel = null,
+            checkoutOption = null,
+            displayItems = listOf(
+                GooglePayJsonFactory.DisplayItem(
+                    label = "Item",
+                    type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                    price = 800L,
+                ),
+                GooglePayJsonFactory.DisplayItem(
+                    label = "Discount",
+                    type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
+                    price = -200L,
+                ),
+            ),
+        )
+
+        val json = factory.createPaymentDataRequest(
+            transactionInfo = transactionInfo,
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(),
+        )
+
+        val transactionInfoJson = json.getJSONObject("transactionInfo")
+        assertThat(transactionInfoJson.getString("totalPrice")).isEqualTo("1000")
+
+        val displayItemsArray = transactionInfoJson.getJSONArray("displayItems")
+        assertThat(displayItemsArray.length()).isEqualTo(2)
+
+        val item0 = displayItemsArray.getJSONObject(0)
+        assertThat(item0.getString("label")).isEqualTo("Item")
+        assertThat(item0.getString("type")).isEqualTo("LINE_ITEM")
+        assertThat(item0.getString("price")).isEqualTo("800")
+
+        val item1 = displayItemsArray.getJSONObject(1)
+        assertThat(item1.getString("label")).isEqualTo("Discount")
+        assertThat(item1.getString("type")).isEqualTo("DISCOUNT")
+        assertThat(item1.getString("price")).isEqualTo("-200")
+    }
 }
 
 @Parcelize

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -63,6 +63,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     private val viewModel = GooglePayPaymentMethodLauncherViewModel(
+        ApplicationProvider.getApplicationContext(),
         paymentsClient,
         REQUEST_OPTIONS,
         ARGS,
@@ -191,6 +192,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     @Test
     fun `createPaymentDataRequest() with isElements=true should set 'stripe-elements' software id`() {
         val viewModel = GooglePayPaymentMethodLauncherViewModel(
+            ApplicationProvider.getApplicationContext(),
             paymentsClient,
             REQUEST_OPTIONS,
             ARGS.copy(isElements = true),
@@ -212,6 +214,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     @Test
     fun `createPaymentDataRequest() with isElements=false should set 'stripe-launcher' software id`() {
         val viewModel = GooglePayPaymentMethodLauncherViewModel(
+            ApplicationProvider.getApplicationContext(),
             paymentsClient,
             REQUEST_OPTIONS,
             ARGS.copy(isElements = false),

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -18,6 +18,7 @@
     <ID>FunctionOnlyReturningConstant:PaymentSheetLauncherModule.kt:PaymentSheetLauncherModule.Companion$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation</ID>
     <ID>LargeClass:CardDefinitionTest.kt:CardDefinitionTest</ID>
     <ID>LargeClass:CheckoutTest.kt:CheckoutTest</ID>
+    <ID>LargeClass:ConfirmationHandlerOptionKtxTest.kt:ConfirmationHandlerOptionKtxTest</ID>
     <ID>LargeClass:CustomerAdapterTest.kt:CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt:CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt:CustomerSheetViewModelTest</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation
 
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkLaunchMode
@@ -19,7 +20,8 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 internal fun PaymentSelection.toConfirmationOption(
     configuration: CommonConfiguration,
     linkConfiguration: LinkConfiguration?,
-    cardFundingFilter: CardFundingFilter
+    cardFundingFilter: CardFundingFilter,
+    googlePayDisplayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
 ): ConfirmationHandler.Option? {
     return when (this) {
         is PaymentSelection.Saved -> toConfirmationOption(linkConfiguration)
@@ -30,7 +32,8 @@ internal fun PaymentSelection.toConfirmationOption(
         is PaymentSelection.New -> toConfirmationOption()
         is PaymentSelection.GooglePay -> toConfirmationOption(
             configuration,
-            cardFundingFilter
+            cardFundingFilter,
+            googlePayDisplayItems,
         )
         is PaymentSelection.Link -> toConfirmationOption(linkConfiguration)
         is PaymentSelection.ShopPay -> toConfirmationOption(configuration)
@@ -122,7 +125,8 @@ private fun PaymentSelection.New.toConfirmationOption(): ConfirmationHandler.Opt
 
 private fun PaymentSelection.GooglePay.toConfirmationOption(
     configuration: CommonConfiguration,
-    cardFundingFilter: CardFundingFilter
+    cardFundingFilter: CardFundingFilter,
+    displayItems: List<GooglePayJsonFactory.DisplayItem>,
 ): GooglePayConfirmationOption? {
     return configuration.googlePay?.let { googlePay ->
         GooglePayConfirmationOption(
@@ -136,7 +140,8 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
                 billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
                 additionalEnabledNetworks = googlePay.additionalEnabledNetworks,
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
-                cardFundingFilter = cardFundingFilter
+                cardFundingFilter = cardFundingFilter,
+                displayItems = displayItems,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -99,6 +99,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             label = config.customLabel,
             clientAttributionMetadata = confirmationArgs.paymentMethodMetadata.clientAttributionMetadata,
             isElements = true,
+            displayItems = config.displayItems,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.gpay
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
@@ -22,6 +23,7 @@ internal data class GooglePayConfirmationOption(
         val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         val cardBrandFilter: CardBrandFilter,
         val cardFundingFilter: CardFundingFilter,
-        val additionalEnabledNetworks: List<String> = emptyList()
+        val additionalEnabledNetworks: List<String> = emptyList(),
+        val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
     ) : Parcelable
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.checkout.CheckoutInstances
+import com.stripe.android.checkout.CheckoutSession
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+
+@OptIn(CheckoutSessionPreview::class)
+internal object GooglePayDisplayItemsFactory {
+
+    fun create(paymentMethodMetadata: PaymentMethodMetadata): List<GooglePayJsonFactory.DisplayItem> {
+        val checkoutSessionMetadata = paymentMethodMetadata.integrationMetadata
+            as? IntegrationMetadata.CheckoutSession ?: return emptyList()
+
+        val checkout = CheckoutInstances[checkoutSessionMetadata.instancesKey].firstOrNull()
+            ?: return emptyList()
+
+        return checkout.checkoutSession.value.lineItems.map { it.asDisplayItem() }
+    }
+
+    private fun CheckoutSession.LineItem.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+        return GooglePayJsonFactory.DisplayItem(
+            label = name,
+            type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+            price = total,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -17,7 +17,17 @@ internal object GooglePayDisplayItemsFactory {
         val checkout = CheckoutInstances[checkoutSessionMetadata.instancesKey].firstOrNull()
             ?: return emptyList()
 
-        return checkout.checkoutSession.value.lineItems.map { it.asDisplayItem() }
+        val checkoutSession = checkout.checkoutSession.value
+        val items = mutableListOf<GooglePayJsonFactory.DisplayItem>()
+
+        items += checkoutSession.lineItems.map { it.asDisplayItem() }
+
+        checkoutSession.totalSummary?.let { summary ->
+            items += summary.discountAmounts.map { it.asDisplayItem() }
+            items += summary.taxAmounts.map { it.asDisplayItem() }
+        }
+
+        return items
     }
 
     private fun CheckoutSession.LineItem.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
@@ -25,6 +35,22 @@ internal object GooglePayDisplayItemsFactory {
             label = name,
             type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
             price = total,
+        )
+    }
+
+    private fun CheckoutSession.DiscountAmount.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+        return GooglePayJsonFactory.DisplayItem(
+            label = displayName,
+            type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
+            price = -amount,
+        )
+    }
+
+    private fun CheckoutSession.TaxAmount.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+        return GooglePayJsonFactory.DisplayItem(
+            label = displayName,
+            type = GooglePayJsonFactory.DisplayItem.Type.TAX,
+            price = amount,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -31,10 +31,11 @@ internal object GooglePayDisplayItemsFactory {
     }
 
     private fun CheckoutSession.LineItem.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+        val label = if (quantity > 1) "$name x$quantity" else name
         return GooglePayJsonFactory.DisplayItem(
-            label = name,
+            label = label,
             type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-            price = total,
+            price = unitAmount ?: total,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -55,7 +56,8 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
         val confirmationOption = confirmationState.selection?.toConfirmationOption(
             configuration = confirmationState.configuration.asCommonConfiguration(),
             linkConfiguration = confirmationState.paymentMethodMetadata.linkState?.configuration,
-            cardFundingFilter = confirmationState.paymentMethodMetadata.cardFundingFilter
+            cardFundingFilter = confirmationState.paymentMethodMetadata.cardFundingFilter,
+            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(confirmationState.paymentMethodMetadata),
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.FormResult
@@ -64,7 +65,8 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
         val confirmationOption = selectionHolder.selection.value?.toConfirmationOption(
             configuration = configuration.asCommonConfiguration(),
             linkConfiguration = paymentMethodMetadata.linkState?.configuration,
-            cardFundingFilter = paymentMethodMetadata.cardFundingFilter
+            cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
+            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(paymentMethodMetadata),
         ) ?: return null
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -37,6 +37,7 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
@@ -575,7 +576,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     ?.toConfirmationOption(
                         configuration = config.asCommonConfiguration(),
                         linkConfiguration = linkHandler.linkConfiguration.value,
-                        cardFundingFilter = paymentMethodMetadata.cardFundingFilter
+                        cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
+                        googlePayDisplayItems = GooglePayDisplayItemsFactory.create(paymentMethodMetadata),
                     )
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -47,6 +47,7 @@ import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
@@ -582,7 +583,8 @@ internal class DefaultFlowController @Inject internal constructor(
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,
                 linkConfiguration = state.linkConfiguration,
-                cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter
+                cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
+                googlePayDisplayItems = GooglePayDisplayItemsFactory.create(state.paymentMethodMetadata),
             )
 
             confirmationOption?.let { option ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
@@ -335,6 +336,7 @@ internal class DefaultWalletButtonsInteractor constructor(
             configuration = arguments.configuration,
             linkConfiguration = arguments.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = arguments.paymentMethodMetadata.cardFundingFilter,
+            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(arguments.paymentMethodMetadata),
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -334,6 +334,64 @@ class ConfirmationHandlerOptionKtxTest {
     }
 
     @Test
+    fun `On Google Pay selection with displayItems, should return expected option with displayItems`() {
+        val displayItems = listOf(
+            com.stripe.android.GooglePayJsonFactory.DisplayItem(
+                label = "Widget",
+                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 2000L,
+            ),
+            com.stripe.android.GooglePayJsonFactory.DisplayItem(
+                label = "Tax",
+                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.TAX,
+                price = 500L,
+            ),
+        )
+
+        val confirmationOption = PaymentSelection.GooglePay.toConfirmationOption(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
+                        countryCode = "US",
+                        currencyCode = "USD",
+                    )
+                )
+                .build()
+                .asCommonConfiguration(),
+            linkConfiguration = null,
+            cardFundingFilter = DefaultCardFundingFilter,
+            googlePayDisplayItems = displayItems,
+        )
+
+        assertThat(
+            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.displayItems
+        ).isEqualTo(displayItems)
+    }
+
+    @Test
+    fun `On Google Pay selection without displayItems, should return empty displayItems`() {
+        val confirmationOption = PaymentSelection.GooglePay.toConfirmationOption(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
+                        countryCode = "US",
+                        currencyCode = "USD",
+                    )
+                )
+                .build()
+                .asCommonConfiguration(),
+            linkConfiguration = null,
+            cardFundingFilter = DefaultCardFundingFilter,
+        )
+
+        assertThat(
+            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.displayItems
+        ).isEmpty()
+    }
+
+    @Test
     fun `On Link selection but with no configuration, should return null`() {
         assertThat(
             PaymentSelection.Link(brand = LinkBrand.Link).toConfirmationOption(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -489,6 +489,57 @@ class GooglePayConfirmationDefinitionTest {
         }
     }
 
+    @Test
+    fun `On 'launch', should pass display items to present`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        val displayItems = listOf(
+            com.stripe.android.GooglePayJsonFactory.DisplayItem(
+                label = "Widget",
+                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 2000L,
+            ),
+            com.stripe.android.GooglePayJsonFactory.DisplayItem(
+                label = "Tax",
+                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.TAX,
+                price = 500L,
+            ),
+        )
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                        displayItems = displayItems,
+                    ),
+                ),
+                confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                        stripeIntent = PAYMENT_INTENT.copy(currency = "USD")
+                    ),
+                ),
+                arguments = EmptyConfirmationLauncherArgs,
+                launcher = launcher,
+            )
+
+            assertThat(createGooglePayPaymentMethodLauncherCalls.awaitItem()).isNotNull()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "USD",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = null,
+                clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
+                isElements = true,
+                displayItems = displayItems,
+            )
+        }
+    }
+
     private fun runActionTest(
         merchantCurrencyCode: String?,
         intent: StripeIntent = SetupIntentFactory.create(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -84,12 +84,12 @@ class GooglePayDisplayItemsFactoryTest {
             displayItem(
                 label = "Widget x2",
                 type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 2000L,
+                price = 1000L,
             ),
             displayItem(
                 label = "Gadget",
                 type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 450L,
+                price = 500L,
             ),
         ).inOrder()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -82,7 +82,7 @@ class GooglePayDisplayItemsFactoryTest {
 
         assertThat(result).containsExactly(
             displayItem(
-                label = "Widget",
+                label = "Widget x2",
                 type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
                 price = 2000L,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -1,0 +1,145 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CheckoutInstances
+import com.stripe.android.checkout.CheckoutStateFactory
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+class GooglePayDisplayItemsFactoryTest {
+
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+
+    @get:Rule
+    val paymentConfigRule = PaymentConfigurationTestRule(applicationContext)
+
+    @After
+    fun tearDown() {
+        CheckoutInstances.clear()
+    }
+
+    @Test
+    fun `returns empty list when integration metadata is not CheckoutSession`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.IntentFirst(clientSecret = "pi_xxx_secret_yyy"),
+        )
+
+        val result = GooglePayDisplayItemsFactory.create(metadata)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `returns empty list when no checkout instance exists for key`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_xxx",
+                instancesKey = "nonexistent_key",
+            ),
+        )
+
+        val result = GooglePayDisplayItemsFactory.create(metadata)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `returns empty list when checkout session has no line items`() {
+        val checkout = createCheckoutWithLineItems(emptyList())
+        CheckoutInstances.add(INSTANCES_KEY, checkout)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_xxx",
+                instancesKey = INSTANCES_KEY,
+            ),
+        )
+
+        val result = GooglePayDisplayItemsFactory.create(metadata)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `maps checkout session line items to display items`() {
+        val lineItems = listOf(
+            CheckoutSessionResponse.LineItem(
+                id = "li_1",
+                name = "Widget",
+                quantity = 2,
+                unitAmount = 1000L,
+                subtotal = 2000L,
+                total = 2000L,
+            ),
+            CheckoutSessionResponse.LineItem(
+                id = "li_2",
+                name = "Gadget",
+                quantity = 1,
+                unitAmount = 500L,
+                subtotal = 500L,
+                total = 450L,
+            ),
+        )
+
+        val checkout = createCheckoutWithLineItems(lineItems)
+        CheckoutInstances.add(INSTANCES_KEY, checkout)
+
+        val metadata = PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_xxx",
+                instancesKey = INSTANCES_KEY,
+            ),
+        )
+
+        val result = GooglePayDisplayItemsFactory.create(metadata)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(
+            GooglePayJsonFactory.DisplayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 2000L,
+            )
+        )
+        assertThat(result[1]).isEqualTo(
+            GooglePayJsonFactory.DisplayItem(
+                label = "Gadget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 450L,
+            )
+        )
+    }
+
+    private fun createCheckoutWithLineItems(
+        lineItems: List<CheckoutSessionResponse.LineItem>,
+    ): Checkout {
+        return Checkout.createWithState(
+            context = applicationContext,
+            state = CheckoutStateFactory.create(
+                key = INSTANCES_KEY,
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    lineItems = lineItems,
+                ),
+            ),
+        )
+    }
+
+    private companion object {
+        const val INSTANCES_KEY = "test_key"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -60,43 +60,155 @@ class GooglePayDisplayItemsFactoryTest {
 
     @Test
     fun `returns empty list when checkout session has no line items`() {
-        val checkout = createCheckoutWithLineItems(emptyList())
-        CheckoutInstances.add(INSTANCES_KEY, checkout)
-
-        val metadata = PaymentMethodMetadataFactory.create(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = "cs_xxx",
-                instancesKey = INSTANCES_KEY,
-            ),
-        )
-
-        val result = GooglePayDisplayItemsFactory.create(metadata)
+        val result = createAndGetDisplayItems(lineItems = emptyList())
 
         assertThat(result).isEmpty()
     }
 
     @Test
     fun `maps checkout session line items to display items`() {
-        val lineItems = listOf(
-            CheckoutSessionResponse.LineItem(
-                id = "li_1",
-                name = "Widget",
-                quantity = 2,
-                unitAmount = 1000L,
-                subtotal = 2000L,
-                total = 2000L,
-            ),
-            CheckoutSessionResponse.LineItem(
-                id = "li_2",
-                name = "Gadget",
-                quantity = 1,
-                unitAmount = 500L,
-                subtotal = 500L,
-                total = 450L,
+        val result = createAndGetDisplayItems(
+            lineItems = listOf(
+                lineItem(
+                    id = "li_1", name = "Widget", quantity = 2,
+                    unitAmount = 1000L, subtotal = 2000L, total = 2000L,
+                ),
+                lineItem(
+                    id = "li_2", name = "Gadget", quantity = 1,
+                    unitAmount = 500L, subtotal = 500L, total = 450L,
+                ),
             ),
         )
 
-        val checkout = createCheckoutWithLineItems(lineItems)
+        assertThat(result).containsExactly(
+            displayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 2000L,
+            ),
+            displayItem(
+                label = "Gadget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 450L,
+            ),
+        ).inOrder()
+    }
+
+    @Test
+    fun `includes discount amounts from total summary`() {
+        val result = createAndGetDisplayItems(
+            lineItems = listOf(
+                lineItem(
+                    id = "li_1", name = "Widget", quantity = 1,
+                    unitAmount = 2000L, subtotal = 2000L, total = 2000L,
+                ),
+            ),
+            totalSummary = totalSummary(
+                subtotal = 2000L,
+                totalDueToday = 1500L,
+                totalAmountDue = 1500L,
+                discountAmounts = listOf(discountAmount(amount = 500L, displayName = "SAVE50")),
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            displayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 2000L,
+            ),
+            displayItem(
+                label = "SAVE50",
+                type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
+                price = -500L,
+            ),
+        ).inOrder()
+    }
+
+    @Test
+    fun `includes tax amounts from total summary`() {
+        val result = createAndGetDisplayItems(
+            lineItems = listOf(
+                lineItem(
+                    id = "li_1", name = "Widget", quantity = 1,
+                    unitAmount = 1000L, subtotal = 1000L, total = 1000L,
+                ),
+            ),
+            totalSummary = totalSummary(
+                subtotal = 1000L,
+                totalDueToday = 1080L,
+                totalAmountDue = 1080L,
+                taxAmounts = listOf(
+                    taxAmount(amount = 80L, displayName = "Sales Tax", percentage = 8.0),
+                ),
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            displayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 1000L,
+            ),
+            displayItem(
+                label = "Sales Tax",
+                type = GooglePayJsonFactory.DisplayItem.Type.TAX,
+                price = 80L,
+            ),
+        ).inOrder()
+    }
+
+    @Test
+    fun `includes both discounts and taxes from total summary`() {
+        val result = createAndGetDisplayItems(
+            lineItems = listOf(
+                lineItem(
+                    id = "li_1", name = "Widget", quantity = 1,
+                    unitAmount = 2000L, subtotal = 2000L, total = 2000L,
+                ),
+            ),
+            totalSummary = totalSummary(
+                subtotal = 2000L,
+                totalDueToday = 1620L,
+                totalAmountDue = 1620L,
+                discountAmounts = listOf(discountAmount(amount = 500L, displayName = "SAVE50")),
+                taxAmounts = listOf(taxAmount(amount = 120L, displayName = "VAT", percentage = 8.0)),
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            displayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 2000L,
+            ),
+            displayItem(
+                label = "SAVE50",
+                type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
+                price = -500L,
+            ),
+            displayItem(
+                label = "VAT",
+                type = GooglePayJsonFactory.DisplayItem.Type.TAX,
+                price = 120L,
+            ),
+        ).inOrder()
+    }
+
+    private fun createAndGetDisplayItems(
+        lineItems: List<CheckoutSessionResponse.LineItem>,
+        totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
+    ): List<GooglePayJsonFactory.DisplayItem> {
+        val checkout = Checkout.createWithState(
+            context = applicationContext,
+            state = CheckoutStateFactory.create(
+                key = INSTANCES_KEY,
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    lineItems = lineItems,
+                    totalSummary = totalSummary,
+                ),
+            ),
+        )
         CheckoutInstances.add(INSTANCES_KEY, checkout)
 
         val metadata = PaymentMethodMetadataFactory.create(
@@ -106,40 +218,69 @@ class GooglePayDisplayItemsFactoryTest {
             ),
         )
 
-        val result = GooglePayDisplayItemsFactory.create(metadata)
-
-        assertThat(result).hasSize(2)
-        assertThat(result[0]).isEqualTo(
-            GooglePayJsonFactory.DisplayItem(
-                label = "Widget",
-                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 2000L,
-            )
-        )
-        assertThat(result[1]).isEqualTo(
-            GooglePayJsonFactory.DisplayItem(
-                label = "Gadget",
-                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 450L,
-            )
-        )
-    }
-
-    private fun createCheckoutWithLineItems(
-        lineItems: List<CheckoutSessionResponse.LineItem>,
-    ): Checkout {
-        return Checkout.createWithState(
-            context = applicationContext,
-            state = CheckoutStateFactory.create(
-                key = INSTANCES_KEY,
-                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                    lineItems = lineItems,
-                ),
-            ),
-        )
+        return GooglePayDisplayItemsFactory.create(metadata)
     }
 
     private companion object {
         const val INSTANCES_KEY = "test_key"
+
+        fun lineItem(
+            id: String,
+            name: String,
+            quantity: Int,
+            unitAmount: Long,
+            subtotal: Long,
+            total: Long,
+        ) = CheckoutSessionResponse.LineItem(
+            id = id,
+            name = name,
+            quantity = quantity,
+            unitAmount = unitAmount,
+            subtotal = subtotal,
+            total = total,
+        )
+
+        fun totalSummary(
+            subtotal: Long,
+            totalDueToday: Long,
+            totalAmountDue: Long,
+            discountAmounts: List<CheckoutSessionResponse.DiscountAmount> = emptyList(),
+            taxAmounts: List<CheckoutSessionResponse.TaxAmount> = emptyList(),
+        ) = CheckoutSessionResponse.TotalSummaryResponse(
+            subtotal = subtotal,
+            totalDueToday = totalDueToday,
+            totalAmountDue = totalAmountDue,
+            discountAmounts = discountAmounts,
+            taxAmounts = taxAmounts,
+            shippingRate = null,
+            appliedBalance = null,
+        )
+
+        fun discountAmount(amount: Long, displayName: String) = CheckoutSessionResponse.DiscountAmount(
+            amount = amount,
+            displayName = displayName,
+        )
+
+        fun taxAmount(
+            amount: Long,
+            displayName: String,
+            percentage: Double,
+            inclusive: Boolean = false,
+        ) = CheckoutSessionResponse.TaxAmount(
+            amount = amount,
+            inclusive = inclusive,
+            displayName = displayName,
+            percentage = percentage,
+        )
+
+        fun displayItem(
+            label: String,
+            type: GooglePayJsonFactory.DisplayItem.Type,
+            price: Long,
+        ) = GooglePayJsonFactory.DisplayItem(
+            label = label,
+            type = type,
+            price = price,
+        )
     }
 }


### PR DESCRIPTION
# Summary
Adds support for displaying line items in the Google Pay payment sheet, allowing merchants to show a detailed breakdown of charges including subtotals, taxes, and discounts.

# Motivation
Merchants need to display itemized pricing information in the Google Pay payment sheet to provide transparency to customers about what they're paying for. This feature enables showing individual line items alongside the total price.

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Added] Added support for Google Pay display items to show line item breakdowns in the payment sheet