### PR TITLE
Add getPromotionProvider to PMM Promotions helper

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -35,6 +35,11 @@ internal interface PaymentMethodMessagePromotionsHelper {
     ): PaymentMethodMessagePromotion?
 
     fun getPromotions(): List<PaymentMethodMessagePromotion>?
+
+    fun getPromotionProvider(
+        code: PaymentMethodCode,
+        metadata: PaymentMethodMetadata
+    ): (() -> PaymentMethodMessagePromotion?)?
 }
 
 @Singleton
@@ -103,6 +108,16 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
             null
         }
     }
+
+    override fun getPromotionProvider(
+        code: PaymentMethodCode,
+        metadata: PaymentMethodMetadata
+    ): (() -> PaymentMethodMessagePromotion?)? {
+        return getPromotionProviderInternal(
+            code = code,
+            metadata = metadata,
+        )
+    }
 }
 
 internal class PrefetchedPaymentMethodMessagePromotionsHelper(
@@ -142,6 +157,16 @@ internal class PrefetchedPaymentMethodMessagePromotionsHelper(
             null
         }
     }
+
+    override fun getPromotionProvider(
+        code: PaymentMethodCode,
+        metadata: PaymentMethodMetadata
+    ): (() -> PaymentMethodMessagePromotion?)? {
+        return getPromotionProviderInternal(
+            code = code,
+            metadata = metadata,
+        )
+    }
 }
 
 internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessagePromotionsHelper {
@@ -159,6 +184,13 @@ internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessage
     override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
         return null
     }
+
+    override fun getPromotionProvider(
+        code: PaymentMethodCode,
+        metadata: PaymentMethodMetadata
+    ): (() -> PaymentMethodMessagePromotion?)? {
+        return null
+    }
 }
 
 internal object PromotionSupportedPaymentMethods {
@@ -167,6 +199,23 @@ internal object PromotionSupportedPaymentMethods {
         PaymentMethod.Type.Affirm.code,
         PaymentMethod.Type.AfterpayClearpay.code
     )
+}
+
+private fun PaymentMethodMessagePromotionsHelper.getPromotionProviderInternal(
+    code: PaymentMethodCode,
+    metadata: PaymentMethodMetadata,
+): (() -> PaymentMethodMessagePromotion?)? {
+    if (!PromotionSupportedPaymentMethods.supportedPaymentMethods.contains(code)) return null
+
+    val variant = metadata.experimentsData?.experimentAssignments[
+        ExperimentAssignment.OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS
+    ]
+
+    return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled && variant == "treatment") {
+        { getPromotionIfAvailableForCode(code, metadata) }
+    } else {
+        null
+    }
 }
 
 @Module

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -4,14 +4,12 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -380,7 +378,10 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             supportedPaymentMethod.asDisplayablePaymentMethod(
                 customerSavedPaymentMethods = paymentMethods,
                 incentive = paymentMethodIncentive,
-                promotionProvider = getPromotionProvider(supportedPaymentMethod.code),
+                promotionProvider = paymentMethodMessagePromotionsHelper?.getPromotionProvider(
+                    code = supportedPaymentMethod.code,
+                    metadata = paymentMethodMetadata
+                ),
                 shouldExpandOnClick = shouldExpandOnClick(supportedPaymentMethod.code)
             ) {
                 handleViewAction(ViewAction.PaymentMethodSelected(supportedPaymentMethod.code))
@@ -656,21 +657,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         }
         is PaymentSelection.New.USBankAccount -> label
         else -> null
-    }
-
-    private fun getPromotionProvider(code: PaymentMethodCode): (() -> PaymentMethodMessagePromotion?)? {
-        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled &&
-            PromotionSupportedPaymentMethods.supportedPaymentMethods.contains(code)
-        ) {
-            {
-                paymentMethodMessagePromotionsHelper?.getPromotionIfAvailableForCode(
-                    code,
-                    paymentMethodMetadata
-                )
-            }
-        } else {
-            null
-        }
     }
 
     private fun shouldTransitionToFormScreen(paymentMethodCode: PaymentMethodCode): Boolean {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -68,6 +68,41 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         assertThat(helper.getPromotionIfAvailableForCode("afterpay_clearpay", metadata)).isNull()
     }
 
+    @Test
+    fun `getPromotionProvider returns null for control`() = runScenario(
+        featureFlagEnabled = true
+    ) {
+        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        dispatcher.scheduler.advanceUntilIdle()
+        val metadata = getMetadata("control")
+        assertThat(helper.getPromotionProvider("afterpay_clearpay", metadata)).isNull()
+    }
+
+    @Test
+    fun `getPromotionProvider returns null for unsupported PMs`() = runScenario(
+        featureFlagEnabled = true
+    ) {
+        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        dispatcher.scheduler.advanceUntilIdle()
+        val metadata = getMetadata("control")
+        assertThat(helper.getPromotionProvider("card", metadata)).isNull()
+    }
+
+    @Test
+    fun `returns promotion provider for treatment group supported pm`() = runScenario(
+        featureFlagEnabled = true
+    ) {
+        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        dispatcher.scheduler.advanceUntilIdle()
+        val metadata = getMetadata("treatment")
+        val result = helper.getPromotionProvider(
+            "afterpay_clearpay",
+            metadata
+        )?.invoke()
+
+        assertThat(result).isEqualTo(AFTERPAY_PROMOTION)
+    }
+
     private fun runScenario(
         featureFlagEnabled: Boolean = false,
         repositoryResult: Result<PaymentMethodMessagePromotionList> = Result.success(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
@@ -32,6 +32,13 @@ internal class FakePaymentMethodMessagePromotionsHelper(
         return promotions
     }
 
+    override fun getPromotionProvider(
+        code: PaymentMethodCode,
+        metadata: PaymentMethodMetadata
+    ): (() -> PaymentMethodMessagePromotion?)? {
+        return { getPromotionIfAvailableForCode(code, metadata) }
+    }
+
     fun validate() {
         calls.ensureAllEventsConsumed()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1765,27 +1765,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun `Does not pass promotion provider to unsupported PMs`() {
-        FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("card", "klarna")
-            )
-        )
-        runScenario(
-            promotionsHelper = FakePaymentMethodMessagePromotionsHelper.Factory.create(),
-            paymentMethodMetadata = metadata
-        ) {
-            interactor.state.test {
-                val paymentMethods = awaitItem().displayablePaymentMethods
-                val paymentMethod = paymentMethods.first { it.code == "card" }
-                assertThat(paymentMethod).isNotNull()
-                assertThat(paymentMethod.promotionProvider).isNull()
-            }
-        }
-    }
-
-    @Test
     fun `shouldExpandOnClick is false when form type is UserInteractionRequired`() {
         FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
         val metadata = PaymentMethodMetadataFactory.create(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add `getPromotionProvider` to PaymentMethodMessageExperimentHandler

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Fix bug where promotion provider would not be null for control group

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
