### PR TITLE
Fetch saved payment methods in parallel with elements session load (for EKs)

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -339,6 +339,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION(
             partialEventName = "card_art_prefetch.invoked_for_confirmation"
+        ),
+        PREFETCHED_PMS_NULL_FOR_EPHEMERAL_KEY(
+            partialEventName = "payment_methods_prefetch.null_for_ephemeral_key"
         );
 
         override val eventName: String

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -5,6 +5,7 @@ import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -288,10 +289,16 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
         }
         networkRule.setupV1PaymentMethodsResponse(card1, card2)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
 
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(
@@ -360,10 +367,16 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
         }
         networkRule.setupV1PaymentMethodsResponse(card1, card2)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
 
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(
@@ -414,10 +427,16 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
         }
         networkRule.setupV1PaymentMethodsResponse(card1, card2)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
 
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementImmediateActionRowSelectionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementImmediateActionRowSelectionTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement
 import androidx.test.espresso.Espresso
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -447,6 +448,8 @@ internal class EmbeddedPaymentElementImmediateActionRowSelectionTest {
             }
             if (shouldSetupV1PaymentMethodsResponse) {
                 networkRule.setupV1PaymentMethodsResponse(card1, card2)
+                networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+                networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
             }
             testBlock(testContext)
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -128,6 +128,8 @@ internal class EmbeddedPaymentElementTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
         }
         networkRule.setupV1PaymentMethodsResponse(card1, card2)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.configure {
             customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
@@ -164,6 +166,8 @@ internal class EmbeddedPaymentElementTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
         }
         networkRule.setupV1PaymentMethodsResponse(card1)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.configure {
             customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
@@ -203,6 +207,8 @@ internal class EmbeddedPaymentElementTest {
                 response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
             }
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
             testContext.configure {
                 customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -361,8 +362,14 @@ internal class FlowControllerAnalyticsTest {
         }
 
         networkRule.setupV1PaymentMethodsResponse(card1, card2)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "mc_custom_sheet_savedpm_show")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -959,23 +959,8 @@ internal class FlowControllerTest {
             response.testBodyFromFile("payment-methods-get-success.json")
         }
 
-        networkRule.enqueue(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/payment_methods"),
-            query("type", PaymentMethod.Type.USBankAccount.code)
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-
-        networkRule.enqueue(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/payment_methods"),
-            query("type", PaymentMethod.Type.SepaDebit.code)
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.configureFlowController {
             configureWithPaymentIntent(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -20,6 +20,7 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -47,6 +48,7 @@ import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_MANAGE_SCREEN_SAVED
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_VIEW_MORE
+import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Rule
@@ -882,9 +884,13 @@ internal class FlowControllerTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
+            query("type", PaymentMethod.Type.Card.code)
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.configureFlowController {
             configureWithPaymentIntent(
@@ -948,8 +954,27 @@ internal class FlowControllerTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
+            query("type", PaymentMethod.Type.Card.code)
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+            query("type", PaymentMethod.Type.USBankAccount.code)
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
+
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+            query("type", PaymentMethod.Type.SepaDebit.code)
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
         }
 
         testContext.configureFlowController {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -436,23 +436,8 @@ internal class LinkTest {
                 response.testBodyFromFile("payment-methods-get-success-empty.json")
             }
 
-            networkRule.enqueue(
-                host("api.stripe.com"),
-                method("GET"),
-                path("/v1/payment_methods"),
-                query("type", PaymentMethod.Type.USBankAccount.code)
-            ) { response ->
-                response.testBodyFromFile("payment-methods-get-success-empty.json")
-            }
-
-            networkRule.enqueue(
-                host("api.stripe.com"),
-                method("GET"),
-                path("/v1/payment_methods"),
-                query("type", PaymentMethod.Type.SepaDebit.code)
-            ) { response ->
-                response.testBodyFromFile("payment-methods-get-success-empty.json")
-            }
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
             networkRule.enqueue(
                 method("POST"),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -5,6 +5,7 @@ import androidx.test.espresso.Espresso.closeSoftKeyboard
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.link.account.DefaultLinkStore
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -15,6 +16,7 @@ import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.RequestMatchers.query
 import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.ProductIntegrationType
@@ -22,6 +24,7 @@ import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -143,9 +146,13 @@ internal class LinkTest {
                 host("api.stripe.com"),
                 method("GET"),
                 path("/v1/payment_methods"),
+                query("type", PaymentMethod.Type.Card.code)
             ) { response ->
                 response.testBodyFromFile("payment-methods-get-success-empty.json")
             }
+
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
             networkRule.enqueue(
                 method("POST"),
@@ -424,6 +431,25 @@ internal class LinkTest {
                 host("api.stripe.com"),
                 method("GET"),
                 path("/v1/payment_methods"),
+                query("type", PaymentMethod.Type.Card.code)
+            ) { response ->
+                response.testBodyFromFile("payment-methods-get-success-empty.json")
+            }
+
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("GET"),
+                path("/v1/payment_methods"),
+                query("type", PaymentMethod.Type.USBankAccount.code)
+            ) { response ->
+                response.testBodyFromFile("payment-methods-get-success-empty.json")
+            }
+
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("GET"),
+                path("/v1/payment_methods"),
+                query("type", PaymentMethod.Type.SepaDebit.code)
             ) { response ->
                 response.testBodyFromFile("payment-methods-get-success-empty.json")
             }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
@@ -331,9 +332,16 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("elements-sessions-requires_cvc_recollection.json")
         }
         networkRule.setupV1PaymentMethodsResponse(card1, card2)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+
         validateAnalyticsRequest(eventName = "mc_complete_init")
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
         validateAnalyticsRequest(eventName = "mc_load_succeeded")
         validateAnalyticsRequest(eventName = "mc_complete_sheet_savedpm_show")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
+import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -16,6 +18,7 @@ import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import org.junit.Rule
 import org.junit.Test
 
@@ -131,6 +134,9 @@ internal class PaymentSheetConfirmationTokenTest {
             ) { response ->
                 response.testBodyFromFile("payment-methods-get-success.json")
             }
+
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         }
 
         testContext.presentPaymentSheet {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
@@ -3,7 +3,9 @@ package com.stripe.android.paymentsheet
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -18,6 +20,7 @@ import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.expectNoResult
 import com.stripe.android.paymentsheet.utils.runMultiplePaymentSheetInstancesTest
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -187,6 +190,9 @@ internal class PaymentSheetDeferredTest {
             response.testBodyFromFile("payment-methods-get-success.json")
         }
 
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+
         testContext.presentPaymentSheet {
             presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -243,6 +249,9 @@ internal class PaymentSheetDeferredTest {
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success-empty.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.presentPaymentSheet {
             presentWithIntentConfiguration(
@@ -326,6 +335,9 @@ internal class PaymentSheetDeferredTest {
             response.testBodyFromFile("payment-methods-get-success.json")
         }
 
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+
         testContext.presentPaymentSheet {
             presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -385,6 +397,9 @@ internal class PaymentSheetDeferredTest {
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success-empty.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.presentPaymentSheet {
             presentWithIntentConfiguration(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.utils.assertFailed
 import com.stripe.android.paymentsheet.utils.expectNoResult
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import com.stripe.paymentelementtestpages.FormPage
 import okhttp3.mockwebserver.SocketPolicy
 import org.json.JSONArray
@@ -458,9 +459,13 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
+            query("type", PaymentMethod.Type.Card.code)
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
@@ -594,6 +599,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("payment-methods-get-success-us-bank.json")
         }
 
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
@@ -657,6 +664,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("payment-methods-get-success-us-bank.json")
         }
 
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
+
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
@@ -706,6 +715,8 @@ internal class PaymentSheetTest {
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         networkRule.enqueue(
             host("api.stripe.com"),
@@ -795,9 +806,13 @@ internal class PaymentSheetTest {
             host("api.stripe.com"),
             method("GET"),
             path("/v1/payment_methods"),
+            query("type", PaymentMethod.Type.Card.code)
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
@@ -940,6 +955,9 @@ internal class PaymentSheetTest {
         ) { response ->
             response.testBodyFromFile("payment-methods-get-success.json")
         }
+
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+        networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
 
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -5,6 +5,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import kotlinx.coroutines.Deferred
@@ -19,6 +20,7 @@ internal data class CustomerState(
 
 internal class CreateCustomerState @Inject constructor(
     private val paymentMethodFilter: PaymentMethodFilter,
+    private val errorReporter: ErrorReporter,
 ) {
     suspend operator fun invoke(
         initializationMode: PaymentElementLoader.InitializationMode,
@@ -112,7 +114,7 @@ internal class CreateCustomerState @Inject constructor(
         prefetchedPaymentMethods: PrefetchedPaymentMethods?,
     ): List<PaymentMethod> {
         if (prefetchedPaymentMethods == null) {
-            // TODO: unexpected error.
+            errorReporter.report(ErrorReporter.UnexpectedErrorEvent.PREFETCHED_PMS_NULL_FOR_EPHEMERAL_KEY)
             return emptyList()
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -7,7 +7,6 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.Deferred
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -19,7 +18,6 @@ internal data class CustomerState(
 ) : Parcelable
 
 internal class CreateCustomerState @Inject constructor(
-    private val customerRepository: CustomerRepository,
     private val paymentMethodFilter: PaymentMethodFilter,
 ) {
     suspend operator fun invoke(
@@ -27,7 +25,7 @@ internal class CreateCustomerState @Inject constructor(
         elementsSession: ElementsSession,
         metadata: PaymentMethodMetadata,
         savedSelection: Deferred<SavedSelection>,
-        prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods?,
     ): CustomerState? {
         val customerMetadata = metadata.customerMetadata
         val customerState = when (customerMetadata) {
@@ -49,10 +47,9 @@ internal class CreateCustomerState @Inject constructor(
                 }
             }
             is CustomerMetadata.LegacyEphemeralKey -> {
-                createForLegacyEphemeralKey(
+               createForLegacyEphemeralKey(
                     paymentMethods = retrieveCustomerPaymentMethods(
                         metadata = metadata,
-                        customerMetadata = customerMetadata,
                         prefetchedPaymentMethods = prefetchedPaymentMethods,
                     )
                 )
@@ -112,18 +109,16 @@ internal class CreateCustomerState @Inject constructor(
 
     private suspend fun retrieveCustomerPaymentMethods(
         metadata: PaymentMethodMetadata,
-        customerMetadata: CustomerMetadata.LegacyEphemeralKey,
-        prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods?,
     ): List<PaymentMethod> {
+        if (prefetchedPaymentMethods == null) {
+            // TODO: unexpected error.
+            return emptyList()
+        }
+
         val paymentMethodTypes = metadata.supportedSavedPaymentMethodTypes()
 
-        val paymentMethods = prefetchedPaymentMethods?.await()?.getOrThrow()
-            ?: customerRepository.getPaymentMethods(
-                customerId = customerMetadata.id,
-                ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
-                types = paymentMethodTypes,
-                silentlyFail = metadata.stripeIntent.isLiveMode,
-            ).getOrThrow()
+        val paymentMethods = prefetchedPaymentMethods.await().getOrThrow()
 
         return paymentMethods.filter { paymentMethod ->
             paymentMethod.hasExpectedDetails() &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -27,6 +27,7 @@ internal class CreateCustomerState @Inject constructor(
         elementsSession: ElementsSession,
         metadata: PaymentMethodMetadata,
         savedSelection: Deferred<SavedSelection>,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
     ): CustomerState? {
         val customerMetadata = metadata.customerMetadata
         val customerState = when (customerMetadata) {
@@ -52,6 +53,7 @@ internal class CreateCustomerState @Inject constructor(
                     paymentMethods = retrieveCustomerPaymentMethods(
                         metadata = metadata,
                         customerMetadata = customerMetadata,
+                        prefetchedPaymentMethods = prefetchedPaymentMethods,
                     )
                 )
             }
@@ -111,18 +113,21 @@ internal class CreateCustomerState @Inject constructor(
     private suspend fun retrieveCustomerPaymentMethods(
         metadata: PaymentMethodMetadata,
         customerMetadata: CustomerMetadata.LegacyEphemeralKey,
+        prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
     ): List<PaymentMethod> {
         val paymentMethodTypes = metadata.supportedSavedPaymentMethodTypes()
 
-        val paymentMethods = customerRepository.getPaymentMethods(
-            customerId = customerMetadata.id,
-            ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
-            types = paymentMethodTypes,
-            silentlyFail = metadata.stripeIntent.isLiveMode,
-        ).getOrThrow()
+        val paymentMethods = prefetchedPaymentMethods?.await()?.getOrThrow()
+            ?: customerRepository.getPaymentMethods(
+                customerId = customerMetadata.id,
+                ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
+                types = paymentMethodTypes,
+                silentlyFail = metadata.stripeIntent.isLiveMode,
+            ).getOrThrow()
 
         return paymentMethods.filter { paymentMethod ->
-            paymentMethod.hasExpectedDetails()
+            paymentMethod.hasExpectedDetails() &&
+                paymentMethodTypes.contains(paymentMethod.type)
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -425,7 +425,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
         configuration: CommonConfiguration,
-    ): Deferred<Result<List<PaymentMethod>>>? {
+    ): PrefetchedPaymentMethods? {
         val customer = configuration.customer ?: return null
         val accessType = customer.accessType
         if (accessType !is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey) return null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -44,10 +44,12 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.model.validate
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository
 import com.stripe.attestation.IntegrityRequestManager
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
@@ -230,6 +232,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val paymentConfiguration: Provider<PaymentConfiguration>,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val analyticsMetadataFactory: AnalyticsMetadataFactory,
+    private val customerRepository: CustomerRepository,
     private val createCustomerState: CreateCustomerState,
     private val checkoutSessionLoader: CheckoutSessionLoader,
     private val elementsSessionLoader: ElementsSessionLoader,
@@ -284,6 +287,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 configuration.isGooglePayReady()
             }
         }
+
+        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
         val elementsSession = loadSession(
@@ -363,6 +368,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     elementsSession = elementsSession,
                     metadata = paymentMethodMetadata,
                     savedSelection = savedSelection,
+                    prefetchedPaymentMethods = prefetchedPaymentMethods,
                 )
             }
         }
@@ -415,6 +421,29 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         )
 
         return@runCatching state
+    }
+
+    private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
+        configuration: CommonConfiguration,
+    ): Deferred<Result<List<PaymentMethod>>>? {
+        val customer = configuration.customer ?: return null
+        val accessType = customer.accessType
+        if (accessType !is PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey) return null
+
+        return async {
+            durationProvider.measureDuration(DurationProvider.Key.PaymentSheetLoadPrefetchPMs) {
+                customerRepository.getPaymentMethods(
+                    customerId = customer.id,
+                    ephemeralKeySecret = accessType.ephemeralKeySecret,
+                    types = listOf(
+                        PaymentMethod.Type.Card,
+                        PaymentMethod.Type.SepaDebit,
+                        PaymentMethod.Type.USBankAccount,
+                    ),
+                    silentlyFail = paymentConfiguration.get().isLiveMode(),
+                )
+            }
+        }
     }
 
     private suspend fun loadSession(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -439,7 +439,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.Card,
                         PaymentMethod.Type.SepaDebit,
                         PaymentMethod.Type.USBankAccount,
-                    ),
+                    ), // These are the only payment method types we support as saved payment methods.
                     silentlyFail = paymentConfiguration.get().isLiveMode(),
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethods.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethods.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.paymentsheet.state
+
+import com.stripe.android.model.PaymentMethod
+import kotlinx.coroutines.Deferred
+
+internal typealias PrefetchedPaymentMethods = Deferred<Result<List<PaymentMethod>>>

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.elementsSession
@@ -95,6 +96,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card"))
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -122,6 +125,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card"))
             networkRule.setupV1PaymentMethodsResponse(type = "card")
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertIsNotVisible()
@@ -151,6 +156,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse(lpms = listOf("card"))
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -172,6 +179,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
             networkRule.setupPaymentMethodDetachResponse("pm_12345")
         },
     ) {
@@ -202,6 +211,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
             networkRule.setupPaymentMethodDetachResponse("pm_12345")
             networkRule.setupPaymentMethodDetachResponse("pm_67890")
         },
@@ -232,6 +243,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
             networkRule.setupPaymentMethodDetachResponse("pm_12345")
         },
     ) {
@@ -256,6 +269,8 @@ internal class VerticalModePaymentSheetActivityTest {
                 card1.copy(addCbcNetworks = true),
                 card2.copy(addCbcNetworks = true)
             )
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
             networkRule.setupPaymentMethodUpdateResponse(paymentMethodDetails = card1, cardBrand = "visa")
         },
     ) {
@@ -288,6 +303,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -314,6 +331,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -348,6 +367,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -363,6 +384,7 @@ internal class VerticalModePaymentSheetActivityTest {
             setupElementsSessionsResponse(lpms = listOf("card", "us_bank_account"))
             networkRule.setupV1PaymentMethodsResponse(usBankAccount1)
             networkRule.setupV1PaymentMethodsResponse(card1, card2)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -398,6 +420,7 @@ internal class VerticalModePaymentSheetActivityTest {
             setupElementsSessionsResponse(lpms = listOf("card", "us_bank_account"))
             networkRule.setupV1PaymentMethodsResponse(usBankAccount1)
             networkRule.setupV1PaymentMethodsResponse(type = "card")
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -413,6 +436,7 @@ internal class VerticalModePaymentSheetActivityTest {
             setupElementsSessionsResponse(lpms = listOf("card", "us_bank_account"))
             networkRule.setupV1PaymentMethodsResponse(usBankAccount1, usBankAccount2)
             networkRule.setupV1PaymentMethodsResponse(type = "card")
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()
@@ -472,6 +496,8 @@ internal class VerticalModePaymentSheetActivityTest {
         networkSetup = {
             setupElementsSessionsResponse()
             networkRule.setupV1PaymentMethodsResponse(card1)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         // Saved Visa card should be filtered out
@@ -493,6 +519,8 @@ internal class VerticalModePaymentSheetActivityTest {
                 card1.copy(addCbcNetworks = true, brand = CardBrand.CartesBancaires),
                 card2.copy(addCbcNetworks = true, brand = CardBrand.CartesBancaires)
             )
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.USBankAccount.code)
+            networkRule.setupV1PaymentMethodsResponse(type = PaymentMethod.Type.SepaDebit.code)
         },
     ) {
         verticalModePage.assertHasSavedPaymentMethods()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakePaymentMethodFilter
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
@@ -131,22 +130,19 @@ internal class CreateCustomerStateTest {
     }
 
     @Test
-    fun `Legacy ephemeral key calls repository and sets null default`() = runScenario(
-        customerRepository = FakeCustomerRepository(
-            paymentMethods = PaymentMethodFactory.cards(3),
-        ),
-    ) {
+    fun `Legacy ephemeral key uses prefetched payment methods and sets null default`() = runScenario {
+        val prefetchedPaymentMethods = CompletableDeferred(
+            Result.success(PaymentMethodFactory.cards(3))
+        )
+
         val result = createCustomerState(
             customerMetadata = LEGACY_EK_METADATA,
+            prefetchedPaymentMethods = prefetchedPaymentMethods,
         )
 
         assertThat(result).isNotNull()
         assertThat(result!!.paymentMethods).hasSize(3)
         assertThat(result.defaultPaymentMethodId).isNull()
-
-        val request = customerRepository.getPaymentMethodsRequests.awaitItem()
-        assertThat(request.customerId).isEqualTo("cus_1")
-        assertThat(request.ephemeralKeySecret).isEqualTo("ek_123")
     }
 
     @Test
@@ -163,7 +159,6 @@ internal class CreateCustomerStateTest {
 
         FakePaymentMethodFilter.test(filteredPaymentMethods = filteredCards) {
             val createCustomerState = CreateCustomerState(
-                customerRepository = customerRepository,
                 paymentMethodFilter = paymentMethodFilter,
             )
 
@@ -186,20 +181,15 @@ internal class CreateCustomerStateTest {
     }
 
     private fun runScenario(
-        customerRepository: FakeCustomerRepository = FakeCustomerRepository(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        Scenario(customerRepository = customerRepository).apply {
+        Scenario().apply {
             block()
-            customerRepository.ensureAllEventsConsumed()
         }
     }
 
-    private inner class Scenario(
-        val customerRepository: FakeCustomerRepository,
-    ) {
+    private class Scenario {
         private val createCustomerStateImpl = CreateCustomerState(
-            customerRepository = customerRepository,
             paymentMethodFilter = FakePaymentMethodFilter.noOp(),
         )
 
@@ -211,6 +201,7 @@ internal class CreateCustomerStateTest {
             metadata: com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata =
                 PaymentMethodMetadataFactory.create().copy(customerMetadata = customerMetadata),
             savedSelection: CompletableDeferred<SavedSelection> = CompletableDeferred(SavedSelection.None),
+            prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
         ): CustomerState? {
             val session = if (elementsSessionCustomer != elementsSession.customer) {
                 elementsSession.copy(customer = elementsSessionCustomer)
@@ -223,6 +214,7 @@ internal class CreateCustomerStateTest {
                 elementsSession = session,
                 metadata = metadata,
                 savedSelection = savedSelection,
+                prefetchedPaymentMethods = prefetchedPaymentMethods,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakePaymentMethodFilter
 import kotlinx.coroutines.CompletableDeferred
@@ -146,6 +147,23 @@ internal class CreateCustomerStateTest {
     }
 
     @Test
+    fun `Legacy ephemeral key filters payment methods by supported type`() = runScenario {
+        val cards = PaymentMethodFactory.cards(2)
+        val paymentMethods = cards + listOf(
+            PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+            PaymentMethodFixtures.AU_BECS_DEBIT,
+        )
+
+        val result = createCustomerState(
+            customerMetadata = LEGACY_EK_METADATA,
+            prefetchedPaymentMethods = CompletableDeferred(Result.success(paymentMethods)),
+        )
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.paymentMethods).containsExactlyElementsIn(cards)
+    }
+
+    @Test
     fun `Null customerMetadata returns null`() = runScenario {
         val result = createCustomerState(customerMetadata = null)
 
@@ -160,6 +178,7 @@ internal class CreateCustomerStateTest {
         FakePaymentMethodFilter.test(filteredPaymentMethods = filteredCards) {
             val createCustomerState = CreateCustomerState(
                 paymentMethodFilter = paymentMethodFilter,
+                errorReporter = FakeErrorReporter(),
             )
 
             val result = createCustomerState(
@@ -191,6 +210,7 @@ internal class CreateCustomerStateTest {
     private class Scenario {
         private val createCustomerStateImpl = CreateCustomerState(
             paymentMethodFilter = FakePaymentMethodFilter.noOp(),
+            errorReporter = FakeErrorReporter(),
         )
 
         suspend fun createCustomerState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
@@ -176,11 +176,6 @@ internal class CreateCustomerStateTest {
         val filteredCards = cards.take(1)
 
         FakePaymentMethodFilter.test(filteredPaymentMethods = filteredCards) {
-            val createCustomerState = CreateCustomerState(
-                paymentMethodFilter = paymentMethodFilter,
-                errorReporter = FakeErrorReporter(),
-            )
-
             val result = createCustomerState(
                 initializationMode = DEFAULT_INITIALIZATION_MODE,
                 elementsSession = DEFAULT_ELEMENTS_SESSION.copy(
@@ -189,6 +184,7 @@ internal class CreateCustomerStateTest {
                 metadata = PaymentMethodMetadataFactory.create()
                     .copy(customerMetadata = CUSTOMER_SESSION_METADATA),
                 savedSelection = CompletableDeferred(SavedSelection.None),
+                paymentMethodFilter = paymentMethodFilter,
             )
 
             assertThat(result).isNotNull()
@@ -208,10 +204,6 @@ internal class CreateCustomerStateTest {
     }
 
     private class Scenario {
-        private val createCustomerStateImpl = CreateCustomerState(
-            paymentMethodFilter = FakePaymentMethodFilter.noOp(),
-            errorReporter = FakeErrorReporter(),
-        )
 
         suspend fun createCustomerState(
             initializationMode: PaymentElementLoader.InitializationMode = DEFAULT_INITIALIZATION_MODE,
@@ -222,12 +214,18 @@ internal class CreateCustomerStateTest {
                 PaymentMethodMetadataFactory.create().copy(customerMetadata = customerMetadata),
             savedSelection: CompletableDeferred<SavedSelection> = CompletableDeferred(SavedSelection.None),
             prefetchedPaymentMethods: PrefetchedPaymentMethods? = null,
+            paymentMethodFilter: PaymentMethodFilter = FakePaymentMethodFilter.noOp(),
         ): CustomerState? {
             val session = if (elementsSessionCustomer != elementsSession.customer) {
                 elementsSession.copy(customer = elementsSessionCustomer)
             } else {
                 elementsSession
             }
+
+            val createCustomerStateImpl = CreateCustomerState(
+                paymentMethodFilter = paymentMethodFilter,
+                errorReporter = FakeErrorReporter(),
+            )
 
             return createCustomerStateImpl(
                 initializationMode = initializationMode,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -4624,9 +4624,9 @@ internal class DefaultPaymentElementLoaderTest {
             tapToAddConnectionStarter = tapToAddConnectionStarter,
             paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
             createCustomerState = CreateCustomerState(
-                customerRepository = customerRepo,
                 paymentMethodFilter = paymentMethodFilter,
             ),
+            customerRepository = customerRepo,
             checkoutSessionLoader = CheckoutSessionLoader(),
             elementsSessionLoader = ElementsSessionLoader(
                 elementsSessionRepository = elementsSessionRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -787,7 +787,11 @@ internal class DefaultPaymentElementLoaderTest {
             )
 
             val request = customerRepository.getPaymentMethodsRequests.awaitItem()
-            assertThat(request.types).containsExactly(PaymentMethod.Type.Card)
+            assertThat(request.types).containsExactly(
+                PaymentMethod.Type.Card,
+                PaymentMethod.Type.SepaDebit,
+                PaymentMethod.Type.USBankAccount
+            )
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -817,7 +821,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
 
             val request = customerRepository.getPaymentMethodsRequests.awaitItem()
-            assertThat(request.types).containsExactly(PaymentMethod.Type.Card)
+            assertThat(request.types).doesNotContain(PaymentMethod.Type.AuBecsDebit)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -953,7 +957,11 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
             )
         assertThat(requestPaymentMethodTypes)
-            .containsExactly(PaymentMethod.Type.Card, PaymentMethod.Type.SepaDebit)
+            .containsExactly(
+                PaymentMethod.Type.Card,
+                PaymentMethod.Type.SepaDebit,
+                PaymentMethod.Type.USBankAccount,
+            )
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -3168,6 +3168,49 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
+    fun `When using 'LegacyEphemeralKey', payment methods should be filtered by supported saved payment methods`() =
+        runScenario {
+            val paymentMethods = PaymentMethodFixtures.createCards(2) +
+                listOf(
+                    PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+                    PaymentMethodFixtures.AU_BECS_DEBIT,
+                )
+
+            val loader = createPaymentElementLoader(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("card")
+                ),
+                customerRepo = FakeCustomerRepository(paymentMethods = paymentMethods),
+            )
+
+            val result = loader.load(
+                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("secret"),
+                paymentSheetConfiguration = mockConfiguration(
+                    customer = PaymentSheet.CustomerConfiguration(
+                        id = "id",
+                        ephemeralKeySecret = "ek_123",
+                    ),
+                    allowsDelayedPaymentMethods = true,
+                ),
+                metadata = PaymentElementLoader.Metadata(
+                    initializedViaCompose = false,
+                ),
+            ).getOrThrow()
+
+            val expectedPaymentMethods = paymentMethods.filter { paymentMethod ->
+                paymentMethod.type?.code == PaymentMethod.Type.Card.code
+            }
+
+            assertThat(result.customer?.paymentMethods)
+                .containsExactlyElementsIn(expectedPaymentMethods)
+
+            consumeLoadingEvents()
+
+            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+        }
+
+    @Test
     fun `When using 'CustomerSession', pass last-used customer payment method to filter`() = runFilterScenario {
         val paymentMethods = PaymentMethodFixtures.createCards(10)
         val lastUsed = paymentMethods[6]
@@ -4625,6 +4668,7 @@ internal class DefaultPaymentElementLoaderTest {
             paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
             createCustomerState = CreateCustomerState(
                 paymentMethodFilter = paymentMethodFilter,
+                errorReporter = errorReporter,
             ),
             customerRepository = customerRepo,
             checkoutSessionLoader = CheckoutSessionLoader(),

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -26,6 +26,7 @@ interface DurationProvider {
         PaymentSheetLoadIsGooglePayReady,
         PaymentSheetLoadRetrieveSavedPaymentMethodSelection,
         PaymentSheetLoadSessionLoad,
+        PaymentSheetLoadPrefetchPMs,
         PaymentSheetLoadCreateLinkState,
         PaymentSheetLoadCreateCustomerState,
         PaymentSheetLoadRetrieveInitialPaymentSelection,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fetch saved payment methods in parallel with elements session load (for EKs)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improve loading latency by parallelizing these requests rather than doing them in sequence. 

Traces show the improvement:
- [Before](https://pages.stripe.me/doudou/diagrams.html?diagram=Z2FudHQKICAgIHRpdGxlIFBheW1lbnRTaGVldCBEdXJhdGlvbiBUcmFjZSAtIGFjZDZkMzNmMWUKICAgIGRhdGVGb3JtYXQgeAoKICAgIHNlY3Rpb24gVGVzdCBMaW5rIE9mZiBXaXRoIEVrIChMYXRlbmN5IDQ4OG1zKQogICAgTG9hZGluZyAoNDg4bXMpIDp0MCwgMCwgNDg4CiAgICBTZXNzaW9uIExvYWQgKDM2MW1zKSA6dDEsIDMsIDM2NAogICAgSXMgR29vZ2xlIFBheSBTdXBwb3J0ZWQgKDEzbXMpIDp0MiwgMywgMTYKICAgIElzIEdvb2dsZSBQYXkgUmVhZHkgKDFtcykgOnQzLCAzLCA0CiAgICBDcmVhdGUgTGluayBTdGF0ZSAoMW1zKSA6dDQsIDM2NSwgMzY2CiAgICBSZXRyaWV2ZSBTYXZlZCBQYXltZW50IE1ldGhvZCBTZWxlY3Rpb24gKDBtcykgOnQ1LCAzNjUsIDM2NgogICAgQ3JlYXRlIEN1c3RvbWVyIFN0YXRlICgxMDNtcykgOnQ2LCAzNzksIDQ4MgogICAgUmV0cmlldmUgSW5pdGlhbCBQYXltZW50IFNlbGVjdGlvbiAoMW1zKSA6dDcsIDQ4MiwgNDgzCiAgICBQcmVwYXJlIEF0dGVzdGF0aW9uICg3bXMpIDp0OCwgNDk4LCA1MDUKCiAgICBzZWN0aW9uIFRlc3QgTGluayBPbiBXaXRoIEVrIChMYXRlbmN5IDEyOThtcykKICAgIExvYWRpbmcgKDEyOThtcykgOnQ5LCAwLCAxMjk4CiAgICBTZXNzaW9uIExvYWQgKDM5NG1zKSA6dDEwLCA1LCAzOTkKICAgIElzIEdvb2dsZSBQYXkgU3VwcG9ydGVkICgxM21zKSA6dDExLCAxNCwgMjcKICAgIElzIEdvb2dsZSBQYXkgUmVhZHkgKDBtcykgOnQxMiwgMTQsIDE1CiAgICBDcmVhdGUgTGluayBTdGF0ZSAoNzQ4bXMpIDp0MTMsIDQwMCwgMTE0OAogICAgUmV0cmlldmUgU2F2ZWQgUGF5bWVudCBNZXRob2QgU2VsZWN0aW9uICgybXMpIDp0MTQsIDQwMCwgNDAyCiAgICBDcmVhdGUgQ3VzdG9tZXIgU3RhdGUgKDExOW1zKSA6dDE1LCAxMTcxLCAxMjkwCiAgICBSZXRyaWV2ZSBJbml0aWFsIFBheW1lbnQgU2VsZWN0aW9uICgwbXMpIDp0MTYsIDEyOTEsIDEyOTIKICAgIFByZXBhcmUgQXR0ZXN0YXRpb24gKDFtcykgOnQxNywgMTMwOCwgMTMwOQoKICAgIHNlY3Rpb24gVGVzdCBMaW5rIE9uIFdpdGggRWsgRGVmYXVsdCBFbWFpbCAoTGF0ZW5jeSAxMTkwbXMpCiAgICBMb2FkaW5nICgxMTkwbXMpIDp0MTgsIDAsIDExOTAKICAgIFNlc3Npb24gTG9hZCAoNDEwbXMpIDp0MTksIDIsIDQxMgogICAgSXMgR29vZ2xlIFBheSBTdXBwb3J0ZWQgKDMxbXMpIDp0MjAsIDIsIDMzCiAgICBJcyBHb29nbGUgUGF5IFJlYWR5ICgxbXMpIDp0MjEsIDIsIDMKICAgIENyZWF0ZSBMaW5rIFN0YXRlICg2NTJtcykgOnQyMiwgNDE0LCAxMDY2CiAgICBSZXRyaWV2ZSBTYXZlZCBQYXltZW50IE1ldGhvZCBTZWxlY3Rpb24gKDBtcykgOnQyMywgNDE0LCA0MTUKICAgIENyZWF0ZSBDdXN0b21lciBTdGF0ZSAoMTAxbXMpIDp0MjQsIDEwODMsIDExODQKICAgIFJldHJpZXZlIEluaXRpYWwgUGF5bWVudCBTZWxlY3Rpb24gKDBtcykgOnQyNSwgMTE4NSwgMTE4NgogICAgUHJlcGFyZSBBdHRlc3RhdGlvbiAoN21zKSA6dDI2LCAxMjEwLCAxMjE3CgogICAgc2VjdGlvbiBUZXN0IEdvb2dsZSBQYXkgT24gTGluayBPZmYgV2l0aCBFayAoTGF0ZW5jeSA1NjhtcykKICAgIExvYWRpbmcgKDU2OG1zKSA6dDI3LCAwLCA1NjgKICAgIFNlc3Npb24gTG9hZCAoNDMzbXMpIDp0MjgsIDMsIDQzNgogICAgSXMgR29vZ2xlIFBheSBSZWFkeSAoNDVtcykgOnQyOSwgMywgNDgKICAgIElzIEdvb2dsZSBQYXkgU3VwcG9ydGVkICgyMW1zKSA6dDMwLCAzLCAyNAogICAgUmV0cmlldmUgU2F2ZWQgUGF5bWVudCBNZXRob2QgU2VsZWN0aW9uICgxbXMpIDp0MzEsIDQzNiwgNDM3CiAgICBDcmVhdGUgTGluayBTdGF0ZSAoMG1zKSA6dDMyLCA0MzcsIDQzOAogICAgQ3JlYXRlIEN1c3RvbWVyIFN0YXRlICgxMTltcykgOnQzMywgNDQ0LCA1NjMKICAgIFJldHJpZXZlIEluaXRpYWwgUGF5bWVudCBTZWxlY3Rpb24gKDBtcykgOnQzNCwgNTYzLCA1NjQKICAgIFByZXBhcmUgQXR0ZXN0YXRpb24gKDNtcykgOnQzNSwgNTc2LCA1NzkK)
- [After](https://pages.stripe.me/doudou/diagrams.html?diagram=Z2FudHQKICAgIHRpdGxlIFBheW1lbnRTaGVldCBEdXJhdGlvbiBUcmFjZSAtIHBhcmFsbGVsLXBtcwogICAgZGF0ZUZvcm1hdCB4CgogICAgc2VjdGlvbiBUZXN0IExpbmsgT2ZmIFdpdGggRWsgKExhdGVuY3kgNDU2bXMpCiAgICBMb2FkaW5nICg0NTZtcykgOnQwLCAwLCA0NTYKICAgIElzIEdvb2dsZSBQYXkgU3VwcG9ydGVkICgzMm1zKSA6dDEsIDUsIDM3CiAgICBQcmVmZXRjaCBQTXMgKDI0N21zKSA6dDIsIDYsIDI1MwogICAgSXMgR29vZ2xlIFBheSBSZWFkeSAoNW1zKSA6dDMsIDYsIDExCiAgICBTZXNzaW9uIExvYWQgKDQwNG1zKSA6dDQsIDE1LCA0MTkKICAgIENyZWF0ZSBMaW5rIFN0YXRlICgwbXMpIDp0NSwgNDI2LCA0MjcKICAgIFJldHJpZXZlIFNhdmVkIFBheW1lbnQgTWV0aG9kIFNlbGVjdGlvbiAoMG1zKSA6dDYsIDQyOCwgNDI5CiAgICBDcmVhdGUgQ3VzdG9tZXIgU3RhdGUgKDJtcykgOnQ3LCA0NTAsIDQ1MgogICAgUmV0cmlldmUgSW5pdGlhbCBQYXltZW50IFNlbGVjdGlvbiAoMG1zKSA6dDgsIDQ1MywgNDU0CiAgICBQcmVwYXJlIEF0dGVzdGF0aW9uICg0bXMpIDp0OSwgNDczLCA0NzcKCiAgICBzZWN0aW9uIFRlc3QgTGluayBPbiBXaXRoIEVrIChMYXRlbmN5IDk5MW1zKQogICAgTG9hZGluZyAoOTkxbXMpIDp0MTAsIDAsIDk5MQogICAgU2Vzc2lvbiBMb2FkICgzNjJtcykgOnQxMSwgNywgMzY5CiAgICBQcmVmZXRjaCBQTXMgKDIwOW1zKSA6dDEyLCA3LCAyMTYKICAgIElzIEdvb2dsZSBQYXkgU3VwcG9ydGVkICgzMW1zKSA6dDEzLCA3LCAzOAogICAgSXMgR29vZ2xlIFBheSBSZWFkeSAoOG1zKSA6dDE0LCA3LCAxNQogICAgQ3JlYXRlIExpbmsgU3RhdGUgKDYwMW1zKSA6dDE1LCAzNjksIDk3MAogICAgUmV0cmlldmUgU2F2ZWQgUGF5bWVudCBNZXRob2QgU2VsZWN0aW9uICgwbXMpIDp0MTYsIDM3MSwgMzcyCiAgICBDcmVhdGUgQ3VzdG9tZXIgU3RhdGUgKDBtcykgOnQxNywgOTg1LCA5ODYKICAgIFJldHJpZXZlIEluaXRpYWwgUGF5bWVudCBTZWxlY3Rpb24gKDBtcykgOnQxOCwgOTg1LCA5ODYKICAgIFByZXBhcmUgQXR0ZXN0YXRpb24gKDZtcykgOnQxOSwgMTAwMiwgMTAwOAoKICAgIHNlY3Rpb24gVGVzdCBMaW5rIE9uIFdpdGggRWsgRGVmYXVsdCBFbWFpbCAoTGF0ZW5jeSA5NjltcykKICAgIExvYWRpbmcgKDk2OW1zKSA6dDIwLCAwLCA5NjkKICAgIFNlc3Npb24gTG9hZCAoMzc0bXMpIDp0MjEsIDExLCAzODUKICAgIFByZWZldGNoIFBNcyAoMjEybXMpIDp0MjIsIDExLCAyMjMKICAgIElzIEdvb2dsZSBQYXkgU3VwcG9ydGVkICg3MG1zKSA6dDIzLCAxMSwgODEKICAgIElzIEdvb2dsZSBQYXkgUmVhZHkgKDZtcykgOnQyNCwgMTEsIDE3CiAgICBDcmVhdGUgTGluayBTdGF0ZSAoNTY5bXMpIDp0MjUsIDM4OSwgOTU4CiAgICBSZXRyaWV2ZSBTYXZlZCBQYXltZW50IE1ldGhvZCBTZWxlY3Rpb24gKDBtcykgOnQyNiwgMzg5LCAzOTAKICAgIENyZWF0ZSBDdXN0b21lciBTdGF0ZSAoMG1zKSA6dDI3LCA5NjYsIDk2NwogICAgUmV0cmlldmUgSW5pdGlhbCBQYXltZW50IFNlbGVjdGlvbiAoMG1zKSA6dDI4LCA5NjcsIDk2OAogICAgUHJlcGFyZSBBdHRlc3RhdGlvbiAoMW1zKSA6dDI5LCA5ODMsIDk4NAoKICAgIHNlY3Rpb24gVGVzdCBHb29nbGUgUGF5IE9uIExpbmsgT2ZmIFdpdGggRWsgKExhdGVuY3kgNDEzbXMpCiAgICBMb2FkaW5nICg0MTNtcykgOnQzMCwgMCwgNDEzCiAgICBTZXNzaW9uIExvYWQgKDM5M21zKSA6dDMxLCA1LCAzOTgKICAgIFByZWZldGNoIFBNcyAoMjcwbXMpIDp0MzIsIDUsIDI3NQogICAgSXMgR29vZ2xlIFBheSBSZWFkeSAoMTI4bXMpIDp0MzMsIDUsIDEzMwogICAgSXMgR29vZ2xlIFBheSBTdXBwb3J0ZWQgKDMzbXMpIDp0MzQsIDUsIDM4CiAgICBSZXRyaWV2ZSBTYXZlZCBQYXltZW50IE1ldGhvZCBTZWxlY3Rpb24gKDFtcykgOnQzNSwgMzk4LCAzOTkKICAgIENyZWF0ZSBMaW5rIFN0YXRlICgwbXMpIDp0MzYsIDM5OSwgNDAwCiAgICBDcmVhdGUgQ3VzdG9tZXIgU3RhdGUgKDBtcykgOnQzNywgNDA4LCA0MDkKICAgIFJldHJpZXZlIEluaXRpYWwgUGF5bWVudCBTZWxlY3Rpb24gKDBtcykgOnQzOCwgNDEwLCA0MTEKICAgIFByZXBhcmUgQXR0ZXN0YXRpb24gKDVtcykgOnQzOSwgNDI0LCA0Mjk%3D)

You can see that now "Create customer state" is ~instant and "Prefetch PMs" happens in parallel with "session load". Prefetch PMs takes longer than the previous "Create customer state" because we now have to fetch saved PMs for all saved PM types we support (sepa, us bank acct, card) since we don't know from elements session which types are available -- we just filter after we've finished loading the elements session.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified