### PR TITLE
Ignore failing bancontact test/Disable browserstack flow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ stages:
       - run-connections-e2e-token-tests-on-push: { }
       - run-connections-e2e-data-tests-on-push: { }
       - run-cardscan-instrumentation-tests: { }
-      - run-paymentsheet-end-to-end-tests: { }
+#     - run-paymentsheet-end-to-end-tests: { }
       - run-crypto-onramp-example-e2e-tests: { }
       - check-dependencies: { }
       - verify-publish-pom: { }

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Ignore
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -61,6 +62,7 @@ internal class PaymentMethodEndToEndTest {
             .isEqualTo(PaymentMethod.Type.Bancontact)
     }
 
+    @Ignore("ir-away-spoke")
     @Test
     fun createPaymentMethod_withBancontact_missingName_shouldFail() {
         val params = PaymentMethodCreateParams.createBancontact(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Test expects payment method create call to fail due to missing name, but call is succeeding anyways
- Browserstack is failing for unrelated reasons, combining fixes in one PR to pass CI

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://incident-reporting.corp.stripe.com/wf/incidents/away-spoke
https://incident-reporting.corp.stripe.com/wf/incidents/chair-tangible

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
