### PR TITLE
Enable `save_transforms` in Save Gradle Cache step

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -550,7 +550,9 @@ workflows:
             - is_enable_public_page: "false"
           title: Deploy test results artifacts
       - save-gradle-configuration-cache@1: { }
-      - save-gradle-cache@1: { }
+      - save-gradle-cache@1:
+          inputs:
+            - save_transforms: true
 step_bundles:
   export_unit_test_results:
     inputs:


### PR DESCRIPTION
# Summary
Enable `save_transforms` in Save Gradle Cache step

# Motivation
Fix Gradle configuration cache usage in Bitrise

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified