### PR TITLE
[Playground] Don't set createCardPresentSetupIntentCallback on FlowController when can't use TTA

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -173,6 +173,7 @@ internal class PaymentSheetPlaygroundActivity :
             val localPlaygroundSettings = playgroundSettings ?: return@setContent
 
             val playgroundState by viewModel.state.collectAsState()
+            val canUseTapToAdd = playgroundState?.asPaymentState()?.canUseTapToAdd == true
 
             val paymentSheet = remember(playgroundState) {
                 PaymentSheet.Builder(viewModel::onPaymentSheetResult)
@@ -180,7 +181,7 @@ internal class PaymentSheetPlaygroundActivity :
                     .confirmCustomPaymentMethodCallback(this)
                     .analyticEventCallback(viewModel::analyticCallback)
                     .also {
-                        if (playgroundState?.asPaymentState()?.canUseTapToAdd == true) {
+                        if (canUseTapToAdd) {
                             it.createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
                         }
 
@@ -199,9 +200,12 @@ internal class PaymentSheetPlaygroundActivity :
                 )
                     .externalPaymentMethodConfirmHandler(this)
                     .confirmCustomPaymentMethodCallback(this)
-                    .createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
                     .analyticEventCallback(viewModel::analyticCallback)
                     .also {
+                        if (canUseTapToAdd) {
+                            it.createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
+                        }
+
                         if (playgroundState?.snapshot[ConfirmationTokenSettingsDefinition] == true) {
                             it.createIntentCallback(viewModel::createIntentWithConfirmationTokenCallback)
                         } else {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -194,24 +194,7 @@ internal class PaymentSheetPlaygroundActivity :
             }
                 .build()
             val flowController = remember(playgroundState) {
-                PaymentSheet.FlowController.Builder(
-                    viewModel::onPaymentSheetResult,
-                    viewModel::onPaymentOptionSelected
-                )
-                    .externalPaymentMethodConfirmHandler(this)
-                    .confirmCustomPaymentMethodCallback(this)
-                    .analyticEventCallback(viewModel::analyticCallback)
-                    .also {
-                        if (canUseTapToAdd) {
-                            it.createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
-                        }
-
-                        if (playgroundState?.snapshot[ConfirmationTokenSettingsDefinition] == true) {
-                            it.createIntentCallback(viewModel::createIntentWithConfirmationTokenCallback)
-                        } else {
-                            it.createIntentCallback(viewModel::createIntentCallback)
-                        }
-                    }
+                flowControllerBuilder(canUseTapToAdd, playgroundState)
             }
                 .build()
             val embeddedPaymentElementBuilder = remember(playgroundState) {
@@ -353,6 +336,29 @@ internal class PaymentSheetPlaygroundActivity :
             }
         }
     }
+
+    @OptIn(ExperimentalAnalyticEventCallbackApi::class, TapToAddPreview::class)
+    private fun flowControllerBuilder(
+        canUseTapToAdd: Boolean,
+        playgroundState: PlaygroundState?
+    ): PaymentSheet.FlowController.Builder = PaymentSheet.FlowController.Builder(
+        viewModel::onPaymentSheetResult,
+        viewModel::onPaymentOptionSelected
+    )
+        .externalPaymentMethodConfirmHandler(this)
+        .confirmCustomPaymentMethodCallback(this)
+        .analyticEventCallback(viewModel::analyticCallback)
+        .also {
+            if (canUseTapToAdd) {
+                it.createCardPresentSetupIntentCallback(viewModel::createCardPresentSetupIntent)
+            }
+
+            if (playgroundState?.snapshot[ConfirmationTokenSettingsDefinition] == true) {
+                it.createIntentCallback(viewModel::createIntentWithConfirmationTokenCallback)
+            } else {
+                it.createIntentCallback(viewModel::createIntentCallback)
+            }
+        }
 
     @Composable
     private fun AppearanceButton() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
[Playground] Don't set createCardPresentSetupIntentCallback on FlowController when can't use TTA

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix issue where FlowController would not load when collecting billing details due to tap to add

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified