### PR TITLE
Remove resolved Detekt baseline suppressions.

### DIFF
--- a/example/detekt-baseline.xml
+++ b/example/detekt-baseline.xml
@@ -9,7 +9,6 @@
     <ID>LongMethod:ManualUSBankAccountPaymentMethodActivity.kt:ManualUSBankAccountPaymentMethodActivity$@Composable private fun CollectBankScreen</ID>
     <ID>LongMethod:ManualUSBankAccountPaymentMethodActivity.kt:ManualUSBankAccountPaymentMethodActivity$@Composable private fun VerifyWithMicrodepositScreen</ID>
     <ID>MagicNumber:PaymentAuthActivity.kt:PaymentAuthActivity$6</ID>
-    <ID>MagicNumber:UpiWaitingActivity.kt:UpiWaitingActivity$5000</ID>
     <ID>VariableNaming:StripeImageActivity.kt:StripeImageActivity$private val LocalStripeImageLoader = staticCompositionLocalOf&lt;StripeImageLoader> { error("No ImageLoader provided") }</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -8,7 +8,6 @@
     <ID>LargeClass:IdentityViewModel.kt:IdentityViewModel : AndroidViewModel</ID>
     <ID>LargeClass:IdentityViewModelTest.kt:IdentityViewModelTest</ID>
     <ID>LongMethod:AddressSection.kt:@Composable internal fun AddressSection</ID>
-    <ID>LongMethod:ConfirmationScreen.kt:@Composable internal fun ConfirmationScreen</ID>
     <ID>LongMethod:DebugScreen.kt:@Composable internal fun CompleteWithTestDataSection</ID>
     <ID>LongMethod:DebugScreen.kt:@Composable internal fun DebugScreen</ID>
     <ID>LongMethod:DocWarmupScreen.kt:@Composable internal fun DocWarmupView</ID>
@@ -24,7 +23,6 @@
     <ID>LongMethod:OTPScreen.kt:@Composable internal fun OTPScreen</ID>
     <ID>LongMethod:OTPScreen.kt:@Composable private fun OTPViewStateEffect</ID>
     <ID>LongMethod:SelfieScreen.kt:@Composable internal fun SelfieScanScreen</ID>
-    <ID>LongMethod:SelfieScreen.kt:@Composable private fun ResultView</ID>
     <ID>LongMethod:SelfieScreen.kt:@Composable private fun SelfieCaptureScreen</ID>
     <ID>LongMethod:UploadScreen.kt:@Composable internal fun UploadScreen</ID>
     <ID>MagicNumber:DefaultIdentityIO.kt:DefaultIdentityIO$5</ID>

--- a/paymentsheet-example/detekt-baseline.xml
+++ b/paymentsheet-example/detekt-baseline.xml
@@ -33,7 +33,6 @@
     <ID>PackageNaming:ServerSideConfirmationCustomFlowActivity.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.custom_flow</ID>
     <ID>PackageNaming:ServerSideConfirmationCustomFlowViewModel.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.custom_flow</ID>
     <ID>PackageNaming:ServerSideConfirmationCustomFlowViewState.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.custom_flow</ID>
-    <ID>TooManyFunctions:CheckoutPlaygroundViewModel.kt:CheckoutPlaygroundViewModel : ViewModel</ID>
     <ID>TooManyFunctions:PaymentSheetPlaygroundViewModel.kt:PaymentSheetPlaygroundViewModel : AndroidViewModel</ID>
     <ID>TooManyFunctions:PlaygroundSettingDefinition.kt:PlaygroundSettingDefinition&lt;T></ID>
     <ID>TooManyFunctions:PlaygroundSettings.kt:PlaygroundSettings$Snapshot : Parcelable</ID>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -33,7 +33,6 @@
     <ID>LargeClass:PaymentMethodMetadataTest.kt:PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt:PaymentOptionsViewModelTest</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt:PaymentSheetActivityTest</ID>
-    <ID>LargeClass:PaymentSheetViewModel.kt:PaymentSheetViewModel : BaseSheetViewModel</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt:PaymentSheetViewModelTest</ID>
     <ID>LargeClass:PlaceholderHelperTest.kt:PlaceholderHelperTest</ID>
     <ID>LargeClass:PrimaryButtonUiStateMapperTest.kt:PrimaryButtonUiStateMapperTest</ID>

