### PR TITLE
Fix line item unit amount parsing from price field.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -424,7 +424,10 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             val quantity = obj.optInt(FIELD_QUANTITY, -1).takeIf { it > 0 } ?: return@mapNotNull null
             val subtotal = obj.optLong(FIELD_SUBTOTAL, -1).takeIf { it >= 0 } ?: return@mapNotNull null
             val total = obj.optLong(FIELD_TOTAL, -1).takeIf { it >= 0 } ?: return@mapNotNull null
-            val unitAmount = if (quantity > 0) total / quantity else null
+            val unitAmount = obj.optLong(FIELD_UNIT_AMOUNT_OVERRIDE, -1).takeIf { it >= 0 }
+                ?: obj.optJSONObject(FIELD_PRICE)
+                    ?.optLong(FIELD_UNIT_AMOUNT, -1)
+                    ?.takeIf { it >= 0 }
             CheckoutSessionResponse.LineItem(
                 id = id,
                 name = name,
@@ -525,6 +528,9 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_LINE_ITEMS = "line_items"
     private const val FIELD_ID = "id"
     private const val FIELD_QUANTITY = "quantity"
+    private const val FIELD_PRICE = "price"
+    private const val FIELD_UNIT_AMOUNT = "unit_amount"
+    private const val FIELD_UNIT_AMOUNT_OVERRIDE = "unit_amount_override"
     private const val FIELD_ADAPTIVE_PRICING_INFO = "adaptive_pricing_info"
     private const val FIELD_ACTIVE_PRESENTMENT_CURRENCY = "active_presentment_currency"
     private const val FIELD_INTEGRATION_AMOUNT = "integration_amount"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
@@ -29,7 +29,10 @@ internal object CheckoutSessionFixtures {
                 "name": "Llama Figure",
                 "quantity": 1,
                 "subtotal": 999,
-                "total": 999
+                "total": 999,
+                "price": {
+                  "unit_amount": 999
+                }
               }
             ]
           },
@@ -578,7 +581,10 @@ internal object CheckoutSessionFixtures {
                         "name": "Llama Figure",
                         "quantity": 2,
                         "subtotal": 1998,
-                        "total": 1998
+                        "total": 1998,
+                        "price": {
+                            "unit_amount": 999
+                        }
                     },
                     {
                         "id": "li_item2",
@@ -586,7 +592,10 @@ internal object CheckoutSessionFixtures {
                         "name": "Alpaca Plushie",
                         "quantity": 1,
                         "subtotal": 2499,
-                        "total": 2499
+                        "total": 2499,
+                        "price": {
+                            "unit_amount": 2499
+                        }
                     }
                 ]
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -97,6 +97,51 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
+    fun `parse line item unitAmount from price when total includes tax`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_tax",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 11034, "subtotal": 10198, "total": 11034 },
+                "line_item_group": {
+                    "currency": "usd",
+                    "total": 11034,
+                    "subtotal": 10198,
+                    "due": 11034,
+                    "line_items": [
+                        {
+                            "id": "li_tax_item",
+                            "object": "item",
+                            "name": "Classic T-Shirt",
+                            "quantity": 2,
+                            "subtotal": 10198,
+                            "total": 11034,
+                            "unit_amount_override": null,
+                            "price": {
+                                "unit_amount": 5099
+                            }
+                        }
+                    ]
+                }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        val lineItems = result!!.lineItems
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems[0].id).isEqualTo("li_tax_item")
+        assertThat(lineItems[0].name).isEqualTo("Classic T-Shirt")
+        assertThat(lineItems[0].quantity).isEqualTo(2)
+        assertThat(lineItems[0].unitAmount).isEqualTo(5099L)
+        assertThat(lineItems[0].subtotal).isEqualTo(10198L)
+        assertThat(lineItems[0].total).isEqualTo(11034L)
+    }
+
+    @Test
     fun `parse returns empty line items when no line_item_group`() {
         val json = JSONObject(
             """

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -97,6 +97,51 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
+    fun `parse line item unitAmount from unit_amount_override`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_override",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 7000, "subtotal": 7000, "total": 7000 },
+                "line_item_group": {
+                    "currency": "usd",
+                    "total": 7000,
+                    "subtotal": 7000,
+                    "due": 7000,
+                    "line_items": [
+                        {
+                            "id": "li_override_item",
+                            "object": "item",
+                            "name": "Widget",
+                            "quantity": 2,
+                            "subtotal": 7000,
+                            "total": 7000,
+                            "unit_amount_override": 3500,
+                            "price": {
+                                "unit_amount": 2999
+                            }
+                        }
+                    ]
+                }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        val lineItems = result!!.lineItems
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems[0].id).isEqualTo("li_override_item")
+        assertThat(lineItems[0].name).isEqualTo("Widget")
+        assertThat(lineItems[0].quantity).isEqualTo(2)
+        assertThat(lineItems[0].unitAmount).isEqualTo(3500L)
+        assertThat(lineItems[0].subtotal).isEqualTo(7000L)
+        assertThat(lineItems[0].total).isEqualTo(7000L)
+    }
+
+    @Test
     fun `parse line item unitAmount from price when total includes tax`() {
         val json = JSONObject(
             """


### PR DESCRIPTION
# Summary
Updates the checkout session parser to read unit amount from the price field instead of calculating it from total/quantity.

# Motivation
The previous implementation calculated unit amount by dividing total by quantity, which was incorrect when the total included taxes or other adjustments. The API provides the correct unit amount in the price field, which should be used instead.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
[Fixed] Fixed incorrect unit amount calculation for line items in checkout sessions when totals include taxes.