### PR TITLE
Update onPaymentMethodMessagePromotionDisplayed duration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -604,7 +604,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onPaymentMethodMessagePromotionDisplayed(displayedSuccessfully: Boolean) {
-        val duration = durationProvider.end(DurationProvider.Key.PaymentMethodMessaging)
+        val duration = durationProvider.elapsed(DurationProvider.Key.PaymentMethodMessaging)
         fireEvent(
             PaymentSheetEvent.PaymentMethodMessaging.Displayed(duration, displayedSuccessfully)
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1433,6 +1433,24 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("selected_lpm", "card")
     }
 
+    @Test
+    fun `onPaymentMethodMessagePromotionDisplayed fires event with duration`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        durationProvider.elapsedCalls.push(
+            FakeDurationProvider.ElapsedCall(
+                key = DurationProvider.Key.PaymentMethodMessaging,
+                duration = 3.seconds,
+            )
+        )
+
+        eventReporter.onPaymentMethodMessagePromotionDisplayed(displayedSuccessfully = true)
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "payment_method_messaging_displayed")
+        assertThat(request.params).containsEntry("duration", 3.0f)
+        assertThat(request.params).containsEntry("displayed_successfully", true)
+    }
+
     private fun runScenario(
         throwInAnalyticsCallback: Boolean = false,
         block: suspend Scenario.() -> Unit
@@ -1526,6 +1544,7 @@ class DefaultEventReporterTest {
     private class FakeDurationProvider : DurationProvider {
         val startCalls: Stack<StartCall> = Stack()
         val endCalls: Stack<EndCall> = Stack()
+        val elapsedCalls: Stack<ElapsedCall> = Stack()
         val completedDurations: MutableMap<DurationProvider.Key, Duration> = mutableMapOf()
 
         override fun start(key: DurationProvider.Key, reset: Boolean) {
@@ -1534,8 +1553,10 @@ class DefaultEventReporterTest {
             assertThat(call.reset).isEqualTo(reset)
         }
 
-        override fun elapsed(key: DurationProvider.Key): Duration? {
-            return null
+        override fun elapsed(key: DurationProvider.Key): Duration {
+            val call = elapsedCalls.pop()
+            assertThat(call.key).isEqualTo(key)
+            return call.duration
         }
 
         override fun end(key: DurationProvider.Key): Duration {
@@ -1563,9 +1584,11 @@ class DefaultEventReporterTest {
         fun validate() {
             assertThat(startCalls).isEmpty()
             assertThat(endCalls).isEmpty()
+            assertThat(elapsedCalls).isEmpty()
         }
 
         data class StartCall(val key: DurationProvider.Key, val reset: Boolean)
         data class EndCall(val key: DurationProvider.Key, val duration: Duration)
+        data class ElapsedCall(val key: DurationProvider.Key, val duration: Duration)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Use `durationProvider.elapsed` instead of `durationProvider.end` in `onPaymentMethodMessagePromotionDisplayed`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- `durationProvider.end` ends the duration timer for the specified key, meaning only the first displayed event will have a duration. Using `elapsed` will allow every displayed event to have a duration, giving us better insight into how long it takes to fetch PMM in the wild.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
