### PR TITLE
Don't use card art for Link passthrough SPMs

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -533,7 +533,7 @@ internal class ElementsSessionJsonParser(
         return paymentMethods.map { pm ->
             val cardArt = cardArtMap[pm.id]
             val card = pm.card
-            if (cardArt != null && card != null) {
+            if (cardArt != null && card != null && !pm.isLinkPassthroughMode) {
                 pm.copy(card = card.copy(cardArt = cardArt))
             } else {
                 pm

--- a/paymentsheet/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.testing.FeatureFlagTestRule
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test
@@ -2012,6 +2013,65 @@ class ElementsSessionJsonParserTest {
         assertThat(pms?.get(1)?.card?.cardArt?.artImage?.url).isEqualTo("https://example.com/amex.png")
     }
 
+    @Test
+    fun `Card art is not merged into Link passthrough payment methods`() {
+        val json = createPaymentIntentWithCustomerSession(enableLinkSpm = true)
+
+        json.getJSONObject("customer").apply {
+            put(
+                "payment_methods_with_link_details",
+                JSONArray().apply {
+                    put(
+                        createPaymentMethodWithLinkDetailsJson(
+                            paymentMethod = createCardPaymentMethodJson(
+                                id = "pm_passthrough",
+                                last4 = "4242",
+                            ),
+                            isLinkOrigin = true,
+                        )
+                    )
+                    put(
+                        createPaymentMethodWithLinkDetailsJson(
+                            paymentMethod = createCardPaymentMethodJson(
+                                id = "pm_regular",
+                                last4 = "0005",
+                            ),
+                            isLinkOrigin = false,
+                        )
+                    )
+                }
+            )
+            put(
+                "card_art",
+                JSONArray().apply {
+                    put(
+                        createCardArtJson(
+                            paymentMethodId = "pm_passthrough",
+                            artUrl = "https://example.com/passthrough.png",
+                        )
+                    )
+                    put(
+                        createCardArtJson(
+                            paymentMethodId = "pm_regular",
+                            artUrl = "https://example.com/regular.png",
+                        )
+                    )
+                }
+            )
+        }
+
+        val paymentMethods = requireNotNull(parseElementsSession(json)?.customer?.paymentMethods)
+        val passthroughPaymentMethod = paymentMethods.first { it.id == "pm_passthrough" }
+        val regularPaymentMethod = paymentMethods.first { it.id == "pm_regular" }
+
+        assertThat(paymentMethods).hasSize(2)
+        assertThat(passthroughPaymentMethod.isLinkPassthroughMode).isTrue()
+        assertThat(passthroughPaymentMethod.card?.cardArt).isNull()
+        assertThat(regularPaymentMethod.isLinkPassthroughMode).isFalse()
+        assertThat(regularPaymentMethod.card?.cardArt?.artImage?.url)
+            .isEqualTo("https://example.com/regular.png")
+    }
+
     private fun parseElementsSession(json: JSONObject): ElementsSession? {
         return ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
@@ -2023,6 +2083,44 @@ class ElementsSessionJsonParserTest {
             ),
             isLiveMode = false,
         ).parse(json)
+    }
+
+    private fun createPaymentMethodWithLinkDetailsJson(
+        paymentMethod: JSONObject,
+        isLinkOrigin: Boolean,
+    ): JSONObject {
+        return JSONObject().apply {
+            put("payment_method", paymentMethod)
+            put("link_payment_details", JSONObject.NULL)
+            put("is_link_origin", isLinkOrigin)
+        }
+    }
+
+    private fun createCardPaymentMethodJson(
+        id: String,
+        last4: String,
+    ): JSONObject {
+        return JSONObject(CARD_PM_JSON).apply {
+            put("id", id)
+            getJSONObject("card").put("last4", last4)
+        }
+    }
+
+    private fun createCardArtJson(
+        paymentMethodId: String,
+        artUrl: String,
+    ): JSONObject {
+        return JSONObject().apply {
+            put("payment_method", paymentMethodId)
+            put(
+                "art_image",
+                JSONObject().apply {
+                    put("url", artUrl)
+                    put("format", "image/png")
+                }
+            )
+            put("program_name", "Test Program")
+        }
     }
 
     private fun createElementsSessionWithLinkBrand(linkBrand: String?): JSONObject {

--- a/paymentsheet/src/test/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParserTest.kt
@@ -14,8 +14,20 @@ class PaymentMethodWithLinkDetailsJsonParserTest {
         }
         val paymentMethod = PaymentMethodWithLinkDetailsJsonParser.parse(json)
 
-        assertThat(paymentMethod).isNotNull()
         assertThat(paymentMethod.linkPaymentDetails).isNull()
+        assertThat(paymentMethod.isLinkPassthroughMode).isFalse()
+    }
+
+    @Test
+    fun `Marks payment method as Link passthrough when it has Link origin and no Link payment details`() {
+        val json = JSONObject().apply {
+            put("payment_method", CARD_PAYMENT_METHOD_JSON)
+            put("is_link_origin", true)
+        }
+        val paymentMethod = PaymentMethodWithLinkDetailsJsonParser.parse(json)
+
+        assertThat(paymentMethod.linkPaymentDetails).isNull()
+        assertThat(paymentMethod.isLinkPassthroughMode).isTrue()
     }
 
     @Test
@@ -25,11 +37,12 @@ class PaymentMethodWithLinkDetailsJsonParserTest {
         val json = JSONObject().apply {
             put("payment_method", PAYMENT_METHOD_JSON)
             put("link_payment_details", linkPaymentDetails)
+            put("is_link_origin", true)
         }
         val paymentMethod = PaymentMethodWithLinkDetailsJsonParser.parse(json)
 
-        assertThat(paymentMethod).isNotNull()
         assertThat(paymentMethod.linkPaymentDetails).isNotNull()
+        assertThat(paymentMethod.isLinkPassthroughMode).isFalse()
     }
 
     @Test
@@ -104,6 +117,61 @@ class PaymentMethodWithLinkDetailsJsonParserTest {
                 "email": "email@email.com"
               },
               "type": "link"
+            }
+            """.trimIndent()
+        )
+
+        val CARD_PAYMENT_METHOD_JSON = JSONObject(
+            """
+            {
+              "id": "pm_1QoYo1Esh8quxL21bpIFTRrP",
+              "object": "payment_method",
+              "allow_redisplay": "always",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": "US",
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": "12345",
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null,
+                "tax_id": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": null
+                },
+                "country": "US",
+                "display_brand": "visa",
+                "exp_month": 4,
+                "exp_year": 2026,
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "4242",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "regulated_status": "unregulated",
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1738624313,
+              "customer": "cus_Qurj8RK03RchBB",
+              "livemode": false,
+              "radar_options": {},
+              "type": "card"
             }
             """.trimIndent()
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request prevents card-art usage for Link passthrough mode SPMs.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-192](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-192)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
