### PR TITLE
Update PMM Experiment analytics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -230,8 +230,10 @@ internal interface EmbeddedActivityModule {
         @Provides
         fun providesPaymentMethodMessagePromotionHelper(
             promotion: PaymentMethodMessagePromotion?,
+            eventReporter: EventReporter
         ): PaymentMethodMessagePromotionsHelper = PrefetchedPaymentMethodMessagePromotionsHelper(
             listOfNotNull(promotion),
+            eventReporter
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -544,7 +544,6 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onPaymentMethodMessagePromotionsFetchBegin() {
         durationProvider.start(DurationProvider.Key.PaymentMethodMessaging)
-        println("yeet fetching")
         fireEvent(
             PaymentSheetEvent.PaymentMethodMessaging.Fetched()
         )
@@ -552,7 +551,6 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onPaymentMethodMessagePromotionDisplayed(displayedSuccessfully: Boolean) {
         val duration = durationProvider.end(DurationProvider.Key.PaymentMethodMessaging)
-        println("yeet displayed $duration $displayedSuccessfully")
         fireEvent(
             PaymentSheetEvent.PaymentMethodMessaging.Displayed(duration, displayedSuccessfully)
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -542,17 +542,19 @@ internal class DefaultEventReporter @Inject internal constructor(
         }
     }
 
-    override fun onPaymentMethodMessagePromotionsFetched() {
+    override fun onPaymentMethodMessagePromotionsFetchBegin() {
         durationProvider.start(DurationProvider.Key.PaymentMethodMessaging)
+        println("yeet fetching")
         fireEvent(
             PaymentSheetEvent.PaymentMethodMessaging.Fetched()
         )
     }
 
-    override fun onPaymentMethodMessagePromotionsIncomplete() {
+    override fun onPaymentMethodMessagePromotionDisplayed(displayedSuccessfully: Boolean) {
         val duration = durationProvider.end(DurationProvider.Key.PaymentMethodMessaging)
+        println("yeet displayed $duration $displayedSuccessfully")
         fireEvent(
-            PaymentSheetEvent.PaymentMethodMessaging.Incomplete(duration)
+            PaymentSheetEvent.PaymentMethodMessaging.Displayed(duration, displayedSuccessfully)
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -271,12 +271,12 @@ internal interface EventReporter : CardScanEventsReporter {
     /**
      * Promotions fetched from PMM API.
      */
-    fun onPaymentMethodMessagePromotionsFetched()
+    fun onPaymentMethodMessagePromotionsFetchBegin()
 
     /**
-     * Promotions request is not completed when attempting to display promotions.
+     * Attempted to display promotions.
      */
-    fun onPaymentMethodMessagePromotionsIncomplete()
+    fun onPaymentMethodMessagePromotionDisplayed(displayedSuccessfully: Boolean)
 
     enum class Mode(val code: String) {
         Complete("complete"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -576,12 +576,14 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     sealed class PaymentMethodMessaging : PaymentSheetEvent() {
 
         class Fetched : PaymentMethodMessaging() {
-            override val eventName: String = "payment_method_messaging_fetched"
+            override val eventName: String = "payment_method_messaging_fetch_begin"
         }
 
-        class Incomplete(val duration: Duration?) : PaymentMethodMessaging() {
+        class Displayed(val duration: Duration?, displayedSuccessfully: Boolean) : PaymentMethodMessaging() {
             override val eventName: String = "payment_method_messaging_incomplete"
-            override val params: Map<String, Any?> = duration.mapOfDurationInSeconds()
+            override val params: Map<String, Any?> = duration.mapOfDurationInSeconds() + mapOf(
+                "displayed_successfully" to displayedSuccessfully
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -48,8 +48,9 @@ internal class PaymentOptionsViewModelModule {
 
     @Provides
     fun providesPaymentMethodMessageHelper(
-        args: PaymentOptionContract.Args
+        args: PaymentOptionContract.Args,
+        eventReporter: EventReporter
     ): PaymentMethodMessagePromotionsHelper {
-        return PrefetchedPaymentMethodMessagePromotionsHelper(args.promotions)
+        return PrefetchedPaymentMethodMessagePromotionsHelper(args.promotions, eventReporter)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodMessagePromotionList
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.amount
 import com.stripe.android.paymentsheet.model.currency
 import dagger.Binds
@@ -48,12 +49,14 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
     private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val workContext: CoroutineContext,
+    private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
     private var promotionsDeferred: Deferred<Result<PaymentMethodMessagePromotionList>>? = null
 
     override fun fetchPromotionsAsync(intent: StripeIntent) {
         if (!FeatureFlags.paymentMethodMessagePromotions.isEnabled) return
 
+        eventReporter.onPaymentMethodMessagePromotionsFetchBegin()
         promotionsDeferred?.cancel()
         promotionsDeferred = null
         promotionsDeferred = viewModelScope.async(workContext) {
@@ -79,19 +82,21 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
                 ExperimentAssignment.OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS
             ] ?: return null
 
-            val promotion = if (variant == "treatment") {
-                if (promotionsDeferred?.isCompleted == true) {
+            if (variant == "treatment") {
+                val promotion = if (promotionsDeferred?.isCompleted == true) {
                     promotionsDeferred?.getCompleted()?.getOrNull()?.promotions?.find {
                         it.paymentMethodType.lowercase() == code
                     }
                 } else {
                     null
                 }
+                eventReporter.onPaymentMethodMessagePromotionDisplayed(
+                    displayedSuccessfully = promotion != null
+                )
+                promotion
             } else {
                 null
             }
-
-            promotion
         } else {
             null
         }
@@ -122,6 +127,7 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
 
 internal class PrefetchedPaymentMethodMessagePromotionsHelper(
     private val promotions: List<PaymentMethodMessagePromotion>?,
+    private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
     override fun fetchPromotionsAsync(intent: StripeIntent) {
         // NO-OP
@@ -134,17 +140,19 @@ internal class PrefetchedPaymentMethodMessagePromotionsHelper(
         return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
             val variant = metadata.experimentsData?.experimentAssignments[
                 ExperimentAssignment.OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS
-            ]
+            ] ?: return null
 
-            val promotion = if (variant == "treatment") {
-                promotions?.find {
+            if (variant == "treatment") {
+                val promotion = promotions?.find {
                     it.paymentMethodType.lowercase() == code
                 }
+                eventReporter.onPaymentMethodMessagePromotionDisplayed(
+                    displayedSuccessfully = promotion != null
+                )
+                promotion
             } else {
                 null
             }
-
-            promotion
         } else {
             null
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -98,9 +98,9 @@ internal class FakeEventReporter : EventReporter {
     val pmmPromotionsFetched: ReceiveTurbine<Unit> =
         _pmmPromotionsFetched
 
-    private val _pmmPromotionsIncomplete = Turbine<Unit>()
-    val pmmPromotionsIncomplete: ReceiveTurbine<Unit> =
-        _pmmPromotionsIncomplete
+    private val _pmmPromotionsDisplayed = Turbine<Boolean>()
+    val pmmPromotionsDisplayed: ReceiveTurbine<Boolean> =
+        _pmmPromotionsDisplayed
 
     fun validate() {
         _paymentFailureCalls.ensureAllEventsConsumed()
@@ -128,7 +128,7 @@ internal class FakeEventReporter : EventReporter {
         _failedToAddCardWithTapToAddCalls.ensureAllEventsConsumed()
         _tapToAddAttemptWithUnsupportedDeviceCalls.ensureAllEventsConsumed()
         _pmmPromotionsFetched.ensureAllEventsConsumed()
-        _pmmPromotionsIncomplete.ensureAllEventsConsumed()
+        _pmmPromotionsDisplayed.ensureAllEventsConsumed()
     }
 
     override fun onInit() {
@@ -281,12 +281,12 @@ internal class FakeEventReporter : EventReporter {
     override fun onShopPayWebViewCancelled(didReceiveECEClick: Boolean) {
     }
 
-    override fun onPaymentMethodMessagePromotionsFetched() {
+    override fun onPaymentMethodMessagePromotionsFetchBegin() {
         _pmmPromotionsFetched.add(Unit)
     }
 
-    override fun onPaymentMethodMessagePromotionsIncomplete() {
-        _pmmPromotionsIncomplete.add(Unit)
+    override fun onPaymentMethodMessagePromotionDisplayed(displayedSuccessfully: Boolean) {
+        _pmmPromotionsDisplayed.add(displayedSuccessfully)
     }
 
     override fun onCardScanStarted(implementation: String) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -63,7 +63,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
     }
 
     @Test
-    fun `getPromotionIfAvailableForCode returns logs displayed successfully as false if not available`() = runScenario(
+    fun `getPromotionIfAvailableForCode logs displayed successfully as false if not available`() = runScenario(
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodMessagePromotionList
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.repositories.DefaultPaymentMethodMessagePromotionsHelper
 import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -36,6 +37,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true,
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
         val request = fakeRepository.calls.awaitItem()
         assertThat(request.amount).isEqualTo(1099)
         assertThat(request.currency).isEqualTo("usd")
@@ -48,6 +50,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
         val result = helper.getPromotionIfAvailableForCode(
@@ -55,7 +58,24 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
             metadata
         )
 
+        assertThat(eventReporter.pmmPromotionsDisplayed.awaitItem()).isTrue()
         assertThat(result).isEqualTo(AFTERPAY_PROMOTION)
+    }
+
+    @Test
+    fun `getPromotionIfAvailableForCode returns logs displayed successfully as false if not available`() = runScenario(
+        featureFlagEnabled = true
+    ) {
+        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
+        val metadata = getMetadata("treatment")
+        val result = helper.getPromotionIfAvailableForCode(
+            "afterpay_clearpay",
+            metadata
+        )
+
+        assertThat(eventReporter.pmmPromotionsDisplayed.awaitItem()).isFalse()
+        assertThat(result).isNull()
     }
 
     @Test
@@ -63,6 +83,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
         assertThat(helper.getPromotionIfAvailableForCode("afterpay_clearpay", metadata)).isNull()
@@ -73,6 +94,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
         assertThat(helper.getPromotionProvider("afterpay_clearpay", metadata)).isNull()
@@ -83,6 +105,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
         assertThat(helper.getPromotionProvider("card", metadata)).isNull()
@@ -93,6 +116,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
         featureFlagEnabled = true
     ) {
         helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
         val result = helper.getPromotionProvider(
@@ -100,6 +124,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
             metadata
         )?.invoke()
 
+        assertThat(eventReporter.pmmPromotionsDisplayed.awaitItem()).isTrue()
         assertThat(result).isEqualTo(AFTERPAY_PROMOTION)
     }
 
@@ -116,6 +141,7 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
         val fakeRepository = FakePromotionsStripeRepository(repositoryResult)
         val testDispatcher = StandardTestDispatcher(testScheduler)
+        val eventReporter = FakeEventReporter()
 
         val helper = DefaultPaymentMethodMessagePromotionsHelper(
             stripeRepository = fakeRepository,
@@ -124,19 +150,24 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
             },
             viewModelScope = this,
             workContext = testDispatcher,
+            eventReporter = eventReporter
         )
 
         Scenario(
             helper = helper,
             fakeRepository = fakeRepository,
             dispatcher = testDispatcher,
+            eventReporter = eventReporter
         ).block()
+
+        eventReporter.validate()
     }
 
     private data class Scenario(
         val helper: DefaultPaymentMethodMessagePromotionsHelper,
         val fakeRepository: FakePromotionsStripeRepository,
         val dispatcher: TestDispatcher,
+        val eventReporter: FakeEventReporter
     )
 
     private class FakePromotionsStripeRepository(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethodMessagePromotionsHelperTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -28,7 +29,29 @@ class PrefetchedPaymentMethodMessagePromotionsHelperTest {
                 )
             )
 
+        assertThat(eventReporter.pmmPromotionsDisplayed.awaitItem()).isTrue()
         assertThat(result).isEqualTo(promotion)
+    }
+
+    @Test
+    fun `logs displayed successfully as false if promotion not available and in treatment`() = runScenario(
+        promotions = null
+    ) {
+        val result = helper.getPromotionIfAvailableForCode(
+            PaymentMethod.Type.Affirm.code,
+            PaymentMethodMetadataFactory.create(
+                experimentsData = ElementsSession.ExperimentsData(
+                    arbId = "arb_123",
+                    experimentAssignments = mapOf(
+                        ElementsSession.ExperimentAssignment
+                            .OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS to "treatment"
+                    )
+                )
+            )
+        )
+
+        assertThat(eventReporter.pmmPromotionsDisplayed.awaitItem()).isFalse()
+        assertThat(result).isNull()
     }
 
     @Test
@@ -63,20 +86,27 @@ class PrefetchedPaymentMethodMessagePromotionsHelperTest {
     }
 
     private fun runScenario(
+        promotions: List<PaymentMethodMessagePromotion>? = listOf(promotion),
         block: suspend Scenario.() -> Unit
     ) = runTest {
         FeatureFlags.paymentMethodMessagePromotions.setEnabled(true)
+        val eventReporter = FakeEventReporter()
         val helper = PrefetchedPaymentMethodMessagePromotionsHelper(
-            promotions = listOf(promotion),
+            promotions = promotions,
+            eventReporter = eventReporter
         )
 
         Scenario(
-            helper = helper
+            helper = helper,
+            eventReporter = eventReporter
         ).block()
+
+        eventReporter.validate()
     }
 
     private class Scenario(
         val helper: PrefetchedPaymentMethodMessagePromotionsHelper,
+        val eventReporter: FakeEventReporter
     )
 
     private companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Send `payment_method_messaging_fetch_begin` when fetching promotions
- Send `payment_method_messaging_displayed` when `getPromotionIfAvailableForCode` which is called when attempting to display the promtion.
- Send displayedSuccessfully as boolean to determine if user actually say promotion

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Allow for experiment analysis

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
