### PR TITLE
Shard PaymentSheet E2E tests into 5 parallel workflows.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,5 +1,5 @@
 ---
-format_version: '11'
+format_version: '25'
 default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
 project_type: android
 trigger_map:
@@ -15,6 +15,15 @@ pipelines:
   main-trigger-pipeline:
     stages:
       - stage-trigger-run-all: { }
+  pipeline-paymentsheet-e2e-tests:
+    triggers:
+      push:
+        - branch: master
+      pull_request:
+        - source_branch: '*'
+    stages:
+      - stage-build-paymentsheet-e2e: { }
+      - stage-run-paymentsheet-e2e-tests: { }
   pipeline-connect-e2e-debug-tests:
     stages:
       - stage-run-connect-e2e-tests: { }
@@ -41,10 +50,19 @@ stages:
       - run-connections-e2e-token-tests-on-push: { }
       - run-connections-e2e-data-tests-on-push: { }
       - run-cardscan-instrumentation-tests: { }
-      - run-paymentsheet-end-to-end-tests: { }
       - run-crypto-onramp-example-e2e-tests: { }
       - check-dependencies: { }
       - verify-publish-pom: { }
+  stage-build-paymentsheet-e2e:
+    workflows:
+      - build-paymentsheet-e2e: { }
+  stage-run-paymentsheet-e2e-tests:
+    workflows:
+      - run-paymentsheet-e2e-shard-1: { }
+      - run-paymentsheet-e2e-shard-2: { }
+      - run-paymentsheet-e2e-shard-3: { }
+      - run-paymentsheet-e2e-shard-4: { }
+      - run-paymentsheet-e2e-shard-5: { }
   stage-run-connect-e2e-tests:
     workflows:
       - run-connect-e2e-tests: { }
@@ -344,28 +362,85 @@ workflows:
           title: Export CardScan instrumentation test results
           inputs:
             - test_title: CardScan instrumentation tests
-  run-paymentsheet-end-to-end-tests:
+  build-paymentsheet-e2e:
     before_run:
       - prepare_all
     after_run:
       - conclude_all
     steps:
       - script@1:
+          title: Compile PaymentSheet E2E tests
           timeout: 1200
           inputs:
-            - content: ./gradlew :paymentsheet-example:assembleBaseDebugAndroidTest :paymentsheet-example:assembleBaseDebug -PIS_BROWSERSTACK_BUILD=true -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN
+            - content: ./gradlew :paymentsheet-example:assembleBaseDebug :paymentsheet-example:assembleBaseDebugAndroidTest -PIS_BROWSERSTACK_BUILD=true -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
+  run-paymentsheet-e2e-shard-1:
+    envs:
+      - SHARD_INDEX: "0"
+    before_run:
+      - _run-paymentsheet-e2e-shard
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
+  run-paymentsheet-e2e-shard-2:
+    envs:
+      - SHARD_INDEX: "1"
+    before_run:
+      - _run-paymentsheet-e2e-shard
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
+  run-paymentsheet-e2e-shard-3:
+    envs:
+      - SHARD_INDEX: "2"
+    before_run:
+      - _run-paymentsheet-e2e-shard
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
+  run-paymentsheet-e2e-shard-4:
+    envs:
+      - SHARD_INDEX: "3"
+    before_run:
+      - _run-paymentsheet-e2e-shard
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
+  run-paymentsheet-e2e-shard-5:
+    envs:
+      - SHARD_INDEX: "4"
+    before_run:
+      - _run-paymentsheet-e2e-shard
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: g2.linux.x-large
+  _run-paymentsheet-e2e-shard:
+    before_run:
+      - prepare_all
+    after_run:
+      - conclude_all
+    steps:
       - script@1:
-          timeout: 120
-          inputs:
-            - content: pip3 install requests_toolbelt requests
-      - script@1:
+          title: Execute PaymentSheet E2E tests (shard $SHARD_INDEX)
           timeout: 2400
           inputs:
-            - content: python3 scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/base/debug/paymentsheet-example-base-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/base/debug/paymentsheet-example-base-debug-androidTest.apk --num-retries 2
+            - content: |-
+                #!/usr/bin/env bash
+                set -euo pipefail
+                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$SHARD_INDEX" --num-shards 5)
+                ./gradlew -PIS_BROWSERSTACK_BUILD=true -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=6 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=6 "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33BaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
       - bundle::export_instrumentation_test_results:
           title: Export PaymentSheet E2E test results
           inputs:
-            - test_title: PaymentSheet E2E tests
+            - test_title: PaymentSheet E2E tests (shard $SHARD_INDEX)
   run-paymentsheet-latency-synthetics:
     before_run:
       - start_emulator

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -70,7 +70,7 @@ android {
         applicationId "com.stripe.android.paymentsheet.example"
         versionCode 11
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.stripe.android.utils.PaymentSheetTestRunner"
 
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
         buildConfigField "boolean", "IS_BROWSERSTACK_BUILD", "$gradle.ext.isBrowserstackBuild"

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/LeakCanaryConfig.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/LeakCanaryConfig.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.utils
+
+import leakcanary.LeakCanary
+import shark.AndroidReferenceMatchers
+import shark.IgnoredReferenceMatcher
+import shark.ReferencePattern
+
+internal fun configureLeakCanaryForManagedDevices() {
+    LeakCanary.config = LeakCanary.config.copy(
+        referenceMatchers = AndroidReferenceMatchers.appDefaults + listOf(
+            IgnoredReferenceMatcher(
+                pattern = ReferencePattern.InstanceFieldPattern(
+                    className = "java.lang.ClassLoader",
+                    fieldName = "runtimeInternalObjects"
+                )
+            ),
+            IgnoredReferenceMatcher(
+                pattern = ReferencePattern.InstanceFieldPattern(
+                    className = "dalvik.system.PathClassLoader",
+                    fieldName = "runtimeInternalObjects"
+                )
+            ),
+            IgnoredReferenceMatcher(
+                pattern = ReferencePattern.InstanceFieldPattern(
+                    className = "java.lang.DexCache",
+                    fieldName = "runtimeInternalObjects"
+                )
+            ),
+        )
+    )
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/PaymentSheetTestRunner.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.utils
+
+import android.os.Bundle
+import androidx.test.runner.AndroidJUnitRunner
+
+internal class PaymentSheetTestRunner : AndroidJUnitRunner() {
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+        configureLeakCanaryForManagedDevices()
+    }
+}

--- a/scripts/get_shard_test_classes.py
+++ b/scripts/get_shard_test_classes.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+
+
+def run_fast_scandir(dir, ext):
+    subfolders, files = [], []
+
+    for f in os.scandir(dir):
+        if f.is_dir():
+            subfolders.append(f.path)
+        if f.is_file():
+            if os.path.splitext(f.name)[1].lower() in ext:
+                files.append(f.path)
+
+    for dir in list(subfolders):
+        sf, f = run_fast_scandir(dir, ext)
+        subfolders.extend(sf)
+        files.extend(f)
+
+    return subfolders, files
+
+
+def test_files_from_kotlin_files(kotlin_files):
+    test_files = []
+    for file in kotlin_files:
+        with open(file) as file_handle:
+            if 'import org.junit.Test' in file_handle.read():
+                test_files.append(file)
+    return test_files
+
+
+def class_names_from_test_files(test_directory, test_file_names):
+    class_names = []
+    for file_name in test_file_names:
+        class_name = (file_name[len(test_directory):][:-3]).replace('/', '.')
+        class_names.append(class_name)
+    return class_names
+
+
+def get_all_test_class_names():
+    directory = 'paymentsheet-example/src/androidTest/java/'
+    _, kotlin_file_names = run_fast_scandir(directory, [".kt"])
+    test_file_names = test_files_from_kotlin_files(kotlin_file_names)
+    return sorted(class_names_from_test_files(directory, test_file_names))
+
+
+def get_shard_classes(shard_index, num_shards):
+    all_classes = get_all_test_class_names()
+    return [c for i, c in enumerate(all_classes) if i % num_shards == shard_index]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Get test classes for a given shard.")
+    parser.add_argument("--shard-index", type=int, required=True)
+    parser.add_argument("--num-shards", type=int, required=True)
+    args = parser.parse_args()
+
+    classes = get_shard_classes(args.shard_index, args.num_shards)
+    if not classes:
+        print("No test classes found for shard", args.shard_index, file=sys.stderr)
+        sys.exit(1)
+
+    print(",".join(classes))


### PR DESCRIPTION
# Summary
Split PaymentSheet end-to-end tests into 5 sharded workflows that run in parallel to reduce overall test execution time.

# Motivation
The PaymentSheet E2E test suite has grown large enough that running all tests sequentially takes too long. By sharding the tests across 5 parallel workflows, we can significantly reduce the total CI pipeline duration and get faster feedback on PRs.

# Testing
- [x] Modified tests
- [x] Manually verified

# Changelog