### PR TITLE
Check if `createCardPresentSetupIntentCallback` has been implemented before using Terminal integration in `PaymentSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/CreateCardPresentSetupIntentCallbackRetriever.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/CreateCardPresentSetupIntentCallbackRetriever.kt
@@ -12,6 +12,8 @@ import javax.inject.Provider
 
 @OptIn(TapToAddPreview::class)
 internal interface CreateCardPresentSetupIntentCallbackRetriever {
+    fun hasCallback(): Boolean
+
     suspend fun waitForCallback(): CreateCardPresentSetupIntentCallback
 }
 
@@ -21,6 +23,10 @@ internal class DefaultCreateCardPresentSetupIntentCallbackRetriever @Inject cons
     requestOptionsProvider: Provider<ApiRequest.Options>,
     private val createCardPresentSetupIntentCallbackProvider: Provider<CreateCardPresentSetupIntentCallback?>
 ) : CallbackRetriever(errorReporter, requestOptionsProvider), CreateCardPresentSetupIntentCallbackRetriever {
+    override fun hasCallback(): Boolean {
+        return createCardPresentSetupIntentCallbackProvider.get() != null
+    }
+
     override suspend fun waitForCallback(): CreateCardPresentSetupIntentCallback {
         return waitForCallback(
             neededWaitEvent = SuccessEvent.FOUND_CREATE_CARD_PRESENT_SETUP_INTENT_CALLBACK_WHILE_POLLING,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -24,6 +24,7 @@ import com.stripe.stripeterminal.external.models.TapUseCase
 import com.stripe.stripeterminal.external.models.TerminalErrorCode
 import com.stripe.stripeterminal.external.models.TerminalException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
@@ -59,6 +60,7 @@ internal interface TapToAddConnectionManager {
             logger: Logger,
             paymentConfiguration: Provider<PaymentConfiguration>,
             workContext: CoroutineContext,
+            callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
         ): TapToAddConnectionManager {
             return if (isStripeTerminalSdkAvailable()) {
@@ -70,6 +72,7 @@ internal interface TapToAddConnectionManager {
                         errorReporter = errorReporter,
                         terminalWrapper = terminalWrapper,
                         logger = logger,
+                        callbackRetriever = callbackRetriever,
                         isSimulatedProvider = isSimulatedProvider,
                     ),
                     fatalErrorChecker = DefaultTapToAddFatalErrorChecker(),
@@ -84,12 +87,13 @@ internal interface TapToAddConnectionManager {
 
 @OptIn(TapToAddPreview::class)
 internal class DefaultTapToAddConnectionManager(
-    applicationContext: Context,
+    private val applicationContext: Context,
     private val workContext: CoroutineContext,
     private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val errorReporter: ErrorReporter,
     private val terminalWrapper: TerminalWrapper,
     private val logger: Logger,
+    private val callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
     isSimulatedProvider: TapToAddIsSimulatedProvider,
 ) : TapToAddConnectionManager, TerminalListener, TapToPayReaderListener {
     private var connectionTask: CompletableDeferred<Unit>? = null
@@ -102,51 +106,33 @@ internal class DefaultTapToAddConnectionManager(
 
     override val isSupported: Boolean
         get() {
+            if (!callbackRetriever.hasCallback()) {
+                return false
+            }
+
+            initializeIfNeeded()
+
             return terminal().supportsReadersOfType(
                 deviceType = DeviceType.TAP_TO_PAY_DEVICE,
                 discoveryConfiguration = discoveryConfiguration,
             ).isSupported
         }
 
-    init {
-        if (!terminalWrapper.isInitialized()) {
-            terminalWrapper.initTerminal(
-                context = applicationContext,
-                tokenProvider = object : ConnectionTokenProvider {
-                    override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
-                        callback.onSuccess(paymentConfiguration.get().publishableKey)
-                    }
-                },
-                listener = this,
-            )
-        }
-    }
-
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) = withContext(workContext) {
         runCatching {
-            if (!isSupported) {
-                throw IllegalStateException("Tap to Add is not supported by this device!")
-            }
-
-            if (terminal().connectedReader != null) {
-                return@withContext
-            }
-
-            val existingTask = connectionTaskLock.withLock {
-                return@withLock connectionTask ?: run {
-                    connectionTask = CompletableDeferred()
-                    null
+            when (val connectSetupResult = setup()) {
+                is ConnectSetupResult.AlreadyConnected -> Unit
+                is ConnectSetupResult.ExistingTask -> connectSetupResult.task.await()
+                is ConnectSetupResult.NotSupported -> {
+                    throw IllegalStateException("Tap to Add is not supported by this device!")
                 }
-            }
+                is ConnectSetupResult.CanStart -> {
+                    val discoverReadersResult = discoverReaders()
 
-            existingTask?.let { task ->
-                return@withContext task.await()
-            }
-
-            val discoverReadersResult = discoverReaders()
-
-            if (discoverReadersResult is DiscoverCallResult.CollectedReaders) {
-                connectReader(discoverReadersResult.readers, config)
+                    if (discoverReadersResult is DiscoverCallResult.CollectedReaders) {
+                        connectReader(discoverReadersResult.readers, config)
+                    }
+                }
             }
         }.fold(
             onSuccess = {
@@ -164,6 +150,26 @@ internal class DefaultTapToAddConnectionManager(
                 throw error
             }
         )
+    }
+
+    private suspend fun setup(): ConnectSetupResult {
+        return connectionTaskLock.withLock {
+            connectionTask?.let {
+                return@withLock ConnectSetupResult.ExistingTask(it)
+            }
+
+            if (!isSupported) {
+                return@withLock ConnectSetupResult.NotSupported
+            }
+
+            if (terminal().connectedReader != null) {
+                return@withLock ConnectSetupResult.AlreadyConnected
+            }
+
+            connectionTask = CompletableDeferred()
+
+            return@withLock ConnectSetupResult.CanStart
+        }
     }
 
     @SuppressLint("MissingPermission")
@@ -284,6 +290,20 @@ internal class DefaultTapToAddConnectionManager(
         )
     }
 
+    private fun initializeIfNeeded() {
+        if (!terminalWrapper.isInitialized()) {
+            terminalWrapper.initTerminal(
+                context = applicationContext,
+                tokenProvider = object : ConnectionTokenProvider {
+                    override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
+                        callback.onSuccess(paymentConfiguration.get().publishableKey)
+                    }
+                },
+                listener = this,
+            )
+        }
+    }
+
     private fun terminal() = terminalWrapper.getInstance()
 
     private fun Throwable.isAlreadyConnectedToReader(): Boolean {
@@ -308,6 +328,13 @@ internal class DefaultTapToAddConnectionManager(
         }
 
         logger.warning("TapToAddConnectionError: $error")
+    }
+
+    private sealed interface ConnectSetupResult {
+        data object CanStart : ConnectSetupResult
+        data object AlreadyConnected : ConnectSetupResult
+        data object NotSupported : ConnectSetupResult
+        class ExistingTask(val task: Deferred<Unit>) : ConnectSetupResult
     }
 
     private sealed interface DiscoverCallResult {

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
+import com.stripe.android.paymentelement.TapToAddPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import dagger.Binds
 import dagger.Module
@@ -38,7 +42,21 @@ internal interface TapToAddConnectionModule {
         isSimulatedProvider: DefaultTapToAddIsSimulatedProvider
     ): TapToAddIsSimulatedProvider
 
+    @Binds
+    fun bindsCreateCardPresentSetupIntentCallbackRetriever(
+        callbackRetriever: DefaultCreateCardPresentSetupIntentCallbackRetriever
+    ): CreateCardPresentSetupIntentCallbackRetriever
+
     companion object {
+        @OptIn(TapToAddPreview::class)
+        @Provides
+        fun providesCreateCardPresentSetupIntentCallback(
+            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
+        ): CreateCardPresentSetupIntentCallback? {
+            return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]
+                ?.createCardPresentSetupIntentCallback
+        }
+
         @Provides
         fun providesTerminalWrapper(): TerminalWrapper {
             return TerminalWrapper.create()
@@ -53,6 +71,7 @@ internal interface TapToAddConnectionModule {
             applicationContext: Context,
             paymentConfiguration: Provider<PaymentConfiguration>,
             @IOContext workContext: CoroutineContext,
+            callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
         ): TapToAddConnectionManager {
             return TapToAddConnectionManager.create(
@@ -63,6 +82,7 @@ internal interface TapToAddConnectionModule {
                 paymentConfiguration = paymentConfiguration,
                 isSimulatedProvider = isSimulatedProvider,
                 logger = logger,
+                callbackRetriever = callbackRetriever,
                 workContext = workContext,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
@@ -3,13 +3,9 @@ package com.stripe.android.common.taptoadd
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.TapToAddPreview
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 
@@ -19,44 +15,29 @@ import dagger.Provides
         TapToAddConnectionModule::class,
     ]
 )
-internal interface TapToAddModule {
-    @Binds
-    fun bindsCreateCardPresentSetupIntentCallbackRetriever(
-        retriever: DefaultCreateCardPresentSetupIntentCallbackRetriever
-    ): CreateCardPresentSetupIntentCallbackRetriever
-
-    companion object {
-        @Provides
-        fun providesCreateCardPresentSetupIntentCallback(
-            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
-        ): CreateCardPresentSetupIntentCallback? {
-            return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]
-                ?.createCardPresentSetupIntentCallback
-        }
-
-        @Provides
-        fun providesTapToAddCollectionHandler(
-            isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
-            connectionManager: TapToAddConnectionManager,
-            stripeRepository: StripeRepository,
-            paymentConfiguration: PaymentConfiguration,
-            terminalWrapper: TerminalWrapper,
-            tapToPayUxConfiguration: TapToPayUxConfiguration,
-            userFacingLogger: UserFacingLogger,
-            errorReporter: ErrorReporter,
-            createCardPresentSetupIntentCallbackRetriever: CreateCardPresentSetupIntentCallbackRetriever
-        ): TapToAddCollectionHandler {
-            return TapToAddCollectionHandler.create(
-                isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
-                connectionManager = connectionManager,
-                terminalWrapper = terminalWrapper,
-                stripeRepository = stripeRepository,
-                paymentConfiguration = paymentConfiguration,
-                tapToPayUxConfiguration = tapToPayUxConfiguration,
-                errorReporter = errorReporter,
-                userFacingLogger = userFacingLogger,
-                createCardPresentSetupIntentCallbackRetriever = createCardPresentSetupIntentCallbackRetriever,
-            )
-        }
+internal class TapToAddModule {
+    @Provides
+    fun providesTapToAddCollectionHandler(
+        isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
+        connectionManager: TapToAddConnectionManager,
+        stripeRepository: StripeRepository,
+        paymentConfiguration: PaymentConfiguration,
+        terminalWrapper: TerminalWrapper,
+        tapToPayUxConfiguration: TapToPayUxConfiguration,
+        userFacingLogger: UserFacingLogger,
+        errorReporter: ErrorReporter,
+        createCardPresentSetupIntentCallbackRetriever: CreateCardPresentSetupIntentCallbackRetriever
+    ): TapToAddCollectionHandler {
+        return TapToAddCollectionHandler.create(
+            isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
+            connectionManager = connectionManager,
+            terminalWrapper = terminalWrapper,
+            stripeRepository = stripeRepository,
+            paymentConfiguration = paymentConfiguration,
+            tapToPayUxConfiguration = tapToPayUxConfiguration,
+            errorReporter = errorReporter,
+            userFacingLogger = userFacingLogger,
+            createCardPresentSetupIntentCallbackRetriever = createCardPresentSetupIntentCallbackRetriever,
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
@@ -4,8 +4,6 @@ import com.stripe.android.common.taptoadd.TapToAddConnectionManager
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentelement.TapToAddPreview
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import javax.inject.Inject
 
 internal interface TapToAddAvailabilityFactory {
@@ -18,17 +16,11 @@ internal interface TapToAddAvailabilityFactory {
 @OptIn(TapToAddPreview::class)
 internal class DefaultTapToAddAvailabilityFactory @Inject constructor(
     private val connectionManager: TapToAddConnectionManager,
-    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
-
 ) : TapToAddAvailabilityFactory {
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
     ): Boolean {
-        return connectionManager.isSupported &&
-            elementsSession.isTapToAddEnabled &&
-            customerMetadata != null &&
-            PaymentElementCallbackReferences[paymentElementCallbackIdentifier]
-                ?.createCardPresentSetupIntentCallback != null
+        return connectionManager.isSupported && elementsSession.isTapToAddEnabled && customerMetadata != null
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.FakeErrorReporter
@@ -56,28 +57,6 @@ class DefaultTapToAddConnectionManagerTest {
         TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
 
     @Test
-    fun `init initializes terminal when not already initialized`() = test(
-        isInitialized = false,
-        autoCheckIsInitializedCall = false,
-    ) {
-        assertThat(wrapperScenario.isInitializedCalls.awaitItem()).isNotNull()
-
-        val initTerminalCall = wrapperScenario.initTerminalCalls.awaitItem()
-
-        assertThat(initTerminalCall.context).isEqualTo(context)
-        assertThat(initTerminalCall.listener).isEqualTo(manager)
-    }
-
-    @Test
-    fun `init does not initialize terminal when already initialized`() = test(
-        isInitialized = true,
-        autoCheckIsInitializedCall = false,
-    ) {
-        assertThat(wrapperScenario.isInitializedCalls.awaitItem()).isNotNull()
-        wrapperScenario.initTerminalCalls.expectNoEvents()
-    }
-
-    @Test
     fun `isSupported returns true when terminal supports tap to add`() = test(
         terminalInstance = mock {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
@@ -123,6 +102,19 @@ class DefaultTapToAddConnectionManagerTest {
         }
     ) {
         assertThat(manager.isSupported).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns false when callbackRetriever has no callback`() = test(
+        hasCallback = false,
+        autoCheckIsInitializedCall = false,
+        terminalInstance = mock {
+            mockSupportedReaderResult(ReaderSupportResult.Supported)
+        }
+    ) {
+        assertThat(manager.isSupported).isFalse()
+
+        wrapperScenario.isInitializedCalls.expectNoEvents()
     }
 
     @Test
@@ -692,10 +684,14 @@ class DefaultTapToAddConnectionManagerTest {
         terminalInstance: Terminal = mock(),
         autoCheckIsInitializedCall: Boolean = true,
         isSimulated: Boolean = true,
+        hasCallback: Boolean = true,
         block: suspend Scenario.() -> Unit
     ) = runTest(UnconfinedTestDispatcher()) {
         val errorReporter = FakeErrorReporter()
         val logger = FakeLogger()
+        val callbackRetriever = FakeCreateCardPresentSetupIntentCallbackRetriever(
+            hasCallback = hasCallback,
+        )
 
         TestTerminalWrapper.test(
             isInitialized = isInitialized,
@@ -712,7 +708,8 @@ class DefaultTapToAddConnectionManagerTest {
                         isSimulatedProvider = object : TapToAddIsSimulatedProvider {
                             override fun get(): Boolean = isSimulated
                         },
-                        paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_test") }
+                        paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_test") },
+                        callbackRetriever = callbackRetriever,
                     ),
                     terminalInstance = terminalInstance,
                     errorReporter = errorReporter,
@@ -740,4 +737,14 @@ class DefaultTapToAddConnectionManagerTest {
         val errorReporter: FakeErrorReporter,
         val wrapperScenario: TestTerminalWrapper.Scenario
     )
+
+    private class FakeCreateCardPresentSetupIntentCallbackRetriever(
+        private val hasCallback: Boolean,
+    ) : CreateCardPresentSetupIntentCallbackRetriever {
+        override fun hasCallback(): Boolean = hasCallback
+
+        override suspend fun waitForCallback(): CreateCardPresentSetupIntentCallback {
+            error("Not expected to be called in connection manager tests")
+        }
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -1173,6 +1173,8 @@ class TapToAddCollectionHandlerTest {
     ) : CreateCardPresentSetupIntentCallbackRetriever {
         private val waitForCallbackCalls = Turbine<Unit>()
 
+        override fun hasCallback(): Boolean = callbackResult.isSuccess
+
         override suspend fun waitForCallback(): CreateCardPresentSetupIntentCallback {
             waitForCallbackCalls.add(Unit)
             return callbackResult.getOrThrow()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -6,13 +6,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.TapToAddPreview
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
-import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.utils.FakeElementsSessionRepository.Companion.DEFAULT_ELEMENTS_SESSION_CONFIG_ID
 import com.stripe.android.utils.FakeElementsSessionRepository.Companion.DEFAULT_ELEMENTS_SESSION_ID
-import com.stripe.android.utils.PaymentElementCallbackTestRule
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,18 +15,10 @@ import org.robolectric.RobolectricTestRunner
 @OptIn(TapToAddPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultTapToAddAvailabilityFactoryTest {
-    @get:Rule
-    val paymentElementCallbackTestRule = PaymentElementCallbackTestRule()
-
     @Test
     fun `isAvailable is true when supported by connection manager, session flag on, and customer metadata present`() {
-        PaymentElementCallbackReferences[CALLBACK_IDENTIFIER] = PaymentElementCallbacks.Builder()
-            .createCardPresentSetupIntentCallback { CreateIntentResult.Success("seti_test_secret") }
-            .build()
-
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -50,7 +37,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
     fun `isAvailable is false when unsupported by connection manager`() {
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = false),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -69,7 +55,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
     fun `isAvailable is false when elements session disables tap to add`() {
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -88,7 +73,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
     fun `isAvailable is false when customer metadata is null`() {
         val factory = DefaultTapToAddAvailabilityFactory(
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
         )
 
         assertThat(
@@ -99,25 +83,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
-            )
-        ).isFalse()
-    }
-
-    @Test
-    fun `isAvailable is false when createCardPresentSetupIntentCallback is not registered`() {
-        val factory = DefaultTapToAddAvailabilityFactory(
-            connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-        )
-
-        assertThat(
-            factory.isAvailable(
-                elementsSession = elementsSession(
-                    flags = mapOf(
-                        ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to true,
-                    ),
-                ),
-                customerMetadata = DEFAULT_CUSTOMER_METADATA,
             )
         ).isFalse()
     }
@@ -146,9 +111,5 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
             accountId = "acct_test",
             merchantId = "acct_test",
         )
-    }
-
-    private companion object {
-        private const val CALLBACK_IDENTIFIER = "DefaultTapToAddAvailabilityFactoryTest"
     }
 }


### PR DESCRIPTION
# Summary
Check if `createCardPresentSetupIntentCallback` has been implemented before using Terminal integration in `PaymentSheet`

# Motivation
Ensure `Terminal` is not used when not required.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified