### PR TITLE
Prevent checkout session confirmation during mutations.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationO
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.payments.DefaultReturnUrl
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.ConfirmCheckoutSessionParams
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -115,53 +116,20 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     private suspend fun confirmCheckoutSession(
         params: ConfirmCheckoutSessionParams,
     ): ConfirmationDefinition.Action<Args> {
+        try {
+            CheckoutInstances.ensureNoMutationInFlight(integrationMetadata.instancesKey)
+        } catch (e: IllegalStateException) {
+            return ConfirmationDefinition.Action.Fail(
+                cause = e,
+                message = e.stripeErrorMessage(),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
+            )
+        }
         return checkoutSessionRepository.confirm(
             id = integrationMetadata.id,
             params = params,
         ).fold(
-            onSuccess = { response ->
-                CheckoutInstances[integrationMetadata.instancesKey].forEach { checkout ->
-                    checkout.updateWithResponse(response)
-                }
-
-                val intent: StripeIntent = response.paymentIntent ?: response.setupIntent
-                    ?: run {
-                        val exception = IllegalStateException(
-                            "No PaymentIntent or SetupIntent in checkout session confirm response"
-                        )
-                        return@fold ConfirmationDefinition.Action.Fail(
-                            cause = exception,
-                            message = exception.stripeErrorMessage(),
-                            errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-                        )
-                    }
-
-                when {
-                    intent.isConfirmed -> {
-                        ConfirmationDefinition.Action.Complete(
-                            intent = intent,
-                            metadata = MutableConfirmationMetadata().apply {
-                                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
-                            },
-                            completedFullPaymentFlow = true,
-                        )
-                    }
-                    intent.requiresAction() -> {
-                        ConfirmationDefinition.Action.Launch(
-                            launcherArguments = Args.NextAction(intent, DeferredIntentConfirmationType.Server),
-                            receivesResultInProcess = false,
-                        )
-                    }
-                    else -> {
-                        val exception = IllegalStateException("Intent has not attempted confirm.")
-                        ConfirmationDefinition.Action.Fail(
-                            cause = exception,
-                            message = exception.stripeErrorMessage(),
-                            errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-                        )
-                    }
-                }
-            },
+            onSuccess = ::handleConfirmResponse,
             onFailure = { error ->
                 ConfirmationDefinition.Action.Fail(
                     cause = error,
@@ -170,6 +138,52 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                 )
             }
         )
+    }
+
+    private fun handleConfirmResponse(
+        response: CheckoutSessionResponse,
+    ): ConfirmationDefinition.Action<Args> {
+        CheckoutInstances[integrationMetadata.instancesKey].forEach { checkout ->
+            checkout.updateWithResponse(response)
+        }
+
+        val intent: StripeIntent = response.paymentIntent ?: response.setupIntent
+            ?: run {
+                val exception = IllegalStateException(
+                    "No PaymentIntent or SetupIntent in checkout session confirm response"
+                )
+                return ConfirmationDefinition.Action.Fail(
+                    cause = exception,
+                    message = exception.stripeErrorMessage(),
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                )
+            }
+
+        return when {
+            intent.isConfirmed -> {
+                ConfirmationDefinition.Action.Complete(
+                    intent = intent,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                    },
+                    completedFullPaymentFlow = true,
+                )
+            }
+            intent.requiresAction() -> {
+                ConfirmationDefinition.Action.Launch(
+                    launcherArguments = Args.NextAction(intent, DeferredIntentConfirmationType.Server),
+                    receivesResultInProcess = false,
+                )
+            }
+            else -> {
+                val exception = IllegalStateException("Intent has not attempted confirm.")
+                ConfirmationDefinition.Action.Fail(
+                    cause = exception,
+                    message = exception.stripeErrorMessage(),
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                )
+            }
+        }
     }
 
     @AssistedFactory

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.checkout.CheckoutInstancesTestRule
 import com.stripe.android.checkout.CheckoutStateFactory
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutConfirm
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf
@@ -45,12 +46,16 @@ import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
@@ -403,6 +408,74 @@ class CheckoutSessionConfirmationInterceptorTest {
 
             assertThat(awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
         }
+    }
+
+    @Test
+    fun `intercept with new PM fails when mutation is in flight`() = runScenario(
+        checkoutInstanceCount = 1,
+    ) {
+        val checkout = checkoutInstances.single()
+        val requestArrived = CountDownLatch(1)
+        val holdResponse = CountDownLatch(1)
+
+        networkRule.checkoutUpdate { response ->
+            requestArrived.countDown()
+            holdResponse.await()
+            response.setBody("{}")
+        }
+
+        val job = backgroundScope.launch(Dispatchers.IO) {
+            checkout.removePromotionCode()
+        }
+
+        assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+
+        val result = interceptNewPm()
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
+        val failAction = result as ConfirmationDefinition.Action.Fail
+        assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
+        assertThat(failAction.cause.message)
+            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
+        assertThat(failAction.errorType)
+            .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
+
+        holdResponse.countDown()
+        job.join()
+    }
+
+    @Test
+    fun `intercept with saved PM fails when mutation is in flight`() = runScenario(
+        checkoutInstanceCount = 1,
+    ) {
+        val checkout = checkoutInstances.single()
+        val requestArrived = CountDownLatch(1)
+        val holdResponse = CountDownLatch(1)
+
+        networkRule.checkoutUpdate { response ->
+            requestArrived.countDown()
+            holdResponse.await()
+            response.setBody("{}")
+        }
+
+        val job = backgroundScope.launch(Dispatchers.IO) {
+            checkout.removePromotionCode()
+        }
+
+        assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+
+        val result = interceptSavedPm()
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
+        val failAction = result as ConfirmationDefinition.Action.Fail
+        assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
+        assertThat(failAction.cause.message)
+            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
+        assertThat(failAction.errorType)
+            .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
+
+        holdResponse.countDown()
+        job.join()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Added validation to prevent checkout session confirmation from running while other mutations (like removing promotion codes) are in progress.

# Motivation
When a checkout session mutation is already in flight, attempting to confirm the session concurrently could lead to race conditions or inconsistent state. This change ensures that confirmation attempts fail fast with a clear error message when a mutation is already happening.

https://jira.corp.stripe.com/browse/MOBILESDK-4584

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
[Fixed] Checkout session confirmation now properly fails when attempted while another mutation is in progress.