### PR TITLE
Add accessibility improvements to currency selector toggle.

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -162,6 +162,12 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_card_updates_failed_error_message">Card was not updated. Please try again.</string>
   <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
+  <!-- Accessibility label for a control that lets the customer choose which currency to pay in. -->
+  <string name="stripe_paymentsheet_currency_selector_label">Choose currency</string>
+  <!-- Accessibility description for a currency option, e.g. "USD, $61.06". Parameters: %1$s = currency code, %2$s = formatted amount -->
+  <string name="stripe_paymentsheet_currency_option_accessibility">%1$s, %2$s</string>
+  <!-- Accessibility description for a selected currency option with exchange rate, e.g. "USD, $61.06, 1 EUR = 1.19749 USD". Parameters: %1$s = currency option description, %2$s = exchange rate -->
+  <string name="stripe_paymentsheet_currency_option_with_exchange_rate">%1$s, %2$s</string>
   <string name="stripe_paymentsheet_close">Close</string>
   <!-- A button used to confirm selecting a saved payment method -->
   <string name="stripe_paymentsheet_confirm">Confirm</string>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -162,12 +162,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_card_updates_failed_error_message">Card was not updated. Please try again.</string>
   <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
-  <!-- Accessibility label for a control that lets the customer choose which currency to pay in. -->
-  <string name="stripe_paymentsheet_currency_selector_label">Choose currency</string>
-  <!-- Accessibility description for a currency option, e.g. "USD, $61.06". Parameters: %1$s = currency code, %2$s = formatted amount -->
-  <string name="stripe_paymentsheet_currency_option_accessibility">%1$s, %2$s</string>
-  <!-- Accessibility description for a selected currency option with exchange rate, e.g. "USD, $61.06, 1 EUR = 1.19749 USD". Parameters: %1$s = currency option description, %2$s = exchange rate -->
-  <string name="stripe_paymentsheet_currency_option_with_exchange_rate">%1$s, %2$s</string>
   <string name="stripe_paymentsheet_close">Close</string>
   <!-- A button used to confirm selecting a saved payment method -->
   <string name="stripe_paymentsheet_confirm">Confirm</string>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
@@ -14,25 +14,29 @@ internal object CurrencySelectorOptionsFactory {
 
         val integrationCode = adaptivePricingInfo.integrationCurrency.uppercase()
         val localCode = localOption.currency.uppercase()
+        val integrationAmount = CurrencyFormatter.format(
+            amount = adaptivePricingInfo.integrationAmount,
+            amountCurrencyCode = adaptivePricingInfo.integrationCurrency,
+            targetLocale = locale,
+        )
+        val localAmount = CurrencyFormatter.format(
+            amount = localOption.amount,
+            amountCurrencyCode = localOption.currency,
+            targetLocale = locale,
+        )
 
         val integrationFlag = currencyCodeToFlagEmoji(integrationCode)
         val integrationCurrencyOption = CurrencyOption(
             code = integrationCode,
-            displayableText = integrationFlag + CurrencyFormatter.format(
-                amount = adaptivePricingInfo.integrationAmount,
-                amountCurrencyCode = adaptivePricingInfo.integrationCurrency,
-                targetLocale = locale,
-            ),
+            displayableText = integrationFlag + integrationAmount,
+            formattedAmount = integrationAmount,
         )
 
         val localFlag = currencyCodeToFlagEmoji(localCode)
         val localCurrencyOption = CurrencyOption(
             code = localCode,
-            displayableText = localFlag + CurrencyFormatter.format(
-                amount = localOption.amount,
-                amountCurrencyCode = localOption.currency,
-                targetLocale = locale,
-            ),
+            displayableText = localFlag + localAmount,
+            formattedAmount = localAmount,
         )
 
         val selectedCode = adaptivePricingInfo.activePresentmentCurrency.uppercase()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.error
 import androidx.compose.ui.semantics.liveRegion
@@ -43,7 +44,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.R
 import androidx.compose.ui.R as ComposeR
 import com.stripe.android.uicore.R as StripeUiCoreR
 
@@ -101,8 +101,6 @@ internal fun CurrencySelectorToggle(
     val fontFamily = appearance.fontResId?.let { FontFamily(Font(it)) }
     val bodyStyle = MaterialTheme.typography.subtitle1.withAppearance(fontFamily, appearance.sizeScaleFactor)
     val captionStyle = MaterialTheme.typography.caption.withAppearance(fontFamily, appearance.sizeScaleFactor)
-    val selectorLabel = stringResource(R.string.stripe_paymentsheet_currency_selector_label)
-
     Column(modifier = modifier) {
         Box(
             modifier = Modifier
@@ -116,7 +114,6 @@ internal fun CurrencySelectorToggle(
                     shape = shape,
                 )
                 .semantics {
-                    contentDescription = selectorLabel
                     if (errorMessage != null) {
                         error(errorMessage)
                     }
@@ -140,8 +137,6 @@ internal fun CurrencySelectorToggle(
                     unselectedTextColor = unselectedText,
                     textStyle = bodyStyle,
                     contentVerticalPaddingDp = appearance.contentVerticalPaddingDp,
-                    exchangeRateText = options.exchangeRateText,
-                    errorMessage = errorMessage,
                 )
                 CurrencyOptionItem(
                     currency = options.second,
@@ -154,8 +149,6 @@ internal fun CurrencySelectorToggle(
                     unselectedTextColor = unselectedText,
                     textStyle = bodyStyle,
                     contentVerticalPaddingDp = appearance.contentVerticalPaddingDp,
-                    exchangeRateText = options.exchangeRateText,
-                    errorMessage = errorMessage,
                 )
             }
         }
@@ -167,8 +160,7 @@ internal fun CurrencySelectorToggle(
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 4.dp)
-                    .semantics { liveRegion = LiveRegionMode.Polite },
+                    .padding(top = 4.dp),
             )
         }
         if (errorMessage != null) {
@@ -199,8 +191,6 @@ private fun RowScope.CurrencyOptionItem(
     unselectedTextColor: Color,
     textStyle: TextStyle,
     contentVerticalPaddingDp: Float,
-    exchangeRateText: String?,
-    errorMessage: String?,
 ) {
     val isSelected = currency.code == options.selectedCode
     val backgroundColor = if (isSelected) pillBackground else trackBackground
@@ -212,11 +202,7 @@ private fun RowScope.CurrencyOptionItem(
             ComposeR.string.not_selected
         }
     )
-    val accessibilityLabel = currencyOptionAccessibilityLabel(
-        currency = currency,
-        isSelected = isSelected,
-        exchangeRateText = exchangeRateText,
-    )
+    val accessibilityLabel = currency.formattedAmount
 
     Box(
         contentAlignment = Alignment.Center,
@@ -236,9 +222,6 @@ private fun RowScope.CurrencyOptionItem(
             .semantics {
                 contentDescription = accessibilityLabel
                 stateDescription = accessibilityDescription
-                if (errorMessage != null) {
-                    error(errorMessage)
-                }
             }
             .padding(vertical = contentVerticalPaddingDp.dp)
             .testTag("$TEST_TAG_CURRENCY_OPTION_PREFIX${currency.code}"),
@@ -253,35 +236,16 @@ private fun RowScope.CurrencyOptionItem(
 }
 
 @Composable
-private fun currencyOptionAccessibilityLabel(
-    currency: CurrencyOption,
-    isSelected: Boolean,
-    exchangeRateText: String?,
-): String {
-    val currencyAccessibilityText = stringResource(
-        R.string.stripe_paymentsheet_currency_option_accessibility,
-        currency.code,
-        currency.formattedAmount,
-    )
-    return if (isSelected && exchangeRateText != null) {
-        stringResource(
-            R.string.stripe_paymentsheet_currency_option_with_exchange_rate,
-            currencyAccessibilityText,
-            exchangeRateText,
-        )
-    } else {
-        currencyAccessibilityText
-    }
-}
-
-@Composable
 private fun CurrencyOptionContent(
     currency: CurrencyOption,
     isSelected: Boolean,
     textColor: Color,
     textStyle: TextStyle,
 ) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.clearAndSetSemantics {},
+    ) {
         if (isSelected) {
             Icon(
                 painter = painterResource(StripeUiCoreR.drawable.stripe_ic_checkmark),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -26,6 +27,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.error
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -34,6 +43,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.R
+import androidx.compose.ui.R as ComposeR
 import com.stripe.android.uicore.R as StripeUiCoreR
 
 internal const val TEST_TAG_CURRENCY_SELECTOR = "TEST_TAG_CURRENCY_SELECTOR"
@@ -47,6 +58,7 @@ private const val DISABLED_ALPHA = 0.6f
 internal data class CurrencyOption(
     val code: String,
     val displayableText: String,
+    val formattedAmount: String,
 )
 
 internal data class CurrencySelectorOptions(
@@ -89,6 +101,7 @@ internal fun CurrencySelectorToggle(
     val fontFamily = appearance.fontResId?.let { FontFamily(Font(it)) }
     val bodyStyle = MaterialTheme.typography.subtitle1.withAppearance(fontFamily, appearance.sizeScaleFactor)
     val captionStyle = MaterialTheme.typography.caption.withAppearance(fontFamily, appearance.sizeScaleFactor)
+    val selectorLabel = stringResource(R.string.stripe_paymentsheet_currency_selector_label)
 
     Column(modifier = modifier) {
         Box(
@@ -102,12 +115,19 @@ internal fun CurrencySelectorToggle(
                     color = borderColor,
                     shape = shape,
                 )
+                .semantics {
+                    contentDescription = selectorLabel
+                    if (errorMessage != null) {
+                        error(errorMessage)
+                    }
+                }
                 .testTag(TEST_TAG_CURRENCY_SELECTOR),
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(IntrinsicSize.Min),
+                    .height(IntrinsicSize.Min)
+                    .selectableGroup(),
             ) {
                 CurrencyOptionItem(
                     currency = options.first,
@@ -120,6 +140,8 @@ internal fun CurrencySelectorToggle(
                     unselectedTextColor = unselectedText,
                     textStyle = bodyStyle,
                     contentVerticalPaddingDp = appearance.contentVerticalPaddingDp,
+                    exchangeRateText = options.exchangeRateText,
+                    errorMessage = errorMessage,
                 )
                 CurrencyOptionItem(
                     currency = options.second,
@@ -132,6 +154,8 @@ internal fun CurrencySelectorToggle(
                     unselectedTextColor = unselectedText,
                     textStyle = bodyStyle,
                     contentVerticalPaddingDp = appearance.contentVerticalPaddingDp,
+                    exchangeRateText = options.exchangeRateText,
+                    errorMessage = errorMessage,
                 )
             }
         }
@@ -143,7 +167,8 @@ internal fun CurrencySelectorToggle(
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 4.dp),
+                    .padding(top = 4.dp)
+                    .semantics { liveRegion = LiveRegionMode.Polite },
             )
         }
         if (errorMessage != null) {
@@ -155,6 +180,7 @@ internal fun CurrencySelectorToggle(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 4.dp)
+                    .semantics { liveRegion = LiveRegionMode.Assertive }
                     .testTag(TEST_TAG_CURRENCY_SELECTOR_ERROR),
             )
         }
@@ -173,10 +199,24 @@ private fun RowScope.CurrencyOptionItem(
     unselectedTextColor: Color,
     textStyle: TextStyle,
     contentVerticalPaddingDp: Float,
+    exchangeRateText: String?,
+    errorMessage: String?,
 ) {
     val isSelected = currency.code == options.selectedCode
     val backgroundColor = if (isSelected) pillBackground else trackBackground
     val textColor = if (isSelected) selectedTextColor else unselectedTextColor
+    val accessibilityDescription = stringResource(
+        if (isSelected) {
+            ComposeR.string.selected
+        } else {
+            ComposeR.string.not_selected
+        }
+    )
+    val accessibilityLabel = currencyOptionAccessibilityLabel(
+        currency = currency,
+        isSelected = isSelected,
+        exchangeRateText = exchangeRateText,
+    )
 
     Box(
         contentAlignment = Alignment.Center,
@@ -185,29 +225,78 @@ private fun RowScope.CurrencyOptionItem(
             .background(backgroundColor)
             .selectable(
                 selected = isSelected,
-                enabled = isEnabled && !isSelected,
-                onClick = { onCurrencySelected(currency) },
+                enabled = isEnabled,
+                role = Role.RadioButton,
+                onClick = {
+                    if (!isSelected) {
+                        onCurrencySelected(currency)
+                    }
+                },
             )
+            .semantics {
+                contentDescription = accessibilityLabel
+                stateDescription = accessibilityDescription
+                if (errorMessage != null) {
+                    error(errorMessage)
+                }
+            }
             .padding(vertical = contentVerticalPaddingDp.dp)
             .testTag("$TEST_TAG_CURRENCY_OPTION_PREFIX${currency.code}"),
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            if (isSelected) {
-                Icon(
-                    painter = painterResource(StripeUiCoreR.drawable.stripe_ic_checkmark),
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                    tint = textColor,
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-            }
-            Text(
-                text = currency.displayableText,
-                style = textStyle,
-                color = textColor,
-                fontWeight = if (isSelected) FontWeight.Medium else null,
+        CurrencyOptionContent(
+            currency = currency,
+            isSelected = isSelected,
+            textColor = textColor,
+            textStyle = textStyle,
+        )
+    }
+}
+
+@Composable
+private fun currencyOptionAccessibilityLabel(
+    currency: CurrencyOption,
+    isSelected: Boolean,
+    exchangeRateText: String?,
+): String {
+    val currencyAccessibilityText = stringResource(
+        R.string.stripe_paymentsheet_currency_option_accessibility,
+        currency.code,
+        currency.formattedAmount,
+    )
+    return if (isSelected && exchangeRateText != null) {
+        stringResource(
+            R.string.stripe_paymentsheet_currency_option_with_exchange_rate,
+            currencyAccessibilityText,
+            exchangeRateText,
+        )
+    } else {
+        currencyAccessibilityText
+    }
+}
+
+@Composable
+private fun CurrencyOptionContent(
+    currency: CurrencyOption,
+    isSelected: Boolean,
+    textColor: Color,
+    textStyle: TextStyle,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (isSelected) {
+            Icon(
+                painter = painterResource(StripeUiCoreR.drawable.stripe_ic_checkmark),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = textColor,
             )
+            Spacer(modifier = Modifier.width(6.dp))
         }
+        Text(
+            text = currency.displayableText,
+            style = textStyle,
+            color = textColor,
+            fontWeight = if (isSelected) FontWeight.Medium else null,
+        )
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCurrencySelectorContentUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCurrencySelectorContentUITest.kt
@@ -1,6 +1,11 @@
 package com.stripe.android.checkout
 
 import android.app.Application
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -54,6 +59,19 @@ internal class CheckoutCurrencySelectorContentUITest {
         composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR).assertExists()
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD").assertExists()
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR").assertExists()
+    }
+
+    @Test
+    fun whenAdaptivePricingInfoIsPresent_currencySelectorContentHasAccessibleLabels() = runScenario {
+        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR)
+            .assertContentDescriptionEquals("Choose currency")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertContentDescriptionContains("EUR")
+            .assertContentDescriptionContains("1 USD = 0.900961 EUR")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertContentDescriptionContains("USD")
     }
 
     @Test
@@ -111,4 +129,15 @@ internal class CheckoutCurrencySelectorContentUITest {
             ),
         )
     }
+}
+
+private fun SemanticsNodeInteraction.assertContentDescriptionContains(value: String): SemanticsNodeInteraction {
+    return assert(
+        SemanticsMatcher("ContentDescription contains '$value'") { node ->
+            node.config.contains(SemanticsProperties.ContentDescription) &&
+                node.config[SemanticsProperties.ContentDescription].any {
+                    it.contains(value)
+                }
+        }
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCurrencySelectorContentUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCurrencySelectorContentUITest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -63,15 +62,11 @@ internal class CheckoutCurrencySelectorContentUITest {
 
     @Test
     fun whenAdaptivePricingInfoIsPresent_currencySelectorContentHasAccessibleLabels() = runScenario {
-        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR)
-            .assertContentDescriptionEquals("Choose currency")
-
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
-            .assertContentDescriptionContains("EUR")
-            .assertContentDescriptionContains("1 USD = 0.900961 EUR")
+            .assertContentDescriptionContains("45.94")
 
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
-            .assertContentDescriptionContains("USD")
+            .assertContentDescriptionContains("50.99")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactoryTest.kt
@@ -27,8 +27,16 @@ class CurrencySelectorOptionsFactoryTest {
 
         assertThat(result).isEqualTo(
             CurrencySelectorOptions(
-                first = CurrencyOption(code = "USD", displayableText = "🇺🇸 \$61.06"),
-                second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €50.99"),
+                first = CurrencyOption(
+                    code = "USD",
+                    displayableText = "🇺🇸 \$61.06",
+                    formattedAmount = "\$61.06",
+                ),
+                second = CurrencyOption(
+                    code = "EUR",
+                    displayableText = "🇪🇺 €50.99",
+                    formattedAmount = "€50.99",
+                ),
                 selectedCode = "USD",
                 exchangeRateText = "1 EUR = 1.19749 USD",
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleAppearanceScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleAppearanceScreenshotTest.kt
@@ -23,8 +23,8 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
     )
 
     private val options = CurrencySelectorOptions(
-        first = CurrencyOption(code = "USD", displayableText = "🇺🇸 \$50.99"),
-        second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87"),
+        first = CurrencyOption(code = "USD", displayableText = "🇺🇸 \$50.99", formattedAmount = "\$50.99"),
+        second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87", formattedAmount = "€45.87"),
         selectedCode = "USD",
         exchangeRateText = "1 USD = 0.91 EUR",
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
@@ -26,8 +26,8 @@ internal class CurrencySelectorToggleScreenshotTest {
     private val defaultAppearance = Checkout.CurrencySelectorContentAppearance().build()
 
     private val options = CurrencySelectorOptions(
-        first = CurrencyOption(code = "USD", displayableText = "🇺🇸 $50.99"),
-        second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87"),
+        first = CurrencyOption(code = "USD", displayableText = "🇺🇸 $50.99", formattedAmount = "$50.99"),
+        second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87", formattedAmount = "€45.87"),
         selectedCode = "USD",
         exchangeRateText = "1 USD = 0.91 EUR",
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
@@ -65,29 +65,23 @@ internal class CurrencySelectorToggleUITest {
     @Test
     fun options_haveAccessibleLabelsAndSelectedStateDescriptions() = runScenario {
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
-            .assertContentDescription("USD, $50.99")
+            .assertContentDescription("$50.99")
             .assertStateDescription("Selected")
 
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
-            .assertContentDescription("EUR, €45.87")
+            .assertContentDescription("€45.87")
             .assertStateDescription("Not selected")
     }
 
     @Test
-    fun selector_hasAccessibleGroupLabel() = runScenario {
-        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR)
-            .assertContentDescription("Choose currency")
-    }
-
-    @Test
-    fun selectedOption_includesExchangeRateInAccessibleLabel() = runScenario(
+    fun exchangeRate_isNotDuplicatedInOptionAccessibleLabel() = runScenario(
         exchangeRateText = "1 USD = 0.900961 EUR",
     ) {
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
-            .assertContentDescription("USD, $50.99, 1 USD = 0.900961 EUR")
+            .assertContentDescription("$50.99")
 
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
-            .assertContentDescription("EUR, €45.87")
+            .assertContentDescription("€45.87")
     }
 
     @Test
@@ -122,24 +116,17 @@ internal class CurrencySelectorToggleUITest {
     }
 
     @Test
-    fun errorMessage_isExposedOnSelectorAndOptions() = runScenario(errorMessage = "Something went wrong.") {
+    fun errorMessage_isExposedOnSelector() = runScenario(errorMessage = "Something went wrong.") {
         composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR)
-            .assertHasErrorMessage("Something went wrong.")
-
-        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
-            .assertHasErrorMessage("Something went wrong.")
-
-        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
             .assertHasErrorMessage("Something went wrong.")
     }
 
     @Test
-    fun exchangeRate_isDisplayedAndAnnouncedPolitely() = runScenario(
+    fun exchangeRate_isDisplayed() = runScenario(
         exchangeRateText = "1 USD = 0.900961 EUR",
     ) {
         composeRule.onNodeWithText("1 USD = 0.900961 EUR")
             .assertIsDisplayed()
-            .assertLiveRegionMode(LiveRegionMode.Polite)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
@@ -1,9 +1,18 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
@@ -26,14 +35,68 @@ internal class CurrencySelectorToggleUITest {
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
 
-    private val usdOption = CurrencyOption(code = "USD", displayableText = "🇺🇸 $50.99")
-    private val eurOption = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87")
+    private val usdOption = CurrencyOption(
+        code = "USD",
+        displayableText = "🇺🇸 $50.99",
+        formattedAmount = "$50.99",
+    )
+    private val eurOption = CurrencyOption(
+        code = "EUR",
+        displayableText = "🇪🇺 €45.87",
+        formattedAmount = "€45.87",
+    )
 
     @Test
     fun clickingSelectedOption_doesNotCallCallback() = runScenario {
         composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD").performClick()
 
         onCurrencySelectedCalls.expectNoEvents()
+    }
+
+    @Test
+    fun selectedOption_isEnabledAndClickableForAccessibility() = runScenario {
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertIsEnabled()
+            .assertHasClickAction()
+            .assertIsSelected()
+            .assertRole(Role.RadioButton)
+    }
+
+    @Test
+    fun options_haveAccessibleLabelsAndSelectedStateDescriptions() = runScenario {
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertContentDescription("USD, $50.99")
+            .assertStateDescription("Selected")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertContentDescription("EUR, €45.87")
+            .assertStateDescription("Not selected")
+    }
+
+    @Test
+    fun selector_hasAccessibleGroupLabel() = runScenario {
+        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR)
+            .assertContentDescription("Choose currency")
+    }
+
+    @Test
+    fun selectedOption_includesExchangeRateInAccessibleLabel() = runScenario(
+        exchangeRateText = "1 USD = 0.900961 EUR",
+    ) {
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertContentDescription("USD, $50.99, 1 USD = 0.900961 EUR")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertContentDescription("EUR, €45.87")
+    }
+
+    @Test
+    fun disabledOptions_areExposedAsDisabledForAccessibility() = runScenario(isEnabled = false) {
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertIsNotEnabled()
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertIsNotEnabled()
     }
 
     @Test
@@ -55,6 +118,28 @@ internal class CurrencySelectorToggleUITest {
         composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR_ERROR)
             .assertIsDisplayed()
             .assertTextEquals("Something went wrong.")
+            .assertLiveRegionMode(LiveRegionMode.Assertive)
+    }
+
+    @Test
+    fun errorMessage_isExposedOnSelectorAndOptions() = runScenario(errorMessage = "Something went wrong.") {
+        composeRule.onNodeWithTag(TEST_TAG_CURRENCY_SELECTOR)
+            .assertHasErrorMessage("Something went wrong.")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertHasErrorMessage("Something went wrong.")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertHasErrorMessage("Something went wrong.")
+    }
+
+    @Test
+    fun exchangeRate_isDisplayedAndAnnouncedPolitely() = runScenario(
+        exchangeRateText = "1 USD = 0.900961 EUR",
+    ) {
+        composeRule.onNodeWithText("1 USD = 0.900961 EUR")
+            .assertIsDisplayed()
+            .assertLiveRegionMode(LiveRegionMode.Polite)
     }
 
     @Test
@@ -66,6 +151,7 @@ internal class CurrencySelectorToggleUITest {
         selectedCode: String = "USD",
         isEnabled: Boolean = true,
         errorMessage: String? = null,
+        exchangeRateText: String? = null,
         block: suspend Scenario.() -> Unit,
     ) {
         val onCurrencySelectedCalls = Turbine<CurrencyOption>()
@@ -76,6 +162,7 @@ internal class CurrencySelectorToggleUITest {
                     first = usdOption,
                     second = eurOption,
                     selectedCode = selectedCode,
+                    exchangeRateText = exchangeRateText,
                 ),
                 onCurrencySelected = { onCurrencySelectedCalls.add(it) },
                 isEnabled = isEnabled,
@@ -95,4 +182,29 @@ internal class CurrencySelectorToggleUITest {
     private class Scenario(
         val onCurrencySelectedCalls: Turbine<CurrencyOption>,
     )
+}
+
+private fun SemanticsNodeInteraction.assertContentDescription(vararg values: String): SemanticsNodeInteraction {
+    assertThat(fetchSemanticsNode().config[SemanticsProperties.ContentDescription]).containsExactly(*values)
+    return this
+}
+
+private fun SemanticsNodeInteraction.assertStateDescription(value: String): SemanticsNodeInteraction {
+    assertThat(fetchSemanticsNode().config[SemanticsProperties.StateDescription]).isEqualTo(value)
+    return this
+}
+
+private fun SemanticsNodeInteraction.assertRole(value: Role): SemanticsNodeInteraction {
+    assertThat(fetchSemanticsNode().config[SemanticsProperties.Role]).isEqualTo(value)
+    return this
+}
+
+private fun SemanticsNodeInteraction.assertLiveRegionMode(value: LiveRegionMode): SemanticsNodeInteraction {
+    assertThat(fetchSemanticsNode().config[SemanticsProperties.LiveRegion]).isEqualTo(value)
+    return this
+}
+
+private fun SemanticsNodeInteraction.assertHasErrorMessage(value: String): SemanticsNodeInteraction {
+    assertThat(fetchSemanticsNode().config[SemanticsProperties.Error]).isEqualTo(value)
+    return this
 }


### PR DESCRIPTION
# Summary
Added accessibility improvements to the currency selector toggle component including proper role semantics, selectable group, and assertive live region for error messages.

# Motivation
The currency selector toggle was missing important accessibility attributes that help screen reader users understand and interact with the component. These changes ensure the toggle behaves as a proper radio button group and announces errors immediately when they occur.
https://jira.corp.stripe.com/browse/MOBILESDK-4527
# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Fixed] Improved accessibility for currency selector in payment sheet vertical mode.