### PR TITLE
Skip ConsentPane image loading in preview to fix flakiness

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ui/ConsentLogoHeader.kt
@@ -77,15 +77,17 @@ internal fun ConsentLogoHeader(
         )
     }
 
-    LaunchedEffect(logos) {
-        bitmaps = logos.map {
-            async {
-                stripeImageLoader.load(it, bitmapLoadSize, bitmapLoadSize)
-                    .getOrNull()
-                    ?.asImageBitmap()
-                    ?: placeholderBitmap
-            }
-        }.awaitAll()
+    if (!isPreview) {
+        LaunchedEffect(logos) {
+            bitmaps = logos.map {
+                async {
+                    stripeImageLoader.load(it, bitmapLoadSize, bitmapLoadSize)
+                        .getOrNull()
+                        ?.asImageBitmap()
+                        ?: placeholderBitmap
+                }
+            }.awaitAll()
+        }
     }
 
     Box(


### PR DESCRIPTION
# Summary

Removes `LaunchedEffect` in preview mode to prevent fallback images sometimes being rendered in snapshot tests, leading to flakiness. By skipping this attempted load entirely in previews, we ensure we keep consistent screenshots.

Once this merges, we can remove these screenshots from the quarantine. They won't run in this PR due to the quarantine

# Motivation

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-176

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
