### PR TITLE
Fix crash occurring in CardScanGoogleLauncher

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncher.kt
@@ -28,8 +28,9 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
     private val _isAvailable = MutableStateFlow(false)
     override val isAvailable: StateFlow<Boolean> = _isAvailable.asStateFlow()
 
-    @VisibleForTesting
-    lateinit var activityLauncher: ActivityResultLauncher<IntentSenderRequest>
+    private var deferredResult: IntentSenderRequest? = null
+
+    private lateinit var _activityLauncher: ActivityResultLauncher<IntentSenderRequest>
 
     init {
         paymentCardRecognitionClient.fetchIntent(
@@ -55,13 +56,35 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
         paymentCardRecognitionClient.fetchIntent(
             context = context,
             onFailure = { e ->
+                _isLaunching = false
                 eventsReporter.onCardScanFailed(implementation, e)
             },
             onSuccess = { intentSenderRequest ->
                 eventsReporter.onCardScanStarted("google_pay")
-                activityLauncher.launch(intentSenderRequest, options)
+                launchIntentSenderOrDefer(intentSenderRequest)
             }
         )
+    }
+
+    fun setLauncher(launcher: ActivityResultLauncher<IntentSenderRequest>) {
+        _activityLauncher = launcher
+
+        val pending = deferredResult ?: return
+
+        try {
+            launcher.launch(pending, options)
+            deferredResult = null
+        } catch (_: IllegalStateException) {
+            _isLaunching = false
+        }
+    }
+
+    private fun launchIntentSenderOrDefer(intentSenderRequest: IntentSenderRequest) {
+        try {
+            _activityLauncher.launch(intentSenderRequest, options)
+        } catch (_: IllegalStateException) {
+            deferredResult = intentSenderRequest
+        }
     }
 
     internal fun parseActivityResult(result: ActivityResult): CardScanResult {
@@ -125,7 +148,7 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
                 onResult(launcher.parseActivityResult(result))
             }
             return remember(activityLauncher) {
-                launcher.apply { this.activityLauncher = activityLauncher }
+                launcher.apply { setLauncher(activityLauncher) }
             }
         }
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncherTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncherTest.kt
@@ -133,6 +133,36 @@ class CardScanGoogleLauncherTest {
     }
 
     @Test
+    fun `deferred intent launches when setLauncher is called after unregistered launcher failure`() = runTest {
+        val failingLauncher = FakeActivityLauncher<IntentSenderRequest>(
+            throwOnNextLaunch = IllegalStateException(
+                "Attempting to launch an unregistered ActivityResultLauncher"
+            )
+        )
+        val succeedingLauncher = FakeActivityLauncher<IntentSenderRequest>()
+        val fakeEventsReporter = FakeCardScanEventsReporter()
+        val launcher = CardScanGoogleLauncher(
+            context = ApplicationProvider.getApplicationContext(),
+            eventsReporter = fakeEventsReporter,
+            options = null,
+            paymentCardRecognitionClient = FakePaymentCardRecognitionClient(true)
+        )
+        launcher.setLauncher(failingLauncher)
+        launcher.launch(ApplicationProvider.getApplicationContext())
+        assertThat(failingLauncher.launchCall.awaitItem()).isEqualTo(Unit)
+
+        launcher.setLauncher(succeedingLauncher)
+        assertThat(succeedingLauncher.launchCall.awaitItem()).isEqualTo(Unit)
+
+        assertThat(fakeEventsReporter.apiCheckSucceededCalls.awaitItem()).isNotNull()
+        assertThat(fakeEventsReporter.scanStartedCalls.awaitItem().implementation).isEqualTo("google_pay")
+
+        failingLauncher.validate()
+        succeedingLauncher.validate()
+        fakeEventsReporter.validate()
+    }
+
+    @Test
     fun `card scan launcher should not be available when fetchIntent fails`() = runScenario(
         isFetchClientSucceed = false
     ) {
@@ -165,7 +195,7 @@ class CardScanGoogleLauncherTest {
             options = null,
             paymentCardRecognitionClient = FakePaymentCardRecognitionClient(isFetchClientSucceed)
         ).apply {
-            this.activityLauncher = activityLauncher
+            setLauncher(activityLauncher)
         }
 
         val scenario = Scenario(

--- a/payments-ui-core/src/test/java/com/stripe/android/utils/FakeActivityLauncher.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/utils/FakeActivityLauncher.kt
@@ -6,7 +6,9 @@ import androidx.core.app.ActivityOptionsCompat
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 
-internal class FakeActivityLauncher<I> : ActivityResultLauncher<I>() {
+internal class FakeActivityLauncher<I>(
+    private var throwOnNextLaunch: Throwable? = null,
+) : ActivityResultLauncher<I>() {
     private val _launchCall = Turbine<Unit>()
     val launchCall: ReceiveTurbine<Unit> = _launchCall
     override val contract: ActivityResultContract<I, *>
@@ -14,6 +16,11 @@ internal class FakeActivityLauncher<I> : ActivityResultLauncher<I>() {
 
     override fun launch(input: I, options: ActivityOptionsCompat?) {
         _launchCall.add(Unit)
+
+        throwOnNextLaunch?.let { error ->
+            throwOnNextLaunch = null
+            throw error
+        }
     }
 
     override fun unregister() {


### PR DESCRIPTION
# Summary
Fix crash occurring in `CardScanGoogleLauncher`

# Motivation
[RUN_MOBILESDK-5402](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5402)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified