### PR TITLE
Restore x-large worker for PaymentSheet E2E

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -375,6 +375,10 @@ workflows:
           title: Export PaymentSheet E2E test results
           inputs:
             - test_title: "PaymentSheet E2E tests (shard $PAYMENTSHEET_E2E_SHARD_DISPLAY)"
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   run-paymentsheet-latency-synthetics:
     before_run:
       - start_emulator


### PR DESCRIPTION
## Summary

Restore `g2.linux.x-large` for `run-paymentsheet-e2e`.

## Context

`run-paymentsheet-e2e` was rewritten in [#13243](https://github.com/stripe/stripe-android/pull/13243), and that rewrite dropped the workflow-specific machine override so the job fell back to the repo default worker size.

[#13260](https://github.com/stripe/stripe-android/pull/13260) added retry logic that kills unhealthy emulators between attempts, which helps mitigate the failure mode but does not address the underlying worker sizing regression for this workflow.

## Testing

Not run; Bitrise configuration change only.
