### PR TITLE
[fc] E2E test improvements

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -238,11 +238,33 @@ workflows:
           inputs:
             - artifact_sources: .*
       - script@1:
+          title: Start logcat capture
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                adb logcat > /tmp/logcat.txt 2>&1 &
+                echo $! > /tmp/logcat.pid
+      - script@1:
           title: Execute Maestro tests
           inputs:
             - content: |-
                 #!/usr/bin/env bash
                 bash ./scripts/execute_maestro_tests.sh -m financial-connections -t $MAESTRO_TAGS
+      - script@1:
+          title: Stop logcat capture
+          is_always_run: true
+          is_skippable: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                kill "$(cat /tmp/logcat.pid)" 2>/dev/null || true
+      - deploy-to-bitrise-io@2:
+          title: Upload logcat on failure
+          run_if: '{{ getenv "BITRISE_BUILD_STATUS" | eq "1" }}'
+          inputs:
+            - deploy_path: /tmp/logcat.txt
+            - notify_user_groups: none
+            - is_enable_public_page: "false"
       - script@1:
           title: Test results
           is_always_run: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -474,6 +474,7 @@ workflows:
                 -no-snapshot
                 -no-audio
                 -no-window
+                -gpu swiftshader_indirect
   start_cardscan_emulator:
     steps:
       - avd-manager@2:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -492,7 +492,7 @@ workflows:
                 -camera-front none
                 -netdelay none
                 -netspeed full
-                -memory 4096
+                -memory 3072
                 -no-snapshot
                 -no-audio
                 -no-window

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -483,7 +483,7 @@ workflows:
     steps:
       - avd-manager@2:
           inputs:
-            - profile: "pixel_6"
+            - profile: "Nexus 5"
             - abi: "x86_64"
             - api_level: 33
             - tag: "google_apis"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -496,7 +496,7 @@ workflows:
                 -no-snapshot
                 -no-audio
                 -no-window
-                -gpu swiftshader_indirect
+                -gpu software
   start_cardscan_emulator:
     steps:
       - avd-manager@2:

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -22,7 +22,11 @@ tags:
     id: "consent_cta"
 # Select Down institution
 - extendedWaitUntil:
-    visible: "Down (Unscheduled)"
+    visible: "Select bank"
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      text: "Down (Unscheduled)"
     timeout: 30000
 - tapOn: "Down (Unscheduled)"
 # Selecting another bank resets the flow


### PR DESCRIPTION
# Summary
Maestro E2E tests changes:
 1. Upload logcat logs to artifacts. Inspecting them revealed that the system UI ANRs are caused by CPU saturation.
 2. To reduce load:
    a. switch to a lower res device (Nexus 5 instead of Pixel 6)
    b. switch to `-gpu software` (from `-gpu auto`) to help select a more efficient software rendering engine
    c. reduce AVD memory from 4096 to 3072; counterintuitive but it should help overall host container performance (my local AVD only has 2 GB ram and it works fine)
 3. Fix one of the tests to work on smaller screens (necessary due to `2a` above)

# Motivation
[RUN_LINK_MOBILE-193](https://go/jira/RUN_LINK_MOBILE-193)

# Testing
Repeated CI runs