### PR TITLE
Fixes Bullet Rendering in HTML Compose View

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
@@ -376,6 +376,7 @@ fun annotatedStringResource(
     return remember(spanned) {
         buildAnnotatedString {
             var currentStart = 0
+            var offset = 0
             spanned.getSpans(0, spanned.length, Any::class.java).forEach { span ->
                 val start = spanned.getSpanStart(span)
                 val end = spanned.getSpanEnd(span)
@@ -385,13 +386,15 @@ fun annotatedStringResource(
                 ) {
                     append(spanned.toString().substring(currentStart, start))
                     currentStart = start
+                    val offsetStart = start + offset
+                    val offsetEnd = end + offset
                     when (span) {
                         is StyleSpan -> when (span.style) {
                             Typeface.BOLD -> {
-                                addStyle(SpanStyle(fontWeight = FontWeight.Bold), start, end)
+                                addStyle(SpanStyle(fontWeight = FontWeight.Bold), offsetStart, offsetEnd)
                             }
                             Typeface.ITALIC -> {
-                                addStyle(SpanStyle(fontStyle = FontStyle.Italic), start, end)
+                                addStyle(SpanStyle(fontStyle = FontStyle.Italic), offsetStart, offsetEnd)
                             }
                             Typeface.BOLD_ITALIC -> {
                                 addStyle(
@@ -399,24 +402,25 @@ fun annotatedStringResource(
                                         fontWeight = FontWeight.Bold,
                                         fontStyle = FontStyle.Italic
                                     ),
-                                    start,
-                                    end
+                                    offsetStart,
+                                    offsetEnd
                                 )
                             }
                         }
                         is UnderlineSpan -> {
                             addStyle(
                                 SpanStyle(textDecoration = TextDecoration.Underline),
-                                start,
-                                end
+                                offsetStart,
+                                offsetEnd
                             )
                         }
                         is BulletSpan -> {
                             // append a bullet and a tab character in front
                             append("\u2022\t")
+                            offset += 2
                         }
                         is ForegroundColorSpan -> {
-                            addStyle(SpanStyle(color = Color(span.foregroundColor)), start, end)
+                            addStyle(SpanStyle(color = Color(span.foregroundColor)), offsetStart, offsetEnd)
                         }
                         is ImageSpan -> {
                             currentStart = end
@@ -430,14 +434,14 @@ fun annotatedStringResource(
                         is URLSpan -> {
                             addStyle(
                                 urlSpanStyle,
-                                start,
-                                end
+                                offsetStart,
+                                offsetEnd
                             )
                             addStringAnnotation(
                                 tag = LINK_TAG,
                                 annotation = span.url,
-                                start = start,
-                                end = end
+                                start = offsetStart,
+                                end = offsetEnd
                             )
                         }
                     }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/text/HtmlTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/text/HtmlTest.kt
@@ -1,0 +1,109 @@
+package com.stripe.android.uicore.text
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HtmlTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `annotatedStringResource applies inline styles used by Html screenshots`() {
+        var bold = AnnotatedString("")
+        var italic = AnnotatedString("")
+        var underline = AnnotatedString("")
+        composeTestRule.setContent {
+            bold = annotatedStringResource(text = "this is some <b>bold</b> text")
+            italic = annotatedStringResource(text = "this is some <i>italic</i> text")
+            underline = annotatedStringResource(text = "this is some <u>underline</u> text")
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(bold.spanStyleFor("bold").fontWeight).isEqualTo(FontWeight.Bold)
+            assertThat(italic.spanStyleFor("italic").fontStyle).isEqualTo(FontStyle.Italic)
+            assertThat(underline.spanStyleFor("underline").textDecoration).isEqualTo(TextDecoration.Underline)
+        }
+    }
+
+    @Test
+    fun `annotatedStringResource keeps anchor annotations used by Html screenshots`() {
+        val annotatedString = annotatedStringFor("this is some <a href='stripe.com'>link</a> text")
+        val links = annotatedString.getStringAnnotations("URL", 0, annotatedString.length)
+
+        assertThat(links).hasSize(1)
+        assertThat(links.single().item).isEqualTo("stripe.com")
+        assertThat(annotatedString.text.substring(links.single().start, links.single().end)).isEqualTo("link")
+    }
+
+    @Test
+    fun `annotatedStringResource keeps list items used by Html screenshots`() {
+        val annotatedString = annotatedStringFor(
+            "these are some list items: <li>item1</li><li>item2</li><li>item3</li>"
+        )
+
+        assertThat(annotatedString.text).contains("\u2022\titem1")
+        assertThat(annotatedString.text).contains("\u2022\titem2")
+        assertThat(annotatedString.text).contains("\u2022\titem3")
+    }
+
+    @Test
+    fun `annotatedStringResource keeps promo links aligned`() {
+        val annotatedString = annotatedStringFor(
+            "Get \$5 back when you pay by bank. " +
+                "<a href=\"https://link.com/promotion-terms\">See&#160;terms</a>"
+        )
+        val link = annotatedString.getStringAnnotations("URL", 0, annotatedString.length).single()
+
+        assertThat(link.item).isEqualTo("https://link.com/promotion-terms")
+        assertThat(annotatedString.text.substring(link.start, link.end)).isEqualTo("See\u00a0terms")
+    }
+
+    @Test
+    fun `annotatedStringResource keeps link annotations aligned after list items`() {
+        val html = "<p>Read <a href=\"https://example.com/terms\">terms</a>.</p>" +
+            "<ul><li>One</li><li>Two</li></ul>" +
+            "<p>Please visit <a href=\"https://support.link.com/topics/crypto\">our support page</a>.</p>"
+
+        var annotatedString = AnnotatedString("")
+        composeTestRule.setContent {
+            annotatedString = annotatedStringResource(text = html)
+        }
+
+        composeTestRule.runOnIdle {
+            val links = annotatedString.getStringAnnotations("URL", 0, annotatedString.length)
+
+            assertThat(
+                links.associate {
+                    it.item to annotatedString.text.substring(it.start, it.end)
+                }
+            ).containsAtLeast(
+                "https://example.com/terms",
+                "terms",
+                "https://support.link.com/topics/crypto",
+                "our support page",
+            )
+            assertThat(annotatedString.text).contains("\u2022\tOne")
+        }
+    }
+
+    private fun annotatedStringFor(html: String): AnnotatedString {
+        var annotatedString = AnnotatedString("")
+        composeTestRule.setContent {
+            annotatedString = annotatedStringResource(text = html)
+        }
+        return composeTestRule.runOnIdle { annotatedString }
+    }
+
+    private fun AnnotatedString.spanStyleFor(text: String) = spanStyles.single {
+        this.text.substring(it.start, it.end) == text
+    }.item
+}


### PR DESCRIPTION
# Summary
Fixes an issue where we were adding characters for a bullet span, but not taking into account the additional offset that would require for future spans.

# Motivation
HTML text from Crypto Onramp is being rendered that includes both bullets and links, and due to the offset issue, links after bullets were not applied correctly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ceaece92-3a1c-4d88-b583-b29e96f42037" width="300" /> | <img src="https://github.com/user-attachments/assets/d5bcfab2-d2ef-4baa-a270-f3aac71e6335" width="300" /> |