### PR TITLE
Clarify no-defaults rule applies to function params too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Multi-module Android library for payment processing and financial services.
 - Dagger/Hilt DI in some modules; binary-compatibility-validator for API compat
 - Gradle with shared deps (dependencies.gradle), AGP 8.13.x, Kotlin 2.3.x
 - Detekt for static analysis, Paparazzi for screenshot testing
-- Nullable field defaults: public models give nullable fields `= null` for ergonomic construction; non-public models (`internal` or `@RestrictTo`) omit defaults to force explicit decisions at each call site
+- No defaults for internal code: public APIs give parameters defaults (`= null`, `= false`) for ergonomic construction; non-public code (`internal` or `@RestrictTo`) omits defaults on both model fields and function parameters to force explicit decisions at each call site
 
 **Testing** — MUST invoke the relevant skill before writing any test code:
 - `write-unit-tests` — unit test structure, runScenario pattern, Turbine Flow testing, Truth assertions


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md to clarify that the no-defaults rule for internal code applies to both model fields AND function parameters, not just model fields

## Test plan
- [ ] N/A - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)