### PR TITLE
Remove ShippingAddress payment method requirement.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.model.LinkMode
-import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 
@@ -15,21 +14,6 @@ internal enum class AddPaymentMethodRequirement {
     UnsupportedForSetup {
         override fun isMetBy(metadata: PaymentMethodMetadata, code: String): Boolean {
             return !metadata.hasIntentToSetup(code)
-        }
-    },
-
-    /** Indicates that a payment method requires shipping information. */
-    ShippingAddress {
-        override fun isMetBy(metadata: PaymentMethodMetadata, code: String): Boolean {
-            if (metadata.allowsPaymentMethodsRequiringShippingAddress) {
-                return true
-            }
-
-            val shipping = (metadata.stripeIntent as? PaymentIntent)?.shipping
-            return shipping?.name != null &&
-                shipping.address.line1 != null &&
-                shipping.address.country != null &&
-                shipping.address.postalCode != null
         }
     },
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement.InstantDebits
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement.LinkCardBrand
-import com.stripe.android.model.Address
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -86,74 +85,6 @@ internal class AddPaymentMethodRequirementTest {
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
         )
         assertThat(AddPaymentMethodRequirement.UnsupportedForSetup.isMetBy(metadata, "")).isFalse()
-    }
-
-    @Test
-    fun testShippingAddressReturnsTrue() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                shipping = PaymentIntent.Shipping(
-                    name = "Example Buyer",
-                    address = Address(
-                        line1 = "123 Main St",
-                        country = "US",
-                        postalCode = "12345"
-                    )
-                )
-            )
-        )
-        assertThat(AddPaymentMethodRequirement.ShippingAddress.isMetBy(metadata, "")).isTrue()
-    }
-
-    @Test
-    fun testShippingAddressReturnsTrueWhenMetadataAllowsPaymentMethodsRequiringShippingAddress() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                shipping = null
-            ),
-            allowsPaymentMethodsRequiringShippingAddress = true,
-        )
-        assertThat(AddPaymentMethodRequirement.ShippingAddress.isMetBy(metadata, "")).isTrue()
-    }
-
-    @Test
-    fun testShippingAddressReturnsFalseWithNullName() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                shipping = PaymentIntent.Shipping(
-                    address = Address(
-                        line1 = "123 Main St",
-                        country = "US",
-                        postalCode = "12345"
-                    )
-                )
-            )
-        )
-        assertThat(AddPaymentMethodRequirement.ShippingAddress.isMetBy(metadata, "")).isFalse()
-    }
-
-    @Test
-    fun testShippingAddressReturnsFalseWithNullLine1() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                shipping = PaymentIntent.Shipping(
-                    name = "Example Buyer",
-                    address = Address(
-                        country = "US",
-                        postalCode = "12345"
-                    )
-                )
-            )
-        )
-        assertThat(AddPaymentMethodRequirement.ShippingAddress.isMetBy(metadata, "")).isFalse()
-    }
-
-    @Test
-    fun testShippingAddressReturnsFalseWithSetupIntent() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
-        )
-        assertThat(AddPaymentMethodRequirement.ShippingAddress.isMetBy(metadata, "")).isFalse()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Removed the `ShippingAddress` requirement from `AddPaymentMethodRequirement` enum along with its associated tests.

# Motivation
The ShippingAddress requirement is no longer needed for payment method validation. This simplifies the payment method requirements by removing unnecessary shipping address checks.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified