### PR TITLE
Update checkout session flow when state is set.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -150,6 +150,7 @@ class Checkout private constructor(
         set(value) {
             ensureNoMutationInFlight()
             internalState = value.internalState
+            _checkoutSession.value = internalState.checkoutSessionResponse.asCheckoutSession()
         }
 
     private val mutex = Mutex()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -777,6 +777,18 @@ class CheckoutTest {
     }
 
     @Test
+    fun `setting state updates checkoutSession flow`() = runCreateWithStateScenario {
+        val initial = checkoutSessionTurbine.awaitItem()
+        assertThat(initial.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+
+        val updatedResponse = CheckoutSessionResponseFactory.create(id = "cs_test_updated")
+        checkout.state = CheckoutStateFactory.create(checkoutSessionResponse = updatedResponse)
+
+        val updated = checkoutSessionTurbine.awaitItem()
+        assertThat(updated.id).isEqualTo("cs_test_updated")
+    }
+
+    @Test
     fun `mutation returns failure when integrationLaunched is true`() = runCreateWithStateScenario(
         shouldValidateEvents = false,
     ) {


### PR DESCRIPTION
# Summary
Fixed an issue where the checkout session flow was not being updated when the checkout state was manually set.

# Motivation
When setting a new state on the Checkout instance, the internal state was being updated but the checkout session flow was not emitting the new value. This meant that observers of the checkout session flow would not receive updates when the state changed programmatically.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
[Fixed] Checkout session flow now properly updates when checkout state is set programmatically.