### PR TITLE
Bump Maestro 2.6.1

### DIFF
--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -47,7 +47,7 @@ echo "test_environment: $test_environment"
 echo "MAESTRO_TAGS: $MAESTRO_TAGS"
 echo "MODULE: $MODULE"
 
-export MAESTRO_VERSION=1.38.1
+export MAESTRO_VERSION=2.6.1
 
 # Retry mechanism for Maestro installation
 MAX_RETRIES=5


### PR DESCRIPTION
# Summary

Bump Maestro to 2.6.1 from 1.38.1.

# Motivation

[RUN_LINK_MOBILE-193](https://go/jira/RUN_LINK_MOBILE-193)

This is a low effort attempt to address test flakiness caused by the "System UI isn't responding" system dialog blocking interactions at the start of tests. A clue bumping Maestro might help is [here](https://github.com/mobile-dev-inc/Maestro/issues/998#issuecomment-1904547058):
> I've also noticed an android alert displays "System UI isn't responding" & also a secondary alert "Process system isn't responding" sometimes occur on the emulator/physical device when this grpc exception is thrown.

The [Maestro changelog](https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md) includes various performance improvements and connection bug-fixes since 1.38.1.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

```sh
export BITRISE_APK_PATH='./financial-connections-example/build/outputs/apk/debug/financial-connections-example-debug.apk'
bash ./scripts/execute_maestro_tests.sh -m financial-connections -t all
```