### PR TITLE
Load flag images from CDN for adaptive pricing currency selector.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -78,6 +78,7 @@
     <ID>LongMethod:UpdatePaymentMethodUI.kt:@Composable internal fun UpdatePaymentMethodUI</ID>
     <ID>LongMethod:WalletScreen.kt:@Composable internal fun WalletBody</ID>
     <ID>LongMethod:WalletScreen.kt:@Composable private fun PaymentMethodSection</ID>
+    <ID>MagicNumber:FlagImageRepository.kt:FlagImageRepository$4</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt:.3f</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt:.4f</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt:.5f</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -97,11 +97,11 @@ class Checkout private constructor(
         ): Map<String, Bitmap>? {
             val adaptivePricingInfo = response.adaptivePricingInfo ?: return null
             val localOption = adaptivePricingInfo.localCurrencyOptions.firstOrNull() ?: return null
-            val repository = FlagImageRepository(
+            val flagImageRepository = FlagImageRepository(
                 imageLoader = DefaultStripeImageLoader(context),
                 displayDensity = context.resources.displayMetrics.density,
             )
-            val result = repository.prefetch(
+            val result = flagImageRepository.fetch(
                 integrationCurrencyCode = adaptivePricingInfo.integrationCurrency,
                 localCurrencyCode = localOption.currency,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.content.Context
+import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
@@ -20,6 +21,7 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorToggle
+import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
@@ -75,15 +77,47 @@ class Checkout private constructor(
                 sessionId = checkoutSessionClientSecret.substringBefore("_secret_"),
                 adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
             ).map { response ->
+                val flagImages = prefetchFlagImages(context, response, component)
                 Checkout(
                     internalState = InternalState(
                         key = UUID.randomUUID().toString(),
                         configuration = configurationState,
                         checkoutSessionResponse = response,
+                        flagImages = flagImages,
                     ),
                     component = component,
                 )
             }
+        }
+
+        private suspend fun prefetchFlagImages(
+            context: Context,
+            response: CheckoutSessionResponse,
+            component: CheckoutComponent,
+        ): Map<String, Bitmap>? {
+            val adaptivePricingInfo = response.adaptivePricingInfo ?: return null
+            val localOption = adaptivePricingInfo.localCurrencyOptions.firstOrNull() ?: return null
+            val repository = FlagImageRepository(
+                imageLoader = DefaultStripeImageLoader(context),
+                displayDensity = context.resources.displayMetrics.density,
+            )
+            val result = repository.prefetch(
+                integrationCurrencyCode = adaptivePricingInfo.integrationCurrency,
+                localCurrencyCode = localOption.currency,
+            )
+            for (failure in result.failures) {
+                val event = PaymentSheetEvent.AdaptivePricingFlagImageLoadFailed(
+                    countryCode = failure.countryCode,
+                    url = failure.url,
+                )
+                component.analyticsRequestExecutor.executeAsync(
+                    component.paymentAnalyticsRequestFactory.createRequest(
+                        event = event,
+                        additionalParams = event.params,
+                    )
+                )
+            }
+            return result.images
         }
 
         /**
@@ -321,12 +355,14 @@ class Checkout private constructor(
         set(value) {
             ensureNoMutationInFlight()
             internalState = value.internalState
-            _checkoutSession.value = internalState.checkoutSessionResponse.asCheckoutSession()
+            _checkoutSession.value = internalState.asCheckoutSession()
         }
 
     private val mutex = Mutex()
 
-    private val _checkoutSession = MutableStateFlow(internalState.checkoutSessionResponse.asCheckoutSession())
+    private val _checkoutSession = MutableStateFlow(
+        internalState.asCheckoutSession()
+    )
 
     /**
      * The current [CheckoutSession], updated after each successful mutation.
@@ -497,7 +533,7 @@ class Checkout private constructor(
 
     internal fun updateWithResponse(response: CheckoutSessionResponse) {
         internalState = internalState.copy(checkoutSessionResponse = response)
-        _checkoutSession.value = response.asCheckoutSession()
+        _checkoutSession.value = internalState.asCheckoutSession()
     }
 
     private suspend fun withInternalState(
@@ -518,7 +554,7 @@ class Checkout private constructor(
                 internalState.block(internalState.checkoutSessionResponse.id).getOrThrow()
             }.map { response ->
                 internalState = internalState.copy(checkoutSessionResponse = response).additionalStateMutations()
-                _checkoutSession.value = response.asCheckoutSession()
+                _checkoutSession.value = internalState.asCheckoutSession()
             }
             _isLoading.value = false
             result

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -2,9 +2,7 @@ package com.stripe.android.checkout
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
-import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptionsFactory
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -258,103 +256,5 @@ class CheckoutSession internal constructor(
          * The total after discounts and taxes.
          */
         val total: Long,
-    )
-}
-
-@OptIn(CheckoutSessionPreview::class)
-internal fun CheckoutSessionResponse.asCheckoutSession(): CheckoutSession {
-    return CheckoutSession(
-        id = id,
-        status = status.asStatus(),
-        liveMode = liveMode,
-        currency = currency,
-        customerEmail = customerEmail,
-        tax = taxStatus.asTax(),
-        totalSummary = totalSummary?.asTotalSummary(),
-        lineItems = lineItems.map { it.asLineItem() },
-        shippingOptions = shippingOptions.map { it.asShippingRate() },
-        currencySelectorOptions = CurrencySelectorOptionsFactory.create(adaptivePricingInfo = adaptivePricingInfo)
-    )
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.Status.asStatus(): CheckoutSession.Status {
-    return when (this) {
-        CheckoutSessionResponse.Status.OPEN -> CheckoutSession.Status.Open
-        CheckoutSessionResponse.Status.COMPLETE -> CheckoutSession.Status.Complete
-        CheckoutSessionResponse.Status.EXPIRED -> CheckoutSession.Status.Expired
-        CheckoutSessionResponse.Status.UNKNOWN -> CheckoutSession.Status.Unknown
-    }
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.TaxStatus.asTax(): CheckoutSession.Tax {
-    val status = when (this) {
-        CheckoutSessionResponse.TaxStatus.READY -> {
-            CheckoutSession.Tax.Status.Ready
-        }
-        CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS -> {
-            CheckoutSession.Tax.Status.RequiresShippingAddress
-        }
-        CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS -> {
-            CheckoutSession.Tax.Status.RequiresBillingAddress
-        }
-        CheckoutSessionResponse.TaxStatus.UNKNOWN -> {
-            CheckoutSession.Tax.Status.Unknown
-        }
-    }
-    return CheckoutSession.Tax(status = status)
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.TotalSummaryResponse.asTotalSummary(): CheckoutSession.TotalSummary {
-    return CheckoutSession.TotalSummary(
-        subtotal = subtotal,
-        totalDueToday = totalDueToday,
-        totalAmountDue = totalAmountDue,
-        discountAmounts = discountAmounts.map { it.asDiscountAmount() },
-        taxAmounts = taxAmounts.map { it.asTaxAmount() },
-        shippingRate = shippingRate?.asShippingRate(),
-        appliedBalance = appliedBalance,
-    )
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.DiscountAmount.asDiscountAmount(): CheckoutSession.DiscountAmount {
-    return CheckoutSession.DiscountAmount(
-        amount = amount,
-        displayName = displayName,
-    )
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.TaxAmount.asTaxAmount(): CheckoutSession.TaxAmount {
-    return CheckoutSession.TaxAmount(
-        amount = amount,
-        inclusive = inclusive,
-        displayName = displayName,
-        percentage = percentage,
-    )
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.ShippingRate.asShippingRate(): CheckoutSession.ShippingRate {
-    return CheckoutSession.ShippingRate(
-        id = id,
-        amount = amount,
-        displayName = displayName,
-        deliveryEstimate = deliveryEstimate,
-    )
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.LineItem.asLineItem(): CheckoutSession.LineItem {
-    return CheckoutSession.LineItem(
-        id = id,
-        name = name,
-        quantity = quantity,
-        unitAmount = unitAmount,
-        subtotal = subtotal,
-        total = total,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageRepository.kt
@@ -10,9 +10,7 @@ internal class FlagImageRepository(
     private val imageLoader: StripeImageLoader,
     private val displayDensity: Float,
 ) {
-    private val cache = mutableMapOf<String, Bitmap>()
-
-    suspend fun prefetch(
+    suspend fun fetch(
         integrationCurrencyCode: String,
         localCurrencyCode: String,
     ): PrefetchResult {
@@ -23,10 +21,12 @@ internal class FlagImageRepository(
             return PrefetchResult(images = null, failures = emptyList())
         }
 
-        val dpr = displayDensity.roundToInt().coerceIn(1, 4)
+        val images = mutableMapOf<String, Bitmap>()
         val failures = mutableListOf<PrefetchFailure>()
 
         coroutineScope {
+            val dpr = displayDensity.roundToInt().coerceIn(1, 4)
+
             val integrationUrl = buildFlagUrl(integrationCountry, dpr)
             val localUrl = buildFlagUrl(localCountry, dpr)
 
@@ -47,19 +47,15 @@ internal class FlagImageRepository(
             }
 
             if (integrationBitmap != null && localBitmap != null) {
-                cache[integrationCurrencyCode.uppercase()] = integrationBitmap
-                cache[localCurrencyCode.uppercase()] = localBitmap
+                images[integrationCurrencyCode.uppercase()] = integrationBitmap
+                images[localCurrencyCode.uppercase()] = localBitmap
             }
         }
 
         return PrefetchResult(
-            images = if (failures.isEmpty()) cache.toMap() else null,
+            images = if (failures.isEmpty()) images else null,
             failures = failures,
         )
-    }
-
-    fun get(currencyCode: String): Bitmap? {
-        return cache[currencyCode.uppercase()]
     }
 
     internal data class PrefetchResult(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageRepository.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.checkout
+
+import android.graphics.Bitmap
+import com.stripe.android.uicore.image.StripeImageLoader
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlin.math.roundToInt
+
+internal class FlagImageRepository(
+    private val imageLoader: StripeImageLoader,
+    private val displayDensity: Float,
+) {
+    private val cache = mutableMapOf<String, Bitmap>()
+
+    suspend fun prefetch(
+        integrationCurrencyCode: String,
+        localCurrencyCode: String,
+    ): PrefetchResult {
+        val integrationCountry = currencyCodeToCountryCode(integrationCurrencyCode)
+        val localCountry = currencyCodeToCountryCode(localCurrencyCode)
+
+        if (integrationCountry == null || localCountry == null) {
+            return PrefetchResult(images = null, failures = emptyList())
+        }
+
+        val dpr = displayDensity.roundToInt().coerceIn(1, 4)
+        val failures = mutableListOf<PrefetchFailure>()
+
+        coroutineScope {
+            val integrationUrl = buildFlagUrl(integrationCountry, dpr)
+            val localUrl = buildFlagUrl(localCountry, dpr)
+
+            val integrationDeferred = async { imageLoader.load(integrationUrl) }
+            val localDeferred = async { imageLoader.load(localUrl) }
+
+            val integrationResult = integrationDeferred.await()
+            val localResult = localDeferred.await()
+
+            val integrationBitmap = integrationResult.getOrNull()
+            val localBitmap = localResult.getOrNull()
+
+            if (integrationBitmap == null) {
+                failures.add(PrefetchFailure(countryCode = integrationCountry, url = integrationUrl))
+            }
+            if (localBitmap == null) {
+                failures.add(PrefetchFailure(countryCode = localCountry, url = localUrl))
+            }
+
+            if (integrationBitmap != null && localBitmap != null) {
+                cache[integrationCurrencyCode.uppercase()] = integrationBitmap
+                cache[localCurrencyCode.uppercase()] = localBitmap
+            }
+        }
+
+        return PrefetchResult(
+            images = if (failures.isEmpty()) cache.toMap() else null,
+            failures = failures,
+        )
+    }
+
+    fun get(currencyCode: String): Bitmap? {
+        return cache[currencyCode.uppercase()]
+    }
+
+    internal data class PrefetchResult(
+        val images: Map<String, Bitmap>?,
+        val failures: List<PrefetchFailure>,
+    )
+
+    internal data class PrefetchFailure(
+        val countryCode: String,
+        val url: String,
+    )
+
+    companion object {
+        private const val FLAGS_BASE = "https://b.stripecdn.com/ocs-mobile/assets/flags/"
+
+        internal fun currencyCodeToCountryCode(currencyCode: String): String? {
+            val code = currencyCode.uppercase()
+            return when {
+                code == "EUR" -> "EU"
+                code.length >= 2 && !code.startsWith("X") -> code.substring(0, 2)
+                else -> null
+            }
+        }
+
+        internal fun buildFlagUrl(countryCode: String, dpr: Int): String {
+            return "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=16,dpr=$dpr/$FLAGS_BASE$countryCode.png"
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.checkout
 
+import android.graphics.Bitmap
 import android.os.Parcelable
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptionsFactory
 import kotlinx.parcelize.Parcelize
 
 @OptIn(CheckoutSessionPreview::class)
@@ -12,6 +14,7 @@ internal data class InternalState(
     val key: String,
     val configuration: Checkout.Configuration.State,
     val checkoutSessionResponse: CheckoutSessionResponse,
+    private val flagImages: Map<String, Bitmap>?,
     val shippingName: String? = null,
     val billingName: String? = null,
     val shippingPhoneNumber: String? = null,
@@ -25,4 +28,111 @@ internal data class InternalState(
             instancesKey = key,
             checkoutSessionResponse = checkoutSessionResponse,
         )
+
+    fun asCheckoutSession(): CheckoutSession {
+        return checkoutSessionResponse.asCheckoutSession(flagImages)
+    }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.asCheckoutSession(
+    flagImages: Map<String, Bitmap>?,
+): CheckoutSession {
+    return CheckoutSession(
+        id = id,
+        status = status.asStatus(),
+        liveMode = liveMode,
+        currency = currency,
+        customerEmail = customerEmail,
+        tax = taxStatus.asTax(),
+        totalSummary = totalSummary?.asTotalSummary(),
+        lineItems = lineItems.map { it.asLineItem() },
+        shippingOptions = shippingOptions.map { it.asShippingRate() },
+        currencySelectorOptions = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            flagImages = flagImages,
+        ),
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.Status.asStatus(): CheckoutSession.Status {
+    return when (this) {
+        CheckoutSessionResponse.Status.OPEN -> CheckoutSession.Status.Open
+        CheckoutSessionResponse.Status.COMPLETE -> CheckoutSession.Status.Complete
+        CheckoutSessionResponse.Status.EXPIRED -> CheckoutSession.Status.Expired
+        CheckoutSessionResponse.Status.UNKNOWN -> CheckoutSession.Status.Unknown
+    }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.TaxStatus.asTax(): CheckoutSession.Tax {
+    val status = when (this) {
+        CheckoutSessionResponse.TaxStatus.READY -> {
+            CheckoutSession.Tax.Status.Ready
+        }
+        CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS -> {
+            CheckoutSession.Tax.Status.RequiresShippingAddress
+        }
+        CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS -> {
+            CheckoutSession.Tax.Status.RequiresBillingAddress
+        }
+        CheckoutSessionResponse.TaxStatus.UNKNOWN -> {
+            CheckoutSession.Tax.Status.Unknown
+        }
+    }
+    return CheckoutSession.Tax(status = status)
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.TotalSummaryResponse.asTotalSummary(): CheckoutSession.TotalSummary {
+    return CheckoutSession.TotalSummary(
+        subtotal = subtotal,
+        totalDueToday = totalDueToday,
+        totalAmountDue = totalAmountDue,
+        discountAmounts = discountAmounts.map { it.asDiscountAmount() },
+        taxAmounts = taxAmounts.map { it.asTaxAmount() },
+        shippingRate = shippingRate?.asShippingRate(),
+        appliedBalance = appliedBalance,
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.DiscountAmount.asDiscountAmount(): CheckoutSession.DiscountAmount {
+    return CheckoutSession.DiscountAmount(
+        amount = amount,
+        displayName = displayName,
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.TaxAmount.asTaxAmount(): CheckoutSession.TaxAmount {
+    return CheckoutSession.TaxAmount(
+        amount = amount,
+        inclusive = inclusive,
+        displayName = displayName,
+        percentage = percentage,
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.ShippingRate.asShippingRate(): CheckoutSession.ShippingRate {
+    return CheckoutSession.ShippingRate(
+        id = id,
+        amount = amount,
+        displayName = displayName,
+        deliveryEstimate = deliveryEstimate,
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.LineItem.asLineItem(): CheckoutSession.LineItem {
+    return CheckoutSession.LineItem(
+        id = id,
+        name = name,
+        quantity = quantity,
+        unitAmount = unitAmount,
+        subtotal = subtotal,
+        total = total,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -391,6 +391,17 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class AdaptivePricingFlagImageLoadFailed(
+        countryCode: String,
+        url: String,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "elements.adaptive_pricing.flag_image_load.failed"
+        override val params: Map<String, Any?> = mapOf(
+            "country_code" to countryCode,
+            "url" to url,
+        )
+    }
+
     class WalletButtonTapped(
         walletType: String,
     ) : PaymentSheetEvent() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactory.kt
@@ -1,14 +1,17 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import android.graphics.Bitmap
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.format.CurrencyFormatter
 import java.util.Locale
 
 internal object CurrencySelectorOptionsFactory {
+    @Suppress("LongMethod")
     fun create(
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo?,
         locale: Locale = Locale.getDefault(),
+        flagImages: Map<String, Bitmap>?,
     ): CurrencySelectorOptions? {
         val localOption = adaptivePricingInfo?.localCurrencyOptions?.firstOrNull() ?: return null
 
@@ -25,18 +28,32 @@ internal object CurrencySelectorOptionsFactory {
             targetLocale = locale,
         )
 
-        val integrationFlag = currencyCodeToFlagEmoji(integrationCode)
+        val useImages = flagImages != null &&
+            flagImages.containsKey(integrationCode) &&
+            flagImages.containsKey(localCode)
+
+        val integrationFlag: FlagContent = if (useImages) {
+            FlagContent.Image(flagImages!!.getValue(integrationCode))
+        } else {
+            FlagContent.Emoji(currencyCodeToFlagEmoji(integrationCode))
+        }
+
+        val localFlag: FlagContent = if (useImages) {
+            FlagContent.Image(flagImages!!.getValue(localCode))
+        } else {
+            FlagContent.Emoji(currencyCodeToFlagEmoji(localCode))
+        }
+
         val integrationCurrencyOption = CurrencyOption(
             code = integrationCode,
-            displayableText = integrationFlag + integrationAmount,
             formattedAmount = integrationAmount,
+            flag = integrationFlag,
         )
 
-        val localFlag = currencyCodeToFlagEmoji(localCode)
         val localCurrencyOption = CurrencyOption(
             code = localCode,
-            displayableText = localFlag + localAmount,
             formattedAmount = localAmount,
+            flag = localFlag,
         )
 
         val selectedCode = adaptivePricingInfo.activePresentmentCurrency.uppercase()
@@ -61,6 +78,6 @@ internal object CurrencySelectorOptionsFactory {
             currencyCode.length >= 2 && !currencyCode.startsWith("X") -> currencyCode.substring(0, 2)
             else -> return ""
         }
-        return CountryConfig.countryCodeToEmoji(countryCode) + " "
+        return CountryConfig.countryCodeToEmoji(countryCode)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -8,6 +10,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,6 +19,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -25,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -36,12 +42,16 @@ import androidx.compose.ui.semantics.error
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import androidx.compose.ui.R as ComposeR
@@ -55,10 +65,15 @@ internal const val TEST_TAG_CURRENCY_SELECTOR_ERROR = "TEST_TAG_CURRENCY_SELECTO
 
 private const val DISABLED_ALPHA = 0.6f
 
+internal sealed interface FlagContent {
+    data class Emoji(val emoji: String) : FlagContent
+    data class Image(val bitmap: Bitmap) : FlagContent
+}
+
 internal data class CurrencyOption(
     val code: String,
-    val displayableText: String,
     val formattedAmount: String,
+    val flag: FlagContent,
 )
 
 internal data class CurrencySelectorOptions(
@@ -242,6 +257,37 @@ private fun CurrencyOptionContent(
     textColor: Color,
     textStyle: TextStyle,
 ) {
+    val annotatedText = buildAnnotatedString {
+        when (val flag = currency.flag) {
+            is FlagContent.Image -> {
+                appendInlineContent("flag", "[flag]")
+                append(" ")
+            }
+            is FlagContent.Emoji -> {
+                append(flag.emoji)
+                append(" ")
+            }
+        }
+        append(currency.formattedAmount)
+    }
+    val inlineContent = when (val flag = currency.flag) {
+        is FlagContent.Image -> mapOf(
+            "flag" to InlineTextContent(
+                Placeholder(
+                    width = 1.2.em,
+                    height = 1.2.em,
+                    placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+                )
+            ) {
+                Image(
+                    bitmap = flag.bitmap.asImageBitmap(),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        )
+        is FlagContent.Emoji -> emptyMap()
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.clearAndSetSemantics {},
@@ -256,7 +302,8 @@ private fun CurrencyOptionContent(
             Spacer(modifier = Modifier.width(6.dp))
         }
         Text(
-            text = currency.displayableText,
+            text = annotatedText,
+            inlineContent = inlineContent,
             style = textStyle,
             color = textColor,
             fontWeight = if (isSelected) FontWeight.Medium else null,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
@@ -13,132 +13,132 @@ class AsCheckoutSessionTest {
 
     @Test
     fun `maps id`() {
-        val session = createResponse(id = "cs_test_123").asCheckoutSession()
+        val session = createSession(id = "cs_test_123")
         assertThat(session.id).isEqualTo("cs_test_123")
     }
 
     @Test
     fun `maps status open`() {
-        val session = createResponse(status = CheckoutSessionResponse.Status.OPEN).asCheckoutSession()
+        val session = createSession(status = CheckoutSessionResponse.Status.OPEN)
         assertThat(session.status).isEqualTo(CheckoutSession.Status.Open)
     }
 
     @Test
     fun `maps status complete`() {
-        val session = createResponse(status = CheckoutSessionResponse.Status.COMPLETE).asCheckoutSession()
+        val session = createSession(status = CheckoutSessionResponse.Status.COMPLETE)
         assertThat(session.status).isEqualTo(CheckoutSession.Status.Complete)
     }
 
     @Test
     fun `maps status expired`() {
-        val session = createResponse(status = CheckoutSessionResponse.Status.EXPIRED).asCheckoutSession()
+        val session = createSession(status = CheckoutSessionResponse.Status.EXPIRED)
         assertThat(session.status).isEqualTo(CheckoutSession.Status.Expired)
     }
 
     @Test
     fun `maps status unknown`() {
-        val session = createResponse(status = CheckoutSessionResponse.Status.UNKNOWN).asCheckoutSession()
+        val session = createSession(status = CheckoutSessionResponse.Status.UNKNOWN)
         assertThat(session.status).isEqualTo(CheckoutSession.Status.Unknown)
     }
 
     @Test
     fun `maps livemode true`() {
-        val session = createResponse(liveMode = true).asCheckoutSession()
+        val session = createSession(liveMode = true)
         assertThat(session.liveMode).isTrue()
     }
 
     @Test
     fun `maps livemode false`() {
-        val session = createResponse(liveMode = false).asCheckoutSession()
+        val session = createSession(liveMode = false)
         assertThat(session.liveMode).isFalse()
     }
 
     @Test
     fun `maps currency`() {
-        val session = createResponse(currency = "eur").asCheckoutSession()
+        val session = createSession(currency = "eur")
         assertThat(session.currency).isEqualTo("eur")
     }
 
     @Test
     fun `maps customerEmail`() {
-        val session = createResponse(customerEmail = "test@example.com").asCheckoutSession()
+        val session = createSession(customerEmail = "test@example.com")
         assertThat(session.customerEmail).isEqualTo("test@example.com")
     }
 
     @Test
     fun `null customerEmail maps to null`() {
-        val session = createResponse(customerEmail = null).asCheckoutSession()
+        val session = createSession(customerEmail = null)
         assertThat(session.customerEmail).isNull()
     }
 
     @Test
     fun `maps tax status ready`() {
-        val session = createResponse(taxStatus = CheckoutSessionResponse.TaxStatus.READY).asCheckoutSession()
+        val session = createSession(taxStatus = CheckoutSessionResponse.TaxStatus.READY)
         assertThat(session.tax.status).isEqualTo(CheckoutSession.Tax.Status.Ready)
     }
 
     @Test
     fun `maps tax status requires shipping address`() {
-        val session = createResponse(
+        val session = createSession(
             taxStatus = CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS
-        ).asCheckoutSession()
+        )
         assertThat(session.tax.status).isEqualTo(CheckoutSession.Tax.Status.RequiresShippingAddress)
     }
 
     @Test
     fun `maps tax status requires billing address`() {
-        val session = createResponse(
+        val session = createSession(
             taxStatus = CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS
-        ).asCheckoutSession()
+        )
         assertThat(session.tax.status).isEqualTo(CheckoutSession.Tax.Status.RequiresBillingAddress)
     }
 
     @Test
     fun `maps tax status unknown`() {
-        val session = createResponse(taxStatus = CheckoutSessionResponse.TaxStatus.UNKNOWN).asCheckoutSession()
+        val session = createSession(taxStatus = CheckoutSessionResponse.TaxStatus.UNKNOWN)
         assertThat(session.tax.status).isEqualTo(CheckoutSession.Tax.Status.Unknown)
     }
 
     @Test
     fun `null totalSummary maps to null`() {
-        val session = createResponse(totalSummary = null).asCheckoutSession()
+        val session = createSession(totalSummary = null)
         assertThat(session.totalSummary).isNull()
     }
 
     @Test
     fun `maps totalSummary subtotal`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(subtotal = 5000L),
-        ).asCheckoutSession()
+        )
         assertThat(session.totalSummary?.subtotal).isEqualTo(5000L)
     }
 
     @Test
     fun `maps totalSummary totalDueToday`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(totalDueToday = 4044L),
-        ).asCheckoutSession()
+        )
         assertThat(session.totalSummary?.totalDueToday).isEqualTo(4044L)
     }
 
     @Test
     fun `maps totalSummary totalAmountDue`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(totalAmountDue = 3000L),
-        ).asCheckoutSession()
+        )
         assertThat(session.totalSummary?.totalAmountDue).isEqualTo(3000L)
     }
 
     @Test
     fun `maps discountAmounts`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(
                 discountAmounts = listOf(
                     CheckoutSessionResponse.DiscountAmount(amount = 500L, displayName = "SUMMER10"),
                     CheckoutSessionResponse.DiscountAmount(amount = 250L, displayName = "LOYALTY5"),
                 ),
             ),
-        ).asCheckoutSession()
+        )
         val discounts = session.totalSummary!!.discountAmounts
         assertThat(discounts).hasSize(2)
         assertThat(discounts[0].amount).isEqualTo(500L)
@@ -149,7 +149,7 @@ class AsCheckoutSessionTest {
 
     @Test
     fun `maps taxAmounts`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(
                 taxAmounts = listOf(
                     CheckoutSessionResponse.TaxAmount(
@@ -160,7 +160,7 @@ class AsCheckoutSessionTest {
                     ),
                 ),
             ),
-        ).asCheckoutSession()
+        )
         val taxes = session.totalSummary!!.taxAmounts
         assertThat(taxes).hasSize(1)
         assertThat(taxes[0].amount).isEqualTo(294L)
@@ -171,7 +171,7 @@ class AsCheckoutSessionTest {
 
     @Test
     fun `maps shippingRate`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(
                 shippingRate = CheckoutSessionResponse.ShippingRate(
                     id = "shr_standard",
@@ -180,7 +180,7 @@ class AsCheckoutSessionTest {
                     deliveryEstimate = "5-7 business days",
                 ),
             ),
-        ).asCheckoutSession()
+        )
         val shipping = session.totalSummary!!.shippingRate!!
         assertThat(shipping.id).isEqualTo("shr_standard")
         assertThat(shipping.amount).isEqualTo(500L)
@@ -190,31 +190,31 @@ class AsCheckoutSessionTest {
 
     @Test
     fun `null shippingRate maps to null`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(shippingRate = null),
-        ).asCheckoutSession()
+        )
         assertThat(session.totalSummary!!.shippingRate).isNull()
     }
 
     @Test
     fun `maps appliedBalance`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(appliedBalance = -200L),
-        ).asCheckoutSession()
+        )
         assertThat(session.totalSummary!!.appliedBalance).isEqualTo(-200L)
     }
 
     @Test
     fun `null appliedBalance maps to null`() {
-        val session = createResponse(
+        val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(appliedBalance = null),
-        ).asCheckoutSession()
+        )
         assertThat(session.totalSummary!!.appliedBalance).isNull()
     }
 
     @Test
     fun `maps lineItems`() {
-        val session = createResponse(
+        val session = createSession(
             lineItems = listOf(
                 CheckoutSessionResponse.LineItem(
                     id = "li_1",
@@ -225,7 +225,7 @@ class AsCheckoutSessionTest {
                     total = 1998L,
                 ),
             ),
-        ).asCheckoutSession()
+        )
         val items = session.lineItems
         assertThat(items).hasSize(1)
         assertThat(items[0].id).isEqualTo("li_1")
@@ -238,13 +238,13 @@ class AsCheckoutSessionTest {
 
     @Test
     fun `empty lineItems maps to empty list`() {
-        val session = createResponse().asCheckoutSession()
+        val session = createSession()
         assertThat(session.lineItems).isEmpty()
     }
 
     @Test
     fun `maps shippingOptions`() {
-        val session = createResponse(
+        val session = createSession(
             shippingOptions = listOf(
                 CheckoutSessionResponse.ShippingRate(
                     id = "shr_standard",
@@ -259,7 +259,7 @@ class AsCheckoutSessionTest {
                     deliveryEstimate = "1-3 business days",
                 ),
             ),
-        ).asCheckoutSession()
+        )
         val options = session.shippingOptions
         assertThat(options).hasSize(2)
         assertThat(options[0].id).isEqualTo("shr_standard")
@@ -274,11 +274,11 @@ class AsCheckoutSessionTest {
 
     @Test
     fun `empty shippingOptions maps to empty list`() {
-        val session = createResponse().asCheckoutSession()
+        val session = createSession()
         assertThat(session.shippingOptions).isEmpty()
     }
 
-    private fun createResponse(
+    private fun createSession(
         id: String = DEFAULT_CHECKOUT_SESSION_ID,
         status: CheckoutSessionResponse.Status = CheckoutSessionResponse.Status.OPEN,
         liveMode: Boolean = false,
@@ -288,17 +288,22 @@ class AsCheckoutSessionTest {
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
-    ): CheckoutSessionResponse {
-        return CheckoutSessionResponseFactory.create(
-            id = id,
-            status = status,
-            liveMode = liveMode,
-            currency = currency,
-            customerEmail = customerEmail,
-            taxStatus = taxStatus,
-            totalSummary = totalSummary,
-            lineItems = lineItems,
-            shippingOptions = shippingOptions,
-        )
+    ): CheckoutSession {
+        return InternalState(
+            key = "CheckoutConfigurationMergerTest",
+            configuration = Checkout.Configuration().build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                id = id,
+                status = status,
+                liveMode = liveMode,
+                currency = currency,
+                customerEmail = customerEmail,
+                taxStatus = taxStatus,
+                totalSummary = totalSummary,
+                lineItems = lineItems,
+                shippingOptions = shippingOptions,
+            ),
+            flagImages = null,
+        ).asCheckoutSession()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
@@ -623,6 +623,7 @@ class CheckoutConfigurationMergerTest {
             billingPhoneNumber = billingPhoneNumber,
             shippingAddress = shippingAddress,
             billingAddress = billingAddress,
+            flagImages = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateFactory.kt
@@ -40,6 +40,7 @@ internal object CheckoutStateFactory {
                 shippingAddress = shippingAddress,
                 billingAddress = billingAddress,
                 integrationLaunched = integrationLaunched,
+                flagImages = null,
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
@@ -78,7 +78,12 @@ internal class CurrencySelectorViewModelTest {
         viewModel.errorMessage.test {
             assertThat(awaitItem()).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
 
-            checkoutSessionFlow.value = CheckoutSessionResponseFactory.create(currency = "eur").asCheckoutSession()
+            checkoutSessionFlow.value = InternalState(
+                key = "CheckoutConfigurationMergerTest",
+                configuration = Checkout.Configuration().build(),
+                CheckoutSessionResponseFactory.create(currency = "eur"),
+                flagImages = null,
+            ).asCheckoutSession()
 
             assertThat(awaitItem()).isNull()
         }
@@ -116,7 +121,12 @@ internal class CurrencySelectorViewModelTest {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val fakeAnalyticsRequestExecutor = FakeAnalyticsRequestExecutor()
         val checkoutSessionFlow = MutableStateFlow(
-            CheckoutSessionResponseFactory.create().asCheckoutSession()
+            InternalState(
+                key = "CheckoutConfigurationMergerTest",
+                configuration = Checkout.Configuration().build(),
+                CheckoutSessionResponseFactory.create(),
+                flagImages = null,
+            ).asCheckoutSession()
         )
         val updateCurrencyCalls = Turbine<String>()
         val updateCurrencyResult = Turbine<Result<Unit>>()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageRepositoryTest.kt
@@ -1,0 +1,170 @@
+package com.stripe.android.checkout
+
+import android.graphics.Bitmap
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.uicore.image.StripeImageLoader
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class FlagImageRepositoryTest {
+
+    @Test
+    fun `both downloads succeed - returns images for both currencies`() = runTest {
+        val fakeLoader = FakeStripeImageLoader()
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        val result = repository.prefetch("usd", "eur")
+
+        assertThat(result.images).isNotNull()
+        assertThat(result.images!!.keys).containsExactly("USD", "EUR")
+        assertThat(result.failures).isEmpty()
+    }
+
+    @Test
+    fun `integration download fails - returns null images and failure`() = runTest {
+        val fakeLoader = FakeStripeImageLoader(
+            failingUrls = setOf(FlagImageRepository.buildFlagUrl("US", dpr = 3)),
+        )
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        val result = repository.prefetch("usd", "eur")
+
+        assertThat(result.images).isNull()
+        assertThat(result.failures).hasSize(1)
+        assertThat(result.failures[0].countryCode).isEqualTo("US")
+        assertThat(result.failures[0].url).isEqualTo(FlagImageRepository.buildFlagUrl("US", dpr = 3))
+    }
+
+    @Test
+    fun `local download fails - returns null images and failure`() = runTest {
+        val fakeLoader = FakeStripeImageLoader(
+            failingUrls = setOf(FlagImageRepository.buildFlagUrl("EU", dpr = 3)),
+        )
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        val result = repository.prefetch("usd", "eur")
+
+        assertThat(result.images).isNull()
+        assertThat(result.failures).hasSize(1)
+        assertThat(result.failures[0].countryCode).isEqualTo("EU")
+    }
+
+    @Test
+    fun `both downloads fail - returns null images and two failures`() = runTest {
+        val fakeLoader = FakeStripeImageLoader(
+            failingUrls = setOf(
+                FlagImageRepository.buildFlagUrl("US", dpr = 3),
+                FlagImageRepository.buildFlagUrl("EU", dpr = 3),
+            ),
+        )
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        val result = repository.prefetch("usd", "eur")
+
+        assertThat(result.images).isNull()
+        assertThat(result.failures).hasSize(2)
+    }
+
+    @Test
+    fun `X-currency integration code - skips prefetch and returns empty failures`() = runTest {
+        val fakeLoader = FakeStripeImageLoader()
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        val result = repository.prefetch("xaf", "usd")
+
+        assertThat(result.images).isNull()
+        assertThat(result.failures).isEmpty()
+    }
+
+    @Test
+    fun `X-currency local code - skips prefetch and returns empty failures`() = runTest {
+        val fakeLoader = FakeStripeImageLoader()
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        val result = repository.prefetch("usd", "xpf")
+
+        assertThat(result.images).isNull()
+        assertThat(result.failures).isEmpty()
+    }
+
+    @Test
+    fun `get returns cached bitmap after successful prefetch`() = runTest {
+        val fakeLoader = FakeStripeImageLoader()
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        repository.prefetch("usd", "eur")
+
+        assertThat(repository.get("USD")).isNotNull()
+        assertThat(repository.get("EUR")).isNotNull()
+    }
+
+    @Test
+    fun `get returns null when prefetch failed`() = runTest {
+        val fakeLoader = FakeStripeImageLoader(
+            failingUrls = setOf(FlagImageRepository.buildFlagUrl("US", dpr = 3)),
+        )
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        repository.prefetch("usd", "eur")
+
+        assertThat(repository.get("USD")).isNull()
+        assertThat(repository.get("EUR")).isNull()
+    }
+
+    @Test
+    fun `get returns null for currency not prefetched`() = runTest {
+        val fakeLoader = FakeStripeImageLoader()
+        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+
+        repository.prefetch("usd", "eur")
+
+        assertThat(repository.get("GBP")).isNull()
+    }
+
+    @Test
+    fun `EUR maps to EU country code`() {
+        assertThat(FlagImageRepository.currencyCodeToCountryCode("EUR")).isEqualTo("EU")
+    }
+
+    @Test
+    fun `USD maps to US country code`() {
+        assertThat(FlagImageRepository.currencyCodeToCountryCode("USD")).isEqualTo("US")
+    }
+
+    @Test
+    fun `XAF returns null country code`() {
+        assertThat(FlagImageRepository.currencyCodeToCountryCode("XAF")).isNull()
+    }
+
+    @Test
+    fun `buildFlagUrl produces correct CDN proxy URL`() {
+        val url = FlagImageRepository.buildFlagUrl("US", dpr = 3)
+        assertThat(url).isEqualTo(
+            "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=16,dpr=3/" +
+                "https://b.stripecdn.com/ocs-mobile/assets/flags/US.png"
+        )
+    }
+}
+
+private class FakeStripeImageLoader(
+    private val failingUrls: Set<String> = emptySet(),
+) : StripeImageLoader {
+    override suspend fun load(url: String, width: Int, height: Int): Result<Bitmap?> {
+        return load(url)
+    }
+
+    override suspend fun load(url: String): Result<Bitmap?> {
+        return if (url in failingUrls) {
+            Result.failure(RuntimeException("Download failed"))
+        } else {
+            Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888))
+        }
+    }
+
+    override suspend fun get(url: String): Result<Bitmap?> {
+        return Result.success(null)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageRepositoryTest.kt
@@ -16,7 +16,7 @@ class FlagImageRepositoryTest {
         val fakeLoader = FakeStripeImageLoader()
         val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
 
-        val result = repository.prefetch("usd", "eur")
+        val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNotNull()
         assertThat(result.images!!.keys).containsExactly("USD", "EUR")
@@ -30,7 +30,7 @@ class FlagImageRepositoryTest {
         )
         val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
 
-        val result = repository.prefetch("usd", "eur")
+        val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).hasSize(1)
@@ -45,7 +45,7 @@ class FlagImageRepositoryTest {
         )
         val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
 
-        val result = repository.prefetch("usd", "eur")
+        val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).hasSize(1)
@@ -62,66 +62,32 @@ class FlagImageRepositoryTest {
         )
         val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
 
-        val result = repository.prefetch("usd", "eur")
+        val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).hasSize(2)
     }
 
     @Test
-    fun `X-currency integration code - skips prefetch and returns empty failures`() = runTest {
+    fun `X-currency integration code - skips fetch and returns empty failures`() = runTest {
         val fakeLoader = FakeStripeImageLoader()
         val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
 
-        val result = repository.prefetch("xaf", "usd")
+        val result = repository.fetch("xaf", "usd")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).isEmpty()
     }
 
     @Test
-    fun `X-currency local code - skips prefetch and returns empty failures`() = runTest {
+    fun `X-currency local code - skips fetch and returns empty failures`() = runTest {
         val fakeLoader = FakeStripeImageLoader()
         val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
 
-        val result = repository.prefetch("usd", "xpf")
+        val result = repository.fetch("usd", "xpf")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).isEmpty()
-    }
-
-    @Test
-    fun `get returns cached bitmap after successful prefetch`() = runTest {
-        val fakeLoader = FakeStripeImageLoader()
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
-        repository.prefetch("usd", "eur")
-
-        assertThat(repository.get("USD")).isNotNull()
-        assertThat(repository.get("EUR")).isNotNull()
-    }
-
-    @Test
-    fun `get returns null when prefetch failed`() = runTest {
-        val fakeLoader = FakeStripeImageLoader(
-            failingUrls = setOf(FlagImageRepository.buildFlagUrl("US", dpr = 3)),
-        )
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
-        repository.prefetch("usd", "eur")
-
-        assertThat(repository.get("USD")).isNull()
-        assertThat(repository.get("EUR")).isNull()
-    }
-
-    @Test
-    fun `get returns null for currency not prefetched`() = runTest {
-        val fakeLoader = FakeStripeImageLoader()
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
-        repository.prefetch("usd", "eur")
-
-        assertThat(repository.get("GBP")).isNull()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/AdaptivePricingFlagImageLoadFailedEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/AdaptivePricingFlagImageLoadFailedEventTest.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.paymentsheet.analytics
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class AdaptivePricingFlagImageLoadFailedEventTest {
+
+    private val testUrl =
+        "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=16,dpr=3/" +
+            "https://b.stripecdn.com/ocs-mobile/assets/flags/EU.png"
+
+    @Test
+    fun `event name is correct`() {
+        val event = PaymentSheetEvent.AdaptivePricingFlagImageLoadFailed(
+            countryCode = "US",
+            url = "https://example.com/flag.png",
+        )
+
+        assertThat(event.eventName)
+            .isEqualTo("elements.adaptive_pricing.flag_image_load.failed")
+    }
+
+    @Test
+    fun `params contain country_code and url`() {
+        val event = PaymentSheetEvent.AdaptivePricingFlagImageLoadFailed(
+            countryCode = "EU",
+            url = testUrl,
+        )
+
+        assertThat(event.params).containsExactly(
+            "country_code", "EU",
+            "url", testUrl,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorOptionsFactoryTest.kt
@@ -1,10 +1,14 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import android.graphics.Bitmap
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.util.Locale
 import kotlin.test.Test
 
+@RunWith(RobolectricTestRunner::class)
 class CurrencySelectorOptionsFactoryTest {
 
     @Test
@@ -23,19 +27,23 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
         assertThat(result).isEqualTo(
             CurrencySelectorOptions(
                 first = CurrencyOption(
                     code = "USD",
-                    displayableText = "🇺🇸 \$61.06",
                     formattedAmount = "\$61.06",
+                    flag = FlagContent.Emoji("🇺🇸"),
                 ),
                 second = CurrencyOption(
                     code = "EUR",
-                    displayableText = "🇪🇺 €50.99",
                     formattedAmount = "€50.99",
+                    flag = FlagContent.Emoji("🇪🇺"),
                 ),
                 selectedCode = "USD",
                 exchangeRateText = "1 EUR = 1.19749 USD",
@@ -52,7 +60,11 @@ class CurrencySelectorOptionsFactoryTest {
             localCurrencyOptions = emptyList(),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
         assertThat(result).isNull()
     }
@@ -73,7 +85,11 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
         assertThat(result?.selectedCode).isEqualTo("EUR")
         assertThat(result?.exchangeRateText).isNull()
@@ -95,7 +111,11 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
         assertThat(result?.selectedCode).isEqualTo("USD")
     }
@@ -116,10 +136,14 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
-        assertThat(result?.first?.displayableText).isEqualTo("🇺🇸 \$35.00")
-        assertThat(result?.second?.displayableText).isEqualTo("🇯🇵 ¥5,000")
+        assertThat(result?.first?.formattedAmount).isEqualTo("\$35.00")
+        assertThat(result?.second?.formattedAmount).isEqualTo("¥5,000")
         assertThat(result?.exchangeRateText).isEqualTo("1 JPY = 0.00680 USD")
     }
 
@@ -139,7 +163,11 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
         assertThat(result?.selectedCode).isEqualTo("EUR")
         assertThat(result?.exchangeRateText).isEqualTo("1 USD = 0.897235 EUR")
@@ -161,10 +189,14 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
-        assertThat(result?.first?.displayableText).isEqualTo("🇺🇸 \$15.00")
-        assertThat(result?.second?.displayableText).isEqualTo("FCFA1,000")
+        assertThat(result?.first?.formattedAmount).isEqualTo("\$15.00")
+        assertThat(result?.second?.formattedAmount).isEqualTo("FCFA1,000")
     }
 
     @Test
@@ -183,10 +215,14 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
-        assertThat(result?.first?.displayableText).isEqualTo("🇪🇺 €6.00")
-        assertThat(result?.second?.displayableText).isEqualTo("CFPF500")
+        assertThat(result?.first?.formattedAmount).isEqualTo("€6.00")
+        assertThat(result?.second?.formattedAmount).isEqualTo("CFPF500")
     }
 
     @Test
@@ -205,11 +241,90 @@ class CurrencySelectorOptionsFactoryTest {
             ),
         )
 
-        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US)
+        val result = CurrencySelectorOptionsFactory.create(
+            adaptivePricingInfo = adaptivePricingInfo,
+            locale = Locale.US,
+            flagImages = null,
+        )
 
         assertThat(result?.first?.code).isEqualTo("USD")
         assertThat(result?.second?.code).isEqualTo("EUR")
         assertThat(result?.selectedCode).isEqualTo("USD")
         assertThat(result?.exchangeRateText).isEqualTo("1 EUR = 1.10000 USD")
+    }
+
+    @Test
+    fun `flag images used when both currencies have bitmaps`() {
+        val usBitmap = Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)
+        val euBitmap = Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)
+        val flagImages = mapOf("USD" to usBitmap, "EUR" to euBitmap)
+
+        val adaptivePricingInfo = CheckoutSessionResponse.AdaptivePricingInfo(
+            activePresentmentCurrency = "usd",
+            integrationAmount = 5099L,
+            integrationCurrency = "eur",
+            localCurrencyOptions = listOf(
+                CheckoutSessionResponse.LocalCurrencyOption(
+                    amount = 6106L,
+                    conversionMarkupBps = 150,
+                    currency = "usd",
+                    presentmentExchangeRate = "1.19749",
+                )
+            ),
+        )
+
+        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US, flagImages)
+
+        assertThat(result?.first?.flag).isEqualTo(FlagContent.Image(usBitmap))
+        assertThat(result?.second?.flag).isEqualTo(FlagContent.Image(euBitmap))
+        assertThat(result?.first?.formattedAmount).isEqualTo("\$61.06")
+        assertThat(result?.second?.formattedAmount).isEqualTo("€50.99")
+    }
+
+    @Test
+    fun `flag images not used when one currency bitmap is missing`() {
+        val usBitmap = Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)
+        val flagImages = mapOf("USD" to usBitmap)
+
+        val adaptivePricingInfo = CheckoutSessionResponse.AdaptivePricingInfo(
+            activePresentmentCurrency = "usd",
+            integrationAmount = 5099L,
+            integrationCurrency = "eur",
+            localCurrencyOptions = listOf(
+                CheckoutSessionResponse.LocalCurrencyOption(
+                    amount = 6106L,
+                    conversionMarkupBps = 150,
+                    currency = "usd",
+                    presentmentExchangeRate = "1.19749",
+                )
+            ),
+        )
+
+        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US, flagImages)
+
+        assertThat(result?.first?.flag).isInstanceOf(FlagContent.Emoji::class.java)
+        assertThat(result?.second?.flag).isInstanceOf(FlagContent.Emoji::class.java)
+    }
+
+    @Test
+    fun `flag images not used when null`() {
+        val adaptivePricingInfo = CheckoutSessionResponse.AdaptivePricingInfo(
+            activePresentmentCurrency = "usd",
+            integrationAmount = 5099L,
+            integrationCurrency = "eur",
+            localCurrencyOptions = listOf(
+                CheckoutSessionResponse.LocalCurrencyOption(
+                    amount = 6106L,
+                    conversionMarkupBps = 150,
+                    currency = "usd",
+                    presentmentExchangeRate = "1.19749",
+                )
+            ),
+        )
+
+        val result = CurrencySelectorOptionsFactory.create(adaptivePricingInfo, Locale.US, null)
+
+        assertThat(result?.first?.flag).isInstanceOf(FlagContent.Emoji::class.java)
+        assertThat(result?.second?.flag).isInstanceOf(FlagContent.Emoji::class.java)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleAppearanceScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleAppearanceScreenshotTest.kt
@@ -23,8 +23,8 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
     )
 
     private val options = CurrencySelectorOptions(
-        first = CurrencyOption(code = "USD", displayableText = "🇺🇸 \$50.99", formattedAmount = "\$50.99"),
-        second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87", formattedAmount = "€45.87"),
+        first = CurrencyOption(code = "USD", formattedAmount = "\$50.99", flag = FlagContent.Emoji("🇺🇸")),
+        second = CurrencyOption(code = "EUR", formattedAmount = "€45.87", flag = FlagContent.Emoji("🇪🇺")),
         selectedCode = "USD",
         exchangeRateText = "1 USD = 0.91 EUR",
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
@@ -26,8 +26,8 @@ internal class CurrencySelectorToggleScreenshotTest {
     private val defaultAppearance = Checkout.CurrencySelectorContentAppearance().build()
 
     private val options = CurrencySelectorOptions(
-        first = CurrencyOption(code = "USD", displayableText = "🇺🇸 $50.99", formattedAmount = "$50.99"),
-        second = CurrencyOption(code = "EUR", displayableText = "🇪🇺 €45.87", formattedAmount = "€45.87"),
+        first = CurrencyOption(code = "USD", formattedAmount = "$50.99", flag = FlagContent.Emoji("🇺🇸")),
+        second = CurrencyOption(code = "EUR", formattedAmount = "€45.87", flag = FlagContent.Emoji("🇪🇺")),
         selectedCode = "USD",
         exchangeRateText = "1 USD = 0.91 EUR",
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
@@ -37,13 +37,13 @@ internal class CurrencySelectorToggleUITest {
 
     private val usdOption = CurrencyOption(
         code = "USD",
-        displayableText = "🇺🇸 $50.99",
         formattedAmount = "$50.99",
+        flag = FlagContent.Emoji("🇺🇸"),
     )
     private val eurOption = CurrencyOption(
         code = "EUR",
-        displayableText = "🇪🇺 €45.87",
         formattedAmount = "€45.87",
+        flag = FlagContent.Emoji("🇪🇺"),
     )
 
     @Test


### PR DESCRIPTION
# Summary
Load flag images from the server for adaptive priving.

# Motivation
When displaying currency options in adaptive pricing, flag images need to be loaded from the CDN. By prefetching these images during checkout session initialization, we can ensure they're available immediately when the currency selector is displayed. This also allows us to track image load failures via analytics and fall back to emoji flags when images aren't available.

https://jira.corp.stripe.com/browse/MOBILESDK-4519

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
