### PR TITLE
Add autofill support to the Address Element text fields and state dro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
-
-## 23.9.3 - 2026-06-09
 ### AddressElement
 * [ADDED] Added autofill support for Address Element text fields and the state/province dropdown.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### AddressElement
+* [ADDED] Added autofill support for Address Element text fields and the state/province dropdown.
+
 ## 23.10.0 - 2026-06-08
 
 ### Identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+
+## 23.9.3 - 2026-06-09
 ### AddressElement
 * [ADDED] Added autofill support for Address Element text fields and the state/province dropdown.
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -8,9 +8,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
+import com.stripe.android.uicore.elements.AddressTextFieldConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaElement
-import com.stripe.android.uicore.elements.AddressTextFieldConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PostalCodeConfig
@@ -19,6 +19,7 @@ import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextElement
+import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.utils.asIndividualDigits
@@ -318,19 +319,32 @@ private fun FieldType.toConfig(
             country = countryCode,
             optional = optional,
         )
-        else -> AddressTextFieldConfig(
-            label = resolvableString(label),
-            capitalization = capitalization,
-            keyboard = keyboardType,
-            optional = optional,
-            autofillContentType = when (this) {
+        else -> {
+            val autofillContentType = when (this) {
                 FieldType.AddressLine1 -> ContentType.AddressStreet
                 FieldType.AddressLine2 -> ContentType.AddressAuxiliaryDetails
                 FieldType.Locality -> ContentType.AddressLocality
                 FieldType.AdministrativeArea -> ContentType.AddressRegion
                 else -> null
-            },
-        )
+            }
+            if (autofillContentType != null) {
+                AddressTextFieldConfig(
+                    label = resolvableString(label),
+                    capitalization = capitalization,
+                    keyboard = keyboardType,
+                    optional = optional,
+                    autofillContentType = autofillContentType,
+                )
+            } else {
+                SimpleTextFieldConfig(
+                    label = resolvableString(label),
+                    capitalization = capitalization,
+                    keyboard = keyboardType,
+                    optional = optional,
+                    allowsEmojis = false,
+                )
+            }
+        }
     }
 }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -2,6 +2,7 @@ package com.stripe.android.uicore.address
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.core.strings.ResolvableString
@@ -293,7 +294,8 @@ private fun FieldType.toElement(
                 AdministrativeAreaElement(
                     identifierSpec,
                     DropdownFieldController(
-                        AdministrativeAreaConfig(country)
+                        AdministrativeAreaConfig(country),
+                        autofillType = ContentType.AddressRegion,
                     )
                 )
             } else {
@@ -323,6 +325,13 @@ private fun FieldType.toConfig(
             keyboard = keyboardType,
             optional = optional,
             allowsEmojis = false,
+            contentType = when (this) {
+                FieldType.AddressLine1 -> ContentType.AddressStreet
+                FieldType.AddressLine2 -> ContentType.AddressAuxiliaryDetails
+                FieldType.Locality -> ContentType.AddressLocality
+                FieldType.AdministrativeArea -> ContentType.AddressRegion
+                else -> null
+            },
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaElement
+import com.stripe.android.uicore.elements.AddressTextFieldConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PostalCodeConfig
@@ -18,7 +19,6 @@ import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextElement
-import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.utils.asIndividualDigits
@@ -295,7 +295,6 @@ private fun FieldType.toElement(
                     identifierSpec,
                     DropdownFieldController(
                         AdministrativeAreaConfig(country),
-                        autofillType = ContentType.AddressRegion,
                     )
                 )
             } else {
@@ -319,13 +318,12 @@ private fun FieldType.toConfig(
             country = countryCode,
             optional = optional,
         )
-        else -> SimpleTextFieldConfig(
+        else -> AddressTextFieldConfig(
             label = resolvableString(label),
             capitalization = capitalization,
             keyboard = keyboardType,
             optional = optional,
-            allowsEmojis = false,
-            contentType = when (this) {
+            autofillContentType = when (this) {
                 FieldType.AddressLine1 -> ContentType.AddressStreet
                 FieldType.AddressLine2 -> ContentType.AddressAuxiliaryDetails
                 FieldType.Locality -> ContentType.AddressLocality

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldConfig.kt
@@ -9,14 +9,8 @@ import com.stripe.android.core.strings.ResolvableString
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldConfig(
     label: ResolvableString,
-    capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
-    keyboard: KeyboardType = KeyboardType.Text,
-    optional: Boolean = false,
-    val autofillContentType: ContentType? = null,
-) : SimpleTextFieldConfig(
-    label = label,
-    capitalization = capitalization,
-    keyboard = keyboard,
-    optional = optional,
-    allowsEmojis = false,
-)
+    capitalization: KeyboardCapitalization,
+    keyboard: KeyboardType,
+    optional: Boolean,
+    val autofillContentType: ContentType?,
+) : SimpleTextFieldConfig(label, capitalization, keyboard, optional = optional, allowsEmojis = false)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldConfig.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.uicore.elements
+
+import androidx.annotation.RestrictTo
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import com.stripe.android.core.strings.ResolvableString
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class AddressTextFieldConfig(
+    label: ResolvableString,
+    capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
+    keyboard: KeyboardType = KeyboardType.Text,
+    optional: Boolean = false,
+    val autofillContentType: ContentType? = null,
+) : SimpleTextFieldConfig(
+    label = label,
+    capitalization = capitalization,
+    keyboard = keyboard,
+    optional = optional,
+    allowsEmojis = false,
+)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaConfig.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.ui.autofill.ContentType
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.R as CoreR
 
@@ -13,6 +14,7 @@ class AdministrativeAreaConfig(
 
     override val mode = DropdownConfig.Mode.Full(selectsFirstOptionAsDefault = false)
     override val debugLabel = "administrativeArea"
+    override val autofillType: ContentType = ContentType.AddressRegion
 
     override val label = resolvableString(country.label)
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownConfig.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.ui.autofill.ContentType
 import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -24,6 +25,10 @@ interface DropdownConfig {
     /** Whether the dropdown should be disabled when there is only one single item **/
     val disableDropdownWithSingleElement: Boolean
         get() = false
+
+    /** The autofill content type for this dropdown, or null if not autofillable **/
+    val autofillType: ContentType?
+        get() = null
 
     /** The label identifying the selected item used when the dropdown menu is collapsed **/
     fun getSelectedItemLabel(index: Int): String

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownConfig.kt
@@ -26,7 +26,6 @@ interface DropdownConfig {
     val disableDropdownWithSingleElement: Boolean
         get() = false
 
-    /** The autofill content type for this dropdown, or null if not autofillable **/
     val autofillType: ContentType?
         get() = null
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -3,6 +3,7 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -19,7 +20,8 @@ import kotlinx.coroutines.flow.StateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DropdownFieldController(
     private val config: DropdownConfig,
-    initialValue: String? = null
+    initialValue: String? = null,
+    val autofillType: ContentType? = null,
 ) : InputController, SectionFieldValidationController, SectionFieldComposable {
     val displayItems: List<String> = config.displayItems
     val disableDropdownWithSingleElement = config.disableDropdownWithSingleElement

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -84,7 +84,7 @@ class DropdownFieldController(
 
     fun onAutofillValue(value: String) {
         val displayItemIndex = displayItems.indexOfFirst { it.equals(value, ignoreCase = true) }
-            .takeIf { it != -1 }
+            .takeUnless { it == -1 }
         if (displayItemIndex != null) {
             onValueChange(displayItemIndex)
         } else {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.ContentType
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -21,8 +20,8 @@ import kotlinx.coroutines.flow.StateFlow
 class DropdownFieldController(
     private val config: DropdownConfig,
     initialValue: String? = null,
-    val autofillType: ContentType? = null,
 ) : InputController, SectionFieldValidationController, SectionFieldComposable {
+    val autofillType = config.autofillType
     val displayItems: List<String> = config.displayItems
     val disableDropdownWithSingleElement = config.disableDropdownWithSingleElement
     private val dropdownMode = config.mode
@@ -81,6 +80,16 @@ class DropdownFieldController(
         safelyUpdateSelectedIndex(
             displayItems.indexOf(config.convertFromRaw(rawValue)).takeUnless { it == -1 } ?: initialIndex
         )
+    }
+
+    fun onAutofillValue(value: String) {
+        val displayItemIndex = displayItems.indexOfFirst { it.equals(value, ignoreCase = true) }
+            .takeIf { it != -1 }
+        if (displayItemIndex != null) {
+            onValueChange(displayItemIndex)
+        } else {
+            onRawValueChange(value)
+        }
     }
 
     private fun safelyUpdateSelectedIndex(index: Int?) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
@@ -127,7 +127,7 @@ fun DropDown(
                         contentType = autofillType
                         contentDataType = ContentDataType.Text
                         onAutofillText { text ->
-                            controller.onRawValueChange(text.text)
+                            controller.onAutofillValue(text.text)
                             true
                         }
                     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentDataType
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -37,6 +38,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDataType
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.onAutofillText
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
@@ -116,6 +121,18 @@ fun DropDown(
             .wrapContentSize(Alignment.TopStart)
             .background(MaterialTheme.stripeColors.component)
             .then(modifier)
+            .then(
+                controller.autofillType?.let { autofillType ->
+                    Modifier.semantics {
+                        contentType = autofillType
+                        contentDataType = ContentDataType.Text
+                        onAutofillText { text ->
+                            controller.onRawValueChange(text.text)
+                            true
+                        }
+                    }
+                } ?: Modifier
+            )
     ) {
         // Click handling happens on the box, so that it is a single accessible item
         Box(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -17,7 +16,6 @@ open class SimpleTextFieldConfig(
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
     override val optional: Boolean = false,
     val allowsEmojis: Boolean = true,
-    val contentType: ContentType? = null,
 ) : TextFieldConfig {
     override val debugLabel: String = "generic_text"
     override val visualTransformation: VisualTransformation? = null

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -16,6 +17,7 @@ open class SimpleTextFieldConfig(
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
     override val optional: Boolean = false,
     val allowsEmojis: Boolean = true,
+    val contentType: ContentType? = null,
 ) : TextFieldConfig {
     override val debugLabel: String = "generic_text"
     override val visualTransformation: VisualTransformation? = null

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -156,7 +156,8 @@ class SimpleTextFieldController(
         is PostalCodeConfig -> ContentType.PostalCode
         is EmailConfig -> ContentType.EmailAddress
         is NameConfig -> ContentType.PersonFullName
-        else -> (textFieldConfig as? SimpleTextFieldConfig)?.contentType
+        is AddressTextFieldConfig -> textFieldConfig.autofillContentType
+        else -> null
     }
 
     override val placeHolder = MutableStateFlow(textFieldConfig.placeHolder)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -156,7 +156,7 @@ class SimpleTextFieldController(
         is PostalCodeConfig -> ContentType.PostalCode
         is EmailConfig -> ContentType.EmailAddress
         is NameConfig -> ContentType.PersonFullName
-        else -> null
+        else -> (textFieldConfig as? SimpleTextFieldConfig)?.contentType
     }
 
     override val placeHolder = MutableStateFlow(textFieldConfig.placeHolder)

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/DropdownFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/DropdownFieldControllerTest.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.uicore.elements
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DropdownFieldControllerTest {
+
+    private val controller = DropdownFieldController(
+        AdministrativeAreaConfig(AdministrativeAreaConfig.Country.US())
+    )
+
+    @Test
+    fun `onAutofillValue with abbreviation selects matching state`() {
+        controller.onAutofillValue("CA")
+        assertThat(controller.rawFieldValue.value).isEqualTo("CA")
+    }
+
+    @Test
+    fun `onAutofillValue with full name selects matching state`() {
+        controller.onAutofillValue("California")
+        assertThat(controller.rawFieldValue.value).isEqualTo("CA")
+    }
+
+    @Test
+    fun `onAutofillValue with full name is case insensitive`() {
+        controller.onAutofillValue("california")
+        assertThat(controller.rawFieldValue.value).isEqualTo("CA")
+    }
+}

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -3,6 +3,9 @@ package com.stripe.android.uicore.elements
 import android.os.Build
 import android.os.Looper.getMainLooper
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
@@ -306,6 +309,20 @@ internal class SimpleTextFieldControllerTest {
             visibleErrorTurbine.cancelAndIgnoreRemainingEvents()
             errorTurbine.cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `Verify autofillType for AddressTextFieldConfig`() {
+        val controller = SimpleTextFieldController(
+            AddressTextFieldConfig(
+                label = resolvableString(CoreR.string.stripe_address_label_full_name),
+                capitalization = KeyboardCapitalization.Words,
+                keyboard = KeyboardType.Text,
+                optional = false,
+                autofillContentType = ContentType.AddressStreet,
+            )
+        )
+        assertThat(controller.autofillType).isEqualTo(ContentType.AddressStreet)
     }
 
     private fun createControllerWithState(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add autofill support to the Address Element with Android autofill hints so the system can recognize and populate them. Text fields and the state dropdown (US/CA/BR) also gets autofill support.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address fields in the Address Element had no autofill hints, so Android autofill services (e.g. Google Autofill) could not recognize or populate them. This is a usability gap, users with autofill set up expect address forms to fill automatically.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Also tested with the debug `TestAutofillService` in `paymentsheet-example`


# Recording
[Recording Link](https://drive.google.com/file/d/1SvLOBw_veWh2a2C-3ixp8WDYcnfdSFFR/view?usp=sharing)



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[Added] Address fields in the Address Element now support Android autofill, including the state dropdown for US, Canada, and Brazil.