### PR TITLE
StripeCryptoOnramp: UserFacingLogger Switch

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -12,6 +12,8 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.networking.StripeNetworkClient
+import com.stripe.android.core.utils.RealUserFacingLogger
+import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.crypto.onramp.DEFAULT_ONRAMP_INSTANCE_KEY
 import com.stripe.android.crypto.onramp.OnrampCallbackReferences
 import com.stripe.android.crypto.onramp.analytics.OnrampAnalyticsService
@@ -39,6 +41,9 @@ internal class OnrampModule {
 
     @Provides
     fun provideAppContext(application: Application): Context = application.applicationContext
+
+    @Provides
+    fun provideUserFacingLogger(logger: RealUserFacingLogger): UserFacingLogger = logger
 
     @Provides
     fun provideRequestSurface(): RequestSurface = RequestSurface.CryptoOnramp

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/OnrampErrorLogger.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/OnrampErrorLogger.kt
@@ -1,19 +1,18 @@
 package com.stripe.android.crypto.onramp.exception
 
-import com.stripe.android.core.Logger
+import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.crypto.onramp.analytics.OnrampAnalyticsEvent.ErrorOccurred.Operation
 import javax.inject.Inject
 
 internal class OnrampErrorLogger @Inject constructor(
-    private val logger: Logger,
+    private val logger: UserFacingLogger,
 ) {
     fun log(
         operation: Operation,
         error: Throwable,
     ) {
-        logger.error(
-            "[Stripe Crypto Onramp] ${operation.value} failed.\n${error.developerLogMessage()}",
-            error
+        logger.logWarningWithoutPii(
+            "[Stripe Crypto Onramp] ${operation.value} failed.\n${error.developerLogMessage()}"
         )
     }
 

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -5,10 +5,10 @@ import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.Logger
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.crypto.onramp.analytics.OnrampAnalyticsEvent
 import com.stripe.android.crypto.onramp.analytics.OnrampAnalyticsService
 import com.stripe.android.crypto.onramp.exception.AppAttestationException
@@ -93,13 +93,17 @@ class OnrampInteractorTest {
     private val analyticsServiceFactory: OnrampAnalyticsService.Factory = mock {
         on { create(any()) } doReturn testAnalyticsService
     }
-    private val errorLogger = OnrampErrorLogger(Logger.noop())
+    private val errorLogger = OnrampErrorLogger(NoopUserFacingLogger)
     private val savedStateHandle = SavedStateHandle()
 
     private val interactor: OnrampInteractor = createInteractor(
         cryptoApiRepository = cryptoApiRepository,
         savedStateHandle = savedStateHandle
     )
+
+    private object NoopUserFacingLogger : UserFacingLogger {
+        override fun logWarningWithoutPii(message: String) = Unit
+    }
 
     @Test
     fun testConfigureIsSuccessful() = runTest {


### PR DESCRIPTION
# Summary
Switches Crypto Onramp error logging to use a UserFacingLogger so external developers can see messages.

# Motivation
Error logging should be exposed to external developers for crypto onramp.
Saw feedback [here](https://github.com/stripe/stripe-android/pull/13230#discussion_r3454211850) that led to this change.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified