### PR TITLE
Add NFC scanning security checks

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -597,6 +597,7 @@ internal class PlaygroundSettings private constructor(
             CustomStripeApiDefinition,
             CaptureMethodSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.enableNfcScanning),
+            FeatureFlagSettingsDefinition(FeatureFlags.disableNfcScanningSecurity),
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.nfcscan
 
+import com.stripe.android.common.nfcscan.security.IsDeviceSecureForNfc
 import com.stripe.android.core.utils.FeatureFlags.enableNfcScanning
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.ElementsSession
@@ -14,6 +15,7 @@ internal interface IsNfcScanningAvailable {
 }
 
 internal class DefaultIsNfcScanningAvailable @Inject constructor(
+    val isDeviceSecureForNfc: IsDeviceSecureForNfc,
     val tapToAddAvailabilityFactory: TapToAddAvailabilityFactory
 ) : IsNfcScanningAvailable {
     override fun get(
@@ -21,6 +23,7 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
         customerMetadata: CustomerMetadata?
     ): Boolean {
         return enableNfcScanning.isEnabled &&
-            !tapToAddAvailabilityFactory.isAvailable(elementsSession, customerMetadata)
+            !tapToAddAvailabilityFactory.isAvailable(elementsSession, customerMetadata) &&
+            isDeviceSecureForNfc.get()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAvailabilityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAvailabilityModule.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.common.nfcscan
+
+import com.stripe.android.common.nfcscan.security.NfcSecurityModule
+import dagger.Binds
+import dagger.Module
+
+@Module(includes = [NfcSecurityModule::class])
+internal interface NfcScanningAvailabilityModule {
+    @Binds
+    fun bindsIsNfcScanningAvailable(isNfcScanningAvailable: DefaultIsNfcScanningAvailable): IsNfcScanningAvailable
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/security/IsDeviceSecureForNfc.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/security/IsDeviceSecureForNfc.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.common.nfcscan.security
+
+import android.provider.Settings
+import com.stripe.android.core.utils.FeatureFlags
+import javax.inject.Inject
+
+internal fun interface IsDeviceSecureForNfc {
+    fun get(): Boolean
+}
+
+/**
+ * Default implementation of [IsDeviceSecureForNfc] that checks if the user's device is secure for NFC scanning
+ *
+ * In addition to checking if the developer option master toggle is enabled, this also checks if various other toggles
+ * are enabled, including toggles that could:
+ * - Allow debugging over USB or Wi-Fi
+ * - Log sensitive NFC data directly to logcat
+ */
+internal class DefaultIsDeviceSecureForNfc @Inject constructor(
+    @OsSettingsDevicePropertiesKey private val osProperties: PlatformDeviceProperties,
+    @GlobalSettingsDevicePropertiesKey private val globalProperties: PlatformDeviceProperties,
+) : IsDeviceSecureForNfc {
+    override fun get(): Boolean {
+        // Override security checks if flag is enabled
+        if (FeatureFlags.disableNfcScanningSecurity.isEnabled) {
+            return true
+        }
+
+        // Check for developer mode and debugging toggles
+        val isDeveloperModeDisabled = globalProperties.getBoolean(TOGGLE_DEVELOPER_MODE) != true
+        val isUsbDebuggingDisabled = globalProperties.getBoolean(USB_DEBUGGING) != true
+        val isWifiDebuggingDisabled = globalProperties.getBoolean(WIFI_DEBUGGING) != true
+
+        // Check for verbose NFC logging toggles, which could expose sensitive NFC message data
+        val isNotSnoopLogModeFull = osProperties.getString(NFC_SNOOP_LOG_MODE) != NFC_SNOOP_LOG_MODE_FULL
+        val vendorDebugDisabled = osProperties.getBoolean(NFC_VENDOR_DEBUG_ENABLED) != true
+
+        return isDeveloperModeDisabled &&
+            isUsbDebuggingDisabled &&
+            isWifiDebuggingDisabled &&
+            isNotSnoopLogModeFull &&
+            vendorDebugDisabled
+    }
+
+    private companion object {
+        const val TOGGLE_DEVELOPER_MODE = Settings.Global.DEVELOPMENT_SETTINGS_ENABLED
+        const val USB_DEBUGGING = Settings.Global.ADB_ENABLED
+        const val WIFI_DEBUGGING = "adb_wifi_enabled"
+        const val NFC_SNOOP_LOG_MODE = "persist.nfc.snoop_log_mode"
+        const val NFC_VENDOR_DEBUG_ENABLED = "persist.nfc.vendor_debug_enabled"
+        const val NFC_SNOOP_LOG_MODE_FULL = "full"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/security/NfcSecurityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/security/NfcSecurityModule.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.common.nfcscan.security
+
+import dagger.Binds
+import dagger.Module
+import javax.inject.Qualifier
+
+@Module
+internal interface NfcSecurityModule {
+    @GlobalSettingsDevicePropertiesKey
+    @Binds
+    fun bindsGlobalSettingsDeviceProperties(
+        deviceProperties: GlobalSettingsDeviceProperties
+    ): PlatformDeviceProperties
+
+    @OsSettingsDevicePropertiesKey
+    @Binds
+    fun bindsOsSettingsDeviceProperties(
+        deviceProperties: OsSettingsDeviceProperties
+    ): PlatformDeviceProperties
+
+    @Binds
+    fun bindsIsDeviceSecureForNfc(
+        isDeviceSecureForNfc: DefaultIsDeviceSecureForNfc
+    ): IsDeviceSecureForNfc
+}
+
+@Qualifier
+internal annotation class GlobalSettingsDevicePropertiesKey
+
+@Qualifier
+internal annotation class OsSettingsDevicePropertiesKey

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/security/PlatformDeviceProperties.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/security/PlatformDeviceProperties.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.common.nfcscan.security
+
+import android.content.ContentResolver
+import android.content.Context
+import android.provider.Settings
+import javax.inject.Inject
+
+internal interface PlatformDeviceProperties {
+    @Throws(IllegalArgumentException::class)
+    fun getString(key: String): String?
+
+    @Throws(IllegalArgumentException::class)
+    fun getBoolean(key: String): Boolean? = getString(key)?.toBoolean()
+}
+
+/**
+ * Uses the [Settings.Global] content provider to access global device properties.
+ */
+internal class GlobalSettingsDeviceProperties @Inject constructor(
+    context: Context,
+) : PlatformDeviceProperties {
+    private val contentResolver: ContentResolver = context.contentResolver
+
+    override fun getString(key: String): String? {
+        return Settings.Global.getString(contentResolver, key)
+    }
+
+    override fun getBoolean(key: String): Boolean? {
+        return getString(key)?.toInt()?.let { it != 0 }
+    }
+}
+
+/**
+ * Uses reflection to access system properties from `android.os.SystemProperties`. Some of these properties are meant
+ * to only be read by and written by the system itself. In case these properties cannot be accessed via reflection,
+ * property reads will all return `null`.
+ */
+internal class OsSettingsDeviceProperties @Inject constructor() : PlatformDeviceProperties {
+    override fun getString(key: String): String? {
+        return runCatchingAndGet { Class.forName("android.os.SystemProperties") }
+            ?.runCatchingAndGet { getMethod("get", String::class.java) }
+            ?.runCatchingAndGet { invoke(null, key) as String? }
+            ?.takeUnless { it.isEmpty() }
+    }
+
+    override fun getBoolean(key: String): Boolean? {
+        return getString(key)?.toBoolean()
+    }
+
+    private fun <R, T> R.runCatchingAndGet(
+        throwableBlock: R.() -> T,
+    ): T? = runCatching { throwableBlock() }.getOrNull()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -5,8 +5,7 @@ import android.content.Context
 import android.content.res.Resources
 import androidx.core.os.LocaleListCompat
 import com.stripe.android.BuildConfig
-import com.stripe.android.common.nfcscan.DefaultIsNfcScanningAvailable
-import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.common.nfcscan.NfcScanningAvailabilityModule
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -47,7 +46,13 @@ import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
-@Module(includes = [PaymentConfigurationModule::class, StripeNetworkClientModule::class])
+@Module(
+    includes = [
+        PaymentConfigurationModule::class,
+        StripeNetworkClientModule::class,
+        NfcScanningAvailabilityModule::class,
+    ]
+)
 internal interface CustomerSheetViewModelModule {
     @Binds
     fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
@@ -81,11 +86,6 @@ internal interface CustomerSheetViewModelModule {
     fun bindsTapToAddAvailabilityFactory(
         tapToAddAvailabilityFactory: TapToAddAvailabilityFactoryForCustomerSheet
     ): TapToAddAvailabilityFactory
-
-    @Binds
-    fun bindsIsNfcScanningAvailable(
-        isNfcScanningAvailable: DefaultIsNfcScanningAvailable
-    ): IsNfcScanningAvailable
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -1,8 +1,7 @@
 package com.stripe.android.paymentelement.embedded
 
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.common.nfcscan.DefaultIsNfcScanningAvailable
-import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.common.nfcscan.NfcScanningAvailabilityModule
 import com.stripe.android.common.taptoadd.TapToAddConnectionModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -57,6 +56,7 @@ import kotlin.coroutines.CoroutineContext
         PaymentConfigurationModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
+        NfcScanningAvailabilityModule::class,
     ],
 )
 internal interface EmbeddedCommonModule {
@@ -83,11 +83,6 @@ internal interface EmbeddedCommonModule {
     fun bindsPaymentAnalyticsRequestFactory(
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
     ): AnalyticsRequestFactory
-
-    @Binds
-    fun bindsIsNfcScanningAvailable(
-        isNfcScanningAvailable: DefaultIsNfcScanningAvailable,
-    ): IsNfcScanningAvailable
 
     companion object {
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -3,8 +3,7 @@ package com.stripe.android.paymentsheet.injection
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
-import com.stripe.android.common.nfcscan.DefaultIsNfcScanningAvailable
-import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.common.nfcscan.NfcScanningAvailabilityModule
 import com.stripe.android.common.taptoadd.DefaultTapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddConnectionModule
 import com.stripe.android.common.taptoadd.TapToAddHelper
@@ -87,6 +86,7 @@ import javax.inject.Singleton
         PaymentConfigurationModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
+        NfcScanningAvailabilityModule::class,
     ]
 )
 internal abstract class PaymentSheetCommonModule {
@@ -185,11 +185,6 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsTapToAddHelperFactory(factory: DefaultTapToAddHelper.Factory): TapToAddHelper.Factory
-
-    @Binds
-    abstract fun bindsIsNfcScanningAvailable(
-        isNfcScanningAvailable: DefaultIsNfcScanningAvailable,
-    ): IsNfcScanningAvailable
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.nfcscan
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.security.FakeIsDeviceSecureForNfc
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.ElementsSession
@@ -26,6 +27,7 @@ internal class IsNfcScanningAvailableTest {
         FeatureFlags.enableNfcScanning.setEnabled(false)
 
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
+            isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
         )
 
@@ -37,6 +39,7 @@ internal class IsNfcScanningAvailableTest {
         FeatureFlags.enableNfcScanning.setEnabled(true)
 
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
+            isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = true),
         )
 
@@ -44,10 +47,23 @@ internal class IsNfcScanningAvailableTest {
     }
 
     @Test
-    fun `IsNfcScanningAvailableForPaymentElement returns true when NFC flag on and tap to add unavailable`() {
+    fun `IsNfcScanningAvailableForPaymentElement returns false when device is not sure`() {
         FeatureFlags.enableNfcScanning.setEnabled(true)
 
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
+            isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = false),
+            tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
+        )
+
+        assertThat(isNfcScanningAvailable.get(elementsSession, customerMetadata)).isFalse()
+    }
+
+    @Test
+    fun `IsNfcScanningAvailableForPaymentElement returns true when NFC flag on, tap to add unavailable, and secure`() {
+        FeatureFlags.enableNfcScanning.setEnabled(true)
+
+        val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
+            isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/FakeIsDeviceSecureForNfc.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/FakeIsDeviceSecureForNfc.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.common.nfcscan.security
+
+internal class FakeIsDeviceSecureForNfc(
+    private val result: Boolean = true,
+) : IsDeviceSecureForNfc {
+    override fun get(): Boolean = result
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/GlobalSettingsDevicePropertiesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/GlobalSettingsDevicePropertiesTest.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.common.nfcscan.security
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class GlobalSettingsDevicePropertiesTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val deviceProperties = GlobalSettingsDeviceProperties(context)
+
+    @Test
+    fun `getString returns value from Settings Global`() {
+        Settings.Global.putString(context.contentResolver, TEST_KEY, TEST_VALUE)
+
+        assertThat(deviceProperties.getString(TEST_KEY)).isEqualTo(TEST_VALUE)
+    }
+
+    @Test
+    fun `getString returns null for missing key`() {
+        assertThat(deviceProperties.getString(MISSING_KEY)).isNull()
+    }
+
+    @Test
+    fun `getBoolean returns true when stored value is non-zero`() {
+        Settings.Global.putString(context.contentResolver, TEST_KEY, "1")
+
+        assertThat(deviceProperties.getBoolean(TEST_KEY)).isTrue()
+    }
+
+    @Test
+    fun `getBoolean returns false when stored value is zero`() {
+        Settings.Global.putString(context.contentResolver, TEST_KEY, "0")
+
+        assertThat(deviceProperties.getBoolean(TEST_KEY)).isFalse()
+    }
+
+    @Test
+    fun `getBoolean returns null for missing key`() {
+        assertThat(deviceProperties.getBoolean(MISSING_KEY)).isNull()
+    }
+
+    private companion object {
+        const val TEST_KEY = "stripe_test_global_setting"
+        const val TEST_VALUE = "test_value"
+        const val MISSING_KEY = "stripe_missing_global_setting"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/IsDeviceSecureForNfcTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/IsDeviceSecureForNfcTest.kt
@@ -1,0 +1,137 @@
+package com.stripe.android.common.nfcscan.security
+
+import android.provider.Settings
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.utils.FeatureFlags
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class IsDeviceSecureForNfcTest {
+    @After
+    fun tearDown() {
+        FeatureFlags.disableNfcScanningSecurity.reset()
+    }
+
+    @Test
+    fun `returns true when all security checks pass`() = runScenario {
+        assertThat(isDeviceSecureForNfc.get()).isTrue()
+    }
+
+    @Test
+    fun `returns true when property values are unavailable`() = runScenario(
+        globalProperties = FakePlatformDeviceProperties(
+            booleanValues = mapOf(
+                DEVELOPMENT_SETTINGS_ENABLED to null,
+                ADB_ENABLED to null,
+                ADB_WIFI_ENABLED to null,
+            ),
+        ),
+        osProperties = FakePlatformDeviceProperties(
+            stringValues = mapOf(NFC_SNOOP_LOG_MODE to null),
+            booleanValues = mapOf(NFC_VENDOR_DEBUG_ENABLED to null),
+        ),
+    ) {
+        assertThat(isDeviceSecureForNfc.get()).isTrue()
+    }
+
+    @Test
+    fun `returns false when developer mode is enabled`() = runScenario(
+        globalProperties = FakePlatformDeviceProperties(
+            booleanValues = mapOf(DEVELOPMENT_SETTINGS_ENABLED to true),
+        ),
+    ) {
+        assertThat(isDeviceSecureForNfc.get()).isFalse()
+    }
+
+    @Test
+    fun `returns false when USB debugging is enabled`() = runScenario(
+        globalProperties = FakePlatformDeviceProperties(
+            booleanValues = mapOf(ADB_ENABLED to true),
+        ),
+    ) {
+        assertThat(isDeviceSecureForNfc.get()).isFalse()
+    }
+
+    @Test
+    fun `returns false when Wi-Fi debugging is enabled`() = runScenario(
+        globalProperties = FakePlatformDeviceProperties(
+            booleanValues = mapOf(ADB_WIFI_ENABLED to true),
+        ),
+    ) {
+        assertThat(isDeviceSecureForNfc.get()).isFalse()
+    }
+
+    @Test
+    fun `returns false when NFC snoop log mode is full`() = runScenario(
+        osProperties = FakePlatformDeviceProperties(
+            stringValues = mapOf(NFC_SNOOP_LOG_MODE to NFC_SNOOP_LOG_MODE_FULL),
+        ),
+    ) {
+        assertThat(isDeviceSecureForNfc.get()).isFalse()
+    }
+
+    @Test
+    fun `returns false when NFC vendor debug is enabled`() = runScenario(
+        osProperties = FakePlatformDeviceProperties(
+            booleanValues = mapOf(NFC_VENDOR_DEBUG_ENABLED to true),
+        ),
+    ) {
+        assertThat(isDeviceSecureForNfc.get()).isFalse()
+    }
+
+    @Test
+    fun `returns true when security checks are disabled by feature flag`() = runScenario(
+        globalProperties = FakePlatformDeviceProperties(
+            booleanValues = mapOf(
+                DEVELOPMENT_SETTINGS_ENABLED to true,
+                ADB_ENABLED to true,
+                ADB_WIFI_ENABLED to true,
+            ),
+        ),
+        osProperties = FakePlatformDeviceProperties(
+            stringValues = mapOf(NFC_SNOOP_LOG_MODE to NFC_SNOOP_LOG_MODE_FULL),
+            booleanValues = mapOf(NFC_VENDOR_DEBUG_ENABLED to true),
+        ),
+    ) {
+        FeatureFlags.disableNfcScanningSecurity.setEnabled(true)
+
+        assertThat(isDeviceSecureForNfc.get()).isTrue()
+    }
+
+    private fun runScenario(
+        globalProperties: FakePlatformDeviceProperties = FakePlatformDeviceProperties(),
+        osProperties: FakePlatformDeviceProperties = FakePlatformDeviceProperties(),
+        block: Scenario.() -> Unit,
+    ) {
+        val isDeviceSecureForNfc = DefaultIsDeviceSecureForNfc(
+            osProperties = osProperties,
+            globalProperties = globalProperties,
+        )
+
+        Scenario(isDeviceSecureForNfc = isDeviceSecureForNfc).block()
+    }
+
+    private data class Scenario(
+        val isDeviceSecureForNfc: DefaultIsDeviceSecureForNfc,
+    )
+
+    private class FakePlatformDeviceProperties(
+        private val stringValues: Map<String, String?> = emptyMap(),
+        private val booleanValues: Map<String, Boolean?> = emptyMap(),
+    ) : PlatformDeviceProperties {
+        override fun getString(key: String): String? = stringValues[key]
+        override fun getBoolean(key: String): Boolean? = booleanValues[key]
+    }
+
+    private companion object {
+        const val DEVELOPMENT_SETTINGS_ENABLED = Settings.Global.DEVELOPMENT_SETTINGS_ENABLED
+        const val ADB_ENABLED = Settings.Global.ADB_ENABLED
+        const val ADB_WIFI_ENABLED = "adb_wifi_enabled"
+        const val NFC_SNOOP_LOG_MODE = "persist.nfc.snoop_log_mode"
+        const val NFC_VENDOR_DEBUG_ENABLED = "persist.nfc.vendor_debug_enabled"
+        const val NFC_SNOOP_LOG_MODE_FULL = "full"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/OsSettingsDevicePropertiesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/security/OsSettingsDevicePropertiesTest.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.common.nfcscan.security
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowSystemProperties
+
+@RunWith(RobolectricTestRunner::class)
+internal class OsSettingsDevicePropertiesTest {
+    private val deviceProperties = OsSettingsDeviceProperties()
+
+    @After
+    fun tearDown() {
+        ShadowSystemProperties.reset()
+    }
+
+    @Test
+    fun `getString returns overridden system property value`() {
+        ShadowSystemProperties.override(TEST_KEY, TEST_VALUE)
+
+        assertThat(deviceProperties.getString(TEST_KEY)).isEqualTo(TEST_VALUE)
+    }
+
+    @Test
+    fun `getString returns null for missing property`() {
+        assertThat(deviceProperties.getString(MISSING_KEY)).isNull()
+    }
+
+    @Test
+    fun `getString returns null for empty property value`() {
+        ShadowSystemProperties.override(TEST_KEY, "")
+
+        assertThat(deviceProperties.getString(TEST_KEY)).isNull()
+    }
+
+    @Test
+    fun `getBoolean returns true when property value is true`() {
+        ShadowSystemProperties.override(TEST_KEY, "true")
+
+        assertThat(deviceProperties.getBoolean(TEST_KEY)).isTrue()
+    }
+
+    @Test
+    fun `getBoolean returns false when property value is false`() {
+        ShadowSystemProperties.override(TEST_KEY, "false")
+
+        assertThat(deviceProperties.getBoolean(TEST_KEY)).isFalse()
+    }
+
+    @Test
+    fun `getBoolean returns null when property is missing`() {
+        assertThat(deviceProperties.getBoolean(MISSING_KEY)).isNull()
+    }
+
+    private companion object {
+        const val TEST_KEY = "stripe.test.os_setting"
+        const val TEST_VALUE = "test_value"
+        const val MISSING_KEY = "stripe.missing.os_setting"
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -18,6 +18,7 @@ object FeatureFlags {
     val forceOnelinkConsumer = FeatureFlag("Link: Force Onelink consumer")
     val enableKlarnaFormRemoval = FeatureFlag("Remove forms from Klarna")
     val enableNfcScanning = FeatureFlag("Enable NFC Scanning")
+    val disableNfcScanningSecurity = FeatureFlag("Disable NFC Scanning Security")
     val disablePassiveCaptchaWarmup = FeatureFlag("Disable Passive Captcha Warm-Up")
     val forceTapToAddWithTerminal = FeatureFlag("Tap to Add: Force Terminal integration to be available")
     val inlineAddressAutocompleteEnabled = FeatureFlag("Address Element: inline autocomplete suggestions")


### PR DESCRIPTION
# Summary
Add NFC scanning security checks when checking if NFC scanning is available during payment element and customer sheet loading. The security checks look for if users have developer options or NFC logging available by looking at the global properties as well as the system properties of the device.

# Motivation
[SECREV](https://jira.corp.stripe.com/browse/SECREV-5819)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified