### PR TITLE
Find and remove network requests synchronously NetworkDispatcher

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -11,6 +11,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dispatcher() {
     private val enqueuedResponses: Queue<Entry> = ConcurrentLinkedQueue()
+    private val enqueuedResponsesLock = Any()
     private val unmatchedRequests: MutableList<UnmatchedRequest> = Collections.synchronizedList(mutableListOf())
 
     fun enqueue(vararg requestMatcher: RequestMatcher, responseFactory: (MockResponse) -> Unit) {
@@ -104,12 +105,9 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
 
     override fun dispatch(request: RecordedRequest): MockResponse {
         val testRequest = TestRecordedRequest(request)
-        val matchedEntry = enqueuedResponses.firstOrNull { entry ->
-            entry.requestMatcher.matches(testRequest)
-        }
+        val matchedEntry = consumeMatchingEntry(testRequest)
 
         matchedEntry?.let { capturedEntry ->
-            enqueuedResponses.remove(capturedEntry)
             return capturedEntry.responseFactory(testRequest)
         }
 
@@ -129,6 +127,17 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
         )
 
         return MockResponse().setResponseCode(UNMATCHED_RESPONSE_CODE).setBody("Request not mocked")
+    }
+
+    private fun consumeMatchingEntry(request: TestRecordedRequest): Entry? {
+        synchronized(enqueuedResponsesLock) {
+            val matchedEntry = enqueuedResponses.firstOrNull { entry ->
+                entry.requestMatcher.matches(request)
+            } ?: return null
+
+            enqueuedResponses.remove(matchedEntry)
+            return matchedEntry
+        }
     }
 
     private fun buildNearMissDiagnostics(request: TestRecordedRequest): String {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Find and remove network requests synchronously in NetworkDispatcher

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
With the current logic, if two requests with the same matcher are sent around similar times it's possible to get into a race condition where both requests attempt to remove the same enqueued response. This fixes that.

Should reduce flakes. I noticed this because my changes in https://github.com/stripe/stripe-android/pull/13151 add some extra analytics requests. The tests were very flaky locally (probably hidden in CI via RetryRule) and this fixed it.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified