### PR TITLE
[Playground] Remove IME padding from BuyButton

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
@@ -560,7 +559,6 @@ internal class PaymentSheetPlaygroundActivity :
             onClick = flowController::presentPaymentOptions
         )
         BuyButton(
-            modifier = Modifier.imePadding(),
             buyButtonEnabled = flowControllerState?.selectedPaymentOption != null,
             onClick = flowController::confirm
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Payment.kt
@@ -84,13 +84,12 @@ fun PaymentMethodSelector(
 
 @Composable
 fun BuyButton(
-    modifier: Modifier = Modifier,
     buyButtonEnabled: Boolean,
     onClick: () -> Unit,
 ) {
     TextButton(
         enabled = buyButtonEnabled,
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .padding(top = 4.dp)
             .testTag(CHECKOUT_TEST_TAG),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove IME padding from BuyButton

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes a bug in the playground where trying to search playground settings after loading FlowController would hide all the content behind the keyboard and playground buttons

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
Before:

https://github.com/user-attachments/assets/61142aaf-eaf0-4cab-9c24-8dfdc3c1c65d

After:
https://github.com/user-attachments/assets/946ce250-71fb-403c-ab0e-1b6d70d13697
