### PR TITLE
[Crypto Onramp] Send ui_mode=headless in getPlatformSettings request

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CreatePaymentTokenRequest.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CreatePaymentTokenRequest.kt
@@ -9,4 +9,6 @@ internal data class CreatePaymentTokenRequest(
     val cryptoCustomerId: String,
     @SerialName("payment_method")
     val paymentMethod: String,
+    @SerialName("ui_mode")
+    val uiMode: String = "headless",
 )

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -247,7 +247,8 @@ internal class CryptoApiRepository @Inject constructor(
             options = buildRequestOptions(),
             params = mapOf(
                 "crypto_customer_id" to cryptoCustomerId,
-                "country_hint" to countryHint
+                "country_hint" to countryHint,
+                "ui_mode" to "headless"
             ).filterNotNullValues()
         )
 
@@ -267,7 +268,7 @@ internal class CryptoApiRepository @Inject constructor(
         )
         return executePost(
             url = paymentToken,
-            paramsJson = Json.encodeToJsonElement(params).jsonObject,
+            paramsJson = json.encodeToJsonElement(params).jsonObject,
             responseSerializer = CreatePaymentTokenResponse.serializer()
         )
     }


### PR DESCRIPTION
The crypto-onramp SDK is headless-only, so always include ui_mode=headless in the platform settings request params. This param needs to show up in getPlatformSettings and createPaymentToken

Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