--- a/stripecardscan/detekt-baseline.xml
+++ b/stripecardscan/detekt-baseline.xml
@@ -1,44 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>EmptyFunctionBlock:CardScanFragment.kt$CardScanFragment${}</ID>
-    <ID>ForbiddenComment:PaymentCardUtils.kt$* Determine if a PAN is valid. * * TODO: this should use a contract like the following once contracts are no longer experimental: * ``` * contract { returns(true) implies (pan != null) } * ```</ID>
-    <ID>ForbiddenComment:SSD.kt$* The model outputs a particular location or a particular class of each prior before moving on to * the next prior. For instance, the model will output probabilities for background class * corresponding to all priors before outputting the probability of next class for the first prior. * This method serves to rearrange the output if you are using outputs from multiple layers If you * use outputs from single layer use the method defined above * * TODO: simplify this</ID>
-    <ID>ForbiddenComment:ScanActivity.kt$ScanActivity$// TODO: this should be reported as part of scanstats, but is not yet supported</ID>
-    <ID>ForbiddenComment:ScanActivity.kt$ScanActivity$// TODO: this should probably be reported as part of scanstats, but is not yet supported</ID>
-    <ID>ForbiddenComment:ScanFragment.kt$ScanFragment$// TODO: this should be reported as part of scanstats, but is not yet supported</ID>
-    <ID>ForbiddenComment:ScanFragment.kt$ScanFragment$// TODO: this should probably be reported as part of scanstats, but is not yet supported</ID>
-    <ID>ForbiddenComment:Timer.kt$* Measure the amount of time a process takes. * * TODO: use contracts when they are no longer experimental</ID>
-    <ID>ForbiddenComment:Timer.kt$LoggingTimer$// TODO: use contracts when they are no longer experimental</ID>
-    <ID>ForbiddenComment:Timer.kt$NoOpTimer$// TODO: use contracts when they are no longer experimental</ID>
-    <ID>MagicNumber:CombinePriors.kt$12</ID>
-    <ID>MagicNumber:CombinePriors.kt$16</ID>
-    <ID>MagicNumber:CombinePriors.kt$19</ID>
-    <ID>MagicNumber:CombinePriors.kt$24</ID>
-    <ID>MagicNumber:CombinePriors.kt$31</ID>
-    <ID>MagicNumber:CombinePriors.kt$38</ID>
-    <ID>MagicNumber:MLImage.kt$MLImage$0xFF</ID>
-    <ID>MagicNumber:MLImage.kt$MLImage$16</ID>
-    <ID>MagicNumber:MLImage.kt$MLImage$8</ID>
-    <ID>MagicNumber:NonMaximumSuppression.kt$0.00001f</ID>
-    <ID>MagicNumber:NonMaximumSuppression.kt$200</ID>
-    <ID>MagicNumber:PanValidator.kt$LuhnPanValidator$10</ID>
-    <ID>MagicNumber:PanValidator.kt$LuhnPanValidator$9</ID>
-    <ID>MagicNumber:RectForm.kt$1000F</ID>
-    <ID>MagicNumber:RectForm.kt$3</ID>
-    <ID>MagicNumber:ScanActivity.kt$ScanActivity$1500</ID>
-    <ID>MagicNumber:ScanFragment.kt$ScanFragment$1500</ID>
-    <ID>MagicNumber:SizeAndCenter.kt$3</ID>
-    <ID>MatchingDeclarationName:SSD.kt$OcrFeatureMapSizes</ID>
-    <ID>NestedBlockDepth:SSD.kt$internal fun rearrangeOCRArray( locations: Array&lt;FloatArray>, featureMapSizes: OcrFeatureMapSizes, numberOfPriors: Int, locationsPerPrior: Int ): Array&lt;FloatArray></ID>
-    <ID>SwallowedException:Loader.kt$Loader$t: Throwable</ID>
-    <ID>TooGenericExceptionCaught:Loader.kt$Loader$t: Throwable</ID>
-    <ID>TooGenericExceptionCaught:TensorFlowLiteAnalyzer.kt$TFLAnalyzerFactory$t: Throwable</ID>
-    <ID>TooManyFunctions:ArrayExtensions.kt$com.stripe.android.stripecardscan.framework.util.ArrayExtensions.kt</ID>
-    <ID>TooManyFunctions:RectForm.kt$com.stripe.android.stripecardscan.framework.ml.ssd.RectForm.kt</ID>
-    <ID>TooManyFunctions:ScanActivity.kt$ScanActivity : CameraPermissionCheckingActivityCoroutineScope</ID>
-    <ID>TooManyFunctions:ScanFragment.kt$ScanFragment : FragmentCoroutineScope</ID>
-    <ID>TooManyFunctions:SizeAndCenter.kt$com.stripe.android.stripecardscan.framework.ml.ssd.SizeAndCenter.kt</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>


### PR DESCRIPTION
# Summary
Cleaned up Detekt baseline files by removing suppressions for issues that have been resolved in the codebase.

# Motivation
These Detekt suppressions are no longer needed as the underlying code issues have been fixed. Removing them from the baseline keeps the suppression files accurate and prevents masking of any future similar issues.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
No user-facing changes.