### PR TITLE
[fc] Disable emulator boot animation in Maestro tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -470,6 +470,7 @@ workflows:
                 -no-snapshot
                 -no-audio
                 -no-window
+                -no-boot-anim
   start_cardscan_emulator:
     steps:
       - avd-manager@2:


### PR DESCRIPTION
# Summary
As the title says.

# Motivation
[RUN_LINK_MOBILE-193](https://go/jira/RUN_LINK_MOBILE-193)

May help with "System UI isn't responding" issues

# Testing
CI