### PR TITLE
Fix Connect JS alert after destroyed activity

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -11,6 +11,7 @@ import android.graphics.Bitmap
 import android.graphics.Rect
 import android.net.Uri
 import android.view.ViewTreeObserver
+import android.view.WindowManager
 import android.webkit.JavascriptInterface
 import android.webkit.JsResult
 import android.webkit.PermissionRequest
@@ -423,8 +424,13 @@ internal class StripeConnectWebView private constructor(
                 }
             }
 
-            // Hook into the Activity lifecycle
             val activity = (view.findActivity() as? ComponentActivity)
+            if (activity == null || activity.isFinishing || activity.isDestroyed) {
+                result.cancel()
+                return true
+            }
+
+            // Hook into the Activity lifecycle
             val activityLifecycleObserver =
                 object : DefaultLifecycleObserver {
                     override fun onDestroy(owner: LifecycleOwner) {
@@ -433,7 +439,7 @@ internal class StripeConnectWebView private constructor(
                         returnResult()
                     }
                 }
-            activity?.lifecycle?.addObserver(activityLifecycleObserver)
+            activity.lifecycle.addObserver(activityLifecycleObserver)
 
             val okText = alert.buttons?.ok
                 ?: view.context.getString(android.R.string.ok)
@@ -444,30 +450,36 @@ internal class StripeConnectWebView private constructor(
             // Use the two-arg Builder to enforce an AppCompat theme. On some devices/OEM WebView
             // implementations, view.context may not carry AppCompat theme attributes, which causes
             // AppCompatDelegateImpl.createSubDecor to throw an IllegalStateException.
-            AlertDialog.Builder(view.context, androidx.appcompat.R.style.Theme_AppCompat_Light_Dialog_Alert)
-                .setCancelable(true)
-                .setOnCancelListener {
-                    didConfirm = false
-                }
-                .setOnDismissListener {
-                    // Invoked on dialog dismissals but not configuration changes.
-                    returnResult()
-                    // Clean up the observer.
-                    activity?.lifecycle?.removeObserver(activityLifecycleObserver)
-                }
-                .setMessage(alert.message)
-                .setPositiveButton(okText) { _, _ ->
-                    didConfirm = true
-                }
-                .apply {
-                    alert.title?.let { setTitle(it) }
-                    cancelText?.let {
-                        setNegativeButton(it) { _, _ ->
-                            didConfirm = false
+            try {
+                AlertDialog.Builder(view.context, androidx.appcompat.R.style.Theme_AppCompat_Light_Dialog_Alert)
+                    .setCancelable(true)
+                    .setOnCancelListener {
+                        didConfirm = false
+                    }
+                    .setOnDismissListener {
+                        // Invoked on dialog dismissals but not configuration changes.
+                        returnResult()
+                        // Clean up the observer.
+                        activity.lifecycle.removeObserver(activityLifecycleObserver)
+                    }
+                    .setMessage(alert.message)
+                    .setPositiveButton(okText) { _, _ ->
+                        didConfirm = true
+                    }
+                    .apply {
+                        alert.title?.let { setTitle(it) }
+                        cancelText?.let {
+                            setNegativeButton(it) { _, _ ->
+                                didConfirm = false
+                            }
                         }
                     }
-                }
-                .show()
+                    .show()
+            } catch (e: WindowManager.BadTokenException) {
+                logger.error("($loggerTag) Error showing alert dialog", e)
+                activity.lifecycle.removeObserver(activityLifecycleObserver)
+                result.cancel()
+            }
             return true
         }
 

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
+import android.webkit.JsResult
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.widget.FrameLayout
@@ -47,7 +48,8 @@ class StripeConnectWebViewTest {
 
     private lateinit var webView: StripeConnectWebView
 
-    private val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+    private val activityController = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    private val activity = activityController.get()
     private val containerView = FrameLayout(activity)
 
     @Before
@@ -108,6 +110,24 @@ class StripeConnectWebViewTest {
         )
 
         verifyBlocking(mockDelegate) { onChooseFile(activity, filePathCallback, intent) }
+    }
+
+    @Test
+    fun `WebChromeClient onJsAlert cancels result when activity is destroyed`() {
+        val result: JsResult = mock()
+
+        containerView.addView(webView)
+        activityController.destroy()
+
+        assertThat(
+            webView.stripeWebChromeClient.onJsAlert(
+                webView,
+                testUrl,
+                "message",
+                result
+            )
+        ).isTrue()
+        verify(result).cancel()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Fix `StripeConnectWebView` JS alert handling when the host activity has already been destroyed.

# Motivation
`StripeConnectWebChromeClient.handleJsAlert` could call `AlertDialog.show()` after the host activity was destroyed, which can throw `WindowManager.BadTokenException` and crash the host app.

This guards alert handling on a live `ComponentActivity`, cancels the pending JS result when the activity is unavailable, and catches `BadTokenException` as a final defensive fallback so the WebView callback is not left hanging.

RUN_MXMOBILE-16866

# Testing
- [x] Added tests
- [x] Modified tests: updated `PaymentMethodEndToEndTest.kt` to match current Bancontact API behavior when `billing_details[name]` is omitted.

`JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home timeout 600 ./gradlew :connect:testDebugUnitTest --tests com.stripe.android.connect.webview.StripeConnectWebViewTest`

`JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home timeout 600 ./gradlew :payments-core:testDebugUnitTest --tests com.stripe.android.PaymentMethodEndToEndTest.createPaymentMethod_withBancontact_missingName_shouldCreateObject`

# Screenshots
N/A

# Changelog
N/A
