### PR TITLE
Add `NfcHardwareDelegate` and use when checking availability

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.nfcscan
 
+import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegate
 import com.stripe.android.common.nfcscan.security.IsDeviceSecureForNfc
 import com.stripe.android.core.utils.FeatureFlags.enableNfcScanning
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
@@ -16,7 +17,8 @@ internal interface IsNfcScanningAvailable {
 
 internal class DefaultIsNfcScanningAvailable @Inject constructor(
     val isDeviceSecureForNfc: IsDeviceSecureForNfc,
-    val tapToAddAvailabilityFactory: TapToAddAvailabilityFactory
+    val tapToAddAvailabilityFactory: TapToAddAvailabilityFactory,
+    val nfcHardwareDelegate: NfcHardwareDelegate,
 ) : IsNfcScanningAvailable {
     override fun get(
         elementsSession: ElementsSession,
@@ -24,6 +26,7 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
     ): Boolean {
         return enableNfcScanning.isEnabled &&
             !tapToAddAvailabilityFactory.isAvailable(elementsSession, customerMetadata) &&
-            isDeviceSecureForNfc.get()
+            isDeviceSecureForNfc.get() &&
+            nfcHardwareDelegate.isAvailable()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAvailabilityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAvailabilityModule.kt
@@ -1,10 +1,16 @@
 package com.stripe.android.common.nfcscan
 
+import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegateModule
 import com.stripe.android.common.nfcscan.security.NfcSecurityModule
 import dagger.Binds
 import dagger.Module
 
-@Module(includes = [NfcSecurityModule::class])
+@Module(
+    includes = [
+        NfcSecurityModule::class,
+        NfcHardwareDelegateModule::class,
+    ]
+)
 internal interface NfcScanningAvailabilityModule {
     @Binds
     fun bindsIsNfcScanningAvailable(isNfcScanningAvailable: DefaultIsNfcScanningAvailable): IsNfcScanningAvailable

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegate.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.common.nfcscan.hardware
+
+import android.content.Context
+import android.nfc.NfcAdapter
+import javax.inject.Inject
+
+internal interface NfcHardwareDelegate {
+    fun isAvailable(): Boolean
+}
+
+internal class DefaultNfcHardwareDelegate @Inject constructor(
+    context: Context
+) : NfcHardwareDelegate {
+    private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(context)
+
+    override fun isAvailable(): Boolean {
+        return nfcAdapter?.isEnabled == true
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateModule.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.common.nfcscan.hardware
+
+import dagger.Binds
+import dagger.Module
+
+@Module
+internal interface NfcHardwareDelegateModule {
+    @Binds
+    fun bindsNfcHardwareDelegate(
+        delegate: DefaultNfcHardwareDelegate
+    ): NfcHardwareDelegate
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.nfcscan
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.hardware.FakeNfcHardwareDelegate
 import com.stripe.android.common.nfcscan.security.FakeIsDeviceSecureForNfc
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
@@ -29,6 +30,7 @@ internal class IsNfcScanningAvailableTest {
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
             isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
+            nfcHardwareDelegate = FakeNfcHardwareDelegate(result = true),
         )
 
         assertThat(isNfcScanningAvailable.get(elementsSession, customerMetadata)).isFalse()
@@ -41,6 +43,7 @@ internal class IsNfcScanningAvailableTest {
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
             isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = true),
+            nfcHardwareDelegate = FakeNfcHardwareDelegate(result = true),
         )
 
         assertThat(isNfcScanningAvailable.get(elementsSession, customerMetadata)).isFalse()
@@ -53,18 +56,33 @@ internal class IsNfcScanningAvailableTest {
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
             isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = false),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
+            nfcHardwareDelegate = FakeNfcHardwareDelegate(result = true),
         )
 
         assertThat(isNfcScanningAvailable.get(elementsSession, customerMetadata)).isFalse()
     }
 
     @Test
-    fun `IsNfcScanningAvailableForPaymentElement returns true when NFC flag on, tap to add unavailable, and secure`() {
+    fun `IsNfcScanningAvailableForPaymentElement returns false when NFC hardware is unavailable`() {
         FeatureFlags.enableNfcScanning.setEnabled(true)
 
         val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
             isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
             tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
+            nfcHardwareDelegate = FakeNfcHardwareDelegate(result = false),
+        )
+
+        assertThat(isNfcScanningAvailable.get(elementsSession, customerMetadata)).isFalse()
+    }
+
+    @Test
+    fun `IsNfcScanningAvailableForPaymentElement returns true when flag on, TTA off, and NFC enabled & secure`() {
+        FeatureFlags.enableNfcScanning.setEnabled(true)
+
+        val isNfcScanningAvailable = DefaultIsNfcScanningAvailable(
+            isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = true),
+            tapToAddAvailabilityFactory = FakeTapToAddAvailabilityFactory(isAvailableResult = false),
+            nfcHardwareDelegate = FakeNfcHardwareDelegate(result = true),
         )
 
         assertThat(isNfcScanningAvailable.get(elementsSession, customerMetadata)).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/FakeNfcHardwareDelegate.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/FakeNfcHardwareDelegate.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.common.nfcscan.hardware
+
+internal class FakeNfcHardwareDelegate(
+    private val result: Boolean = true,
+) : NfcHardwareDelegate {
+    override fun isAvailable(): Boolean = result
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateTest.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.common.nfcscan.hardware
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.nfc.NfcAdapter
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+internal class NfcHardwareDelegateTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `isAvailable returns false when device has no NFC hardware`() = test(
+        hasNfcFeature = false,
+    ) {
+        assertThat(delegate.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `isAvailable returns false when NFC adapter is available but disabled`() = test(
+        hasNfcFeature = true,
+        isNfcEnabled = false,
+    ) {
+        assertThat(delegate.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `isAvailable returns true when NFC adapter is available & enabled`() = test(
+        hasNfcFeature = true,
+        isNfcEnabled = true,
+    ) {
+        assertThat(delegate.isAvailable()).isTrue()
+    }
+
+    private fun test(
+        hasNfcFeature: Boolean = true,
+        isNfcEnabled: Boolean = true,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        shadowOf(context.packageManager)
+            .setSystemFeature(PackageManager.FEATURE_NFC, hasNfcFeature)
+
+        if (hasNfcFeature) {
+            val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+            shadowOf(nfcAdapter).setEnabled(isNfcEnabled)
+        }
+
+        block(Scenario(DefaultNfcHardwareDelegate(context)))
+    }
+
+    private class Scenario(
+        val delegate: NfcHardwareDelegate,
+    )
+}


### PR DESCRIPTION
# Summary
Add `NfcHardwareDelegate` and use when checking availability for `IsNfcScanningAvailable`.

# Motivation
Setup for NFC scanner UI and improvement on availability check.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified