### PR TITLE
Payment Sheet Playground - Allow Unset SPM Parameters and Custom Customer ID

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1132,7 +1132,7 @@ internal class PlaygroundTestDriver(
                     }
                 }
             }
-            is CustomerType.Existing, is CustomerType.RETURNING -> {
+            is CustomerType.Existing, is CustomerType.RETURNING, is CustomerType.CUSTOM -> {
                 composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
                     composeTestRule.onAllNodesWithTag("AddCard")
                         .fetchSemanticsNodes()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.CollectPhoneS
 import com.stripe.android.paymentsheet.example.playground.settings.CollectionModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomCustomerIdSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomEndpointDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionOnBehalfOfSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
@@ -244,7 +245,11 @@ internal sealed interface PlaygroundState : Parcelable {
     }
 
     fun customerId(): String? {
-        return (snapshot[CustomerSettingsDefinition] as? CustomerType.Existing)?.value
+        return when (val customerType = snapshot[CustomerSettingsDefinition]) {
+            is CustomerType.Existing -> customerType.customerId
+            CustomerType.CUSTOM -> snapshot[CustomCustomerIdSettingsDefinition]
+            else -> null
+        }
     }
 
     companion object {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -309,9 +309,7 @@ class CheckoutRequest private constructor(
                 paymentMethodSaveFeature = paymentMethodSaveFeature,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodSetAsDefaultFeature = paymentMethodSetAsDefaultFeature,
-                paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature.takeIf {
-                    paymentMethodRemoveLastFeature == FeatureState.Enabled
-                },
+                paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,
                 paymentMethodOverrideRedisplay = paymentMethodOverrideRedisplay,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundSharedModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundSharedModel.kt
@@ -1,15 +1,19 @@
 package com.stripe.android.paymentsheet.example.playground.model
 
+import com.stripe.android.paymentsheet.example.playground.settings.ValueEnum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class FeatureState {
+enum class FeatureState(override val value: String) : ValueEnum {
     @SerialName("enabled")
-    Enabled,
+    Enabled("enabled"),
 
     @SerialName("disabled")
-    Disabled;
+    Disabled("disabled"),
+
+    @SerialName("unset")
+    Unset("unset");
 
     companion object {
         fun fromBoolean(value: Boolean): FeatureState {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/SharedPaymentTokenPlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/SharedPaymentTokenPlaygroundRequester.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.example.playground.model.SharedPaymentTok
 import com.stripe.android.paymentsheet.example.playground.model.SharedPaymentTokenCreateIntentResponse
 import com.stripe.android.paymentsheet.example.playground.model.SharedPaymentTokenCreateSessionRequest
 import com.stripe.android.paymentsheet.example.playground.model.SharedPaymentTokenCreateSessionResponse
+import com.stripe.android.paymentsheet.example.playground.settings.CustomCustomerIdSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
@@ -33,6 +34,7 @@ internal class SharedPaymentTokenPlaygroundRequester(
         val customerId = playgroundSnapshot[CustomerSettingsDefinition].run {
             when (this) {
                 is CustomerType.Existing -> customerId
+                CustomerType.CUSTOM -> playgroundSnapshot[CustomCustomerIdSettingsDefinition]
                 else -> null
             }
         }
@@ -89,6 +91,7 @@ internal class SharedPaymentTokenPlaygroundRequester(
         val customerId = playgroundSnapshot[CustomerSettingsDefinition].run {
             when (this) {
                 is CustomerType.Existing -> customerId
+                CustomerType.CUSTOM -> playgroundSnapshot[CustomCustomerIdSettingsDefinition]
                 else -> throw IllegalStateException("Cannot create SPT without en existing customer!")
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomCustomerIdSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomCustomerIdSettingsDefinition.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
+
+internal object CustomCustomerIdSettingsDefinition :
+    PlaygroundSettingDefinition<String>,
+    PlaygroundSettingDefinition.Saveable<String>,
+    PlaygroundSettingDefinition.Displayable<String> {
+    override val key: String = "customerId"
+    override val displayName: String = "Customer ID"
+    override val defaultValue: String = ""
+
+    override fun convertToString(value: String): String = value
+
+    override fun convertToValue(value: String): String = value
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = emptyList<PlaygroundSettingDefinition.Displayable.Option<String>>()
+
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[CustomerSettingsDefinition] == CustomerType.CUSTOM
+    }
+
+    override fun configure(value: String, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.customer(value)
+    }
+
+    override fun configure(
+        value: String,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        customerEphemeralKeyRequestBuilder.customerType(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveLastSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveLastSettingsDefinition.kt
@@ -4,11 +4,24 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 import com.stripe.android.paymentsheet.example.playground.model.FeatureState
 
-internal object CustomerSessionRemoveLastSettingsDefinition : BooleanSettingsDefinition(
-    defaultValue = true,
-    displayName = "Customer Session Remove Last Payment Method",
-    key = "customer_session_payment_method_remove"
-) {
+internal object CustomerSessionRemoveLastSettingsDefinition :
+    PlaygroundSettingDefinition<FeatureState>,
+    PlaygroundSettingDefinition.Saveable<FeatureState> by EnumSaveable(
+        key = "customer_session_payment_method_remove_last",
+        values = FeatureState.entries.toTypedArray(),
+        defaultValue = FeatureState.Enabled,
+    ),
+    PlaygroundSettingDefinition.Displayable<FeatureState> {
+    override val displayName: String = "Customer Session Remove Last Payment Method"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ): List<PlaygroundSettingDefinition.Displayable.Option<FeatureState>> {
+        return FeatureState.entries.map { featureState ->
+            option(name = featureState.name, value = featureState)
+        }
+    }
+
     override fun applicable(
         configurationData: PlaygroundConfigurationData,
         settings: Map<PlaygroundSettingDefinition<*>, Any?>,
@@ -20,11 +33,14 @@ internal object CustomerSessionRemoveLastSettingsDefinition : BooleanSettingsDef
         return settings[CustomerSessionSettingsDefinition] == true
     }
 
-    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        checkoutRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.fromBoolean(value))
+    override fun configure(value: FeatureState, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.paymentMethodRemoveLastFeature(value)
     }
 
-    override fun configure(value: Boolean, customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder) {
-        customerEphemeralKeyRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.fromBoolean(value))
+    override fun configure(
+        value: FeatureState,
+        customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
+    ) {
+        customerEphemeralKeyRequestBuilder.paymentMethodRemoveLastFeature(value)
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSetAsDefaultSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSetAsDefaultSettingsDefinition.kt
@@ -3,13 +3,26 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.FeatureState
 
-internal object CustomerSessionSetAsDefaultSettingsDefinition : BooleanSettingsDefinition(
-    defaultValue = false,
-    displayName = "Customer Session Set As Default Feature",
-    key = "customer_session_set_as_default"
-) {
-    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.fromBoolean(value))
+internal object CustomerSessionSetAsDefaultSettingsDefinition :
+    PlaygroundSettingDefinition<FeatureState>,
+    PlaygroundSettingDefinition.Saveable<FeatureState> by EnumSaveable(
+        key = "customer_session_set_as_default",
+        values = FeatureState.entries.toTypedArray(),
+        defaultValue = FeatureState.Disabled,
+    ),
+    PlaygroundSettingDefinition.Displayable<FeatureState> {
+    override val displayName: String = "Customer Session Set As Default Feature"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ): List<PlaygroundSettingDefinition.Displayable.Option<FeatureState>> {
+        return FeatureState.entries.map { featureState ->
+            option(name = featureState.name, value = featureState)
+        }
+    }
+
+    override fun configure(value: FeatureState, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(value)
     }
 
     override fun applicable(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
@@ -25,6 +25,8 @@ internal object CustomerSettingsDefinition :
             if (!configurationData.integrationType.isSptFlow()) {
                 add(option("Returning", CustomerType.RETURNING))
             }
+
+            add(option("Custom", CustomerType.CUSTOM))
         }
     }
 
@@ -32,14 +34,18 @@ internal object CustomerSettingsDefinition :
         value: CustomerType,
         checkoutRequestBuilder: CheckoutRequest.Builder,
     ) {
-        checkoutRequestBuilder.customer(value.backendParamValue)
+        if (value != CustomerType.CUSTOM) {
+            checkoutRequestBuilder.customer(value.backendParamValue)
+        }
     }
 
     override fun configure(
         value: CustomerType,
         customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
     ) {
-        customerEphemeralKeyRequestBuilder.customerType(value.backendParamValue)
+        if (value != CustomerType.CUSTOM) {
+            customerEphemeralKeyRequestBuilder.customerType(value.backendParamValue)
+        }
     }
 
     override fun configure(
@@ -82,6 +88,7 @@ internal object CustomerSettingsDefinition :
             CustomerType.GUEST.value to CustomerType.GUEST,
             CustomerType.NEW.value to CustomerType.NEW,
             CustomerType.RETURNING.value to CustomerType.RETURNING,
+            CustomerType.CUSTOM.value to CustomerType.CUSTOM,
         )
         return if (value.startsWith("cus_")) {
             CustomerType.Existing(value)
@@ -103,6 +110,8 @@ sealed class CustomerType(val value: String) {
     object NEW : CustomerType("new")
 
     object RETURNING : CustomerType("returning")
+
+    object CUSTOM : CustomerType("custom")
 
     class Existing(val customerId: String) : CustomerType(customerId) {
         override fun toString(): String {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -518,6 +518,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSessionOverrideRedisplaySettingsDefinition,
             CustomerSessionOnBehalfOfSettingsDefinition,
             CustomerSettingsDefinition,
+            CustomCustomerIdSettingsDefinition,
             CustomerEmailSettingsDefinition,
             CheckoutModeSettingsDefinition,
             UserCountryOverrideSettingsDefinition,


### PR DESCRIPTION
# Summary
This backend sandbox [PR](https://git.corp.stripe.com/stripe-internal/sandbox-apps/pull/1164) enables unset values to be passed for `payment_method_set_as_default` and `payment_method_remove_last`. Backend gates need to be enabled for a merchant to use these parameters. If these fields are included in the customer session params and the merchant is not included in those gates, the customer session request fails. There are other features of the customer session that are able to be tested when the merchant is not gated in, so this PR allows these values to remain unset and not sent from the backend sandbox to the customer session endpoint.

This PR also adds a custom customer ID text field to the playground sample app. This allows for testing with known customers IDs in the playground.

# Motivation
Link mobile is working on testing SPMs backed by Link LPM funding sources. Testing for this is (more easily) done using a custom merchant, that is not flagged into the gates mentioned above. Testing was a little tricky without creating a customer in CD2 and using it here. This custom customer textfield makes testing easier.

Matching parity with iOS PRs https://github.com/stripe/stripe-ios/pull/6410 and https://github.com/stripe/stripe-ios/pull/6415

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Follow the steps for Android in [this doc](http://go/th/trh_doc_UViTXMLmLxXvrr). You won't be able see LPMs but with that customer ID entered, you should see a Link-funded card SPM.