### PR TITLE
Fix PaymentSheet builder syntax in example activities.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/complete_flow/CompleteFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/complete_flow/CompleteFlowActivity.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CompletedPaymentAlertDialog
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
-import com.stripe.android.paymentsheet.rememberPaymentSheet
 
 internal class CompleteFlowActivity : AppCompatActivity() {
 
@@ -37,9 +36,9 @@ internal class CompleteFlowActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            val paymentSheet = rememberPaymentSheet(
-                paymentResultCallback = viewModel::handlePaymentSheetResult,
-            )
+            val paymentSheet = PaymentSheet.Builder(
+                resultCallback = viewModel::handlePaymentSheetResult,
+            ).build()
 
             PaymentSheetExampleTheme {
                 val uiState by viewModel.state.collectAsState()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/custom_flow/CustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/custom_flow/CustomFlowActivity.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.ErrorScreen
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
-import com.stripe.android.paymentsheet.rememberPaymentSheetFlowController
 
 internal class CustomFlowActivity : AppCompatActivity() {
 
@@ -45,10 +44,10 @@ internal class CustomFlowActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            val flowController = rememberPaymentSheetFlowController(
+            val flowController = PaymentSheet.FlowController.Builder(
                 paymentOptionCallback = viewModel::handlePaymentOptionChanged,
-                paymentResultCallback = viewModel::handlePaymentSheetResult,
-            )
+                resultCallback = viewModel::handlePaymentSheetResult,
+            ).build()
 
             PaymentSheetExampleTheme {
                 val uiState by viewModel.state.collectAsState()


### PR DESCRIPTION
# Summary
Corrected the PaymentSheet and PaymentSheet.FlowController builder syntax in the example activities to use the proper builder pattern.

# Motivation
The previous code was using `rememberPaymentSheet` and `rememberPaymentSheetFlowController` functions which don't exist in the current API. This change updates the examples to use the correct `PaymentSheet.Builder` and `PaymentSheet.FlowController.Builder` syntax.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Fixed] Corrected PaymentSheet builder usage in example code.