### PR TITLE
Refactor transformGoogleToStripeAddress to accept Locale instead of Context

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -1,12 +1,7 @@
 package com.stripe.android.ui.core.elements.autocomplete.model
 
-import android.content.Context
-import android.os.Build
 import androidx.annotation.RestrictTo
 import java.util.Locale
-
-// Largely duplicated from
-// https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/1c111621/src/elements/inner/autocomplete_suggestions/utils/transformGoogleToStripeAddress.ts#L248-L325
 
 internal data class AddressLine1(
     var streetNumber: String? = null,
@@ -51,7 +46,7 @@ internal fun Place.filter(type: Place.Type): AddressComponent? {
 }
 
 internal fun composeAddressLine1(
-    context: Context,
+    locale: Locale,
     addressLine1: AddressLine1,
     address: Address
 ): String {
@@ -62,7 +57,7 @@ internal fun composeAddressLine1(
 
     return if (countryCode == "JP") {
         val premise = address.addressLine2
-        composeJapaneseAddressLine1(context, addressLine1, locality, premise)
+        composeJapaneseAddressLine1(locale, addressLine1, locality, premise)
     } else if (streetNumber.isNotBlank() || streetName.isNotBlank()) {
         // Depending on the country we'll want either
         // "123 King Street" or "King Street 123"
@@ -77,7 +72,7 @@ internal fun composeAddressLine1(
 }
 
 internal fun composeJapaneseAddressLine1(
-    context: Context,
+    locale: Locale,
     addressLine1: AddressLine1,
     localityComponent: String?,
     premiseComponent: String?
@@ -93,12 +88,6 @@ internal fun composeJapaneseAddressLine1(
     val municipality = addressLine1.subLocalityLevel2
 
     val composite: String
-
-    val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        context.resources.configuration.locales.get(0)
-    } else {
-        context.resources.configuration.locale
-    }
 
     if (locale == Locale.JAPANESE) {
         // In Japanese, address line 1 components should be in this order:
@@ -180,7 +169,7 @@ internal fun Address.modifyStripeAddressByCountry(place: Place): Address {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Place.transformGoogleToStripeAddress(
-    context: Context
+    locale: Locale
 ): com.stripe.android.model.Address {
     var address = Address()
     val addressLine1 = AddressLine1()
@@ -250,7 +239,7 @@ fun Place.transformGoogleToStripeAddress(
         }
     }
 
-    address.addressLine1 = composeAddressLine1(context, addressLine1, address)
+    address.addressLine1 = composeAddressLine1(locale, addressLine1, address)
     address = address.modifyStripeAddressByCountry(this)
 
     return com.stripe.android.model.Address.Builder()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddressTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddressTest.kt
@@ -1,18 +1,15 @@
 package com.stripe.android.ui.core.elements.autocomplete.model
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 class TransformGoogleToStripeAddressTest {
-
-    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
     fun `test US address without sublocality`() {
@@ -65,7 +62,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val stripeAddress = place.transformGoogleToStripeAddress(Locale.getDefault())
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -130,7 +127,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val stripeAddress = place.transformGoogleToStripeAddress(Locale.getDefault())
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -190,7 +187,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val stripeAddress = place.transformGoogleToStripeAddress(Locale.getDefault())
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -250,7 +247,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val stripeAddress = place.transformGoogleToStripeAddress(Locale.getDefault())
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -320,7 +317,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val stripeAddress = place.transformGoogleToStripeAddress(Locale.getDefault())
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -385,7 +382,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val stripeAddress = place.transformGoogleToStripeAddress(Locale.getDefault())
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -450,7 +447,7 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        assertThat(place.transformGoogleToStripeAddress(context)).isEqualTo(
+        assertThat(place.transformGoogleToStripeAddress(Locale.getDefault())).isEqualTo(
             Address(
                 city = "New York",
                 country = "US",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
 import com.stripe.android.R as StripeR
@@ -115,7 +117,8 @@ internal class AutocompleteViewModel @Inject constructor(
             )?.fold(
                 onSuccess = {
                     _loading.value = false
-                    val address = it.place.transformGoogleToStripeAddress(getApplication())
+                    val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+                    val address = it.place.transformGoogleToStripeAddress(locale)
 
                     _event.emit(
                         Event.GoBack(


### PR DESCRIPTION

Avoids capturing Context in ViewModels which can cause memory leaks. The locale is used only for Japanese address formatting logic. Callers now pass Locale.getDefault() instead of a Context reference. 

# Summary
<!-- Simple summary of what was changed. -->

Refactored `transformGoogleToStripeAddress` and its internal helpers to accept `Locale` instead of `Context`. The caller in `AutocompleteViewModel` now resolves the locale via `AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()`, matching the existing pattern in `ExpiryDateContentDescriptionFormatter`. More simply, the function only needed Context to get the user's locale (for Japanese address formatting). Instead of passing the whole Context, which is heavy and causes memory leaks if held in a ViewModel, we now just pass the Locale directly.The caller figures out the locale the same way the rest of the codebase does.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This is pre-work for the inline autocomplete dropdown feature. Reviewer feedback identified that passing `Context` into `transformGoogleToStripeAddress` encourages capturing it in ViewModels, which leads to memory leaks. Since the only use of `Context` was to extract the locale for Japanese address formatting, accepting `Locale` directly is sufficient. (feedback from https://github.com/stripe/stripe-android/pull/13273#discussion_r3455887612)


## Context
**Issue**: When a user picks an address from Google Places autocomplete, the SDK converts Google's address into Stripe's format. That conversion depends on locale, especially for Japanese addresses, where the order of address parts changes based on whether the locale is Japanese.The previous code used Locale.getDefault(), which is the device/system language, not necessarily the app's language. If a user sets the app to Japanese but their phone is set to English, address line 1 could be formatted incorrectly.

**Solution**: use AppCompatDelegate.getApplicationLocales() , which returns the locale the app is actually running in. It falls back to Locale.getDefault() only if no app locale is set.So address formatting now matches what the user sees in the UI, not what the phone's system settings are.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

Updated all existing `TransformGoogleToStripeAddressTest` cases to pass `Locale` instead of `Context`

