### PR TITLE
Use customer email from elements session response for CustomerSession

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -60,6 +60,7 @@ data class ElementsSession(
         val paymentMethods: List<PaymentMethod>,
         val defaultPaymentMethod: String?,
         val session: Session,
+        val email: String? = null,
     ) : StripeModel {
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -176,10 +176,13 @@ internal class ElementsSessionJsonParser(
             it.isNotBlank()
         }
 
+        val email = json.optString(FIELD_CUSTOMER_EMAIL).takeIf { it.isNotBlank() }
+
         return ElementsSession.Customer(
             paymentMethods = paymentMethods,
             session = customerSession,
-            defaultPaymentMethod = defaultPaymentMethod
+            defaultPaymentMethod = defaultPaymentMethod,
+            email = email,
         )
     }
 
@@ -327,6 +330,7 @@ internal class ElementsSessionJsonParser(
         private const val FIELD_CUSTOMER_PAYMENT_METHODS = "payment_methods"
         private const val FIELD_CUSTOMER_SESSION = "customer_session"
         private const val FIELD_DEFAULT_PAYMENT_METHOD = "default_payment_method"
+        private const val FIELD_CUSTOMER_EMAIL = "email"
         private const val FIELD_CUSTOMER_ID = "id"
         private const val FIELD_CUSTOMER_LIVE_MODE = "livemode"
         private const val FIELD_CUSTOMER_API_KEY = "api_key"

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -167,7 +167,8 @@ internal object ElementsSessionFixtures {
     )
 
     fun createPaymentIntentWithCustomerSession(
-        allowRedisplay: String? = "limited"
+        allowRedisplay: String? = "limited",
+        customerEmail: String? = null,
     ): JSONObject {
         return JSONObject(
             """
@@ -294,6 +295,7 @@ internal object ElementsSessionFixtures {
                   }
                 ],
                 "payment_methods_with_link_details": []
+                ${customerEmail?.let { ""","email": "$it"""" } ?: ""}
               }
             }
             """.trimIndent()

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -570,6 +570,40 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `ElementsSession parses customer email when present in response`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                customerSessionClientSecret = "customer_session_client_secret",
+                externalPaymentMethods = emptyList(),
+            ),
+            isLiveMode = false,
+        )
+
+        val intent = createPaymentIntentWithCustomerSession(customerEmail = "customer@example.com")
+        val elementsSession = parser.parse(intent)
+
+        assertThat(elementsSession?.customer?.email).isEqualTo("customer@example.com")
+    }
+
+    @Test
+    fun `ElementsSession returns null customer email when not present in response`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                customerSessionClientSecret = "customer_session_client_secret",
+                externalPaymentMethods = emptyList(),
+            ),
+            isLiveMode = false,
+        )
+
+        val intent = createPaymentIntentWithCustomerSession()
+        val elementsSession = parser.parse(intent)
+
+        assertThat(elementsSession?.customer?.email).isNull()
+    }
+
+    @Test
     fun `ElementsSession has 'unspecified' allow redisplay override`() {
         allowRedisplayTest(
             rawAllowRedisplayValue = "unspecified",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -431,14 +431,16 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             null
         }
 
-        val customerEmail = configuration.defaultBillingDetails?.email ?: customer?.let {
-            customerRepository.retrieveCustomer(
-                CustomerRepository.CustomerInfo(
-                    id = it.id,
-                    ephemeralKeySecret = it.ephemeralKeySecret
+        val customerEmail = configuration.defaultBillingDetails?.email
+            ?: (customer as? CustomerInfo.CustomerSession)?.elementsSessionCustomer?.email
+            ?: customer?.let {
+                customerRepository.retrieveCustomer(
+                    CustomerRepository.CustomerInfo(
+                        id = it.id,
+                        ephemeralKeySecret = it.ephemeralKeySecret
+                    )
                 )
-            )
-        }?.email
+            }?.email
 
         val merchantName = configuration.merchantDisplayName
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1739,7 +1739,49 @@ internal class DefaultPaymentElementLoaderTest {
 
     @OptIn(ExperimentalCustomerSessionApi::class)
     @Test
-    fun `When using 'CustomerSession' & no default billing details, customer email for Link config is fetched using 'elements_session' ephemeral key`() =
+    fun `When using 'CustomerSession' & email present in elements session, use it for Link config without API call`() =
+        runTest {
+            val customerRepository = spy(FakeCustomerRepository())
+
+            val loader = createPaymentElementLoader(
+                customerRepo = customerRepository,
+                customer = ElementsSession.Customer(
+                    paymentMethods = PaymentMethodFactory.cards(1),
+                    session = ElementsSession.Customer.Session(
+                        id = "cuss_1",
+                        customerId = "cus_1",
+                        liveMode = false,
+                        apiKey = "ek_123",
+                        apiKeyExpiry = 555555555,
+                        components = ElementsSession.Customer.Components(
+                            mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
+                            customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+                        ),
+                    ),
+                    defaultPaymentMethod = null,
+                    email = "customer@example.com",
+                )
+            )
+
+            val result = loader.load(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
+                paymentSheetConfiguration = mockConfiguration(
+                    customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                        id = "id",
+                        clientSecret = "cuss_1",
+                    ),
+                    defaultBillingDetails = null,
+                ),
+                initializedViaCompose = false,
+            ).getOrThrow()
+
+            assertThat(result.linkState?.configuration?.customerInfo?.email)
+                .isEqualTo("customer@example.com")
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When using 'CustomerSession' & no email in elements session, customer email for Link config is fetched via API`() =
         runTest {
             val customerRepository = spy(
                 FakeCustomerRepository(


### PR DESCRIPTION
When using CustomerSession, the customer's email can be available directly from the elements session response. This avoids an unnecessary API call to retrieve the customer when the email is needed for Link configuration.

Priority order for resolving the customer email:
1. Default billing details email from configuration
2. Email from the elements session customer (CustomerSession only)
3. API call to retrieve the customer (fallback)

Committed-By-Agent: goose

# Summary
<!-- Simple summary of what was changed. -->
Use customer email from elements session response for CustomerSession

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Latency improvement -- skips an unnecessary network request in the customer session path

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified