### PR TITLE
Make propose release process resumable after PR creation

### DIFF
--- a/scripts/deploy/propose_release.rb
+++ b/scripts/deploy/propose_release.rb
@@ -21,6 +21,35 @@ def print_propose_release_handoff
     end
 end
 
+def pause_for_pr_merge
+    if @is_dry_run
+        rputs "Dry run: skipping PR merge wait. Continuing to create release tag."
+        return
+    end
+
+    resume_command = "./scripts/deploy/propose_release.rb --continue-from 8 --version #{@version}"
+    resume_command += " --branch #{@deploy_branch}" if @deploy_branch != 'master'
+    puts ""
+    rputs "Version bump PR has been created. Get it reviewed and merged."
+    puts ""
+    puts "Once the PR is merged, resume the release process by running:"
+    puts ""
+    puts "  #{resume_command}"
+    puts ""
+
+    exit 0
+end
+
+def prepare_propose_release_resume(step_index)
+    # When resuming after the PR merge pause (step 8+), ensure we have a
+    # clean repo and are on the deploy branch with latest changes.
+    return if step_index < 8
+
+    ensure_clean_repo
+    execute_or_fail("git checkout #{@deploy_branch}")
+    execute_or_fail("git pull")
+end
+
 def cleanup_propose_release_dry_run
     delete_release_tag
     delete_git_branch(release_branch, @deploy_branch)
@@ -35,6 +64,7 @@ steps = [
     method(:ensure_clean_repo),
     method(:pull_latest),
     method(:create_version_bump_pr),
+    method(:pause_for_pr_merge),
     method(:create_release_tag),
     method(:print_propose_release_handoff),
 ]
@@ -42,7 +72,7 @@ steps = [
 @propose_release_succeeded = false
 
 begin
-    execute_steps(steps)
+    execute_steps(steps, before_resume: method(:prepare_propose_release_resume))
     @propose_release_succeeded = true
 ensure
     if @is_dry_run && @propose_release_succeeded

--- a/scripts/deploy/release_cli.rb
+++ b/scripts/deploy/release_cli.rb
@@ -64,6 +64,8 @@ def execute_steps(steps, before_resume: nil)
             step.call
             step_index += 1
         end
+    rescue SystemExit, Interrupt
+        raise
     rescue Exception
         command = "./scripts/deploy/#{File.basename($PROGRAM_NAME)}"
         rputs "Restart #{@flow_name} with `#{command} --continue-from #{step_index} --version #{@version}` to re-run from this step."

--- a/scripts/deploy/version_bump_pr_steps.rb
+++ b/scripts/deploy/version_bump_pr_steps.rb
@@ -38,9 +38,9 @@ def create_version_bump_pr()
     
         pr_description = create_pr_description()
         if (@is_dry_run)
-          user_message = "Verify that a draft PR containing version number bumps was opened. If this was a real release, you would need to wait for this PR to merge before continuing."
+          user_message = "Verify that a draft PR containing version number bumps was opened."
         else
-          user_message = "Verify that a PR containing version number bumps was opened. Merge this PR before continuing to the next steps."
+          user_message = "Verify that a PR containing version number bumps was opened. Press enter once you've confirmed the PR was created."
         end
 
         create_pr(


### PR DESCRIPTION
Instead of blocking and waiting for the version bump PR to be merged before continuing to create the release tag, the script now:

1. Creates the PR and asks the user to confirm it was opened
2. Prints the exact command to resume after the PR merges
3. Exits cleanly

The user can then merge the PR at their leisure and resume with:
  ./scripts/deploy/propose_release.rb --continue-from 8 --version X.Y.Z

On resume, the script verifies the PR is merged (via the existing verify_release_pr_merged check in create_release_tag) before proceeding to create the signed release tag.

The dry-run flow is unchanged: it skips the pause and runs straight through so the full propose flow can still be tested end-to-end.

Also adds SystemExit/Interrupt to the rescue chain in execute_steps so that a clean exit (or Ctrl-C) does not print a misleading restart hint.

Committed-By-Agent: goose

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Make it so that the proposer can do other things while waiting for proposal PR to merge and know exactly how to resume the process after
