### PR TITLE
Use GZIP + URL-safe Base64 for bitriseQuarantinedTests encoding

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/QuarantinedTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/QuarantinedTestRule.kt
@@ -60,7 +60,7 @@ internal class QuarantinedTestMatcher(
             ?: return emptyList()
 
         return try {
-            val compressed = Base64.decode(encoded, Base64.URL_SAFE or Base64.NO_WRAP)
+            val compressed = Base64.decode(encoded, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
             val rawJson = GZIPInputStream(ByteArrayInputStream(compressed))
                 .bufferedReader()
                 .use { it.readText() }

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/QuarantinedTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/QuarantinedTestRule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.testing
 
 import android.os.Bundle
+import android.util.Base64
 import androidx.test.platform.app.InstrumentationRegistry
 import org.json.JSONArray
 import org.json.JSONException
@@ -8,6 +9,8 @@ import org.junit.Assume
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
 
 class QuarantinedTestRule : TestRule {
     override fun apply(base: Statement, description: Description): Statement {
@@ -51,19 +54,24 @@ internal class QuarantinedTestMatcher(
     }
 
     private fun decode(): List<Match> {
-        val rawHex = arguments.getString(QUARANTINE_ENV_KEY)
+        val encoded = arguments.getString(QUARANTINE_ENV_KEY)
             ?.trim()
             ?.takeIf { it.isNotEmpty() }
             ?: return emptyList()
 
         return try {
-            val rawJson = rawHex.hexToByteArray().decodeToString()
+            val compressed = Base64.decode(encoded, Base64.URL_SAFE or Base64.NO_WRAP)
+            val rawJson = GZIPInputStream(ByteArrayInputStream(compressed))
+                .bufferedReader()
+                .use { it.readText() }
             val listOfTestsJson = JSONArray(rawJson)
 
             parseQuarantineCases(listOfTestsJson)
         } catch (_: IllegalArgumentException) {
             return emptyList()
         } catch (_: JSONException) {
+            return emptyList()
+        } catch (_: java.io.IOException) {
             return emptyList()
         }
     }

--- a/payments-core-testing/src/test/java/com/stripe/android/testing/QuarantinedTestMatcherTest.kt
+++ b/payments-core-testing/src/test/java/com/stripe/android/testing/QuarantinedTestMatcherTest.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.testing
 
 import android.os.Bundle
+import android.util.Base64
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.Description
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
 
 @RunWith(RobolectricTestRunner::class)
 class QuarantinedTestMatcherTest {
@@ -13,7 +16,7 @@ class QuarantinedTestMatcherTest {
     @Test
     fun `match is true when description matches a quarantined class and method`() {
         val json = """[{"className":"com.example.Foo","testCaseName":"bar"}]"""
-        val matcher = matcherForHexPayload(json)
+        val matcher = matcherForGzipBase64Payload(json)
 
         val description = Description.createTestDescription("com.example.Foo", "bar")
         assertThat(matcher.match(description)).isTrue()
@@ -22,7 +25,7 @@ class QuarantinedTestMatcherTest {
     @Test
     fun `match is false when class does not match`() {
         val json = """[{"className":"com.example.Foo","testCaseName":"bar"}]"""
-        val matcher = matcherForHexPayload(json)
+        val matcher = matcherForGzipBase64Payload(json)
 
         val description = Description.createTestDescription("com.other.Foo", "bar")
         assertThat(matcher.match(description)).isFalse()
@@ -31,7 +34,7 @@ class QuarantinedTestMatcherTest {
     @Test
     fun `match is false when method does not match`() {
         val json = """[{"className":"com.example.Foo","testCaseName":"bar"}]"""
-        val matcher = matcherForHexPayload(json)
+        val matcher = matcherForGzipBase64Payload(json)
 
         val description = Description.createTestDescription("com.example.Foo", "baz")
         assertThat(matcher.match(description)).isFalse()
@@ -55,9 +58,9 @@ class QuarantinedTestMatcherTest {
     }
 
     @Test
-    fun `match is false when payload is not valid hex`() {
+    fun `match is false when payload is not valid gzip base64`() {
         val bundle = Bundle().apply {
-            putString("bitriseQuarantinedTests", "not-hex-json")
+            putString("bitriseQuarantinedTests", "not-valid-data!!!")
         }
         val matcher = QuarantinedTestMatcher(bundle)
 
@@ -67,7 +70,7 @@ class QuarantinedTestMatcherTest {
 
     @Test
     fun `match is false when decoded json is not a valid array`() {
-        val matcher = matcherForHexPayload("""{"className":"com.example.Foo","testCaseName":"bar"}""")
+        val matcher = matcherForGzipBase64Payload("""{"className":"com.example.Foo","testCaseName":"bar"}""")
 
         val description = Description.createTestDescription("com.example.Foo", "bar")
         assertThat(matcher.match(description)).isFalse()
@@ -75,7 +78,7 @@ class QuarantinedTestMatcherTest {
 
     @Test
     fun `match is false when decoded json is invalid`() {
-        val matcher = matcherForHexPayload("not json at all")
+        val matcher = matcherForGzipBase64Payload("not json at all")
 
         val description = Description.createTestDescription("com.example.Foo", "bar")
         assertThat(matcher.match(description)).isFalse()
@@ -90,7 +93,7 @@ class QuarantinedTestMatcherTest {
               {"className":"com.b.Second","testCaseName":"m2"}
             ]
             """.trimIndent()
-        val matcher = matcherForHexPayload(json)
+        val matcher = matcherForGzipBase64Payload(json)
 
         assertThat(matcher.match(Description.createTestDescription("com.a.First", "m1"))).isTrue()
         assertThat(matcher.match(Description.createTestDescription("com.b.Second", "m2"))).isTrue()
@@ -107,15 +110,19 @@ class QuarantinedTestMatcherTest {
               {"className":"com.ok.Cls","testCaseName":"good"}
             ]
             """.trimIndent()
-        val matcher = matcherForHexPayload(json)
+        val matcher = matcherForGzipBase64Payload(json)
 
         assertThat(matcher.match(Description.createTestDescription("com.ok.Cls", "good"))).isTrue()
         assertThat(matcher.match(Description.createTestDescription("com.ok.Cls", "x"))).isFalse()
     }
 
-    private fun matcherForHexPayload(json: String): QuarantinedTestMatcher {
-        val hex = json.encodeToByteArray().toHexString()
-        val bundle = Bundle().apply { putString("bitriseQuarantinedTests", hex) }
+    private fun matcherForGzipBase64Payload(json: String): QuarantinedTestMatcher {
+        val compressed = ByteArrayOutputStream().use { baos ->
+            GZIPOutputStream(baos).use { gzip -> gzip.write(json.encodeToByteArray()) }
+            baos.toByteArray()
+        }
+        val encoded = Base64.encodeToString(compressed, Base64.URL_SAFE or Base64.NO_WRAP)
+        val bundle = Bundle().apply { putString("bitriseQuarantinedTests", encoded) }
         return QuarantinedTestMatcher(bundle)
     }
 }

--- a/payments-core-testing/src/test/java/com/stripe/android/testing/QuarantinedTestMatcherTest.kt
+++ b/payments-core-testing/src/test/java/com/stripe/android/testing/QuarantinedTestMatcherTest.kt
@@ -121,7 +121,7 @@ class QuarantinedTestMatcherTest {
             GZIPOutputStream(baos).use { gzip -> gzip.write(json.encodeToByteArray()) }
             baos.toByteArray()
         }
-        val encoded = Base64.encodeToString(compressed, Base64.URL_SAFE or Base64.NO_WRAP)
+        val encoded = Base64.encodeToString(compressed, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
         val bundle = Bundle().apply { putString("bitriseQuarantinedTests", encoded) }
         return QuarantinedTestMatcher(bundle)
     }

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -1,5 +1,8 @@
 #!/bin/python
 import argparse
+import base64
+import gzip
+import json
 import os
 import shutil
 import requests
@@ -281,9 +284,13 @@ def executeTests(appUrl, testUrl):
     }
 
     if bitriseQuarantinedTests:
+        # Minify the JSON, GZIP compress, then URL-safe Base64 encode
+        minified = json.dumps(json.loads(bitriseQuarantinedTests), separators=(",", ":"))
+        compressed = gzip.compress(minified.encode("utf-8"))
+        encoded = base64.urlsafe_b64encode(compressed).decode("ascii")
         instrumentationOptionsParams = {
             "instrumentationOptions": {
-                "bitriseQuarantinedTests": bitriseQuarantinedTests.encode("utf-8").hex(),
+                "bitriseQuarantinedTests": encoded,
             }
         }
     else:

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -284,10 +284,10 @@ def executeTests(appUrl, testUrl):
     }
 
     if bitriseQuarantinedTests:
-        # Minify the JSON, GZIP compress, then URL-safe Base64 encode
+        # Minify the JSON, GZIP compress, then URL-safe Base64 encode (no padding)
         minified = json.dumps(json.loads(bitriseQuarantinedTests), separators=(",", ":"))
         compressed = gzip.compress(minified.encode("utf-8"))
-        encoded = base64.urlsafe_b64encode(compressed).decode("ascii")
+        encoded = base64.urlsafe_b64encode(compressed).decode("ascii").rstrip("=")
         instrumentationOptionsParams = {
             "instrumentationOptions": {
                 "bitriseQuarantinedTests": encoded,


### PR DESCRIPTION
# Summary
Replace hex encoding with a more size-efficient pipeline:
- browserstack.py: Minify JSON, GZIP compress, URL-safe Base64 encode
- QuarantinedTestRule: URL-safe Base64 decode, GZIP decompress, parse JSON

Committed-By-Agent: goose

# Motivation
This reduces the payload size sent as an instrumentation argument to BrowserStack, avoiding potential issues with argument length limits.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified