### PR TITLE
Refactor card scan into a `CardDetailsAction`

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsAction.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsAction.kt
@@ -6,5 +6,5 @@ import androidx.compose.runtime.Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface CardDetailsAction {
     @Composable
-    fun Content(enabled: Boolean)
+    fun Content(enabled: Boolean, controller: CardDetailsSectionController)
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -12,7 +12,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.DateUtils
 import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.cardscan.CardScanResult
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.DefaultFieldValidationMessageComparator
@@ -111,27 +110,23 @@ internal class CardDetailsController(
         )
     )
 
-    val onCardScanResult: (CardScanResult) -> Unit = { result ->
-        (result as? CardScanResult.Completed)?.scannedCard?.let { scannedCard ->
-            cvcElement.controller.onRawValueChange("")
-            numberElement.controller.onRawValueChange(
-                scannedCard.pan
+    fun onScannedCard(cardNumber: String, expirationYear: Int?, expirationMonth: Int?) {
+        cvcElement.controller.onRawValueChange("")
+        numberElement.controller.onRawValueChange(cardNumber)
+        val newDate = if (
+            expirationMonth != null &&
+            expirationYear != null &&
+            DateUtils.isExpiryDataValid(
+                expiryMonth = expirationMonth,
+                expiryYear = expirationYear
             )
-            val newDate = if (
-                scannedCard.expirationMonth != null &&
-                scannedCard.expirationYear != null &&
-                DateUtils.isExpiryDataValid(
-                    expiryMonth = scannedCard.expirationMonth,
-                    expiryYear = scannedCard.expirationYear
-                )
-            ) {
-                @Suppress("MagicNumber")
-                "%02d%02d".format(scannedCard.expirationMonth, scannedCard.expirationYear % 100)
-            } else {
-                ""
-            }
-            expirationDateElement.controller.onRawValueChange(newDate)
+        ) {
+            @Suppress("MagicNumber")
+            "%02d%02d".format(expirationMonth, expirationYear % 100)
+        } else {
+            ""
         }
+        expirationDateElement.controller.onRawValueChange(newDate)
     }
 
     private val rowFields = listOf(expirationDateElement, cvcElement)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -6,7 +6,6 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.cards.CardAccountRangeRepository
-import com.stripe.android.ui.core.cardscan.CardScanResult
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionFieldValidationController
@@ -20,10 +19,6 @@ class CardDetailsSectionController(
     cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
     val cardDetailsAction: CardDetailsAction? = null,
-    private val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
-    val isStripeCardScanAllowed: Boolean = false,
-    val enableMlKitCardScan: Boolean = false,
-    val disableSsdOcrCardScan: Boolean = false,
 ) : SectionFieldValidationController {
 
     internal val cardDetailsElement = CardDetailsElement(
@@ -36,24 +31,13 @@ class CardDetailsSectionController(
         cardFundingFilter,
     )
 
-    fun shouldAutomaticallyLaunchCardScan(): Boolean {
-        return cardDetailsAction == null &&
-            automaticallyLaunchedCardScanFormDataHelper?.shouldLaunchCardScanAutomatically == true
-    }
-
-    fun setHasAutomaticallyLaunchedCardScan() {
-        this.automaticallyLaunchedCardScanFormDataHelper?.let {
-            it.hasAutomaticallyLaunchedCardScan = true
-        }
-    }
-
     override val validationMessage = cardDetailsElement.controller.validationMessage
 
     override fun onValidationStateChanged(isValidating: Boolean) {
         cardDetailsElement.onValidationStateChanged(isValidating)
     }
 
-    internal fun onCardScanResult(cardScanResult: CardScanResult) {
-        cardDetailsElement.controller.onCardScanResult.invoke(cardScanResult)
+    internal fun onScannedCard(cardNumber: String, expirationYear: Int?, expirationMonth: Int?) {
+        cardDetailsElement.controller.onScannedCard(cardNumber, expirationYear, expirationMonth)
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -16,16 +16,12 @@ import kotlinx.coroutines.flow.StateFlow
 class CardDetailsSectionElement(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     initialValues: Map<IdentifierSpec, String?>,
-    automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
     private val collectName: Boolean = false,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter,
     override val identifier: IdentifierSpec,
     private val cardDetailsAction: CardDetailsAction? = null,
-    private val isStripeCardScanAllowed: Boolean = false,
-    private val enableMlKitCardScan: Boolean = false,
-    private val disableSsdOcrCardScan: Boolean = false,
     override val controller: CardDetailsSectionController = CardDetailsSectionController(
         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
         initialValues = initialValues,
@@ -34,10 +30,6 @@ class CardDetailsSectionElement(
         cardBrandFilter = cardBrandFilter,
         cardFundingFilter = cardFundingFilter,
         cardDetailsAction = cardDetailsAction,
-        automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
-        isStripeCardScanAllowed = isStripeCardScanAllowed,
-        enableMlKitCardScan = enableMlKitCardScan,
-        disableSsdOcrCardScan = disableSsdOcrCardScan,
     )
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -7,16 +7,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.cardscan.rememberCardScanLauncher
 import com.stripe.android.uicore.elements.H6Text
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionController
@@ -32,22 +29,6 @@ fun CardDetailsSectionElementUI(
     lastTextFieldIdentifier: IdentifierSpec?,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-
-    val cardScanLauncher = rememberCardScanLauncher(
-        isStripeCardScanAllowed = controller.isStripeCardScanAllowed,
-        enableMlKitCardScan = controller.enableMlKitCardScan,
-        disableSsdOcrCardScan = controller.disableSsdOcrCardScan,
-        onResult = { controller.onCardScanResult(it) },
-    )
-
-    if (controller.shouldAutomaticallyLaunchCardScan() && cardScanLauncher != null) {
-        SideEffect {
-            controller.setHasAutomaticallyLaunchedCardScan()
-            cardScanLauncher.launch(context)
-        }
-    }
-
     Column(modifier) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -62,12 +43,7 @@ fun CardDetailsSectionElementUI(
                         heading()
                     }
             )
-            controller.cardDetailsAction?.Content(enabled) ?: run {
-                ScanCardButtonUI(
-                    enabled = enabled,
-                    cardScanLauncher = cardScanLauncher
-                )
-            }
+            controller.cardDetailsAction?.Content(enabled, controller)
         }
         SectionElementUI(
             modifier = Modifier.padding(top = 8.dp),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalContext
+import com.stripe.android.ui.core.cardscan.CardScanResult
+import com.stripe.android.ui.core.cardscan.rememberCardScanLauncher
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CardScanAction(
+    private val isStripeCardScanAllowed: Boolean,
+    private val enableMlKitCardScan: Boolean,
+    private val disableSsdOcrCardScan: Boolean,
+    val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+) : CardDetailsAction {
+    @Composable
+    override fun Content(enabled: Boolean, controller: CardDetailsSectionController) {
+        val context = LocalContext.current
+        val launcher = rememberCardScanLauncher(
+            isStripeCardScanAllowed = isStripeCardScanAllowed,
+            enableMlKitCardScan = enableMlKitCardScan,
+            disableSsdOcrCardScan = disableSsdOcrCardScan,
+            onResult = { result ->
+                (result as? CardScanResult.Completed)?.scannedCard?.let { scannedCard ->
+                    controller.onScannedCard(
+                        cardNumber = scannedCard.pan,
+                        expirationYear = scannedCard.expirationYear,
+                        expirationMonth = scannedCard.expirationMonth,
+                    )
+                }
+            },
+        )
+
+        if (
+            automaticallyLaunchedCardScanFormDataHelper?.shouldLaunchCardScanAutomatically == true &&
+            launcher != null
+        ) {
+            SideEffect {
+                automaticallyLaunchedCardScanFormDataHelper.hasAutomaticallyLaunchedCardScan = true
+                launcher.launch(context)
+            }
+        }
+
+        ScanCardButtonUI(enabled = enabled, cardScanLauncher = launcher)
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -10,8 +10,6 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.ui.core.cardscan.CardScanResult
-import com.stripe.android.ui.core.cardscan.ScannedCard
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.FieldValidationMessage
@@ -115,18 +113,13 @@ class CardDetailsControllerTest {
         assertThat(cardController.cvcElement.controller.rawFieldValue.value)
             .isEqualTo("")
 
-        val scannedCard = ScannedCard(
-            pan = "5555555555554444",
+        idleLooper()
+
+        cardController.onScannedCard(
+            cardNumber = "5555555555554444",
             expirationYear = 2044,
             expirationMonth = 4,
         )
-
-        val cardScanResult = CardScanResult.Completed(
-            scannedCard = scannedCard
-        )
-        idleLooper()
-
-        cardController.onCardScanResult.invoke(cardScanResult)
 
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
             .isEqualTo("5555555555554444")
@@ -153,18 +146,13 @@ class CardDetailsControllerTest {
         assertThat(cardController.cvcElement.controller.rawFieldValue.value)
             .isEqualTo("123")
 
-        val scannedCard = ScannedCard(
-            pan = "5555555555554444",
+        idleLooper()
+
+        cardController.onScannedCard(
+            cardNumber = "5555555555554444",
             expirationYear = 2044,
             expirationMonth = 4,
         )
-
-        val cardScanResult = CardScanResult.Completed(
-            scannedCard = scannedCard
-        )
-        idleLooper()
-
-        cardController.onCardScanResult.invoke(cardScanResult)
 
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
             .isEqualTo("5555555555554444")
@@ -191,18 +179,13 @@ class CardDetailsControllerTest {
         assertThat(cardController.cvcElement.controller.rawFieldValue.value)
             .isEqualTo("123")
 
-        val scannedCard = ScannedCard(
-            pan = "5555555555554444",
+        idleLooper()
+
+        cardController.onScannedCard(
+            cardNumber = "5555555555554444",
             expirationYear = 2009,
             expirationMonth = 12,
         )
-
-        val cardScanResult = CardScanResult.Completed(
-            scannedCard = scannedCard
-        )
-        idleLooper()
-
-        cardController.onCardScanResult.invoke(cardScanResult)
 
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
             .isEqualTo("5555555555554444")
@@ -214,18 +197,13 @@ class CardDetailsControllerTest {
     fun `When new card scanned with single digit month, date is correctly formatted`() = runTest {
         val cardController = cardDetailsController()
 
-        val scannedCard = ScannedCard(
-            pan = "5555555555554444",
+        idleLooper()
+
+        cardController.onScannedCard(
+            cardNumber = "5555555555554444",
             expirationYear = 2029,
             expirationMonth = 1,
         )
-
-        val cardScanResult = CardScanResult.Completed(
-            scannedCard = scannedCard
-        )
-        idleLooper()
-
-        cardController.onCardScanResult.invoke(cardScanResult)
 
         assertThat(cardController.expirationDateElement.controller.rawFieldValue.value)
             .isEqualTo("0129")
@@ -248,18 +226,13 @@ class CardDetailsControllerTest {
         assertThat(cardController.cvcElement.controller.rawFieldValue.value)
             .isEqualTo("123")
 
-        val scannedCard = ScannedCard(
-            pan = "5555555555554444",
+        idleLooper()
+
+        cardController.onScannedCard(
+            cardNumber = "5555555555554444",
             expirationYear = null,
             expirationMonth = null,
         )
-
-        val cardScanResult = CardScanResult.Completed(
-            scannedCard = scannedCard
-        )
-        idleLooper()
-
-        cardController.onCardScanResult.invoke(cardScanResult)
 
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
             .isEqualTo("5555555555554444")

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -8,8 +8,6 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.ui.core.cardscan.CardScanResult
-import com.stripe.android.ui.core.cardscan.ScannedCard
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -280,14 +278,10 @@ class CardDetailsElementTest {
             controller = cardController
         )
 
-        cardController.onCardScanResult(
-            CardScanResult.Completed(
-                scannedCard = ScannedCard(
-                    pan = "4242424242424242",
-                    expirationMonth = 1,
-                    expirationYear = 2030,
-                )
-            )
+        cardController.onScannedCard(
+            cardNumber = "4242424242424242",
+            expirationMonth = 1,
+            expirationYear = 2030,
         )
 
         cardDetailsElement.getFormFieldValueFlow().test {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
@@ -1,43 +1,19 @@
 package com.stripe.android.ui.core.elements
 
-import android.app.Activity
 import android.content.Context
-import android.content.Intent
-import androidx.activity.compose.LocalActivityResultRegistryOwner
-import androidx.activity.result.ActivityResultRegistry
-import androidx.activity.result.ActivityResultRegistryOwner
-import androidx.activity.result.contract.ActivityResultContract
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.core.app.ActivityOptionsCompat
-import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
-import com.google.android.gms.wallet.CreditCardExpirationDate
-import com.google.android.gms.wallet.PaymentCardRecognitionResult
-import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
-import com.stripe.android.ui.core.cardscan.CardScanResult
-import com.stripe.android.ui.core.cardscan.FakeCardScanEventsReporter
-import com.stripe.android.ui.core.cardscan.FakePaymentCardRecognitionClient
-import com.stripe.android.ui.core.cardscan.LocalCardScanEventsReporter
-import com.stripe.android.ui.core.cardscan.LocalPaymentCardRecognitionClient
-import com.stripe.android.ui.core.cardscan.ScannedCard
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.mockStatic
-import org.mockito.Mockito.spy
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.kotlin.any
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
@@ -49,107 +25,11 @@ internal class CardDetailsSectionElementUITest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `CardDetailsSectionElement automatically launches card scan and gets result`() {
-        runScenario(
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                openCardScanAutomaticallyConfig = true,
-                hasAutomaticallyLaunchedCardScanInitialValue = false,
-                savedStateHandle = SavedStateHandle()
-            )
-        ) {
-            composeTestRule.onNodeWithText("4242 4242 4242 4242").assertExists()
-
-            verify(controller, times(1)).onCardScanResult(
-                CardScanResult.Completed(
-                    scannedCard = ScannedCard(
-                        pan = "4242424242424242",
-                        expirationYear = 2042,
-                        expirationMonth = 2,
-                    )
-                )
-            )
-            verify(controller, times(1)).setHasAutomaticallyLaunchedCardScan()
-
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isFalse()
-        }
-    }
-
-    @Test
-    fun `CardDetailsSectionElement does not launch card scan when openCardScanAutomaticallyConfig false`() {
-        runScenario(
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                openCardScanAutomaticallyConfig = false,
-                hasAutomaticallyLaunchedCardScanInitialValue = false,
-                savedStateHandle = SavedStateHandle()
-            )
-        ) {
-            composeTestRule.onNodeWithText("4242 4242 4242 4242").assertDoesNotExist()
-            composeTestRule.onNodeWithText("Card number").assertExists()
-
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isFalse()
-
-            verify(controller, times(0)).onCardScanResult(any())
-            verify(controller, times(0)).setHasAutomaticallyLaunchedCardScan()
-        }
-    }
-
-    @Test
-    fun `CardDetailsSectionElement does not launch card scan when hasAutomaticallyLaunchedCardScanInitialValue true`() {
-        runScenario(
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                openCardScanAutomaticallyConfig = true,
-                hasAutomaticallyLaunchedCardScanInitialValue = true,
-                savedStateHandle = SavedStateHandle()
-            )
-        ) {
-            composeTestRule.onNodeWithText("4242 4242 4242 4242").assertDoesNotExist()
-            composeTestRule.onNodeWithText("Card number").assertExists()
-
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isFalse()
-            verify(controller, times(0)).onCardScanResult(any())
-            verify(controller, times(0)).setHasAutomaticallyLaunchedCardScan()
-        }
-    }
-
-    @Test
-    fun `CardDetailsSectionElement does not launch card scan when automaticallyLaunchedCardScanFormDataHelper null`() {
-        runScenario(
-            automaticallyLaunchedCardScanFormDataHelper = null
-        ) {
-            composeTestRule.onNodeWithText("4242 4242 4242 4242").assertDoesNotExist()
-            composeTestRule.onNodeWithText("Card number").assertExists()
-
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isFalse()
-            verify(controller, times(0)).onCardScanResult(any())
-            verify(controller, times(0)).setHasAutomaticallyLaunchedCardScan()
-        }
-    }
-
-    @Test
     fun `CardDetailsSectionElement shows custom action and not card scan when cardDetailsAction is provided`() {
         runScenario(
             cardDetailsAction = FakeCardDetailsAction(contentText = "Tap to add card")
         ) {
             composeTestRule.onNodeWithText("Tap to add card").assertExists()
-            composeTestRule.onNodeWithText("Scan card").assertDoesNotExist()
-        }
-    }
-
-    @Test
-    fun `CardDetailsSectionElement does not auto open card scan if custom action provided`() {
-        runScenario(
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                openCardScanAutomaticallyConfig = true,
-                hasAutomaticallyLaunchedCardScanInitialValue = false,
-                savedStateHandle = SavedStateHandle()
-            ),
-            cardDetailsAction = FakeCardDetailsAction(contentText = "Tap to add card")
-        ) {
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isFalse()
-            verify(controller, times(0))
-                .onCardScanResult(any())
-            verify(controller, times(0))
-                .setHasAutomaticallyLaunchedCardScan()
         }
     }
 
@@ -157,98 +37,39 @@ internal class CardDetailsSectionElementUITest {
         private val contentText: String,
     ) : CardDetailsAction {
         @Composable
-        override fun Content(enabled: Boolean) {
+        override fun Content(enabled: Boolean, controller: CardDetailsSectionController) {
             androidx.compose.material.Text(contentText)
         }
     }
 
-    private class Scenario(
-        val controller: CardDetailsSectionController,
-    )
+    private class Scenario
 
-    private fun getController(
-        context: Context,
-        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
-        cardDetailsAction: CardDetailsAction? = null,
-    ): CardDetailsSectionController {
-        val cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context)
-
-        val output = CardDetailsSectionController(
-            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+    private fun runScenario(
+        cardDetailsAction: CardDetailsAction,
+        block: suspend Scenario.() -> Unit
+    ) = runTest {
+        val controller = CardDetailsSectionController(
+            cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = emptyMap(),
             collectName = false,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             cardBrandFilter = DefaultCardBrandFilter,
-            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
             cardDetailsAction = cardDetailsAction,
         )
-        return output
-    }
 
-    private fun runScenario(
-        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper? = null,
-        cardDetailsAction: CardDetailsAction? = null,
-        block: suspend Scenario.() -> Unit
-    ) = runTest {
-        val mockResult = mock<PaymentCardRecognitionResult>()
-        val mockExpirationDate = mock<CreditCardExpirationDate>()
-        whenever(mockResult.pan).thenReturn("4242424242424242")
-        whenever(mockResult.creditCardExpirationDate).thenReturn(mockExpirationDate)
-        whenever(mockExpirationDate.month).thenReturn(2)
-        whenever(mockExpirationDate.year).thenReturn(2042)
-        val intent = Intent().putExtra(
-            "com.google.android.gms.wallet.PaymentCardRecognitionResult",
-            mockResult
-        )
-        val registryOwner = object : ActivityResultRegistryOwner {
-            override val activityResultRegistry: ActivityResultRegistry =
-                object : ActivityResultRegistry() {
-                    override fun <I : Any?, O : Any?> onLaunch(
-                        requestCode: Int,
-                        contract: ActivityResultContract<I, O>,
-                        input: I,
-                        options: ActivityOptionsCompat?
-                    ) {
-                        this.dispatchResult(
-                            requestCode,
-                            Activity.RESULT_OK,
-                            intent
-                        )
-                    }
-                }
-        }
-        val controller = getController(
-            context = context,
-            cardDetailsAction = cardDetailsAction,
-            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper
-        )
-
-        val cardDetailsSectionControllerSpy = spy(controller)
-        val scenario = Scenario(
-            controller = cardDetailsSectionControllerSpy,
-        )
-
-        mockStatic(PaymentCardRecognitionResult::class.java).use { mockedStatic ->
-            mockedStatic.`when`<PaymentCardRecognitionResult> {
-                PaymentCardRecognitionResult.getFromIntent(any())
-            }.thenReturn(mockResult)
-            composeTestRule.setContent {
-                CompositionLocalProvider(
-                    LocalActivityResultRegistryOwner provides registryOwner,
-                    LocalCardNumberCompletedEventReporter provides { },
-                    LocalCardScanEventsReporter provides FakeCardScanEventsReporter(),
-                    LocalPaymentCardRecognitionClient provides FakePaymentCardRecognitionClient(true)
-                ) {
-                    CardDetailsSectionElementUI(
-                        enabled = true,
-                        controller = cardDetailsSectionControllerSpy,
-                        hiddenIdentifiers = emptySet(),
-                        lastTextFieldIdentifier = IdentifierSpec.PostalCode
-                    )
-                }
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalCardNumberCompletedEventReporter provides { },
+            ) {
+                CardDetailsSectionElementUI(
+                    enabled = true,
+                    controller = controller,
+                    hiddenIdentifiers = emptySet(),
+                    lastTextFieldIdentifier = IdentifierSpec.PostalCode
+                )
             }
         }
 
-        scenario.block()
+        Scenario().block()
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
@@ -1,0 +1,163 @@
+package com.stripe.android.ui.core.elements
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.core.app.ActivityOptionsCompat
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.wallet.CreditCardExpirationDate
+import com.google.android.gms.wallet.PaymentCardRecognitionResult
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.ui.core.cardscan.FakeCardScanEventsReporter
+import com.stripe.android.ui.core.cardscan.FakePaymentCardRecognitionClient
+import com.stripe.android.ui.core.cardscan.LocalCardScanEventsReporter
+import com.stripe.android.ui.core.cardscan.LocalPaymentCardRecognitionClient
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+internal class CardScanActionTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `automatically launches card scan and gets result`() {
+        val helper = AutomaticallyLaunchedCardScanFormDataHelper(
+            openCardScanAutomaticallyConfig = true,
+            hasAutomaticallyLaunchedCardScanInitialValue = false,
+            savedStateHandle = SavedStateHandle()
+        )
+        runScenario(helper = helper) {
+            verify(controller, times(1)).onScannedCard(
+                cardNumber = "4242424242424242",
+                expirationYear = 2042,
+                expirationMonth = 2,
+            )
+            assertThat(helper.hasAutomaticallyLaunchedCardScan).isTrue()
+            assertThat(helper.shouldLaunchCardScanAutomatically).isFalse()
+        }
+    }
+
+    @Test
+    fun `does not launch card scan when openCardScanAutomaticallyConfig false`() {
+        val helper = AutomaticallyLaunchedCardScanFormDataHelper(
+            openCardScanAutomaticallyConfig = false,
+            hasAutomaticallyLaunchedCardScanInitialValue = false,
+            savedStateHandle = SavedStateHandle()
+        )
+        runScenario(helper = helper) {
+            verify(controller, never()).onScannedCard(any(), anyOrNull(), anyOrNull())
+            assertThat(helper.shouldLaunchCardScanAutomatically).isFalse()
+        }
+    }
+
+    @Test
+    fun `does not launch card scan when hasAutomaticallyLaunchedCardScanInitialValue true`() {
+        val helper = AutomaticallyLaunchedCardScanFormDataHelper(
+            openCardScanAutomaticallyConfig = true,
+            hasAutomaticallyLaunchedCardScanInitialValue = true,
+            savedStateHandle = SavedStateHandle()
+        )
+        runScenario(helper = helper) {
+            verify(controller, never()).onScannedCard(any(), anyOrNull(), anyOrNull())
+            assertThat(helper.shouldLaunchCardScanAutomatically).isFalse()
+        }
+    }
+
+    @Test
+    fun `does not launch card scan when automaticallyLaunchedCardScanFormDataHelper null`() {
+        runScenario(helper = null) {
+            verify(controller, never()).onScannedCard(any(), anyOrNull(), anyOrNull())
+        }
+    }
+
+    private class Scenario(
+        val controller: CardDetailsSectionController,
+    )
+
+    private fun runScenario(
+        helper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        block: suspend Scenario.() -> Unit
+    ) = runTest {
+        val mockResult = mock<PaymentCardRecognitionResult>()
+        val mockExpirationDate = mock<CreditCardExpirationDate>()
+        whenever(mockResult.pan).thenReturn("4242424242424242")
+        whenever(mockResult.creditCardExpirationDate).thenReturn(mockExpirationDate)
+        whenever(mockExpirationDate.month).thenReturn(2)
+        whenever(mockExpirationDate.year).thenReturn(2042)
+        val intent = Intent().putExtra(
+            "com.google.android.gms.wallet.PaymentCardRecognitionResult",
+            mockResult
+        )
+        val registryOwner = object : ActivityResultRegistryOwner {
+            override val activityResultRegistry: ActivityResultRegistry =
+                object : ActivityResultRegistry() {
+                    override fun <I : Any?, O : Any?> onLaunch(
+                        requestCode: Int,
+                        contract: ActivityResultContract<I, O>,
+                        input: I,
+                        options: ActivityOptionsCompat?
+                    ) {
+                        this.dispatchResult(requestCode, Activity.RESULT_OK, intent)
+                    }
+                }
+        }
+        val action = CardScanAction(
+            isStripeCardScanAllowed = false,
+            enableMlKitCardScan = false,
+            disableSsdOcrCardScan = false,
+            automaticallyLaunchedCardScanFormDataHelper = helper,
+        )
+        val controller = CardDetailsSectionController(
+            cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            initialValues = emptyMap(),
+            collectName = false,
+            cbcEligibility = CardBrandChoiceEligibility.Ineligible,
+            cardBrandFilter = DefaultCardBrandFilter,
+            cardDetailsAction = action,
+        )
+        val controllerSpy = spy(controller)
+        val scenario = Scenario(controller = controllerSpy)
+
+        mockStatic(PaymentCardRecognitionResult::class.java).use { mockedStatic ->
+            mockedStatic.`when`<PaymentCardRecognitionResult> {
+                PaymentCardRecognitionResult.getFromIntent(any())
+            }.thenReturn(mockResult)
+            composeTestRule.setContent {
+                CompositionLocalProvider(
+                    LocalActivityResultRegistryOwner provides registryOwner,
+                    LocalCardScanEventsReporter provides FakeCardScanEventsReporter(),
+                    LocalPaymentCardRecognitionClient provides FakePaymentCardRecognitionClient(true)
+                ) {
+                    action.Content(enabled = true, controllerSpy)
+                }
+            }
+        }
+
+        scenario.block()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsAction.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.ui.core.elements.CardDetailsAction
+import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.uicore.utils.collectAsState
 
 internal class TapToAddCardDetailsAction(
@@ -15,7 +16,7 @@ internal class TapToAddCardDetailsAction(
     private val paymentMethodMetadata: PaymentMethodMetadata,
 ) : CardDetailsAction {
     @Composable
-    override fun Content(enabled: Boolean) {
+    override fun Content(enabled: Boolean, controller: CardDetailsSectionController) {
         val isTapToAddEnabled by tapToAddHelper.isTapToAddEnabled.collectAsState()
         var buttonReportedShown by rememberSaveable { mutableStateOf(false) }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -27,7 +27,9 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.CardDetailsAction
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
+import com.stripe.android.ui.core.elements.CardScanAction
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.RenderableFormElement
@@ -127,18 +129,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                     cbcEligibility = arguments.cbcEligibility,
                     cardBrandFilter = arguments.cardBrandFilter,
                     cardFundingFilter = arguments.cardFundingFilter,
-                    cardDetailsAction = arguments.tapToAddHelper?.takeIf {
-                        metadata.isTapToAddSupported
-                    }?.let {
-                        TapToAddCardDetailsAction(
-                            tapToAddHelper = it,
-                            paymentMethodMetadata = metadata,
-                        )
-                    },
-                    automaticallyLaunchedCardScanFormDataHelper = arguments.automaticallyLaunchedCardScanFormDataHelper,
-                    isStripeCardScanAllowed = metadata.isStripeCardScanAllowed,
-                    enableMlKitCardScan = metadata.enableMlKitCardScan,
-                    disableSsdOcrCardScan = metadata.disableSsdOcrCardScan,
+                    cardDetailsAction = createCardDetailsAction(metadata, arguments)
                 )
             )
 
@@ -207,6 +198,26 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                     )
                 )
             }
+        }
+    }
+
+    private fun createCardDetailsAction(
+        metadata: PaymentMethodMetadata,
+        arguments: UiDefinitionFactory.Arguments,
+    ): CardDetailsAction {
+        return if (metadata.isTapToAddSupported && arguments.tapToAddHelper != null) {
+            TapToAddCardDetailsAction(
+                tapToAddHelper = arguments.tapToAddHelper,
+                paymentMethodMetadata = metadata,
+            )
+        } else {
+            CardScanAction(
+                isStripeCardScanAllowed = metadata.isStripeCardScanAllowed,
+                enableMlKitCardScan = metadata.enableMlKitCardScan,
+                disableSsdOcrCardScan = metadata.disableSsdOcrCardScan,
+                automaticallyLaunchedCardScanFormDataHelper =
+                    arguments.automaticallyLaunchedCardScanFormDataHelper,
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.ui.core.elements.CardDetailsSectionController
+import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +36,7 @@ internal class TapToAddCardDetailsActionTest {
             )
 
             composeTestRule.setContent {
-                action.Content(enabled = true)
+                action.Content(enabled = true, controller = fakeController())
             }
 
             composeTestRule.waitForIdle()
@@ -57,7 +59,7 @@ internal class TapToAddCardDetailsActionTest {
             )
 
             composeTestRule.setContent {
-                action.Content(enabled = false)
+                action.Content(enabled = false, controller = fakeController())
             }
 
             composeTestRule.waitForIdle()
@@ -81,7 +83,7 @@ internal class TapToAddCardDetailsActionTest {
             val enabledHolder = mutableStateOf(true)
 
             composeTestRule.setContent {
-                action.Content(enabled = enabledHolder.value)
+                action.Content(enabled = enabledHolder.value, controller = fakeController())
             }
 
             composeTestRule.waitForIdle()
@@ -95,4 +97,9 @@ internal class TapToAddCardDetailsActionTest {
             composeTestRule.waitForIdle()
         }
     }
+
+    private fun fakeController() = CardDetailsSectionController(
+        cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+        initialValues = emptyMap(),
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -57,6 +57,8 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.BankFormScreenStateFactory
+import com.stripe.android.utils.setHasAutomaticallyLaunchedCardScan
+import com.stripe.android.utils.shouldAutomaticallyLaunchCardScan
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -3317,7 +3319,7 @@ class CustomerSheetViewModelTest {
             assertThat(formElements[0]).isInstanceOf<CardDetailsSectionElement>()
 
             val controller = (formElements[0] as CardDetailsSectionElement).controller
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isTrue()
+            assertThat(controller.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
         }
     }
 
@@ -3342,7 +3344,7 @@ class CustomerSheetViewModelTest {
             val formElements = item.asAddState().formElements
             assertThat(formElements[0]).isInstanceOf<CardDetailsSectionElement>()
             val controller = (formElements[0] as CardDetailsSectionElement).controller
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isTrue()
+            assertThat(controller.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
         }
     }
 
@@ -3365,9 +3367,9 @@ class CustomerSheetViewModelTest {
 
             val firstCardFormController = getAddPaymentMethodCardDetailsSectionController(viewState)
             assertThat(firstCardFormController).isNotNull()
-            assertThat(firstCardFormController!!.shouldAutomaticallyLaunchCardScan()).isTrue()
-            firstCardFormController.setHasAutomaticallyLaunchedCardScan()
-            assertThat(firstCardFormController.shouldAutomaticallyLaunchCardScan()).isFalse()
+            assertThat(firstCardFormController!!.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
+            firstCardFormController.cardDetailsAction?.setHasAutomaticallyLaunchedCardScan()
+            assertThat(firstCardFormController.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isFalse()
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
@@ -3389,7 +3391,7 @@ class CustomerSheetViewModelTest {
                 .isEqualTo("card")
             val secondCardFormController = getAddPaymentMethodCardDetailsSectionController(viewState)
             assertThat(secondCardFormController).isNotNull()
-            assertThat(secondCardFormController!!.shouldAutomaticallyLaunchCardScan()).isFalse()
+            assertThat(secondCardFormController!!.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isFalse()
         }
     }
 
@@ -3411,9 +3413,9 @@ class CustomerSheetViewModelTest {
 
             val firstCardFormController = getAddPaymentMethodCardDetailsSectionController(viewState)
             assertThat(firstCardFormController).isNotNull()
-            assertThat(firstCardFormController!!.shouldAutomaticallyLaunchCardScan()).isTrue()
-            firstCardFormController.setHasAutomaticallyLaunchedCardScan()
-            assertThat(firstCardFormController.shouldAutomaticallyLaunchCardScan()).isFalse()
+            assertThat(firstCardFormController!!.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
+            firstCardFormController.cardDetailsAction?.setHasAutomaticallyLaunchedCardScan()
+            assertThat(firstCardFormController.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isFalse()
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnFormFieldValuesCompleted(
@@ -3450,7 +3452,7 @@ class CustomerSheetViewModelTest {
 
             val secondCardFormController = getAddPaymentMethodCardDetailsSectionController(viewState)
             assertThat(secondCardFormController).isNotNull()
-            assertThat(secondCardFormController!!.shouldAutomaticallyLaunchCardScan()).isTrue()
+            assertThat(secondCardFormController!!.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
         }
     }
 
@@ -3471,9 +3473,9 @@ class CustomerSheetViewModelTest {
 
             val firstCardFormController = getAddPaymentMethodCardDetailsSectionController(viewState)
             assertThat(firstCardFormController).isNotNull()
-            assertThat(firstCardFormController!!.shouldAutomaticallyLaunchCardScan()).isTrue()
-            firstCardFormController.setHasAutomaticallyLaunchedCardScan()
-            assertThat(firstCardFormController.shouldAutomaticallyLaunchCardScan()).isFalse()
+            assertThat(firstCardFormController!!.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
+            firstCardFormController.cardDetailsAction?.setHasAutomaticallyLaunchedCardScan()
+            assertThat(firstCardFormController.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isFalse()
 
             viewModel.handleViewAction(CustomerSheetViewAction.OnBackPressed)
 
@@ -3486,7 +3488,7 @@ class CustomerSheetViewModelTest {
 
             val secondCardFormController = getAddPaymentMethodCardDetailsSectionController(viewState)
             assertThat(secondCardFormController).isNotNull()
-            assertThat(secondCardFormController!!.shouldAutomaticallyLaunchCardScan()).isTrue()
+            assertThat(secondCardFormController!!.cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormData
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
+import com.stripe.android.ui.core.elements.CardScanAction
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
@@ -568,65 +569,65 @@ class CardDefinitionTest {
 
     @Test
     fun `createFormElements shouldAutomaticallyLaunchCardScan in CardDetailsSectionController`() {
+        val helper = AutomaticallyLaunchedCardScanFormDataHelper(
+            hasAutomaticallyLaunchedCardScanInitialValue = false,
+            openCardScanAutomaticallyConfig = true,
+            savedStateHandle = SavedStateHandle()
+        )
+
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
                 )
             ),
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                hasAutomaticallyLaunchedCardScanInitialValue = false,
-                openCardScanAutomaticallyConfig = true,
-                savedStateHandle = SavedStateHandle()
-            )
+            automaticallyLaunchedCardScanFormDataHelper = helper,
         )
         assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
-        assertThat(
-            (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
-        ).isTrue()
+        assertThat(helper.shouldLaunchCardScanAutomatically).isTrue()
     }
 
     @Test
     fun `createFormElements should not automaticallyLaunchCardScan when config is false`() {
+        val helper = AutomaticallyLaunchedCardScanFormDataHelper(
+            hasAutomaticallyLaunchedCardScanInitialValue = false,
+            openCardScanAutomaticallyConfig = false,
+            savedStateHandle = SavedStateHandle()
+        )
+
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
                 )
             ),
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                hasAutomaticallyLaunchedCardScanInitialValue = false,
-                openCardScanAutomaticallyConfig = false,
-                savedStateHandle = SavedStateHandle()
-            )
+            automaticallyLaunchedCardScanFormDataHelper = helper,
         )
         assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
-        assertThat(
-            (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
-        ).isFalse()
+        assertThat(helper.shouldLaunchCardScanAutomatically).isFalse()
     }
 
     @Test
     fun `createFormElements should not automaticallyLaunchCardScan when has automaticallyLaunchedCardScan`() {
+        val helper = AutomaticallyLaunchedCardScanFormDataHelper(
+            hasAutomaticallyLaunchedCardScanInitialValue = true,
+            openCardScanAutomaticallyConfig = true,
+            savedStateHandle = SavedStateHandle()
+        )
+
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
                 )
             ),
-            automaticallyLaunchedCardScanFormDataHelper = AutomaticallyLaunchedCardScanFormDataHelper(
-                hasAutomaticallyLaunchedCardScanInitialValue = true,
-                openCardScanAutomaticallyConfig = true,
-                savedStateHandle = SavedStateHandle()
-            )
+            automaticallyLaunchedCardScanFormDataHelper = helper,
         )
         assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
-        assertThat(
-            (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
-        ).isFalse()
+        assertThat(helper.shouldLaunchCardScanAutomatically).isFalse()
     }
 
     @Test
@@ -671,7 +672,7 @@ class CardDefinitionTest {
     }
 
     @Test
-    fun `createFormElements has null cardDetailsAction when tap to add is not supported`() {
+    fun `createFormElements has CardScanAction when tap to add is not supported`() {
         val metadata = PaymentMethodMetadataFactory.create(
             isTapToAddSupported = false,
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -691,11 +692,11 @@ class CardDefinitionTest {
         val cardDetailsSectionElement = formElements[0] as CardDetailsSectionElement
         val controller = cardDetailsSectionElement.controller
 
-        assertThat(controller.cardDetailsAction).isNull()
+        assertThat(controller.cardDetailsAction).isInstanceOf<CardScanAction>()
     }
 
     @Test
-    fun `createFormElements has null cardDetailsAction when tapToAddHelper is null`() {
+    fun `createFormElements has CardScanAction when tapToAddHelper is null`() {
         val metadata = PaymentMethodMetadataFactory.create(
             isTapToAddSupported = false,
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -714,7 +715,7 @@ class CardDefinitionTest {
         val cardDetailsSectionElement = formElements[0] as CardDetailsSectionElement
         val controller = cardDetailsSectionElement.controller
 
-        assertThat(controller.cardDetailsAction).isNull()
+        assertThat(controller.cardDetailsAction).isInstanceOf<CardScanAction>()
     }
 
     private fun createLinkConfiguration(): LinkConfiguration {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -38,6 +38,7 @@ import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import com.stripe.android.utils.shouldAutomaticallyLaunchCardScan
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -66,7 +67,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
             assertThat(
-                (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
+                (formElements[0].controller as CardDetailsSectionController)
+                    .cardDetailsAction
+                    ?.shouldAutomaticallyLaunchCardScan
             ).isFalse()
         }
     }
@@ -82,7 +85,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
             assertThat(
-                (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
+                (formElements[0].controller as CardDetailsSectionController)
+                    .cardDetailsAction
+                    ?.shouldAutomaticallyLaunchCardScan
             ).isTrue()
         }
     }
@@ -101,7 +106,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
             assertThat(
-                (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
+                (formElements[0].controller as CardDetailsSectionController)
+                    .cardDetailsAction
+                    ?.shouldAutomaticallyLaunchCardScan
             ).isFalse()
         }
     }
@@ -117,7 +124,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             assertThat(formElements[0].controller).isInstanceOf<CardDetailsSectionController>()
 
             assertThat(
-                (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
+                (formElements[0].controller as CardDetailsSectionController)
+                    .cardDetailsAction
+                    ?.shouldAutomaticallyLaunchCardScan
             ).isTrue()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -43,6 +43,7 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import com.stripe.android.utils.shouldAutomaticallyLaunchCardScan
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -215,7 +216,9 @@ internal class DefaultVerticalModeFormInteractorTest {
 
             val controller = elements[0].controller as CardDetailsSectionController
 
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isTrue()
+            assertThat(
+                controller.cardDetailsAction?.shouldAutomaticallyLaunchCardScan
+            ).isTrue()
         }
     }
 
@@ -229,7 +232,9 @@ internal class DefaultVerticalModeFormInteractorTest {
 
             val controller = elements[0].controller as CardDetailsSectionController
 
-            assertThat(controller.shouldAutomaticallyLaunchCardScan()).isFalse()
+            assertThat(
+                controller.cardDetailsAction?.shouldAutomaticallyLaunchCardScan
+            ).isFalse()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/CardScanActionUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/CardScanActionUtils.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.utils
+
+import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
+import com.stripe.android.ui.core.elements.CardDetailsAction
+import com.stripe.android.ui.core.elements.CardScanAction
+
+val CardDetailsAction.shouldAutomaticallyLaunchCardScan: Boolean?
+    get() = getAutomaticallyLaunchedCardScanFormDataHelper()?.shouldLaunchCardScanAutomatically
+
+val CardDetailsAction.hasAutomaticallyLaunchedCardScan: Boolean?
+    get() = getAutomaticallyLaunchedCardScanFormDataHelper()?.hasAutomaticallyLaunchedCardScan
+
+fun CardDetailsAction.setHasAutomaticallyLaunchedCardScan() {
+    getAutomaticallyLaunchedCardScanFormDataHelper()?.let { helper ->
+        helper.hasAutomaticallyLaunchedCardScan = true
+    }
+}
+
+private fun CardDetailsAction.getAutomaticallyLaunchedCardScanFormDataHelper():
+    AutomaticallyLaunchedCardScanFormDataHelper? {
+    val cardScanAction = this as? CardScanAction
+
+    return cardScanAction?.automaticallyLaunchedCardScanFormDataHelper
+}


### PR DESCRIPTION
# Summary
Cleans up usage of card scan inside the Card Scan directly inside the `CardDetailsSectionElement` and uses it in `CardDefinition` as well. Also abstracts out camera scan from `CardDetailsSectionElement` so that it refers to more general card scanning.

# Motivation
Refactor to help setup for NFC Scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified