### PR TITLE
Add updateFormElements to FormViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -51,8 +51,8 @@ internal class FormViewModel(
         private set
 
     fun updateFormElements(newFormElements: List<FormElement>) {
-        val currentIdentifiers = elements.map { it.identifier }
-        val newIdentifiers = newFormElements.map { it.identifier }
+        val currentIdentifiers = elements.map { it.identifier to it::class }
+        val newIdentifiers = newFormElements.map { it.identifier to it::class }
         if (currentIdentifiers != newIdentifiers) {
             elements = newFormElements
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
  * to display the UI fields on screen.  It also informs us of the backing fields to be created.
  */
 internal class FormViewModel(
-    val elements: List<FormElement>,
+    formElements: List<FormElement>,
     val formArguments: FormArguments,
 ) : ViewModel() {
     internal class Factory(
@@ -41,9 +41,20 @@ internal class FormViewModel(
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return FormViewModel(
-                elements = formElements,
+                formElements = formElements,
                 formArguments = formArguments,
             ) as T
+        }
+    }
+
+    var elements: List<FormElement> = formElements
+        private set
+
+    fun updateFormElements(newFormElements: List<FormElement>) {
+        val currentIdentifiers = elements.map { it.identifier }
+        val newIdentifiers = newFormElements.map { it.identifier }
+        if (currentIdentifiers != newIdentifiers) {
+            elements = newFormElements
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -33,6 +33,8 @@ internal fun PaymentMethodForm(
         )
     )
 
+    formViewModel.updateFormElements(formElements)
+
     val elements = formViewModel.elements
     val hiddenIdentifiers by formViewModel.hiddenIdentifiers.collectAsState()
     val lastTextFieldIdentifier by formViewModel.lastTextFieldIdentifier.collectAsState()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.AffirmHeaderElement
 import com.stripe.android.ui.core.elements.CountrySpec
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.IbanSpec
@@ -20,6 +21,7 @@ import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
+import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.CountryElement
@@ -804,6 +806,31 @@ internal class FormViewModelTest {
 
         assertThat(updatedNameController?.fieldValue?.first()).isEqualTo("Jane Doe")
         assertThat(updatedEmailController?.fieldValue?.first()).isEqualTo("jane@example.com")
+    }
+
+    @Test
+    fun `updateFormElements updates elements when identifiers match but types differ`() {
+        val args = COMPOSE_FRAGMENT_ARGS.copy(
+            paymentMethodCode = PaymentMethod.Type.Card.code
+        )
+        val originalElements = listOf(
+            AffirmHeaderElement(
+                identifier = IdentifierSpec.Generic("affirm_promotion")
+            ),
+        )
+        val formViewModel = createViewModel(args, originalElements)
+
+        assertThat(formViewModel.elements).isEqualTo(originalElements)
+
+        val newElements = listOf(
+            StaticTextElement(
+                identifier = IdentifierSpec.Generic("affirm_promotion"),
+                text = resolvableString("Static text"),
+            ),
+        )
+        formViewModel.updateFormElements(newElements)
+
+        assertThat(formViewModel.elements).isEqualTo(newElements)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -743,11 +743,94 @@ internal class FormViewModelTest {
         }
     }
 
+    @Test
+    fun `updateFormElements updates elements when identifiers differ`() {
+        val args = COMPOSE_FRAGMENT_ARGS.copy(
+            paymentMethodCode = PaymentMethod.Type.Card.code
+        )
+        val originalElements = listOf(
+            EmailSpec().transform(emptyMap()),
+        )
+        val formViewModel = createViewModel(args, originalElements)
+
+        assertThat(formViewModel.elements).isEqualTo(originalElements)
+
+        val newElements = listOf(
+            NameSpec().transform(emptyMap()),
+            EmailSpec().transform(emptyMap()),
+        )
+        formViewModel.updateFormElements(newElements)
+
+        assertThat(formViewModel.elements).isEqualTo(newElements)
+    }
+
+    @Test
+    fun `updateFormElements preserves form field values when identifiers match`() = runTest {
+        val args = COMPOSE_FRAGMENT_ARGS.copy(
+            paymentMethodCode = PaymentMethod.Type.P24.code
+        )
+        val originalElements = listOf(
+            NameSpec().transform(emptyMap()),
+            EmailSpec().transform(emptyMap()),
+        )
+        val formViewModel = createViewModel(args, originalElements)
+
+        val nameController = getSectionFieldTextControllerWithLabel(
+            formViewModel,
+            CoreR.string.stripe_address_label_full_name
+        )
+        val emailController = getSectionFieldTextControllerWithLabel(
+            formViewModel,
+            UiCoreR.string.stripe_email
+        )
+
+        nameController?.onValueChange("Jane Doe")
+        emailController?.onValueChange("jane@example.com")
+
+        val newElementsWithSameIdentifiers = listOf(
+            NameSpec().transform(emptyMap()),
+            EmailSpec().transform(emptyMap()),
+        )
+        formViewModel.updateFormElements(newElementsWithSameIdentifiers)
+
+        val updatedNameController = getSectionFieldTextControllerWithLabel(
+            formViewModel,
+            CoreR.string.stripe_address_label_full_name
+        )
+        val updatedEmailController = getSectionFieldTextControllerWithLabel(
+            formViewModel,
+            UiCoreR.string.stripe_email
+        )
+
+        assertThat(updatedNameController?.fieldValue?.first()).isEqualTo("Jane Doe")
+        assertThat(updatedEmailController?.fieldValue?.first()).isEqualTo("jane@example.com")
+    }
+
+    @Test
+    fun `updateFormElements does not update elements when identifiers match`() {
+        val args = COMPOSE_FRAGMENT_ARGS.copy(
+            paymentMethodCode = PaymentMethod.Type.Card.code
+        )
+        val originalElements = listOf(
+            EmailSpec().transform(emptyMap()),
+            CountrySpec().transform(emptyMap()),
+        )
+        val formViewModel = createViewModel(args, originalElements)
+
+        val newElementsWithSameIdentifiers = listOf(
+            EmailSpec().transform(emptyMap()),
+            CountrySpec().transform(emptyMap()),
+        )
+        formViewModel.updateFormElements(newElementsWithSameIdentifiers)
+
+        assertThat(formViewModel.elements).isSameInstanceAs(originalElements)
+    }
+
     private fun createViewModel(
         arguments: FormArguments,
         formElements: List<FormElement>,
     ) = FormViewModel(
         formArguments = arguments,
-        elements = formElements,
+        formElements = formElements,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add `updateFormElements` to FormViewModel to check if the passed form elements match the form elements passed to the factory, updating if not

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Fix bug where new form elements are not shown in UI

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Screenshots
## Before
https://github.com/user-attachments/assets/6c18376e-3bd4-4512-83c9-b36d3907abff
## After
https://github.com/user-attachments/assets/dc0e84c3-378a-4c05-89be-20600d4d0f7b

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
