### PR TITLE
Implement mc_wallet_button_tapped analytic event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -175,6 +175,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             confirmationHandler = confirmationHandler,
             coroutineScope = coroutineScope,
             errorReporter = errorReporter,
+            eventReporter = eventReporter,
             linkPaymentLauncher = linkPaymentLauncher,
             linkAccountHolder = linkAccountHolder,
             linkInlineInteractor = NoOpLinkInlineInteractor(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -269,6 +269,14 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onWalletButtonTapped(walletType: String) {
+        fireEvent(
+            PaymentSheetEvent.WalletButtonTapped(
+                walletType = walletType,
+            )
+        )
+    }
+
     override fun onPressConfirmButton(paymentSelection: PaymentSelection) {
         val duration = durationProvider.end(DurationProvider.Key.ConfirmButtonClicked)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -114,6 +114,11 @@ internal interface EventReporter : CardScanEventsReporter {
     fun onAnalyticsEvent(event: AnalyticsEvent)
 
     /**
+     * The customer has tapped a wallet button (e.g. Google Pay, Link, Shop Pay).
+     */
+    fun onWalletButtonTapped(walletType: String)
+
+    /**
      * The customer has pressed the confirm button.
      */
     fun onPressConfirmButton(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -391,6 +391,15 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class WalletButtonTapped(
+        walletType: String,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_wallet_button_tapped"
+        override val params: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_LPM to walletType
+        )
+    }
+
     class ShopPayWebviewLoadAttempt : PaymentSheetEvent() {
         override val eventName: String = "mc_shoppay_webview_load_attempt"
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -35,6 +35,7 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.ButtonThemes.LinkButtonTheme
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.configType
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerViewModel
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -156,6 +157,7 @@ internal class DefaultWalletButtonsInteractor constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val coroutineScope: CoroutineScope,
     private val errorReporter: ErrorReporter,
+    private val eventReporter: EventReporter,
     private val linkInlineInteractor: LinkInlineInteractor,
     private val linkPaymentLauncher: LinkPaymentLauncher,
     private val linkAccountHolder: LinkAccountHolder,
@@ -248,6 +250,7 @@ internal class DefaultWalletButtonsInteractor constructor(
     override fun handleViewAction(action: WalletButtonsInteractor.ViewAction) {
         when (action) {
             is OnButtonPressed -> {
+                eventReporter.onWalletButtonTapped(action.button.walletType.code)
                 analyticsCallbackProvider.get()?.onEvent(
                     AnalyticEvent.TapsButtonInWalletsButtonsView(action.button.walletType.code)
                 )
@@ -362,6 +365,7 @@ internal class DefaultWalletButtonsInteractor constructor(
 
             return DefaultWalletButtonsInteractor(
                 errorReporter = flowControllerViewModel.flowControllerStateComponent.errorReporter,
+                eventReporter = flowControllerViewModel.flowControllerStateComponent.eventReporter,
                 arguments = combineAsStateFlow(
                     linkHandler.linkConfigurationCoordinator.emailFlow,
                     flowControllerViewModel.stateFlow,
@@ -399,12 +403,14 @@ internal class DefaultWalletButtonsInteractor constructor(
             confirmationHandler: ConfirmationHandler,
             coroutineScope: CoroutineScope,
             errorReporter: ErrorReporter,
+            eventReporter: EventReporter,
             linkPaymentLauncher: LinkPaymentLauncher,
             linkAccountHolder: LinkAccountHolder,
             analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
         ): WalletButtonsInteractor {
             return DefaultWalletButtonsInteractor(
                 errorReporter = errorReporter,
+                eventReporter = eventReporter,
                 arguments = combineAsStateFlow(
                     embeddedLinkHelper.linkEmail,
                     confirmationStateHolder.stateFlow,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -461,6 +461,18 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onWalletButtonTapped fires event`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        eventReporter.onWalletButtonTapped(walletType = "google_pay")
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_wallet_button_tapped")
+        assertThat(request.params).containsEntry("selected_lpm", "google_pay")
+        assertThat(request.params).containsEntry("example_from_test", true)
+    }
+
+    @Test
     fun `onAutofill fires event`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -60,6 +60,9 @@ internal class FakeEventReporter : EventReporter {
     private val _formCompletedCalls = Turbine<FormCompletedCall>()
     val formCompletedCalls: ReceiveTurbine<FormCompletedCall> = _formCompletedCalls
 
+    private val _walletButtonTappedCalls = Turbine<String>()
+    val walletButtonTappedCalls: ReceiveTurbine<String> = _walletButtonTappedCalls
+
     private val _pressConfirmButtonCalls = Turbine<PaymentSelection>()
     val pressConfirmButtonCalls: ReceiveTurbine<PaymentSelection> = _pressConfirmButtonCalls
 
@@ -117,6 +120,7 @@ internal class FakeEventReporter : EventReporter {
         _experimentExposureCalls.ensureAllEventsConsumed()
         _removePaymentMethodCalls.ensureAllEventsConsumed()
         _formCompletedCalls.ensureAllEventsConsumed()
+        _walletButtonTappedCalls.ensureAllEventsConsumed()
         _pressConfirmButtonCalls.ensureAllEventsConsumed()
         _usBankAccountFormEventCalls.ensureAllEventsConsumed()
         _tapToAddButtonShownCalls.ensureAllEventsConsumed()
@@ -173,6 +177,10 @@ internal class FakeEventReporter : EventReporter {
     }
 
     override fun onSelectPaymentOption(paymentSelection: PaymentSelection) {
+    }
+
+    override fun onWalletButtonTapped(walletType: String) {
+        _walletButtonTappedCalls.add(walletType)
     }
 
     override fun onPressConfirmButton(paymentSelection: PaymentSelection) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOptio
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.ButtonThemes.LinkButtonTheme
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.testing.CoroutineTestRule
@@ -246,6 +247,35 @@ class DefaultWalletButtonsInteractorTest {
                 assertThat(state.buttonsEnabled).isTrue()
             }
         }
+
+    @Test
+    fun `on button pressed, should fire wallet button tapped analytics event`() = runTest {
+        val eventReporter = FakeEventReporter()
+        val interactor = createInteractor(
+            arguments = null,
+            eventReporter = eventReporter,
+        )
+
+        interactor.handleViewAction(
+            WalletButtonsInteractor.ViewAction.OnButtonPressed(
+                button = WalletButtonsInteractor.WalletButton.GooglePay(
+                    buttonType = null,
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                    allowCreditCards = true,
+                    cardBrandFilter = PaymentSheetCardBrandFilter(
+                        cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.all()
+                    ),
+                    cardFundingFilter = DefaultCardFundingFilter,
+                    additionalEnabledNetworks = emptyList(),
+                ),
+                clickHandler = { false },
+            )
+        )
+
+        assertThat(eventReporter.walletButtonTappedCalls.awaitItem()).isEqualTo("google_pay")
+
+        eventReporter.validate()
+    }
 
     @Test
     fun `on button pressed with no arguments, should report unexpected error`() = runTest {
@@ -1085,6 +1115,7 @@ class DefaultWalletButtonsInteractorTest {
         arguments: DefaultWalletButtonsInteractor.Arguments? = null,
         confirmationHandler: ConfirmationHandler = FakeConfirmationHandler(),
         errorReporter: ErrorReporter = FakeErrorReporter(),
+        eventReporter: FakeEventReporter = FakeEventReporter(),
         linkPaymentLauncher: LinkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
         linkAccountHolder: LinkAccountHolder = LinkAccountHolder(SavedStateHandle()),
         onWalletButtonsRenderStateChanged: (isRendered: Boolean) -> Unit = {
@@ -1096,6 +1127,7 @@ class DefaultWalletButtonsInteractorTest {
             confirmationHandler = confirmationHandler,
             coroutineScope = CoroutineScope(testDispatcher),
             errorReporter = errorReporter,
+            eventReporter = eventReporter,
             linkInlineInteractor = NoOpLinkInlineInteractor(),
             linkPaymentLauncher = linkPaymentLauncher,
             linkAccountHolder = linkAccountHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -273,6 +273,9 @@ class DefaultWalletButtonsInteractorTest {
         )
 
         assertThat(eventReporter.walletButtonTappedCalls.awaitItem()).isEqualTo("google_pay")
+        analyticsEventCallbackRule.assertMatchesExpectedEvent(
+            AnalyticEvent.TapsButtonInWalletsButtonsView(walletType = "google_pay")
+        )
 
         eventReporter.validate()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add the mc_wallet_button_tapped internal analytics event to Android, analogous to the iOS implementation. The event is fired when a user taps any wallet button (Google Pay, Link, or Shop Pay) in the wallet buttons view, with the selected_lpm parameter identifying which wallet was tapped.

Changes:
- Add WalletButtonTapped event class to PaymentSheetEvent
- Add onWalletButtonTapped() method to EventReporter interface
- Implement onWalletButtonTapped() in DefaultEventReporter
- Fire the event in DefaultWalletButtonsInteractor when a wallet button is pressed
- Update FakeEventReporter with Turbine tracking for the new method
- Add tests in DefaultEventReporterTest and DefaultWalletButtonsInteractorTest

Committed-By-Agent: goose

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improve visibility into wallet buttons view usage on android

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
