### PR TITLE
Turn off default email for most tests in TestLatency

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -113,6 +113,7 @@ internal class TestLatency(
             this[LinkSettingsDefinition] = false
             this[CustomerSettingsDefinition] = CustomerType.GUEST
             this[GooglePaySettingsDefinition] = GooglePayMode.Off
+            this[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.Off
         }
 
         @JvmStatic

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -55,7 +55,10 @@ internal class TestLatency(
             testDriver.loadComplete(
                 testParameters = TestParameters.create(
                     paymentMethodCode = "card",
-                    playgroundSettingsBlock = testConfig.playgroundSettingsBlock,
+                    playgroundSettingsBlock = { settings ->
+                        settings.latencyTestDefaults()
+                        testConfig.updateSettings(settings)
+                    },
                 ),
                 isReturningCustomer = testConfig.isReturningCustomer,
             )
@@ -95,7 +98,7 @@ internal class TestLatency(
     class TestConfig(
         val name: String,
         val isReturningCustomer: Boolean,
-        val playgroundSettingsBlock: (PlaygroundSettings) -> Unit,
+        val updateSettings: (PlaygroundSettings) -> Unit,
         val skipMeasurement: Boolean,
         val requiredSuccessfulSamples: Int,
     ) {
@@ -104,6 +107,13 @@ internal class TestLatency(
 
     companion object {
         private const val MAX_FAILED_ATTEMPTS = 3
+
+        private fun PlaygroundSettings.latencyTestDefaults() {
+            this[MerchantSettingsDefinition] = Merchant.US
+            this[LinkSettingsDefinition] = false
+            this[CustomerSettingsDefinition] = CustomerType.GUEST
+            this[GooglePaySettingsDefinition] = GooglePayMode.Off
+        }
 
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
@@ -115,108 +125,80 @@ internal class TestLatency(
                     isReturningCustomer = false,
                     skipMeasurement = true,
                     requiredSuccessfulSamples = 1,
-                ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
-                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                ) { _ ->
+                    // No test specific settings.
                 },
                 testConfig(
                     testName = "test_link_off_with_no_customer",
                     isReturningCustomer = false,
-                ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
-                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
+                ) { _ ->
+                    // No test specific settings.
                 },
                 testConfig(
                     testName = "test_link_off_with_ek",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = false
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_link_off_with_cs",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_link_on_with_no_customer",
                     isReturningCustomer = false,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
                     settings[LinkSettingsDefinition] = true
-                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_link_on_with_ek",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
                     settings[LinkSettingsDefinition] = true
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = false
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_link_on_with_cs",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
                     settings[LinkSettingsDefinition] = true
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_link_on_with_ek_default_email",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
                     settings[LinkSettingsDefinition] = true
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = false
                     settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_link_on_with_cs_default_email",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[MerchantSettingsDefinition] = Merchant.US
                     settings[LinkSettingsDefinition] = true
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
                     settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
-                    settings[GooglePaySettingsDefinition] = GooglePayMode.Off
                 },
                 testConfig(
                     testName = "test_google_pay_on_link_off_with_no_customer",
                     isReturningCustomer = false,
                 ) { settings: PlaygroundSettings ->
                     settings[GooglePaySettingsDefinition] = GooglePayMode.Test
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
-                    settings[CustomerSettingsDefinition] = CustomerType.GUEST
                 },
                 testConfig(
                     testName = "test_google_pay_on_link_off_with_ek",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
                     settings[GooglePaySettingsDefinition] = GooglePayMode.Test
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = false
                 },
@@ -225,8 +207,6 @@ internal class TestLatency(
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
                     settings[GooglePaySettingsDefinition] = GooglePayMode.Test
-                    settings[MerchantSettingsDefinition] = Merchant.US
-                    settings[LinkSettingsDefinition] = false
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
                 },
@@ -235,7 +215,6 @@ internal class TestLatency(
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
                     settings[GooglePaySettingsDefinition] = GooglePayMode.Test
-                    settings[MerchantSettingsDefinition] = Merchant.US
                     settings[LinkSettingsDefinition] = true
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
@@ -256,7 +235,7 @@ internal class TestLatency(
                     isReturningCustomer = isReturningCustomer,
                     skipMeasurement = skipMeasurement,
                     requiredSuccessfulSamples = requiredSuccessfulSamples,
-                    playgroundSettingsBlock = playgroundSettingsBlock,
+                    updateSettings = playgroundSettingsBlock,
                 )
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Turn off default email for most tests in TestLatency

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We have specific test cases to enable default email. But since our playground settings enable default email automatically, actually all of the tests had it enabled 🫠 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified