### PR TITLE
Add conditional tax_region check for address updates 🪿✨

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -480,7 +480,11 @@ class Checkout private constructor(
     }
 
     /**
-     * Updates the shipping address and recalculates taxes.
+     * Sets the shipping address for this checkout.
+     *
+     * The address is stored locally and used when presenting payment UI. If automatic tax is
+     * enabled and the tax address source is shipping, the address is also sent to the server
+     * to compute updated tax amounts.
      *
      * @param name The recipient's name.
      * @param phoneNumber The recipient's phone number.
@@ -490,7 +494,7 @@ class Checkout private constructor(
         name: String? = null,
         phoneNumber: String? = null,
         address: Address,
-    ): Result<Unit> = updateAddress("shipping", address) {
+    ): Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.SHIPPING, address) {
         copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
     }
 
@@ -508,7 +512,11 @@ class Checkout private constructor(
     }
 
     /**
-     * Updates the billing address and recalculates taxes.
+     * Sets the billing address for this checkout.
+     *
+     * The address is stored locally and used when presenting payment UI. If automatic tax is
+     * enabled and the tax address source is billing, the address is also sent to the server
+     * to compute updated tax amounts.
      *
      * @param name The billing name.
      * @param phoneNumber The billing phone number.
@@ -518,19 +526,19 @@ class Checkout private constructor(
         name: String? = null,
         phoneNumber: String? = null,
         address: Address,
-    ): Result<Unit> = updateAddress("billing", address) {
+    ): Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.BILLING, address) {
         copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = it)
     }
 
     private suspend fun updateAddress(
-        addressType: String,
+        addressType: CheckoutSessionResponse.TaxAddressSource,
         address: Address,
         mutation: InternalState.(Address.State) -> InternalState,
     ): Result<Unit> {
         val built = address.build()
         val response = internalState.checkoutSessionResponse
         val shouldSendTaxRegion =
-            response.automaticTaxEnabled && response.automaticTaxAddressSource == addressType
+            response.automaticTaxEnabled && response.taxAddressSource == addressType
         return withInternalState(
             additionalStateMutations = { mutation(built) },
         ) { sessionId ->

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -490,21 +490,8 @@ class Checkout private constructor(
         name: String? = null,
         phoneNumber: String? = null,
         address: Address,
-    ): Result<Unit> {
-        val built = address.build()
-        return if (internalState.checkoutSessionResponse.shouldSendTaxRegion("shipping")) {
-            withInternalState(
-                additionalStateMutations = {
-                    copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = built)
-                },
-            ) { sessionId ->
-                component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
-            }
-        } else {
-            withLocalStateMutation {
-                copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = built)
-            }
-        }
+    ): Result<Unit> = updateAddress("shipping", address) {
+        copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
     }
 
     /**
@@ -531,20 +518,24 @@ class Checkout private constructor(
         name: String? = null,
         phoneNumber: String? = null,
         address: Address,
+    ): Result<Unit> = updateAddress("billing", address) {
+        copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = it)
+    }
+
+    private suspend fun updateAddress(
+        addressType: String,
+        address: Address,
+        mutation: InternalState.(Address.State) -> InternalState,
     ): Result<Unit> {
         val built = address.build()
-        return if (internalState.checkoutSessionResponse.shouldSendTaxRegion("billing")) {
+        return if (internalState.checkoutSessionResponse.shouldSendTaxRegion(addressType)) {
             withInternalState(
-                additionalStateMutations = {
-                    copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = built)
-                },
+                additionalStateMutations = { mutation(built) },
             ) { sessionId ->
                 component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
             }
         } else {
-            withLocalStateMutation {
-                copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = built)
-            }
+            withLocalStateMutation { mutation(built) }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -528,20 +528,18 @@ class Checkout private constructor(
         mutation: InternalState.(Address.State) -> InternalState,
     ): Result<Unit> {
         val built = address.build()
-        return if (shouldSendTaxRegion(addressType)) {
-            withInternalState(
-                additionalStateMutations = { mutation(built) },
-            ) { sessionId ->
-                component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
-            }
-        } else {
-            withLocalStateMutation { mutation(built) }
-        }
-    }
-
-    private fun shouldSendTaxRegion(addressType: String): Boolean {
         val response = internalState.checkoutSessionResponse
-        return response.automaticTaxEnabled && response.automaticTaxAddressSource == addressType
+        val shouldSendTaxRegion =
+            response.automaticTaxEnabled && response.automaticTaxAddressSource == addressType
+        return withInternalState(
+            additionalStateMutations = { mutation(built) },
+        ) { sessionId ->
+            if (shouldSendTaxRegion) {
+                component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
+            } else {
+                Result.success(checkoutSessionResponse)
+            }
+        }
     }
 
     internal suspend fun updateCurrency(currency: String): Result<Unit> {
@@ -577,22 +575,7 @@ class Checkout private constructor(
         _checkoutSession.value = internalState.asCheckoutSession()
     }
 
-    private fun withLocalStateMutation(
-        mutation: InternalState.() -> InternalState,
-    ): Result<Unit> {
-        if (internalState.integrationLaunched) {
-            return Result.failure(
-                IllegalStateException(
-                    "Cannot mutate checkout session while a payment flow is presented."
-                )
-            )
-        }
-        internalState = internalState.mutation()
-        _checkoutSession.value = internalState.asCheckoutSession()
-        return Result.success(Unit)
-    }
-
-    private suspend fun withInternalState(
+private suspend fun withInternalState(
         additionalStateMutations: InternalState.() -> InternalState = { this },
         block: suspend InternalState.(sessionId: String) -> Result<CheckoutSessionResponse>,
     ): Result<Unit> {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -575,7 +575,7 @@ class Checkout private constructor(
         _checkoutSession.value = internalState.asCheckoutSession()
     }
 
-private suspend fun withInternalState(
+    private suspend fun withInternalState(
         additionalStateMutations: InternalState.() -> InternalState = { this },
         block: suspend InternalState.(sessionId: String) -> Result<CheckoutSessionResponse>,
     ): Result<Unit> {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -528,7 +528,7 @@ class Checkout private constructor(
         mutation: InternalState.(Address.State) -> InternalState,
     ): Result<Unit> {
         val built = address.build()
-        return if (internalState.checkoutSessionResponse.shouldSendTaxRegion(addressType)) {
+        return if (shouldSendTaxRegion(addressType)) {
             withInternalState(
                 additionalStateMutations = { mutation(built) },
             ) { sessionId ->
@@ -537,6 +537,11 @@ class Checkout private constructor(
         } else {
             withLocalStateMutation { mutation(built) }
         }
+    }
+
+    private fun shouldSendTaxRegion(addressType: String): Boolean {
+        val response = internalState.checkoutSessionResponse
+        return response.automaticTaxEnabled && response.automaticTaxAddressSource == addressType
     }
 
     internal suspend fun updateCurrency(currency: String): Result<Unit> {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -492,12 +492,18 @@ class Checkout private constructor(
         address: Address,
     ): Result<Unit> {
         val built = address.build()
-        return withInternalState(
-            additionalStateMutations = {
+        return if (internalState.checkoutSessionResponse.shouldSendTaxRegion("shipping")) {
+            withInternalState(
+                additionalStateMutations = {
+                    copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = built)
+                },
+            ) { sessionId ->
+                component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
+            }
+        } else {
+            withLocalStateMutation {
                 copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = built)
-            },
-        ) { sessionId ->
-            component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
+            }
         }
     }
 
@@ -527,12 +533,18 @@ class Checkout private constructor(
         address: Address,
     ): Result<Unit> {
         val built = address.build()
-        return withInternalState(
-            additionalStateMutations = {
+        return if (internalState.checkoutSessionResponse.shouldSendTaxRegion("billing")) {
+            withInternalState(
+                additionalStateMutations = {
+                    copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = built)
+                },
+            ) { sessionId ->
+                component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
+            }
+        } else {
+            withLocalStateMutation {
                 copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = built)
-            },
-        ) { sessionId ->
-            component.checkoutSessionRepository.updateTaxRegion(sessionId, built)
+            }
         }
     }
 
@@ -567,6 +579,21 @@ class Checkout private constructor(
     internal fun updateWithResponse(response: CheckoutSessionResponse) {
         internalState = internalState.copy(checkoutSessionResponse = response)
         _checkoutSession.value = internalState.asCheckoutSession()
+    }
+
+    private fun withLocalStateMutation(
+        mutation: InternalState.() -> InternalState,
+    ): Result<Unit> {
+        if (internalState.integrationLaunched) {
+            return Result.failure(
+                IllegalStateException(
+                    "Cannot mutate checkout session while a payment flow is presented."
+                )
+            )
+        }
+        internalState = internalState.mutation()
+        _checkoutSession.value = internalState.asCheckoutSession()
+        return Result.success(Unit)
     }
 
     private suspend fun withInternalState(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -30,10 +30,6 @@ internal data class CheckoutSessionResponse(
     val automaticTaxAddressSource: String?,
 ) : StripeModel {
 
-    fun shouldSendTaxRegion(addressType: String): Boolean {
-        return automaticTaxEnabled && automaticTaxAddressSource == addressType
-    }
-
     @Parcelize
     data class SavedPaymentMethodsOfferSave(
         val enabled: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -26,7 +26,17 @@ internal data class CheckoutSessionResponse(
     val lineItems: List<LineItem>,
     val shippingOptions: List<ShippingRate>,
     val adaptivePricingInfo: AdaptivePricingInfo?,
+    val automaticTaxEnabled: Boolean,
+    val automaticTaxAddressSource: String?,
 ) : StripeModel {
+
+    /**
+     * Returns true if the tax region should be sent to the server for the given address type.
+     * Only sends when automatic tax is enabled and the address source matches the address type.
+     */
+    fun shouldSendTaxRegion(addressType: String): Boolean {
+        return automaticTaxEnabled && automaticTaxAddressSource == addressType
+    }
 
     @Parcelize
     data class SavedPaymentMethodsOfferSave(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -30,12 +30,9 @@ internal data class CheckoutSessionResponse(
     val automaticTaxAddressSource: String?,
 ) : StripeModel {
 
-    /**
-     * Returns true if the tax region should be sent to the server for the given address type.
-     * Only sends when automatic tax is enabled and the address source matches the address type.
-     */
     fun shouldSendTaxRegion(addressType: String): Boolean {
-        return automaticTaxEnabled && automaticTaxAddressSource == addressType
+        return automaticTaxEnabled &&
+            (automaticTaxAddressSource == null || automaticTaxAddressSource == addressType)
     }
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -27,8 +27,13 @@ internal data class CheckoutSessionResponse(
     val shippingOptions: List<ShippingRate>,
     val adaptivePricingInfo: AdaptivePricingInfo?,
     val automaticTaxEnabled: Boolean,
-    val automaticTaxAddressSource: String?,
+    val taxAddressSource: TaxAddressSource?,
 ) : StripeModel {
+
+    enum class TaxAddressSource {
+        SHIPPING,
+        BILLING,
+    }
 
     @Parcelize
     data class SavedPaymentMethodsOfferSave(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -31,8 +31,7 @@ internal data class CheckoutSessionResponse(
 ) : StripeModel {
 
     fun shouldSendTaxRegion(addressType: String): Boolean {
-        return automaticTaxEnabled &&
-            (automaticTaxAddressSource == null || automaticTaxAddressSource == addressType)
+        return automaticTaxEnabled && automaticTaxAddressSource == addressType
     }
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -80,6 +80,13 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             json.optJSONObject(FIELD_ADAPTIVE_PRICING_INFO)
         )
 
+        val taxContext = json.optJSONObject(FIELD_TAX_CONTEXT)
+        val automaticTaxEnabled = taxContext?.optBoolean(FIELD_AUTOMATIC_TAX_ENABLED, false) ?: false
+        val automaticTaxAddressSource = taxContext
+            ?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE)
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { if (it.startsWith("session.")) it.removePrefix("session.") else it }
+
         return CheckoutSessionResponse(
             id = sessionId,
             amount = amount,
@@ -98,6 +105,8 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             lineItems = lineItems,
             shippingOptions = shippingOptions,
             adaptivePricingInfo = adaptivePricingInfo,
+            automaticTaxEnabled = automaticTaxEnabled,
+            automaticTaxAddressSource = automaticTaxAddressSource,
         )
     }
 
@@ -505,6 +514,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_LIVE_MODE = "livemode"
     private const val FIELD_TAX_META = "tax_meta"
     private const val FIELD_TAX_CONTEXT = "tax_context"
+    private const val FIELD_AUTOMATIC_TAX_ENABLED = "automatic_tax_enabled"
     private const val FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE = "automatic_tax_address_source"
     private const val FIELD_CURRENCY = "currency"
     private const val FIELD_CUSTOMER_EMAIL = "customer_email"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -40,9 +40,16 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val mode = parseMode(json.optString(FIELD_MODE))
         val status = parseStatus(json.optString(FIELD_STATUS))
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
+        val taxContext = json.optJSONObject(FIELD_TAX_CONTEXT)
+        val rawAddressSource = taxContext
+            ?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE)
+            ?.takeIf { it.isNotEmpty() }
+        val automaticTaxEnabled = taxContext?.optBoolean(FIELD_AUTOMATIC_TAX_ENABLED, false) ?: false
+        val automaticTaxAddressSource = rawAddressSource
+            ?.let { if (it.startsWith("session.")) it.removePrefix("session.") else it }
         val taxStatus = parseTaxStatusFromMeta(
             taxMeta = json.optJSONObject(FIELD_TAX_META),
-            taxContext = json.optJSONObject(FIELD_TAX_CONTEXT),
+            rawAddressSource = rawAddressSource,
         )
         val amount = extractDueAmount(json) ?: return null
         val currency = json.optString(FIELD_CURRENCY).takeIf { it.isNotEmpty() } ?: return null
@@ -79,13 +86,6 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val adaptivePricingInfo = parseAdaptivePricingInfo(
             json.optJSONObject(FIELD_ADAPTIVE_PRICING_INFO)
         )
-
-        val taxContext = json.optJSONObject(FIELD_TAX_CONTEXT)
-        val automaticTaxEnabled = taxContext?.optBoolean(FIELD_AUTOMATIC_TAX_ENABLED, false) ?: false
-        val automaticTaxAddressSource = taxContext
-            ?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE)
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { if (it.startsWith("session.")) it.removePrefix("session.") else it }
 
         return CheckoutSessionResponse(
             id = sessionId,
@@ -129,13 +129,12 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
 
     private fun parseTaxStatusFromMeta(
         taxMeta: JSONObject?,
-        taxContext: JSONObject?,
+        rawAddressSource: String?,
     ): CheckoutSessionResponse.TaxStatus {
         if (taxMeta == null) return CheckoutSessionResponse.TaxStatus.UNKNOWN
         val metaStatus = taxMeta.optString(FIELD_STATUS)
         if (metaStatus == "requires_location_inputs") {
-            val addressSource = taxContext?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE) ?: ""
-            return if (addressSource == "session.shipping") {
+            return if (rawAddressSource == "session.shipping") {
                 CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS
             } else {
                 CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -41,15 +41,11 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val status = parseStatus(json.optString(FIELD_STATUS))
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
         val taxContext = json.optJSONObject(FIELD_TAX_CONTEXT)
-        val rawAddressSource = taxContext
-            ?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE)
-            ?.takeIf { it.isNotEmpty() }
         val automaticTaxEnabled = taxContext?.optBoolean(FIELD_AUTOMATIC_TAX_ENABLED, false) ?: false
-        val automaticTaxAddressSource = rawAddressSource
-            ?.let { if (it.startsWith("session.")) it.removePrefix("session.") else it }
+        val taxAddressSource = parseTaxAddressSource(taxContext)
         val taxStatus = parseTaxStatusFromMeta(
             taxMeta = json.optJSONObject(FIELD_TAX_META),
-            rawAddressSource = rawAddressSource,
+            taxAddressSource = taxAddressSource,
         )
         val amount = extractDueAmount(json) ?: return null
         val currency = json.optString(FIELD_CURRENCY).takeIf { it.isNotEmpty() } ?: return null
@@ -106,7 +102,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             shippingOptions = shippingOptions,
             adaptivePricingInfo = adaptivePricingInfo,
             automaticTaxEnabled = automaticTaxEnabled,
-            automaticTaxAddressSource = automaticTaxAddressSource,
+            taxAddressSource = taxAddressSource,
         )
     }
 
@@ -129,12 +125,12 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
 
     private fun parseTaxStatusFromMeta(
         taxMeta: JSONObject?,
-        rawAddressSource: String?,
+        taxAddressSource: CheckoutSessionResponse.TaxAddressSource?,
     ): CheckoutSessionResponse.TaxStatus {
         if (taxMeta == null) return CheckoutSessionResponse.TaxStatus.UNKNOWN
         val metaStatus = taxMeta.optString(FIELD_STATUS)
         if (metaStatus == "requires_location_inputs") {
-            return if (rawAddressSource == "session.shipping") {
+            return if (taxAddressSource == CheckoutSessionResponse.TaxAddressSource.SHIPPING) {
                 CheckoutSessionResponse.TaxStatus.REQUIRES_SHIPPING_ADDRESS
             } else {
                 CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS
@@ -144,6 +140,20 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             return CheckoutSessionResponse.TaxStatus.READY
         }
         return CheckoutSessionResponse.TaxStatus.UNKNOWN
+    }
+
+    private fun parseTaxAddressSource(
+        taxContext: JSONObject?,
+    ): CheckoutSessionResponse.TaxAddressSource? {
+        val raw = taxContext?.optString(FIELD_AUTOMATIC_TAX_ADDRESS_SOURCE)
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { if (it.startsWith("session.")) it.removePrefix("session.") else it }
+            ?: return null
+        return when (raw) {
+            "shipping" -> CheckoutSessionResponse.TaxAddressSource.SHIPPING
+            "billing" -> CheckoutSessionResponse.TaxAddressSource.BILLING
+            else -> null
+        }
     }
 
     private fun parseElementsSessionParams(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -227,7 +227,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario(checkoutSessionResponse = taxEnabledForShipping()) {
+        runCreateWithStateScenario {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -273,9 +273,7 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
-    ) {
+    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -292,9 +290,7 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
-    ) {
+    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -376,7 +372,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores address in internalState`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -442,7 +437,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -480,7 +474,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -512,7 +505,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -737,9 +729,7 @@ class CheckoutTest {
     }
 
     @Test
-    fun `concurrent calls to withInternalState are serialized`() = runCreateWithStateScenario(
-        checkoutSessionResponse = taxEnabledForShipping(),
-    ) {
+    fun `concurrent calls to withInternalState are serialized`() = runCreateWithStateScenario {
         // First call: applyPromotionCode hits the initial session ID with promotion_code param.
         networkRule.checkoutUpdate(
             bodyPart("promotion_code", "10OFF"),
@@ -1200,7 +1190,7 @@ class CheckoutTest {
     }
 
     private fun runCreateWithStateScenario(
-        checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
+        checkoutSessionResponse: CheckoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents: Boolean = true,
         block: suspend Scenario.() -> Unit,
     ) = runTest {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -43,13 +43,19 @@ class CheckoutTest {
 
     private fun taxEnabledForShipping() = CheckoutSessionResponseFactory.create(
         automaticTaxEnabled = true,
-        automaticTaxAddressSource = "shipping",
+        taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
     )
 
     private fun taxEnabledForBilling() = CheckoutSessionResponseFactory.create(
         automaticTaxEnabled = true,
-        automaticTaxAddressSource = "billing",
+        taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
     )
+
+    private val testAddress = Address()
+        .city("Denver")
+        .country("US")
+        .postalCode("80202")
+        .state("CO")
 
     @get:Rule
     val ruleChain: RuleChain = RuleChain
@@ -568,18 +574,12 @@ class CheckoutTest {
         runCreateWithStateScenario(
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                 automaticTaxEnabled = false,
-                automaticTaxAddressSource = "shipping",
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
             ),
-            shouldValidateEvents = false,
         ) {
             checkoutSessionTurbine.awaitItem()
 
-            val address = Address()
-                .city("Denver")
-                .country("US")
-                .postalCode("80202")
-                .state("CO")
-            val result = checkout.updateShippingAddress(name = "John", address = address)
+            val result = checkout.updateShippingAddress(name = "John", address = testAddress)
             assertThat(result.isSuccess).isTrue()
 
             val state = checkout.internalState
@@ -591,20 +591,11 @@ class CheckoutTest {
     @Test
     fun `updateShippingAddress does not send tax_region when address source is billing`() =
         runCreateWithStateScenario(
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                automaticTaxEnabled = true,
-                automaticTaxAddressSource = "billing",
-            ),
-            shouldValidateEvents = false,
+            checkoutSessionResponse = taxEnabledForBilling(),
         ) {
             checkoutSessionTurbine.awaitItem()
 
-            val address = Address()
-                .city("Denver")
-                .country("US")
-                .postalCode("80202")
-                .state("CO")
-            val result = checkout.updateShippingAddress(name = "John", address = address)
+            val result = checkout.updateShippingAddress(name = "John", address = testAddress)
             assertThat(result.isSuccess).isTrue()
 
             val state = checkout.internalState
@@ -617,18 +608,12 @@ class CheckoutTest {
         runCreateWithStateScenario(
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                 automaticTaxEnabled = false,
-                automaticTaxAddressSource = "billing",
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
             ),
-            shouldValidateEvents = false,
         ) {
             checkoutSessionTurbine.awaitItem()
 
-            val address = Address()
-                .city("Denver")
-                .country("US")
-                .postalCode("80202")
-                .state("CO")
-            val result = checkout.updateBillingAddress(name = "Jane", address = address)
+            val result = checkout.updateBillingAddress(name = "Jane", address = testAddress)
             assertThat(result.isSuccess).isTrue()
 
             val state = checkout.internalState
@@ -638,21 +623,10 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not send tax_region when address source is shipping`() =
-        runCreateWithStateScenario(
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                automaticTaxEnabled = true,
-                automaticTaxAddressSource = "shipping",
-            ),
-            shouldValidateEvents = false,
-        ) {
+        runCreateWithStateScenario {
             checkoutSessionTurbine.awaitItem()
 
-            val address = Address()
-                .city("Denver")
-                .country("US")
-                .postalCode("80202")
-                .state("CO")
-            val result = checkout.updateBillingAddress(name = "Jane", address = address)
+            val result = checkout.updateBillingAddress(name = "Jane", address = testAddress)
             assertThat(result.isSuccess).isTrue()
 
             val state = checkout.internalState

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -41,6 +41,16 @@ class CheckoutTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
     private val networkRule = NetworkRule()
 
+    private fun taxEnabledForShipping() = CheckoutSessionResponseFactory.create(
+        automaticTaxEnabled = true,
+        automaticTaxAddressSource = "shipping",
+    )
+
+    private fun taxEnabledForBilling() = CheckoutSessionResponseFactory.create(
+        automaticTaxEnabled = true,
+        automaticTaxAddressSource = "billing",
+    )
+
     @get:Rule
     val ruleChain: RuleChain = RuleChain
         .outerRule(networkRule)
@@ -217,7 +227,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario {
+        runCreateWithStateScenario(checkoutSessionResponse = taxEnabledForShipping()) {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -263,7 +273,9 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario {
+    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
+    ) {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -280,7 +292,9 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario {
+    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
+    ) {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -306,7 +320,7 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario {
+        runCreateWithStateScenario(checkoutSessionResponse = taxEnabledForBilling()) {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -342,7 +356,9 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateBillingAddress returns failure on error response`() = runCreateWithStateScenario {
+    fun `updateBillingAddress returns failure on error response`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForBilling(),
+    ) {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -360,6 +376,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores address in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -392,6 +409,7 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress stores address in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForBilling(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -424,6 +442,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -442,6 +461,7 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForBilling(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -460,6 +480,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -475,6 +496,7 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForBilling(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -490,6 +512,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -506,6 +529,7 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForBilling(),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -521,7 +545,9 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario {
+    fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForBilling(),
+    ) {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -711,7 +737,9 @@ class CheckoutTest {
     }
 
     @Test
-    fun `concurrent calls to withInternalState are serialized`() = runCreateWithStateScenario {
+    fun `concurrent calls to withInternalState are serialized`() = runCreateWithStateScenario(
+        checkoutSessionResponse = taxEnabledForShipping(),
+    ) {
         // First call: applyPromotionCode hits the initial session ID with promotion_code param.
         networkRule.checkoutUpdate(
             bodyPart("promotion_code", "10OFF"),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -217,7 +217,12 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario {
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                automaticTaxAddressSource = "shipping",
+            ),
+        ) {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -263,7 +268,12 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario {
+    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "shipping",
+        ),
+    ) {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -280,7 +290,12 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario {
+    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "shipping",
+        ),
+    ) {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -306,7 +321,12 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario {
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                automaticTaxAddressSource = "billing",
+            ),
+        ) {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -342,7 +362,12 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateBillingAddress returns failure on error response`() = runCreateWithStateScenario {
+    fun `updateBillingAddress returns failure on error response`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "billing",
+        ),
+    ) {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -360,6 +385,10 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores address in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "shipping",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -392,6 +421,10 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress stores address in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "billing",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -424,6 +457,10 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "shipping",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -442,6 +479,10 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "billing",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -460,6 +501,10 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "shipping",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -475,6 +520,10 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "billing",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -490,6 +539,10 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "shipping",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -506,6 +559,10 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "billing",
+        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -521,7 +578,12 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario {
+    fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario(
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            automaticTaxAddressSource = "billing",
+        ),
+    ) {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -544,6 +606,114 @@ class CheckoutTest {
         checkoutSessionTurbine.awaitItem()
         result.getOrThrow()
     }
+
+    @Test
+    fun `updateShippingAddress does not send tax_region when automatic_tax is disabled`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = false,
+                automaticTaxAddressSource = "shipping",
+            ),
+        ) {
+            val initial = checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .city("Denver")
+                .country("US")
+                .postalCode("80202")
+                .state("CO")
+            val result = checkout.updateShippingAddress(name = "John", address = address)
+            assertThat(result.isSuccess).isTrue()
+
+            // State is updated locally without network call
+            val state = checkout.internalState
+            assertThat(state.shippingName).isEqualTo("John")
+            assertThat(state.shippingAddress?.country).isEqualTo("US")
+            assertThat(state.shippingAddress?.postalCode).isEqualTo("80202")
+
+            // CheckoutSession emission from local state mutation
+            val updated = checkoutSessionTurbine.awaitItem()
+            assertThat(updated.id).isEqualTo(initial.id)
+        }
+
+    @Test
+    fun `updateShippingAddress does not send tax_region when address source is billing`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                automaticTaxAddressSource = "billing",
+            ),
+        ) {
+            val initial = checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .city("Denver")
+                .country("US")
+                .postalCode("80202")
+                .state("CO")
+            val result = checkout.updateShippingAddress(name = "John", address = address)
+            assertThat(result.isSuccess).isTrue()
+
+            // State is updated locally without network call
+            val state = checkout.internalState
+            assertThat(state.shippingName).isEqualTo("John")
+            assertThat(state.shippingAddress?.country).isEqualTo("US")
+
+            val updated = checkoutSessionTurbine.awaitItem()
+            assertThat(updated.id).isEqualTo(initial.id)
+        }
+
+    @Test
+    fun `updateBillingAddress does not send tax_region when automatic_tax is disabled`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = false,
+                automaticTaxAddressSource = "billing",
+            ),
+        ) {
+            val initial = checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .city("Denver")
+                .country("US")
+                .postalCode("80202")
+                .state("CO")
+            val result = checkout.updateBillingAddress(name = "Jane", address = address)
+            assertThat(result.isSuccess).isTrue()
+
+            val state = checkout.internalState
+            assertThat(state.billingName).isEqualTo("Jane")
+            assertThat(state.billingAddress?.country).isEqualTo("US")
+
+            val updated = checkoutSessionTurbine.awaitItem()
+            assertThat(updated.id).isEqualTo(initial.id)
+        }
+
+    @Test
+    fun `updateBillingAddress does not send tax_region when address source is shipping`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                automaticTaxAddressSource = "shipping",
+            ),
+        ) {
+            val initial = checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .city("Denver")
+                .country("US")
+                .postalCode("80202")
+                .state("CO")
+            val result = checkout.updateBillingAddress(name = "Jane", address = address)
+            assertThat(result.isSuccess).isTrue()
+
+            val state = checkout.internalState
+            assertThat(state.billingName).isEqualTo("Jane")
+            assertThat(state.billingAddress?.country).isEqualTo("US")
+
+            val updated = checkoutSessionTurbine.awaitItem()
+            assertThat(updated.id).isEqualTo(initial.id)
+        }
 
     @Test
     fun `updateTaxId sends type and value and updates checkoutSession on success`() = runCreateWithStateScenario {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -217,12 +217,7 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario(
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                automaticTaxEnabled = true,
-                automaticTaxAddressSource = "shipping",
-            ),
-        ) {
+        runCreateWithStateScenario {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -268,12 +263,7 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "shipping",
-        ),
-    ) {
+    fun `updateShippingAddress returns failure on error response`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -290,12 +280,7 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "shipping",
-        ),
-    ) {
+    fun `updateShippingAddress omits empty fields from request`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -321,12 +306,7 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress sends address fields and updates checkoutSession on success`() =
-        runCreateWithStateScenario(
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                automaticTaxEnabled = true,
-                automaticTaxAddressSource = "billing",
-            ),
-        ) {
+        runCreateWithStateScenario {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
@@ -362,12 +342,7 @@ class CheckoutTest {
         }
 
     @Test
-    fun `updateBillingAddress returns failure on error response`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "billing",
-        ),
-    ) {
+    fun `updateBillingAddress returns failure on error response`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid address"}}""")
@@ -385,10 +360,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores address in internalState`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "shipping",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -421,10 +392,6 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress stores address in internalState`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "billing",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -457,10 +424,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "shipping",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -479,10 +442,6 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not store address in internalState on failure`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "billing",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -501,10 +460,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "shipping",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -520,10 +475,6 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress stores phoneNumber in internalState`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "billing",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -539,10 +490,6 @@ class CheckoutTest {
 
     @Test
     fun `updateShippingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "shipping",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -559,10 +506,6 @@ class CheckoutTest {
 
     @Test
     fun `updateBillingAddress does not store phoneNumber in internalState on failure`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "billing",
-        ),
         shouldValidateEvents = false,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -578,12 +521,7 @@ class CheckoutTest {
     }
 
     @Test
-    fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario(
-        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            automaticTaxAddressSource = "billing",
-        ),
-    ) {
+    fun `updateBillingAddress omits empty fields from request`() = runCreateWithStateScenario {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[postal_code]", "80202"),
@@ -614,8 +552,9 @@ class CheckoutTest {
                 automaticTaxEnabled = false,
                 automaticTaxAddressSource = "shipping",
             ),
+            shouldValidateEvents = false,
         ) {
-            val initial = checkoutSessionTurbine.awaitItem()
+            checkoutSessionTurbine.awaitItem()
 
             val address = Address()
                 .city("Denver")
@@ -625,15 +564,10 @@ class CheckoutTest {
             val result = checkout.updateShippingAddress(name = "John", address = address)
             assertThat(result.isSuccess).isTrue()
 
-            // State is updated locally without network call
             val state = checkout.internalState
             assertThat(state.shippingName).isEqualTo("John")
             assertThat(state.shippingAddress?.country).isEqualTo("US")
             assertThat(state.shippingAddress?.postalCode).isEqualTo("80202")
-
-            // CheckoutSession emission from local state mutation
-            val updated = checkoutSessionTurbine.awaitItem()
-            assertThat(updated.id).isEqualTo(initial.id)
         }
 
     @Test
@@ -643,8 +577,9 @@ class CheckoutTest {
                 automaticTaxEnabled = true,
                 automaticTaxAddressSource = "billing",
             ),
+            shouldValidateEvents = false,
         ) {
-            val initial = checkoutSessionTurbine.awaitItem()
+            checkoutSessionTurbine.awaitItem()
 
             val address = Address()
                 .city("Denver")
@@ -654,13 +589,9 @@ class CheckoutTest {
             val result = checkout.updateShippingAddress(name = "John", address = address)
             assertThat(result.isSuccess).isTrue()
 
-            // State is updated locally without network call
             val state = checkout.internalState
             assertThat(state.shippingName).isEqualTo("John")
             assertThat(state.shippingAddress?.country).isEqualTo("US")
-
-            val updated = checkoutSessionTurbine.awaitItem()
-            assertThat(updated.id).isEqualTo(initial.id)
         }
 
     @Test
@@ -670,8 +601,9 @@ class CheckoutTest {
                 automaticTaxEnabled = false,
                 automaticTaxAddressSource = "billing",
             ),
+            shouldValidateEvents = false,
         ) {
-            val initial = checkoutSessionTurbine.awaitItem()
+            checkoutSessionTurbine.awaitItem()
 
             val address = Address()
                 .city("Denver")
@@ -684,9 +616,6 @@ class CheckoutTest {
             val state = checkout.internalState
             assertThat(state.billingName).isEqualTo("Jane")
             assertThat(state.billingAddress?.country).isEqualTo("US")
-
-            val updated = checkoutSessionTurbine.awaitItem()
-            assertThat(updated.id).isEqualTo(initial.id)
         }
 
     @Test
@@ -696,8 +625,9 @@ class CheckoutTest {
                 automaticTaxEnabled = true,
                 automaticTaxAddressSource = "shipping",
             ),
+            shouldValidateEvents = false,
         ) {
-            val initial = checkoutSessionTurbine.awaitItem()
+            checkoutSessionTurbine.awaitItem()
 
             val address = Address()
                 .city("Denver")
@@ -710,9 +640,6 @@ class CheckoutTest {
             val state = checkout.internalState
             assertThat(state.billingName).isEqualTo("Jane")
             assertThat(state.billingAddress?.country).isEqualTo("US")
-
-            val updated = checkoutSessionTurbine.awaitItem()
-            assertThat(updated.id).isEqualTo(initial.id)
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -25,7 +25,7 @@ internal object CheckoutSessionResponseFactory {
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
-        automaticTaxEnabled: Boolean = false,
+        automaticTaxEnabled: Boolean = true,
         automaticTaxAddressSource: String? = null,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -25,7 +25,7 @@ internal object CheckoutSessionResponseFactory {
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
-        automaticTaxEnabled: Boolean = true,
+        automaticTaxEnabled: Boolean = false,
         automaticTaxAddressSource: String? = null,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -25,6 +25,8 @@ internal object CheckoutSessionResponseFactory {
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
+        automaticTaxEnabled: Boolean = false,
+        automaticTaxAddressSource: String? = null,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -44,6 +46,8 @@ internal object CheckoutSessionResponseFactory {
             lineItems = lineItems,
             shippingOptions = shippingOptions,
             adaptivePricingInfo = adaptivePricingInfo,
+            automaticTaxEnabled = automaticTaxEnabled,
+            automaticTaxAddressSource = automaticTaxAddressSource,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -26,7 +26,7 @@ internal object CheckoutSessionResponseFactory {
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
         automaticTaxEnabled: Boolean = false,
-        automaticTaxAddressSource: String? = null,
+        taxAddressSource: CheckoutSessionResponse.TaxAddressSource? = null,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -47,7 +47,7 @@ internal object CheckoutSessionResponseFactory {
             shippingOptions = shippingOptions,
             adaptivePricingInfo = adaptivePricingInfo,
             automaticTaxEnabled = automaticTaxEnabled,
-            automaticTaxAddressSource = automaticTaxAddressSource,
+            taxAddressSource = taxAddressSource,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1226,11 +1226,12 @@ class CheckoutSessionResponseJsonParserTest {
 
         assertThat(result).isNotNull()
         assertThat(result?.automaticTaxEnabled).isTrue()
-        assertThat(result?.automaticTaxAddressSource).isEqualTo("billing")
+        assertThat(result?.taxAddressSource)
+            .isEqualTo(CheckoutSessionResponse.TaxAddressSource.BILLING)
     }
 
     @Test
-    fun `parse automatic tax address source strips session prefix`() {
+    fun `parse taxAddressSource is null when automatic_tax_enabled but address_source missing`() {
         val json = JSONObject(
             """
             {
@@ -1238,8 +1239,7 @@ class CheckoutSessionResponseJsonParserTest {
                 "ui_mode": "custom",
                 "currency": "usd",
                 "tax_context": {
-                    "automatic_tax_enabled": true,
-                    "automatic_tax_address_source": "session.shipping"
+                    "automatic_tax_enabled": true
                 },
                 "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
             }
@@ -1249,30 +1249,7 @@ class CheckoutSessionResponseJsonParserTest {
 
         assertThat(result).isNotNull()
         assertThat(result?.automaticTaxEnabled).isTrue()
-        assertThat(result?.automaticTaxAddressSource).isEqualTo("shipping")
-    }
-
-    @Test
-    fun `parse automatic tax address source without session prefix is used as-is`() {
-        val json = JSONObject(
-            """
-            {
-                "session_id": "cs_test_123",
-                "ui_mode": "custom",
-                "currency": "usd",
-                "tax_context": {
-                    "automatic_tax_enabled": true,
-                    "automatic_tax_address_source": "billing"
-                },
-                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
-            }
-            """.trimIndent()
-        )
-        val result = CheckoutSessionResponseJsonParser.parse(json)
-
-        assertThat(result).isNotNull()
-        assertThat(result?.automaticTaxEnabled).isTrue()
-        assertThat(result?.automaticTaxAddressSource).isEqualTo("billing")
+        assertThat(result?.taxAddressSource).isNull()
     }
 
     @Test
@@ -1291,6 +1268,6 @@ class CheckoutSessionResponseJsonParserTest {
 
         assertThat(result).isNotNull()
         assertThat(result?.automaticTaxEnabled).isFalse()
-        assertThat(result?.automaticTaxAddressSource).isNull()
+        assertThat(result?.taxAddressSource).isNull()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1205,4 +1205,92 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result).isNotNull()
         assertThat(result?.taxStatus).isEqualTo(CheckoutSessionResponse.TaxStatus.UNKNOWN)
     }
+
+    @Test
+    fun `parse automatic tax enabled and address source from tax_context`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "tax_context": {
+                    "automatic_tax_enabled": true,
+                    "automatic_tax_address_source": "session.billing"
+                },
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.automaticTaxEnabled).isTrue()
+        assertThat(result?.automaticTaxAddressSource).isEqualTo("billing")
+    }
+
+    @Test
+    fun `parse automatic tax address source strips session prefix`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "tax_context": {
+                    "automatic_tax_enabled": true,
+                    "automatic_tax_address_source": "session.shipping"
+                },
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.automaticTaxEnabled).isTrue()
+        assertThat(result?.automaticTaxAddressSource).isEqualTo("shipping")
+    }
+
+    @Test
+    fun `parse automatic tax address source without session prefix is used as-is`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "tax_context": {
+                    "automatic_tax_enabled": true,
+                    "automatic_tax_address_source": "billing"
+                },
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.automaticTaxEnabled).isTrue()
+        assertThat(result?.automaticTaxAddressSource).isEqualTo("billing")
+    }
+
+    @Test
+    fun `parse defaults automaticTaxEnabled to false when tax_context is missing`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.automaticTaxEnabled).isFalse()
+        assertThat(result?.automaticTaxAddressSource).isNull()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
@@ -277,6 +277,8 @@ internal class CreateCustomerMetadataTest {
                     lineItems = emptyList(),
                     shippingOptions = emptyList(),
                     adaptivePricingInfo = null,
+                    automaticTaxEnabled = false,
+                    automaticTaxAddressSource = null,
                 ),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
@@ -278,7 +278,7 @@ internal class CreateCustomerMetadataTest {
                     shippingOptions = emptyList(),
                     adaptivePricingInfo = null,
                     automaticTaxEnabled = false,
-                    automaticTaxAddressSource = null,
+                    taxAddressSource = null,
                 ),
             )
         }


### PR DESCRIPTION
## Summary

Only send `tax_region` to the server when `automatic_tax` is enabled AND `tax_address_source` matches the address type being updated (shipping or billing). When the condition is not met, the address is stored locally without making a separate network call. This aligns Android behavior with the iOS `shouldSendTaxRegion(for:)` logic and EwCS `AutomaticTaxHelpers.ts`.

## Changes

- Parse `tax_context` from the init/update response into `automaticTaxEnabled: Boolean` and `taxAddressSource: TaxAddressSource?` enum
- Consolidate `tax_context` parsing into a single pass (shared between `taxStatus` and the new fields)
- Make `updateShippingAddress`/`updateBillingAddress` conditional: send `tax_region` only when applicable, otherwise store locally
- Route both paths through `withInternalState` (mutex-serialized, matching iOS's `enqueueSessionUpdate` pattern)
- Extract `updateAddress` helper to deduplicate shipping/billing logic
- Update KDoc to match iOS: "stores locally, conditionally sends for tax"

## Platform alignment

| Behavior | iOS | Web (EwCS) | Android (this PR) |
|----------|-----|------------|-------------------|
| Condition | `automaticTaxEnabled && automaticTaxAddressSource == addressType` | `isAutomaticTaxEnabled && mode === addressTypeForTax(store)` | `automaticTaxEnabled && taxAddressSource == addressType` |
| Null source | Does not send | Does not send (`addressTypeForTax` returns null) | Does not send |
| Local mutation serialization | Goes through `enqueueSessionUpdate` | Goes through `updateQueue` | Goes through `withInternalState` (mutex) |

## Testing

- [x] Added tests for conditional behavior (4 scenarios: tax disabled, source mismatch for each address type)
- [x] Added parser test for `automatic_tax_enabled: true` with missing `automatic_tax_address_source`
- [x] Updated existing tests to provide tax config when expecting network calls
- [x] Manually verified with real server (tax-enabled merchant)

## Changelog

Not a user-facing change; internal optimization for Checkout Elements address update behavior.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)