### PR TITLE
Downgrade to Ubuntu 2025 Stack and upgrade emulator API version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -190,7 +190,7 @@ workflows:
       - _run-connections-e2e-tests
     meta:
       bitrise.io:
-        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        stack: ubuntu-noble-24.04-bitrise-2025-android
         machine_type_id: g2.linux.x-large
   run-connections-e2e-livemode-tests:
     envs:
@@ -370,7 +370,7 @@ workflows:
                 envman add --key PAYMENTSHEET_E2E_SHARD_DISPLAY --value "$((BITRISE_IO_PARALLEL_INDEX + 1))"
                 CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$BITRISE_IO_PARALLEL_INDEX" --num-shards 5)
 
-                ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=3 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=6 "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33BaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
+                ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=3 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=3 "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33BaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
       - bundle::export_instrumentation_test_results:
           title: Export PaymentSheet E2E test results
           inputs:

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,8 @@ org.gradle.jvmargs=-Xms4g -Xmx8g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -XX:
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
 
+android.experimental.testOptions.managedDevices.setupTimeoutMinutes=20
+android.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
+
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=23.10.1


### PR DESCRIPTION
# Summary
Downgrade to Ubuntu 2025 Stack and upgrade emulator API version. The 

# Motivation
Fix unstable E2E & instrumentation tests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
