### PR TITLE
Fix tax status parsing to use tax_meta/tax_context

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -40,7 +40,10 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val mode = parseMode(json.optString(FIELD_MODE))
         val status = parseStatus(json.optString(FIELD_STATUS))
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
-        val taxStatus = parseTaxStatus(json.optJSONObject(FIELD_TAX))
+        val taxStatus = parseTaxStatusFromMeta(
+            taxMeta = json.optJSONObject(FIELD_TAX_META),
+            taxContext = json.optJSONObject(FIELD_TAX_CONTEXT),
+        )
         val amount = extractDueAmount(json) ?: return null
         val currency = json.optString(FIELD_CURRENCY).takeIf { it.isNotEmpty() } ?: return null
         val customerEmail = StripeJsonUtils.optString(json, FIELD_CUSTOMER_EMAIL)
@@ -115,14 +118,24 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         }
     }
 
-    private fun parseTaxStatus(taxJson: JSONObject?): CheckoutSessionResponse.TaxStatus {
-        val statusString = taxJson?.optString(FIELD_STATUS) ?: return CheckoutSessionResponse.TaxStatus.UNKNOWN
-        return when (statusString) {
-            "ready" -> CheckoutSessionResponse.TaxStatus.READY
-            "requires_shipping_address" -> CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS
-            "requires_billing_address" -> CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS
-            else -> CheckoutSessionResponse.TaxStatus.UNKNOWN
+    private fun parseTaxStatusFromMeta(
+        taxMeta: JSONObject?,
+        taxContext: JSONObject?,
+    ): CheckoutSessionResponse.TaxStatus {
+        if (taxMeta == null) return CheckoutSessionResponse.TaxStatus.UNKNOWN
+        val metaStatus = taxMeta.optString(FIELD_STATUS)
+        if (metaStatus == "requires_location_inputs") {
+            val addressSource = taxContext?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE) ?: ""
+            return if (addressSource == "session.shipping") {
+                CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS
+            } else {
+                CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS
+            }
         }
+        if (metaStatus == "complete") {
+            return CheckoutSessionResponse.TaxStatus.READY
+        }
+        return CheckoutSessionResponse.TaxStatus.UNKNOWN
     }
 
     private fun parseElementsSessionParams(
@@ -490,7 +503,9 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_MODE = "mode"
     private const val FIELD_STATUS = "status"
     private const val FIELD_LIVE_MODE = "livemode"
-    private const val FIELD_TAX = "tax"
+    private const val FIELD_TAX_META = "tax_meta"
+    private const val FIELD_TAX_CONTEXT = "tax_context"
+    private const val FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE = "automatic_tax_address_source"
     private const val FIELD_CURRENCY = "currency"
     private const val FIELD_CUSTOMER_EMAIL = "customer_email"
     private const val FIELD_ELEMENTS_SESSION = "elements_session"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1109,14 +1109,15 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
-    fun `parse tax status ready`() {
+    fun `parse tax status ready when tax_meta status is complete`() {
         val json = JSONObject(
             """
             {
                 "session_id": "cs_test_123",
                 "ui_mode": "custom",
                 "currency": "usd",
-                "tax": { "status": "ready" },
+                "tax_meta": { "computation_type": "automatic", "status": "complete" },
+                "tax_context": { "automatic_tax_address_source": "session.billing" },
                 "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
             }
             """.trimIndent()
@@ -1128,14 +1129,15 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
-    fun `parse tax status requires_shipping_address`() {
+    fun `parse tax status requires_shipping_address when address source is shipping`() {
         val json = JSONObject(
             """
             {
                 "session_id": "cs_test_123",
                 "ui_mode": "custom",
                 "currency": "usd",
-                "tax": { "status": "requires_shipping_address" },
+                "tax_meta": { "computation_type": "automatic", "status": "requires_location_inputs" },
+                "tax_context": { "automatic_tax_address_source": "session.shipping" },
                 "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
             }
             """.trimIndent()
@@ -1147,14 +1149,15 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
-    fun `parse tax status requires_billing_address`() {
+    fun `parse tax status requires_billing_address when address source is billing`() {
         val json = JSONObject(
             """
             {
                 "session_id": "cs_test_123",
                 "ui_mode": "custom",
                 "currency": "usd",
-                "tax": { "status": "requires_billing_address" },
+                "tax_meta": { "computation_type": "automatic", "status": "requires_location_inputs" },
+                "tax_context": { "automatic_tax_address_source": "session.billing" },
                 "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
             }
             """.trimIndent()
@@ -1166,14 +1169,15 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
-    fun `parse tax status unknown for unrecognized value`() {
+    fun `parse tax status defaults to billing for unrecognized address source`() {
         val json = JSONObject(
             """
             {
                 "session_id": "cs_test_123",
                 "ui_mode": "custom",
                 "currency": "usd",
-                "tax": { "status": "something_new" },
+                "tax_meta": { "computation_type": "automatic", "status": "requires_location_inputs" },
+                "tax_context": { "automatic_tax_address_source": "something_new" },
                 "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
             }
             """.trimIndent()
@@ -1181,11 +1185,11 @@ class CheckoutSessionResponseJsonParserTest {
         val result = CheckoutSessionResponseJsonParser.parse(json)
 
         assertThat(result).isNotNull()
-        assertThat(result?.taxStatus).isEqualTo(CheckoutSessionResponse.TaxStatus.UNKNOWN)
+        assertThat(result?.taxStatus).isEqualTo(CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS)
     }
 
     @Test
-    fun `parse tax status defaults to unknown when tax object is missing`() {
+    fun `parse tax status defaults to unknown when tax_meta is missing`() {
         val json = JSONObject(
             """
             {


### PR DESCRIPTION
init: go/o/req_iENiE8Qtww2PAb
update: go/o/req_yTR1VCIxg3MsF5

## Summary
- Remove the speculative `"tax": { "status": "..." }` parser that read a field that never existed in real server responses
- Add `parseTaxStatusFromMeta` that reads `tax_meta` + `tax_context` directly, matching iOS and web
- Default to `REQUIRES_BILLING_ADDRESS` for unrecognized address sources (only `"session.shipping"` maps to shipping)

## Motivation
The original parser always returned `UNKNOWN` for tax status because the `"tax"` JSON field it looked for doesn't exist in real `/v1/payment_pages/{cs_id}/init` responses. The server actually returns `tax_meta.status` and `tax_context.automatic_tax_address_source`.

## Test plan
- [x] Updated unit tests to use real server response format
- [x] All `CheckoutSessionResponseJsonParserTest` tests pass
- [ ] Verify in example app that `taxStatus` is no longer `UNKNOWN` when automatic tax is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)