### PR TITLE
Add exposure logging for FC Lite experiment

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperiment.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.common.analytics.experiment
+
+import com.stripe.android.common.di.MOBILE_SESSION_ID
+import com.stripe.android.core.version.StripeSdkVersion
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE_AA
+import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.payments.financialconnections.GetDefaultFinancialConnectionsAvailability
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import javax.inject.Inject
+import javax.inject.Named
+
+internal interface LogFcLiteExperiment {
+    operator fun invoke(elementsSession: ElementsSession)
+}
+
+internal class DefaultLogFcLiteExperiment internal constructor(
+    private val eventReporter: EventReporter,
+    private val mobileSessionId: String,
+    isFullSdkAvailable: IsFinancialConnectionsSdkAvailable,
+) : LogFcLiteExperiment {
+
+    @Inject
+    constructor(
+        eventReporter: EventReporter,
+        @Named(MOBILE_SESSION_ID) mobileSessionId: String,
+    ) : this(eventReporter, mobileSessionId, DefaultIsFinancialConnectionsAvailable)
+
+    private val fcSdkAvailability: String = when (GetDefaultFinancialConnectionsAvailability(isFullSdkAvailable)) {
+        FinancialConnectionsAvailability.Full -> "FULL"
+        FinancialConnectionsAvailability.Lite -> "LITE"
+    }
+
+    override fun invoke(elementsSession: ElementsSession) {
+        val experimentsData = elementsSession.experimentsData ?: return
+
+        listOf(CONNECTIONS_FC_LITE_VS_NATIVE, CONNECTIONS_FC_LITE_VS_NATIVE_AA).forEach { assignment ->
+            val group = experimentsData.experimentAssignments[assignment] ?: return@forEach
+            eventReporter.onExperimentExposure(
+                experiment = LoggableExperiment.ConnectionsFCLiteVsNative(
+                    arbId = experimentsData.arbId,
+                    group = group,
+                    experiment = assignment,
+                    elementsSessionId = elementsSession.elementsSessionId,
+                    mobileSessionId = mobileSessionId,
+                    mobileSdkVersion = StripeSdkVersion.VERSION_NAME,
+                    fcSdkAvailability = fcSdkAvailability,
+                    availableLpms = elementsSession.orderedPaymentMethodTypesAndWallets.joinToString(","),
+                )
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperiment.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.analytics.experiment
 
 import com.stripe.android.common.di.MOBILE_SESSION_ID
 import com.stripe.android.core.version.StripeSdkVersion
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE
 import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE_AA
@@ -14,7 +15,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 internal interface LogFcLiteExperiment {
-    operator fun invoke(elementsSession: ElementsSession)
+    operator fun invoke(elementsSession: ElementsSession, paymentMethodMetadata: PaymentMethodMetadata)
 }
 
 internal class DefaultLogFcLiteExperiment internal constructor(
@@ -34,8 +35,9 @@ internal class DefaultLogFcLiteExperiment internal constructor(
         FinancialConnectionsAvailability.Lite -> "LITE"
     }
 
-    override fun invoke(elementsSession: ElementsSession) {
+    override fun invoke(elementsSession: ElementsSession, paymentMethodMetadata: PaymentMethodMetadata) {
         val experimentsData = elementsSession.experimentsData ?: return
+        val availableLpms = paymentMethodMetadata.sortedSupportedPaymentMethods().map { it.code }.joinToString(",")
 
         listOf(CONNECTIONS_FC_LITE_VS_NATIVE, CONNECTIONS_FC_LITE_VS_NATIVE_AA).forEach { assignment ->
             val group = experimentsData.experimentAssignments[assignment] ?: return@forEach
@@ -48,7 +50,7 @@ internal class DefaultLogFcLiteExperiment internal constructor(
                     mobileSessionId = mobileSessionId,
                     mobileSdkVersion = StripeSdkVersion.VERSION_NAME,
                     fcSdkAvailability = fcSdkAvailability,
-                    availableLpms = elementsSession.orderedPaymentMethodTypesAndWallets.joinToString(","),
+                    availableLpms = availableLpms,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
@@ -65,6 +65,28 @@ internal sealed class LoggableExperiment(
         }
     }
 
+    data class ConnectionsFCLiteVsNative(
+        override val arbId: String,
+        override val group: String,
+        override val experiment: ExperimentAssignment,
+        val elementsSessionId: String,
+        val mobileSessionId: String,
+        val mobileSdkVersion: String,
+        val fcSdkAvailability: String,
+        val availableLpms: String,
+    ) : LoggableExperiment(
+        arbId = arbId,
+        group = group,
+        experiment = experiment,
+        dimensions = mapOf(
+            "elements_session_id" to elementsSessionId,
+            "mobile_session_id" to mobileSessionId,
+            "mobile_sdk_version" to mobileSdkVersion,
+            "fc_sdk_availability" to fcSdkAvailability,
+            "available_lpms" to availableLpms,
+        )
+    )
+
     data class OcsMobilePaymentMethodMessagingPromotions(
         val experimentsData: ElementsSession.ExperimentsData,
         override val group: String,

--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -260,7 +260,9 @@ internal data class ElementsSession(
         LINK_GLOBAL_HOLD_BACK("link_global_holdback"),
         LINK_GLOBAL_HOLD_BACK_AA("link_global_holdback_aa"),
         LINK_AB_TEST("link_ab_test"),
-        OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS("ocs_mobile_payment_method_messaging_promotions")
+        OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS("ocs_mobile_payment_method_messaging_promotions"),
+        CONNECTIONS_FC_LITE_VS_NATIVE("connections_fc_lite_vs_native"),
+        CONNECTIONS_FC_LITE_VS_NATIVE_AA("connections_fc_lite_vs_native_aa"),
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailability.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailability.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.financialconnections
 
 import com.stripe.android.core.utils.FeatureFlags.financialConnectionsFullSdkUnavailable
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE
 
 internal object GetFinancialConnectionsAvailability {
 
@@ -29,5 +30,6 @@ internal object GetFinancialConnectionsAvailability {
         this?.flags?.get(ElementsSession.Flag.ELEMENTS_DISABLE_FC_LITE) == true
 
     private fun ElementsSession?.preferLite(): Boolean =
-        this?.flags?.get(ElementsSession.Flag.ELEMENTS_PREFER_FC_LITE) == true
+        this?.flags?.get(ElementsSession.Flag.ELEMENTS_PREFER_FC_LITE) == true ||
+            this?.experimentsData?.experimentAssignments?.get(CONNECTIONS_FC_LITE_VS_NATIVE) == "treatment"
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -2,7 +2,9 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import com.stripe.android.Stripe
+import com.stripe.android.common.analytics.experiment.DefaultLogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.DefaultLogLinkHoldbackExperiment
+import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
@@ -45,6 +47,13 @@ internal class LinkHoldbackExposureModule {
     fun providesLogLinkGlobalHoldbackExposure(
         default: DefaultLogLinkHoldbackExperiment
     ): LogLinkHoldbackExperiment {
+        return default
+    }
+
+    @Provides
+    fun providesLogFcLiteExperiment(
+        default: DefaultLogFcLiteExperiment
+    ): LogFcLiteExperiment {
         return default
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -494,7 +494,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             elementsSession = elementsSession,
             state = state
         )
-        logFcLiteExperiment(elementsSession)
+        logFcLiteExperiment(elementsSession, state.paymentMethodMetadata)
     }
 
     private fun createPaymentMethodMetadata(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromotionsExperimentHandler
 import com.stripe.android.common.coroutines.runCatching
@@ -227,6 +228,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     @IOContext private val workContext: CoroutineContext,
     private val createLinkState: CreateLinkState,
     private val logLinkHoldbackExperiment: LogLinkHoldbackExperiment,
+    private val logFcLiteExperiment: LogFcLiteExperiment,
     private val externalPaymentMethodsRepository: ExternalPaymentMethodsRepository,
     private val userFacingLogger: UserFacingLogger,
     private val integrityRequestManager: IntegrityRequestManager,
@@ -410,7 +412,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             paymentMethodMetadata = pmMetadata,
         )
 
-        logLinkExperimentExposures(
+        logExperimentExposures(
             elementsSession = elementsSession,
             state = state
         )
@@ -479,7 +481,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
     }
 
-    private fun logLinkExperimentExposures(
+    private fun logExperimentExposures(
         elementsSession: ElementsSession,
         state: PaymentElementLoader.State
     ) {
@@ -492,6 +494,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             elementsSession = elementsSession,
             state = state
         )
+        logFcLiteExperiment(elementsSession)
     }
 
     private fun createPaymentMethodMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperimentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperimentTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.analytics.experiment
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.version.StripeSdkVersion
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE
 import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE_AA
@@ -41,7 +42,7 @@ class LogFcLiteExperimentTest {
             )
         )
 
-        createExperiment()(elementsSession)
+        createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
         val firstExposure = eventReporter.experimentExposureCalls.awaitItem()
         val secondExposure = eventReporter.experimentExposureCalls.awaitItem()
@@ -65,7 +66,7 @@ class LogFcLiteExperimentTest {
             )
         )
 
-        createExperiment()(elementsSession)
+        createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
         val exposures = listOf(
             eventReporter.experimentExposureCalls.awaitItem().experiment,
@@ -81,24 +82,25 @@ class LogFcLiteExperimentTest {
 
     @Test
     fun `logs correct dimensions`() = runTest {
+        val metadata = PaymentMethodMetadataFactory.create()
         val elementsSession = createElementsSession(
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "test_arb_id",
                 experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "treatment")
             ),
-            orderedPaymentMethodTypesAndWallets = listOf("card", "us_bank_account"),
         )
 
-        createExperiment()(elementsSession)
+        createExperiment()(elementsSession, metadata)
 
         val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
             as LoggableExperiment.ConnectionsFCLiteVsNative
 
+        val expectedLpms = metadata.sortedSupportedPaymentMethods().map { it.code }.joinToString(",")
         assertThat(exposure.arbId).isEqualTo("test_arb_id")
         assertThat(exposure.elementsSessionId).isEqualTo("session_1234")
         assertThat(exposure.mobileSessionId).isEqualTo("test_mobile_session_id")
         assertThat(exposure.mobileSdkVersion).isEqualTo(StripeSdkVersion.VERSION_NAME)
-        assertThat(exposure.availableLpms).isEqualTo("card,us_bank_account")
+        assertThat(exposure.availableLpms).isEqualTo(expectedLpms)
     }
 
     @Test
@@ -110,7 +112,10 @@ class LogFcLiteExperimentTest {
             )
         )
 
-        createExperiment(isFullSdkAvailable = IsFinancialConnectionsSdkAvailable { true })(elementsSession)
+        createExperiment(isFullSdkAvailable = IsFinancialConnectionsSdkAvailable { true })(
+            elementsSession,
+            PaymentMethodMetadataFactory.create()
+        )
 
         val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
             as LoggableExperiment.ConnectionsFCLiteVsNative
@@ -127,7 +132,10 @@ class LogFcLiteExperimentTest {
             )
         )
 
-        createExperiment(isFullSdkAvailable = IsFinancialConnectionsSdkAvailable { false })(elementsSession)
+        createExperiment(isFullSdkAvailable = IsFinancialConnectionsSdkAvailable { false })(
+            elementsSession,
+            PaymentMethodMetadataFactory.create()
+        )
 
         val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
             as LoggableExperiment.ConnectionsFCLiteVsNative
@@ -139,7 +147,7 @@ class LogFcLiteExperimentTest {
     fun `does not log when experimentsData is null`() = runTest {
         val elementsSession = createElementsSession(experimentsData = null)
 
-        createExperiment()(elementsSession)
+        createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
         eventReporter.experimentExposureCalls.expectNoEvents()
     }
@@ -153,7 +161,7 @@ class LogFcLiteExperimentTest {
             )
         )
 
-        createExperiment()(elementsSession)
+        createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
         eventReporter.experimentExposureCalls.expectNoEvents()
     }
@@ -167,7 +175,7 @@ class LogFcLiteExperimentTest {
             )
         )
 
-        createExperiment()(elementsSession)
+        createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
         val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
             as LoggableExperiment.ConnectionsFCLiteVsNative
@@ -178,8 +186,6 @@ class LogFcLiteExperimentTest {
 
     private fun createElementsSession(
         experimentsData: ElementsSession.ExperimentsData? = null,
-        orderedPaymentMethodTypesAndWallets: List<String> =
-            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes,
     ): ElementsSession {
         return ElementsSession(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
@@ -188,7 +194,7 @@ class LogFcLiteExperimentTest {
             isGooglePayEnabled = false,
             customer = null,
             linkSettings = null,
-            orderedPaymentMethodTypesAndWallets = orderedPaymentMethodTypesAndWallets,
+            orderedPaymentMethodTypesAndWallets = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes,
             customPaymentMethods = emptyList(),
             externalPaymentMethodData = null,
             paymentMethodSpecs = null,

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperimentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperimentTest.kt
@@ -31,53 +31,37 @@ class LogFcLiteExperimentTest {
     )
 
     @Test
-    fun `logs exposure for both experiments when both are assigned`() = runTest {
+    fun `logs exposure for main experiment when assigned`() = runTest {
         val elementsSession = createElementsSession(
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "test_arb_id",
-                experimentAssignments = mapOf(
-                    CONNECTIONS_FC_LITE_VS_NATIVE to "treatment",
-                    CONNECTIONS_FC_LITE_VS_NATIVE_AA to "control",
-                )
+                experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "treatment")
             )
         )
 
         createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
-        val firstExposure = eventReporter.experimentExposureCalls.awaitItem()
-        val secondExposure = eventReporter.experimentExposureCalls.awaitItem()
-
-        val experiments = listOf(firstExposure.experiment, secondExposure.experiment)
-        assertThat(experiments.all { it is LoggableExperiment.ConnectionsFCLiteVsNative }).isTrue()
-
-        val assignments = experiments.map { it.experiment }.toSet()
-        assertThat(assignments).isEqualTo(setOf(CONNECTIONS_FC_LITE_VS_NATIVE, CONNECTIONS_FC_LITE_VS_NATIVE_AA))
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+            as LoggableExperiment.ConnectionsFCLiteVsNative
+        assertThat(exposure.experiment).isEqualTo(CONNECTIONS_FC_LITE_VS_NATIVE)
+        eventReporter.experimentExposureCalls.expectNoEvents()
     }
 
     @Test
-    fun `logs correct group for each experiment`() = runTest {
+    fun `logs exposure for AA experiment when assigned`() = runTest {
         val elementsSession = createElementsSession(
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "test_arb_id",
-                experimentAssignments = mapOf(
-                    CONNECTIONS_FC_LITE_VS_NATIVE to "treatment",
-                    CONNECTIONS_FC_LITE_VS_NATIVE_AA to "control",
-                )
+                experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE_AA to "control")
             )
         )
 
         createExperiment()(elementsSession, PaymentMethodMetadataFactory.create())
 
-        val exposures = listOf(
-            eventReporter.experimentExposureCalls.awaitItem().experiment,
-            eventReporter.experimentExposureCalls.awaitItem().experiment,
-        ).map { it as LoggableExperiment.ConnectionsFCLiteVsNative }
-
-        val mainExperiment = exposures.single { it.experiment == CONNECTIONS_FC_LITE_VS_NATIVE }
-        val aaExperiment = exposures.single { it.experiment == CONNECTIONS_FC_LITE_VS_NATIVE_AA }
-
-        assertThat(mainExperiment.group).isEqualTo("treatment")
-        assertThat(aaExperiment.group).isEqualTo("control")
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+            as LoggableExperiment.ConnectionsFCLiteVsNative
+        assertThat(exposure.experiment).isEqualTo(CONNECTIONS_FC_LITE_VS_NATIVE_AA)
+        eventReporter.experimentExposureCalls.expectNoEvents()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperimentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogFcLiteExperimentTest.kt
@@ -1,0 +1,205 @@
+package com.stripe.android.common.analytics.experiment
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.version.StripeSdkVersion
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE_AA
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class LogFcLiteExperimentTest {
+
+    private lateinit var eventReporter: FakeEventReporter
+
+    @Before
+    fun setUp() {
+        eventReporter = FakeEventReporter()
+    }
+
+    private fun createExperiment(
+        isFullSdkAvailable: IsFinancialConnectionsSdkAvailable = IsFinancialConnectionsSdkAvailable { true },
+    ) = DefaultLogFcLiteExperiment(
+        eventReporter = eventReporter,
+        mobileSessionId = "test_mobile_session_id",
+        isFullSdkAvailable = isFullSdkAvailable,
+    )
+
+    @Test
+    fun `logs exposure for both experiments when both are assigned`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(
+                    CONNECTIONS_FC_LITE_VS_NATIVE to "treatment",
+                    CONNECTIONS_FC_LITE_VS_NATIVE_AA to "control",
+                )
+            )
+        )
+
+        createExperiment()(elementsSession)
+
+        val firstExposure = eventReporter.experimentExposureCalls.awaitItem()
+        val secondExposure = eventReporter.experimentExposureCalls.awaitItem()
+
+        val experiments = listOf(firstExposure.experiment, secondExposure.experiment)
+        assertThat(experiments.all { it is LoggableExperiment.ConnectionsFCLiteVsNative }).isTrue()
+
+        val assignments = experiments.map { it.experiment }.toSet()
+        assertThat(assignments).isEqualTo(setOf(CONNECTIONS_FC_LITE_VS_NATIVE, CONNECTIONS_FC_LITE_VS_NATIVE_AA))
+    }
+
+    @Test
+    fun `logs correct group for each experiment`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(
+                    CONNECTIONS_FC_LITE_VS_NATIVE to "treatment",
+                    CONNECTIONS_FC_LITE_VS_NATIVE_AA to "control",
+                )
+            )
+        )
+
+        createExperiment()(elementsSession)
+
+        val exposures = listOf(
+            eventReporter.experimentExposureCalls.awaitItem().experiment,
+            eventReporter.experimentExposureCalls.awaitItem().experiment,
+        ).map { it as LoggableExperiment.ConnectionsFCLiteVsNative }
+
+        val mainExperiment = exposures.single { it.experiment == CONNECTIONS_FC_LITE_VS_NATIVE }
+        val aaExperiment = exposures.single { it.experiment == CONNECTIONS_FC_LITE_VS_NATIVE_AA }
+
+        assertThat(mainExperiment.group).isEqualTo("treatment")
+        assertThat(aaExperiment.group).isEqualTo("control")
+    }
+
+    @Test
+    fun `logs correct dimensions`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "treatment")
+            ),
+            orderedPaymentMethodTypesAndWallets = listOf("card", "us_bank_account"),
+        )
+
+        createExperiment()(elementsSession)
+
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+            as LoggableExperiment.ConnectionsFCLiteVsNative
+
+        assertThat(exposure.arbId).isEqualTo("test_arb_id")
+        assertThat(exposure.elementsSessionId).isEqualTo("session_1234")
+        assertThat(exposure.mobileSessionId).isEqualTo("test_mobile_session_id")
+        assertThat(exposure.mobileSdkVersion).isEqualTo(StripeSdkVersion.VERSION_NAME)
+        assertThat(exposure.availableLpms).isEqualTo("card,us_bank_account")
+    }
+
+    @Test
+    fun `sets fc_sdk_availability to FULL when full FC SDK is available`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "treatment")
+            )
+        )
+
+        createExperiment(isFullSdkAvailable = IsFinancialConnectionsSdkAvailable { true })(elementsSession)
+
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+            as LoggableExperiment.ConnectionsFCLiteVsNative
+
+        assertThat(exposure.fcSdkAvailability).isEqualTo("FULL")
+    }
+
+    @Test
+    fun `sets fc_sdk_availability to LITE when full FC SDK is unavailable`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "control")
+            )
+        )
+
+        createExperiment(isFullSdkAvailable = IsFinancialConnectionsSdkAvailable { false })(elementsSession)
+
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+            as LoggableExperiment.ConnectionsFCLiteVsNative
+
+        assertThat(exposure.fcSdkAvailability).isEqualTo("LITE")
+    }
+
+    @Test
+    fun `does not log when experimentsData is null`() = runTest {
+        val elementsSession = createElementsSession(experimentsData = null)
+
+        createExperiment()(elementsSession)
+
+        eventReporter.experimentExposureCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `does not log when experiment assignment is absent`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = emptyMap()
+            )
+        )
+
+        createExperiment()(elementsSession)
+
+        eventReporter.experimentExposureCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `logs only the experiment that is assigned`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "control")
+            )
+        )
+
+        createExperiment()(elementsSession)
+
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+            as LoggableExperiment.ConnectionsFCLiteVsNative
+
+        assertThat(exposure.experiment).isEqualTo(CONNECTIONS_FC_LITE_VS_NATIVE)
+        eventReporter.experimentExposureCalls.expectNoEvents()
+    }
+
+    private fun createElementsSession(
+        experimentsData: ElementsSession.ExperimentsData? = null,
+        orderedPaymentMethodTypesAndWallets: List<String> =
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes,
+    ): ElementsSession {
+        return ElementsSession(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            cardBrandChoice = null,
+            merchantCountry = null,
+            isGooglePayEnabled = false,
+            customer = null,
+            linkSettings = null,
+            orderedPaymentMethodTypesAndWallets = orderedPaymentMethodTypesAndWallets,
+            customPaymentMethods = emptyList(),
+            externalPaymentMethodData = null,
+            paymentMethodSpecs = null,
+            elementsSessionId = "session_1234",
+            flags = emptyMap(),
+            experimentsData = experimentsData,
+            passiveCaptcha = null,
+            merchantLogoUrl = null,
+            elementsSessionConfigId = null,
+            accountId = null,
+            merchantId = null,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailabilityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailabilityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.financialconnections
 
 import com.stripe.android.core.utils.FeatureFlags.financialConnectionsFullSdkUnavailable
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.CONNECTIONS_FC_LITE_VS_NATIVE
 import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_DISABLE_FC_LITE
 import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_PREFER_FC_LITE
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -22,7 +23,7 @@ class GetFinancialConnectionsAvailabilityTest {
     @Test
     fun `when prefer lite flag is enabled should return Lite regardless of full SDK availability`() {
         val elementsSession = createSession(
-            mapOf(ELEMENTS_PREFER_FC_LITE to true)
+            flags = mapOf(ELEMENTS_PREFER_FC_LITE to true)
         )
         assertEquals(
             FinancialConnectionsAvailability.Lite,
@@ -36,7 +37,7 @@ class GetFinancialConnectionsAvailabilityTest {
     @Test
     fun `when killswitch is enabled should take priority over prefer lite flag`() {
         val elementsSession = createSession(
-            mapOf(
+            flags = mapOf(
                 ELEMENTS_PREFER_FC_LITE to true,
                 ELEMENTS_DISABLE_FC_LITE to true
             )
@@ -65,7 +66,7 @@ class GetFinancialConnectionsAvailabilityTest {
     @Test
     fun `when lite killswitch is enabled and full not available should return None`() {
         val elementsSession = createSession(
-            mapOf(ELEMENTS_DISABLE_FC_LITE to true)
+            flags = mapOf(ELEMENTS_DISABLE_FC_LITE to true)
         )
         assertEquals(
             null,
@@ -101,9 +102,62 @@ class GetFinancialConnectionsAvailabilityTest {
         )
     }
 
-    private fun createSession(flags: Map<ElementsSession.Flag, Boolean>): ElementsSession {
+    @Test
+    fun `when experiment assignment is treatment should return Lite regardless of full SDK availability`() {
+        val elementsSession = createSession(
+            flags = emptyMap(),
+            experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "treatment")
+        )
+        assertEquals(
+            FinancialConnectionsAvailability.Lite,
+            GetFinancialConnectionsAvailability(
+                elementsSession = elementsSession,
+                isFullSdkAvailable = isFinancialConnectionsFullSdkAvailable(true)
+            )
+        )
+    }
+
+    @Test
+    fun `when experiment assignment is control should not prefer Lite`() {
+        val elementsSession = createSession(
+            flags = emptyMap(),
+            experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "control")
+        )
+        assertEquals(
+            FinancialConnectionsAvailability.Full,
+            GetFinancialConnectionsAvailability(
+                elementsSession = elementsSession,
+                isFullSdkAvailable = isFinancialConnectionsFullSdkAvailable(true)
+            )
+        )
+    }
+
+    @Test
+    fun `when experiment is treatment but killswitch is enabled should not use Lite`() {
+        val elementsSession = createSession(
+            flags = mapOf(ELEMENTS_DISABLE_FC_LITE to true),
+            experimentAssignments = mapOf(CONNECTIONS_FC_LITE_VS_NATIVE to "treatment")
+        )
+        assertEquals(
+            FinancialConnectionsAvailability.Full,
+            GetFinancialConnectionsAvailability(
+                elementsSession = elementsSession,
+                isFullSdkAvailable = isFinancialConnectionsFullSdkAvailable(true)
+            )
+        )
+    }
+
+    private fun createSession(
+        flags: Map<ElementsSession.Flag, Boolean>,
+        experimentAssignments: Map<ElementsSession.ExperimentAssignment, String> = emptyMap(),
+    ): ElementsSession {
+        val experimentsData = ElementsSession.ExperimentsData(
+            arbId = "test_arb_id",
+            experimentAssignments = experimentAssignments,
+        ).takeIf { experimentAssignments.isNotEmpty() }
         return mock<ElementsSession> {
             on { this.flags } doReturn flags
+            on { this.experimentsData } doReturn experimentsData
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogFcLiteExperiment.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogFcLiteExperiment.kt
@@ -3,14 +3,15 @@ package com.stripe.android.paymentsheet.analytics
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ElementsSession
 
 internal class FakeLogFcLiteExperiment : LogFcLiteExperiment {
 
-    private val _calls = Turbine<ElementsSession>()
-    val calls: ReceiveTurbine<ElementsSession> = _calls
+    private val _calls = Turbine<Unit>()
+    val calls: ReceiveTurbine<Unit> = _calls
 
-    override fun invoke(elementsSession: ElementsSession) {
-        _calls.add(elementsSession)
+    override fun invoke(elementsSession: ElementsSession, paymentMethodMetadata: PaymentMethodMetadata) {
+        _calls.add(Unit)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogFcLiteExperiment.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogFcLiteExperiment.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.paymentsheet.analytics
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
+import com.stripe.android.model.ElementsSession
+
+internal class FakeLogFcLiteExperiment : LogFcLiteExperiment {
+
+    private val _calls = Turbine<ElementsSession>()
+    val calls: ReceiveTurbine<ElementsSession> = _calls
+
+    override fun invoke(elementsSession: ElementsSession) {
+        _calls.add(elementsSession)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.analytics.experiment.DefaultPaymentMethodMessagePromotionsExperimentHandler
+import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromotionsExperimentHandler
 import com.stripe.android.common.configuration.ConfigurationDefaults
@@ -72,6 +73,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.FakeLoadingEventReporter
+import com.stripe.android.paymentsheet.analytics.FakeLogFcLiteExperiment
 import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
 import com.stripe.android.paymentsheet.analytics.FakePaymentMethodMessagePromotionsExperimentHandler
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -4772,6 +4774,7 @@ internal class DefaultPaymentElementLoaderTest {
         customer: ElementsSession.Customer? = null,
         externalPaymentMethodData: String? = null,
         logLinkHoldbackExperiment: LogLinkHoldbackExperiment = FakeLogLinkHoldbackExperiment(),
+        logFcLiteExperiment: LogFcLiteExperiment = FakeLogFcLiteExperiment(),
         errorReporter: ErrorReporter = FakeErrorReporter(),
         customPaymentMethods: List<ElementsSession.CustomPaymentMethod> = emptyList(),
         elementsSessionRepository: ElementsSessionRepository = FakeElementsSessionRepository(
@@ -4830,6 +4833,7 @@ internal class DefaultPaymentElementLoaderTest {
             workContext = testDispatcher,
             createLinkState = createLinkState,
             logLinkHoldbackExperiment = logLinkHoldbackExperiment,
+            logFcLiteExperiment = logFcLiteExperiment,
             externalPaymentMethodsRepository = ExternalPaymentMethodsRepository(errorReporter = FakeErrorReporter()),
             userFacingLogger = userFacingLogger,
             integrityRequestManager = integrityRequestManager,


### PR DESCRIPTION
# Summary

Adding experiment exposure logging for `connections_fc_lite_vs_native` and `connections_fc_lite_vs_native_aa` which are upcoming experiments we'll be running.

# Motivation

https://docs.google.com/document/d/1op-_3Wzg1oKxb4DN7NXmLjbjM6DmQ3jii_9naKSQUcM/edit?usp=sharing

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified


# Changelog

N/a
