### PR TITLE
Remove unused test page imports from PaymentSheetCheckoutSessionTest.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
@@ -20,9 +20,6 @@ import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.assertFailed
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
-import com.stripe.paymentelementtestpages.CurrencySelector
-import com.stripe.paymentelementtestpages.FormPage
-import com.stripe.paymentelementtestpages.VerticalModePage
 import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test
@@ -38,9 +35,6 @@ internal class PaymentSheetCheckoutSessionTest {
     private val networkRule = testRules.networkRule
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
-    private val formPage: FormPage = FormPage(composeTestRule)
-    private val verticalModePage: VerticalModePage = VerticalModePage(composeTestRule)
-    private val currencySelector: CurrencySelector = CurrencySelector(composeTestRule)
 
     private val defaultConfiguration = PaymentSheet.Configuration.Builder(
         merchantDisplayName = "Checkout Session Test",


### PR DESCRIPTION
# Summary
Removed unused test page imports from PaymentSheetCheckoutSessionTest that were no longer being referenced in the test class.

# Motivation
These imports were left over from previous test implementations and are no longer needed. Removing them keeps the codebase clean and reduces unnecessary dependencies.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified