### PR TITLE
Make Address Element text field editable for Inline Autocomplete

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
@@ -6,6 +6,8 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -13,8 +15,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
@@ -42,74 +42,72 @@ class AddressElementExampleActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         supportActionBar?.title = getString(R.string.address_element_title)
-
+        val viewModel by viewModels<AddressElementExampleViewModel>()
         setContent {
-            val viewModel by viewModels<AddressElementExampleViewModel>()
-            val viewState by viewModel.state.collectAsState()
+            AddressElementExampleScreen(viewModel)
+        }
+    }
+}
 
-            val addressLauncher = rememberAddressLauncher(
-                callback = viewModel::handleResult,
-            )
-
-            Column(
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(
-                        paddingValues = WindowInsets.systemBars.only(
-                            WindowInsetsSides.Horizontal + WindowInsetsSides.Top
-                        ).asPaddingValues()
-                    ),
-            ) {
-                when (val state = viewState) {
-                    is AddressElementExampleViewState.Loading -> {
-                        CircularProgressIndicator()
-                    }
-                    is AddressElementExampleViewState.Content -> {
-                        state.address?.let { address ->
-                            Address(address)
-                        }
-
-                        var inlineAutocompleteEnabled by remember {
-                            mutableStateOf(FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled)
-                        }
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text("Inline autocomplete")
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Switch(
-                                checked = inlineAutocompleteEnabled,
-                                onCheckedChange = { enabled ->
-                                    inlineAutocompleteEnabled = enabled
-                                    FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(enabled)
-                                },
-                            )
-                        }
-
-                        val context = LocalContext.current
-                        Button(
-                            onClick = {
-                                val config = AddressLauncher.Configuration.Builder()
-                                    // Provide your Google Places API key to enable autocomplete
-                                    .googlePlacesApiKey(Settings(context).googlePlacesApiKey)
-                                    .build()
-
-                                addressLauncher.present(
-                                    publishableKey = state.publishableKey,
-                                    configuration = config,
-                                )
-                            },
-                            modifier = Modifier.testTag(SELECT_ADDRESS_BUTTON)
-                        ) {
-                            Text("Select address")
-                        }
-                    }
-                    is AddressElementExampleViewState.Error -> {
-                        Text(state.message)
-                    }
+@Composable
+private fun AddressElementExampleScreen(viewModel: AddressElementExampleViewModel) {
+    val viewState by viewModel.state.collectAsState()
+    val addressLauncher = rememberAddressLauncher(
+        callback = viewModel::handleResult,
+    )
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(
+                paddingValues = WindowInsets.systemBars.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                ).asPaddingValues()
+            ),
+    ) {
+        when (val state = viewState) {
+            is AddressElementExampleViewState.Loading -> {
+                CircularProgressIndicator()
+            }
+            is AddressElementExampleViewState.Content -> {
+                state.address?.let { address ->
+                    Address(address)
                 }
+                var inlineAutocompleteEnabled by remember {
+                    mutableStateOf(FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled)
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Inline autocomplete")
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Switch(
+                        checked = inlineAutocompleteEnabled,
+                        onCheckedChange = { enabled ->
+                            inlineAutocompleteEnabled = enabled
+                            FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(enabled)
+                        },
+                    )
+                }
+                val context = LocalContext.current
+                Button(
+                    onClick = {
+                        val config = AddressLauncher.Configuration.Builder()
+                            // Provide your Google Places API key to enable autocomplete
+                            .googlePlacesApiKey(Settings(context).googlePlacesApiKey)
+                            .build()
+                        addressLauncher.present(
+                            publishableKey = state.publishableKey,
+                            configuration = config,
+                        )
+                    },
+                    modifier = Modifier.testTag(SELECT_ADDRESS_BUTTON)
+                ) {
+                    Text("Select address")
+                }
+            }
+            is AddressElementExampleViewState.Error -> {
+                Text(state.message)
             }
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
@@ -13,17 +13,25 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.rememberAddressLauncher
@@ -63,6 +71,21 @@ class AddressElementExampleActivity : AppCompatActivity() {
                     is AddressElementExampleViewState.Content -> {
                         state.address?.let { address ->
                             Address(address)
+                        }
+
+                        var inlineAutocompleteEnabled by remember {
+                            mutableStateOf(FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled)
+                        }
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("Inline autocomplete")
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Switch(
+                                checked = inlineAutocompleteEnabled,
+                                onCheckedChange = { enabled ->
+                                    inlineAutocompleteEnabled = enabled
+                                    FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(enabled)
+                                },
+                            )
                         }
 
                         val context = LocalContext.current

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.DefaultStripeTheme
+import com.stripe.android.uicore.elements.AddressInputMode
 import com.stripe.android.uicore.elements.AddressTextFieldController
 import com.stripe.android.uicore.elements.AddressTextFieldUI
 import org.junit.Rule
@@ -53,6 +54,7 @@ class AddressTextFieldUITest {
                 AddressTextFieldUI(
                     controller = AddressTextFieldController(
                         label = resolvableString(UiCoreR.string.stripe_address_label_address),
+                        addressInputMode = AddressInputMode.NoAutocomplete(),
                     ),
                     enabled = enabled,
                     onClick = onClick

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -257,6 +257,7 @@ internal class InputAddressViewModel @Inject constructor(
     }
 
     override fun onAutocomplete(country: String) {
+        if (autocompleteConfig.isInlineAutocompleteEnabled) return
         viewModelScope.launch {
             _collectedAddress.emit(getCurrentAddress())
             navigator.navigateTo(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -32,7 +32,6 @@ class AddressElement(
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     private val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
     private val hideCountry: Boolean = false,
-    private val isInlineAutocompleteEnabled: Boolean = false,
 ) : SectionMultiFieldElement(_identifier), AddressFieldsElement {
 
     override val allowsUserInteraction: Boolean = true
@@ -58,9 +57,7 @@ class AddressElement(
     private val addressAutoCompleteElement = AddressTextFieldElement(
         identifier = IdentifierSpec.OneLineAddress,
         label = resolvableString(R.string.stripe_address_label_address),
-        onNavigation = (addressInputMode as? AddressInputMode.AutocompleteCondensed)?.onNavigation
-            ?.takeIf { !isInlineAutocompleteEnabled },
-        isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
+        addressInputMode = addressInputMode,
     )
 
     @VisibleForTesting
@@ -183,6 +180,7 @@ class AddressElement(
             countryElement.takeUnless { hideCountry },
         ).plus(otherFields)
         val baseElements = when (addressInputMode) {
+            is AddressInputMode.AutocompleteInline -> condensed
             is AddressInputMode.AutocompleteCondensed -> {
                 // If the merchant has supplied Google Places API key, Google Places SDK is
                 // available, and country is supported, use autocomplete
@@ -265,6 +263,7 @@ class AddressElement(
         country: String?
     ): List<SectionFieldElement> {
         val isAutocompleteActive = when (inputMode) {
+            is AddressInputMode.AutocompleteInline -> true
             is AddressInputMode.AutocompleteCondensed -> inputMode.supportsAutoComplete(country, isPlacesAvailable)
             is AddressInputMode.AutocompleteExpanded -> true
             else -> false

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -32,6 +32,7 @@ class AddressElement(
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     private val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
     private val hideCountry: Boolean = false,
+    private val isInlineEnabled: Boolean = false,
 ) : SectionMultiFieldElement(_identifier), AddressFieldsElement {
 
     override val allowsUserInteraction: Boolean = true
@@ -58,6 +59,8 @@ class AddressElement(
         identifier = IdentifierSpec.OneLineAddress,
         label = resolvableString(R.string.stripe_address_label_address),
         onNavigation = (addressInputMode as? AddressInputMode.AutocompleteCondensed)?.onNavigation
+            ?.takeIf { !isInlineEnabled },
+        isInlineEnabled = isInlineEnabled,
     )
 
     @VisibleForTesting

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -32,7 +32,7 @@ class AddressElement(
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     private val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
     private val hideCountry: Boolean = false,
-    private val isInlineEnabled: Boolean = false,
+    private val isInlineAutocompleteEnabled: Boolean = false,
 ) : SectionMultiFieldElement(_identifier), AddressFieldsElement {
 
     override val allowsUserInteraction: Boolean = true
@@ -59,8 +59,8 @@ class AddressElement(
         identifier = IdentifierSpec.OneLineAddress,
         label = resolvableString(R.string.stripe_address_label_address),
         onNavigation = (addressInputMode as? AddressInputMode.AutocompleteCondensed)?.onNavigation
-            ?.takeIf { !isInlineEnabled },
-        isInlineEnabled = isInlineEnabled,
+            ?.takeIf { !isInlineAutocompleteEnabled },
+        isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
     )
 
     @VisibleForTesting

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressInputMode.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressInputMode.kt
@@ -35,6 +35,16 @@ sealed class AddressInputMode : Parcelable {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     @Parcelize
+    data class AutocompleteInline(
+        val googleApiKey: String?,
+        val autocompleteCountries: Set<String>?,
+        override val phoneNumberConfig: AddressFieldConfiguration,
+        override val nameConfig: AddressFieldConfiguration,
+        override val emailConfig: AddressFieldConfiguration,
+    ) : AddressInputMode()
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+    @Parcelize
     data class NoAutocomplete(
         override val phoneNumberConfig: AddressFieldConfiguration =
             AddressFieldConfiguration.HIDDEN,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -11,24 +11,19 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class AddressTextFieldState(
-    val value: String,
-    val isEditable: Boolean,
-    val fieldDisplayState: FieldDisplayState,
-    val showDisabledErrorIndicator: Boolean,
-)
+import kotlinx.coroutines.flow.asStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldController(
     label: ResolvableString,
-    private val onNavigation: (() -> Unit)? = null,
-    isInlineAutocompleteEnabled: Boolean = false,
+    addressInputMode: AddressInputMode,
 ) : InputController, SectionFieldValidationController, SectionFieldComposable {
     private val _isValidating = MutableStateFlow(false)
     private val _inlineQuery = MutableStateFlow("")
-    private val isEditable = isInlineAutocompleteEnabled
+    private val onNavigation = (addressInputMode as? AddressInputMode.AutocompleteCondensed)?.onNavigation
+
+    val isEditable = addressInputMode is AddressInputMode.AutocompleteInline
+    val inlineQuery: StateFlow<String> = _inlineQuery.asStateFlow()
 
     override val showOptionalLabel: Boolean = false
     override val label = stateFlowOf(label)
@@ -43,17 +38,6 @@ class AddressTextFieldController(
     override val formFieldValue: StateFlow<FormFieldEntry> =
         combineAsStateFlow(isComplete, rawFieldValue) { complete, value ->
             FormFieldEntry(value, complete)
-        }
-
-    val textFieldState: StateFlow<AddressTextFieldState> =
-        combineAsStateFlow(_inlineQuery, validationMessage) { query, error ->
-            val isError = error != null
-            AddressTextFieldState(
-                value = if (isEditable) query else "",
-                isEditable = isEditable,
-                fieldDisplayState = if (isError) FieldDisplayState.ERROR else FieldDisplayState.NORMAL,
-                showDisabledErrorIndicator = !isEditable && isError,
-            )
         }
 
     override fun onRawValueChange(rawValue: String) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -13,11 +13,22 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class AddressTextFieldState(
+    val value: String,
+    val isEditable: Boolean,
+    val fieldDisplayState: FieldDisplayState,
+    val showDisabledErrorIndicator: Boolean,
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldController(
     label: ResolvableString,
     private val onNavigation: (() -> Unit)? = null,
+    isInlineEnabled: Boolean = false,
 ) : InputController, SectionFieldValidationController, SectionFieldComposable {
     private val _isValidating = MutableStateFlow(false)
+    private val _inlineQuery = MutableStateFlow("")
+    private val isEditable = isInlineEnabled
 
     override val showOptionalLabel: Boolean = false
     override val label = stateFlowOf(label)
@@ -34,8 +45,24 @@ class AddressTextFieldController(
             FormFieldEntry(value, complete)
         }
 
+    val textFieldState: StateFlow<AddressTextFieldState> = combineAsStateFlow(_inlineQuery, validationMessage) { query, error ->
+        val isError = error != null
+        AddressTextFieldState(
+            value = if (isEditable) query else "",
+            isEditable = isEditable,
+            fieldDisplayState = if (isError) FieldDisplayState.ERROR else FieldDisplayState.NORMAL,
+            showDisabledErrorIndicator = !isEditable && isError,
+        )
+    }
+
     override fun onRawValueChange(rawValue: String) {
         // No-op, this field does not support direct input manipulation
+    }
+
+    fun onInlineQueryChanged(query: String) {
+        if (isEditable) {
+            _inlineQuery.value = query
+        }
     }
 
     override fun onValidationStateChanged(isValidating: Boolean) {
@@ -50,7 +77,7 @@ class AddressTextFieldController(
         hiddenIdentifiers: Set<IdentifierSpec>,
         lastTextFieldIdentifier: IdentifierSpec?
     ) {
-        AddressTextFieldUI(controller = this, enabled = enabled)
+        AddressTextFieldUI(controller = this, enabled = enabled, modifier = modifier)
     }
 
     fun launchAutocompleteScreen() {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -24,11 +24,11 @@ data class AddressTextFieldState(
 class AddressTextFieldController(
     label: ResolvableString,
     private val onNavigation: (() -> Unit)? = null,
-    isInlineEnabled: Boolean = false,
+    isInlineAutocompleteEnabled: Boolean = false,
 ) : InputController, SectionFieldValidationController, SectionFieldComposable {
     private val _isValidating = MutableStateFlow(false)
     private val _inlineQuery = MutableStateFlow("")
-    private val isEditable = isInlineEnabled
+    private val isEditable = isInlineAutocompleteEnabled
 
     override val showOptionalLabel: Boolean = false
     override val label = stateFlowOf(label)
@@ -45,15 +45,16 @@ class AddressTextFieldController(
             FormFieldEntry(value, complete)
         }
 
-    val textFieldState: StateFlow<AddressTextFieldState> = combineAsStateFlow(_inlineQuery, validationMessage) { query, error ->
-        val isError = error != null
-        AddressTextFieldState(
-            value = if (isEditable) query else "",
-            isEditable = isEditable,
-            fieldDisplayState = if (isError) FieldDisplayState.ERROR else FieldDisplayState.NORMAL,
-            showDisabledErrorIndicator = !isEditable && isError,
-        )
-    }
+    val textFieldState: StateFlow<AddressTextFieldState> =
+        combineAsStateFlow(_inlineQuery, validationMessage) { query, error ->
+            val isError = error != null
+            AddressTextFieldState(
+                value = if (isEditable) query else "",
+                isEditable = isEditable,
+                fieldDisplayState = if (isError) FieldDisplayState.ERROR else FieldDisplayState.NORMAL,
+                showDisabledErrorIndicator = !isEditable && isError,
+            )
+        }
 
     override fun onRawValueChange(rawValue: String) {
         // No-op, this field does not support direct input manipulation

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -9,8 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 class AddressTextFieldElement(
     override val identifier: IdentifierSpec,
     label: ResolvableString,
-    onNavigation: (() -> Unit)? = null,
-    isInlineAutocompleteEnabled: Boolean = false,
+    addressInputMode: AddressInputMode,
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
@@ -18,8 +17,7 @@ class AddressTextFieldElement(
     override val controller: AddressTextFieldController =
         AddressTextFieldController(
             label = label,
-            onNavigation = onNavigation,
-            isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
+            addressInputMode = addressInputMode,
         )
 
     override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.flow.StateFlow
 class AddressTextFieldElement(
     override val identifier: IdentifierSpec,
     label: ResolvableString,
-    onNavigation: (() -> Unit)? = null
+    onNavigation: (() -> Unit)? = null,
+    isInlineEnabled: Boolean = false,
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
@@ -17,7 +18,8 @@ class AddressTextFieldElement(
     override val controller: AddressTextFieldController =
         AddressTextFieldController(
             label = label,
-            onNavigation = onNavigation
+            onNavigation = onNavigation,
+            isInlineEnabled = isInlineEnabled,
         )
 
     override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -10,7 +10,7 @@ class AddressTextFieldElement(
     override val identifier: IdentifierSpec,
     label: ResolvableString,
     onNavigation: (() -> Unit)? = null,
-    isInlineEnabled: Boolean = false,
+    isInlineAutocompleteEnabled: Boolean = false,
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
@@ -19,7 +19,7 @@ class AddressTextFieldElement(
         AddressTextFieldController(
             label = label,
             onNavigation = onNavigation,
-            isInlineEnabled = isInlineEnabled,
+            isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
         )
 
     override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.uicore.LocalTextFieldInsets
@@ -32,11 +31,9 @@ fun AddressTextFieldUI(
     val isEditable = controller.isEditable
     val isError = error != null
 
-    val fieldModifier = remember(isEditable, enabled) {
-        modifier.fillMaxWidth().then(
-            if (isEditable) Modifier else Modifier.clickable(enabled = enabled) { onClick() }
-        )
-    }
+    val fieldModifier = modifier.fillMaxWidth().then(
+        if (isEditable) Modifier else Modifier.clickable(enabled = enabled) { onClick() }
+    )
 
     CompatTextField(
         value = if (isEditable) inlineQuery else "",

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.uicore.LocalTextFieldInsets
@@ -24,18 +25,21 @@ fun AddressTextFieldUI(
     }
 ) {
     val label by controller.label.collectAsState()
-    val error by controller.validationMessage.collectAsState()
-
+    val textFieldState by controller.textFieldState.collectAsState()
     val textFieldInsets = LocalTextFieldInsets.current
 
-    val isError = error != null
+    val fieldModifier = remember(textFieldState.isEditable, enabled) {
+        modifier.fillMaxWidth().then(
+            if (textFieldState.isEditable) Modifier else Modifier.clickable(enabled = enabled) { onClick() }
+        )
+    }
 
     CompatTextField(
-        value = "",
-        enabled = false,
-        onValueChange = {},
+        value = textFieldState.value,
+        enabled = textFieldState.isEditable && enabled,
+        onValueChange = { v -> controller.onInlineQueryChanged(v) },
         errorMessage = null,
-        isError = isError,
+        isError = textFieldState.fieldDisplayState == FieldDisplayState.ERROR,
         label = {
             FormLabel(label.resolve())
         },
@@ -44,18 +48,13 @@ fun AddressTextFieldUI(
         singleLine = true,
         contentPadding = textFieldInsets.asPaddingValues(),
         colors = TextFieldColors(
-            fieldDisplayState = when (isError) {
-                true -> FieldDisplayState.ERROR
-                false -> FieldDisplayState.NORMAL
-            },
-            disabledIndicatorColor = if (isError) {
+            fieldDisplayState = textFieldState.fieldDisplayState,
+            disabledIndicatorColor = if (textFieldState.showDisabledErrorIndicator) {
                 MaterialTheme.colors.error
             } else {
                 Color.Transparent
             },
         ),
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(enabled = enabled) { onClick() },
+        modifier = fieldModifier,
     )
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
@@ -25,21 +25,25 @@ fun AddressTextFieldUI(
     }
 ) {
     val label by controller.label.collectAsState()
-    val textFieldState by controller.textFieldState.collectAsState()
+    val inlineQuery by controller.inlineQuery.collectAsState()
+    val error by controller.validationMessage.collectAsState()
     val textFieldInsets = LocalTextFieldInsets.current
 
-    val fieldModifier = remember(textFieldState.isEditable, enabled) {
+    val isEditable = controller.isEditable
+    val isError = error != null
+
+    val fieldModifier = remember(isEditable, enabled) {
         modifier.fillMaxWidth().then(
-            if (textFieldState.isEditable) Modifier else Modifier.clickable(enabled = enabled) { onClick() }
+            if (isEditable) Modifier else Modifier.clickable(enabled = enabled) { onClick() }
         )
     }
 
     CompatTextField(
-        value = textFieldState.value,
-        enabled = textFieldState.isEditable && enabled,
+        value = if (isEditable) inlineQuery else "",
+        enabled = isEditable && enabled,
         onValueChange = { v -> controller.onInlineQueryChanged(v) },
         errorMessage = null,
-        isError = textFieldState.fieldDisplayState == FieldDisplayState.ERROR,
+        isError = isError,
         label = {
             FormLabel(label.resolve())
         },
@@ -48,8 +52,8 @@ fun AddressTextFieldUI(
         singleLine = true,
         contentPadding = textFieldInsets.asPaddingValues(),
         colors = TextFieldColors(
-            fieldDisplayState = textFieldState.fieldDisplayState,
-            disabledIndicatorColor = if (textFieldState.showDisabledErrorIndicator) {
+            fieldDisplayState = if (isError) FieldDisplayState.ERROR else FieldDisplayState.NORMAL,
+            disabledIndicatorColor = if (!isEditable && isError) {
                 MaterialTheme.colors.error
             } else {
                 Color.Transparent

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -114,7 +114,6 @@ class AutocompleteAddressController(
             shippingValuesMap = shippingValuesMap,
             isPlacesAvailable = config.isPlacesAvailable,
             hideCountry = hideCountry,
-            isInlineAutocompleteEnabled = config.isInlineAutocompleteEnabled,
         )
     }
 
@@ -126,6 +125,14 @@ class AutocompleteAddressController(
 
         return if (googlePlacesApiKey == null) {
             AddressInputMode.NoAutocomplete(
+                phoneNumberConfig = phoneNumberConfig,
+                nameConfig = nameConfig,
+                emailConfig = emailConfig,
+            )
+        } else if (config.isInlineAutocompleteEnabled) {
+            AddressInputMode.AutocompleteInline(
+                googleApiKey = googlePlacesApiKey,
+                autocompleteCountries = config.autocompleteCountries,
                 phoneNumberConfig = phoneNumberConfig,
                 nameConfig = nameConfig,
                 emailConfig = emailConfig,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -114,6 +114,7 @@ class AutocompleteAddressController(
             shippingValuesMap = shippingValuesMap,
             isPlacesAvailable = config.isPlacesAvailable,
             hideCountry = hideCountry,
+            isInlineEnabled = config.isInlineAutocompleteEnabled,
         )
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -114,7 +114,7 @@ class AutocompleteAddressController(
             shippingValuesMap = shippingValuesMap,
             isPlacesAvailable = config.isPlacesAvailable,
             hideCountry = hideCountry,
-            isInlineEnabled = config.isInlineAutocompleteEnabled,
+            isInlineAutocompleteEnabled = config.isInlineAutocompleteEnabled,
         )
     }
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
@@ -46,9 +46,100 @@ class AddressTextFieldControllerTest {
         }
     }
 
-    private fun createAddressController(): AddressTextFieldController {
+    @Test
+    fun `non-inline mode - textFieldState is not editable with empty value`() = runTest {
+        val controller = createAddressController(isInlineEnabled = false)
+
+        turbineScope {
+            val stateTurbine = controller.textFieldState.testIn(this)
+
+            val state = stateTurbine.awaitItem()
+            assertThat(state.isEditable).isFalse()
+            assertThat(state.value).isEqualTo("")
+
+            stateTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `non-inline mode - shows disabled error indicator when validating`() = runTest {
+        val controller = createAddressController(isInlineEnabled = false)
+
+        turbineScope {
+            val stateTurbine = controller.textFieldState.testIn(this)
+
+            stateTurbine.awaitItem() // initial state
+
+            controller.onValidationStateChanged(true)
+
+            val state = stateTurbine.awaitItem()
+            assertThat(state.showDisabledErrorIndicator).isTrue()
+            assertThat(state.fieldDisplayState).isEqualTo(FieldDisplayState.ERROR)
+
+            stateTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `inline mode - textFieldState is editable and tracks query`() = runTest {
+        val controller = createAddressController(isInlineEnabled = true)
+
+        turbineScope {
+            val stateTurbine = controller.textFieldState.testIn(this)
+
+            val initial = stateTurbine.awaitItem()
+            assertThat(initial.isEditable).isTrue()
+            assertThat(initial.value).isEqualTo("")
+
+            controller.onInlineQueryChanged("123 Main St")
+
+            val updated = stateTurbine.awaitItem()
+            assertThat(updated.value).isEqualTo("123 Main St")
+
+            stateTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `inline mode - error does not show disabled indicator`() = runTest {
+        val controller = createAddressController(isInlineEnabled = true)
+
+        turbineScope {
+            val stateTurbine = controller.textFieldState.testIn(this)
+
+            stateTurbine.awaitItem() // initial state
+
+            controller.onValidationStateChanged(true)
+
+            val state = stateTurbine.awaitItem()
+            assertThat(state.showDisabledErrorIndicator).isFalse()
+            assertThat(state.fieldDisplayState).isEqualTo(FieldDisplayState.ERROR)
+
+            stateTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `non-inline mode - query ignored when inline is disabled`() = runTest {
+        val controller = createAddressController(isInlineEnabled = false)
+
+        turbineScope {
+            val stateTurbine = controller.textFieldState.testIn(this)
+
+            stateTurbine.awaitItem() // initial state
+
+            controller.onInlineQueryChanged("should be ignored")
+
+            stateTurbine.expectNoEvents()
+
+            stateTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun createAddressController(isInlineEnabled: Boolean = false): AddressTextFieldController {
         return AddressTextFieldController(
             label = resolvableString(value = "Name"),
+            isInlineEnabled = isInlineEnabled,
         )
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
@@ -48,7 +48,7 @@ class AddressTextFieldControllerTest {
 
     @Test
     fun `non-inline mode - textFieldState is not editable with empty value`() = runTest {
-        val controller = createAddressController(isInlineEnabled = false)
+        val controller = createAddressController(isInlineAutocompleteEnabled = false)
 
         turbineScope {
             val stateTurbine = controller.textFieldState.testIn(this)
@@ -63,7 +63,7 @@ class AddressTextFieldControllerTest {
 
     @Test
     fun `non-inline mode - shows disabled error indicator when validating`() = runTest {
-        val controller = createAddressController(isInlineEnabled = false)
+        val controller = createAddressController(isInlineAutocompleteEnabled = false)
 
         turbineScope {
             val stateTurbine = controller.textFieldState.testIn(this)
@@ -82,7 +82,7 @@ class AddressTextFieldControllerTest {
 
     @Test
     fun `inline mode - textFieldState is editable and tracks query`() = runTest {
-        val controller = createAddressController(isInlineEnabled = true)
+        val controller = createAddressController(isInlineAutocompleteEnabled = true)
 
         turbineScope {
             val stateTurbine = controller.textFieldState.testIn(this)
@@ -102,7 +102,7 @@ class AddressTextFieldControllerTest {
 
     @Test
     fun `inline mode - error does not show disabled indicator`() = runTest {
-        val controller = createAddressController(isInlineEnabled = true)
+        val controller = createAddressController(isInlineAutocompleteEnabled = true)
 
         turbineScope {
             val stateTurbine = controller.textFieldState.testIn(this)
@@ -121,7 +121,7 @@ class AddressTextFieldControllerTest {
 
     @Test
     fun `non-inline mode - query ignored when inline is disabled`() = runTest {
-        val controller = createAddressController(isInlineEnabled = false)
+        val controller = createAddressController(isInlineAutocompleteEnabled = false)
 
         turbineScope {
             val stateTurbine = controller.textFieldState.testIn(this)
@@ -136,10 +136,10 @@ class AddressTextFieldControllerTest {
         }
     }
 
-    private fun createAddressController(isInlineEnabled: Boolean = false): AddressTextFieldController {
+    private fun createAddressController(isInlineAutocompleteEnabled: Boolean = false): AddressTextFieldController {
         return AddressTextFieldController(
             label = resolvableString(value = "Name"),
-            isInlineEnabled = isInlineEnabled,
+            isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
         )
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
@@ -47,75 +47,28 @@ class AddressTextFieldControllerTest {
     }
 
     @Test
-    fun `non-inline mode - textFieldState is not editable with empty value`() = runTest {
+    fun `non-inline mode - is not editable`() = runTest {
         val controller = createAddressController(isInlineAutocompleteEnabled = false)
 
-        turbineScope {
-            val stateTurbine = controller.textFieldState.testIn(this)
-
-            val state = stateTurbine.awaitItem()
-            assertThat(state.isEditable).isFalse()
-            assertThat(state.value).isEqualTo("")
-
-            stateTurbine.cancelAndIgnoreRemainingEvents()
-        }
+        assertThat(controller.isEditable).isFalse()
     }
 
     @Test
-    fun `non-inline mode - shows disabled error indicator when validating`() = runTest {
-        val controller = createAddressController(isInlineAutocompleteEnabled = false)
-
-        turbineScope {
-            val stateTurbine = controller.textFieldState.testIn(this)
-
-            stateTurbine.awaitItem() // initial state
-
-            controller.onValidationStateChanged(true)
-
-            val state = stateTurbine.awaitItem()
-            assertThat(state.showDisabledErrorIndicator).isTrue()
-            assertThat(state.fieldDisplayState).isEqualTo(FieldDisplayState.ERROR)
-
-            stateTurbine.cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `inline mode - textFieldState is editable and tracks query`() = runTest {
+    fun `inline mode - is editable and tracks query`() = runTest {
         val controller = createAddressController(isInlineAutocompleteEnabled = true)
 
-        turbineScope {
-            val stateTurbine = controller.textFieldState.testIn(this)
+        assertThat(controller.isEditable).isTrue()
 
-            val initial = stateTurbine.awaitItem()
-            assertThat(initial.isEditable).isTrue()
-            assertThat(initial.value).isEqualTo("")
+        turbineScope {
+            val queryTurbine = controller.inlineQuery.testIn(this)
+
+            assertThat(queryTurbine.awaitItem()).isEqualTo("")
 
             controller.onInlineQueryChanged("123 Main St")
 
-            val updated = stateTurbine.awaitItem()
-            assertThat(updated.value).isEqualTo("123 Main St")
+            assertThat(queryTurbine.awaitItem()).isEqualTo("123 Main St")
 
-            stateTurbine.cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `inline mode - error does not show disabled indicator`() = runTest {
-        val controller = createAddressController(isInlineAutocompleteEnabled = true)
-
-        turbineScope {
-            val stateTurbine = controller.textFieldState.testIn(this)
-
-            stateTurbine.awaitItem() // initial state
-
-            controller.onValidationStateChanged(true)
-
-            val state = stateTurbine.awaitItem()
-            assertThat(state.showDisabledErrorIndicator).isFalse()
-            assertThat(state.fieldDisplayState).isEqualTo(FieldDisplayState.ERROR)
-
-            stateTurbine.cancelAndIgnoreRemainingEvents()
+            queryTurbine.cancelAndIgnoreRemainingEvents()
         }
     }
 
@@ -124,22 +77,32 @@ class AddressTextFieldControllerTest {
         val controller = createAddressController(isInlineAutocompleteEnabled = false)
 
         turbineScope {
-            val stateTurbine = controller.textFieldState.testIn(this)
+            val queryTurbine = controller.inlineQuery.testIn(this)
 
-            stateTurbine.awaitItem() // initial state
+            queryTurbine.awaitItem() // initial ""
 
             controller.onInlineQueryChanged("should be ignored")
 
-            stateTurbine.expectNoEvents()
+            queryTurbine.expectNoEvents()
 
-            stateTurbine.cancelAndIgnoreRemainingEvents()
+            queryTurbine.cancelAndIgnoreRemainingEvents()
         }
     }
 
     private fun createAddressController(isInlineAutocompleteEnabled: Boolean = false): AddressTextFieldController {
         return AddressTextFieldController(
             label = resolvableString(value = "Name"),
-            isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
+            addressInputMode = if (isInlineAutocompleteEnabled) {
+                AddressInputMode.AutocompleteInline(
+                    googleApiKey = "test-key",
+                    autocompleteCountries = emptySet(),
+                    phoneNumberConfig = AddressFieldConfiguration.HIDDEN,
+                    nameConfig = AddressFieldConfiguration.HIDDEN,
+                    emailConfig = AddressFieldConfiguration.HIDDEN,
+                )
+            } else {
+                AddressInputMode.NoAutocomplete()
+            },
         )
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
@@ -12,7 +12,7 @@ class AddressTextFieldElementTest {
         val element = AddressTextFieldElement(
             identifier = IdentifierSpec.OneLineAddress,
             label = "Address".resolvableString,
-            onNavigation = null,
+            addressInputMode = AddressInputMode.NoAutocomplete(),
         )
 
         element.getTextFieldIdentifiers().test {


### PR DESCRIPTION
…UI toggle in example app for testing

# Summary
Adds the UI changes for inline address autocomplete in the Address Element condensed text field. When inline mode is enabled, the address field becomes editable and tracks user input that will later be used to query the Google Places API (separate PR) ; when disabled, it keeps the existing read-only autocomplete behavior that opens a new tab for searching addresses with the Places API.

# Motivation
Inline autocomplete requires the condensed address field to accept direct text input and emit query changes, instead of only opening the full-screen autocomplete flow on tap. This PR includes the UI changes behind the feature flag so the next steps can integrate the Google Places API without changing the existing flow for users.

# Testing
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Unit tests: AddressTextFieldControllerTest covers inline vs non-inline modes, query tracking, validation/error styling, and that queries are ignored when inline mode is off.

Manual testing: Enable "Inline autocomplete" in the Address Element example app and verify the address field is editable when the flag is on, and opens a new search page when off.

When wiring up the Google Places API query, observe textFieldState.value on AddressTextFieldController — not fieldValue, which is always empty (it's driven by onRawValueChange which is intentionally a no-op for this field).

# Recording
https://github.com/user-attachments/assets/93c89168-fe79-4f48-8073-b3061dc120c6

# Changelog