### PR TITLE
Add inline address autocomplete feature flag to playground settings

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -597,6 +597,14 @@ internal class PlaygroundSettings private constructor(
             CaptureMethodSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.enableNfcScanning),
             FeatureFlagSettingsDefinition(FeatureFlags.disableNfcScanningSecurity),
+            FeatureFlagSettingsDefinition(
+                FeatureFlags.inlineAddressAutocompleteEnabled,
+                listOf(
+                    PlaygroundConfigurationData.IntegrationType.PaymentSheet,
+                    PlaygroundConfigurationData.IntegrationType.FlowController,
+                    PlaygroundConfigurationData.IntegrationType.Embedded,
+                ),
+            ),
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -597,14 +597,7 @@ internal class PlaygroundSettings private constructor(
             CaptureMethodSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.enableNfcScanning),
             FeatureFlagSettingsDefinition(FeatureFlags.disableNfcScanningSecurity),
-            FeatureFlagSettingsDefinition(
-                FeatureFlags.inlineAddressAutocompleteEnabled,
-                listOf(
-                    PlaygroundConfigurationData.IntegrationType.PaymentSheet,
-                    PlaygroundConfigurationData.IntegrationType.FlowController,
-                    PlaygroundConfigurationData.IntegrationType.Embedded,
-                ),
-            ),
+            FeatureFlagSettingsDefinition(FeatureFlags.inlineAddressAutocompleteEnabled),
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
@@ -207,6 +208,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                 autocompleteConfig = AutocompleteAddressInteractor.Config(
                                     googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
                                     autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+                                    isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
                                 )
                             ),
                             isLinkUI = true,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -208,7 +208,8 @@ internal class PaymentMethodViewModel @Inject constructor(
                                 autocompleteConfig = AutocompleteAddressInteractor.Config(
                                     googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
                                     autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-                                    isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
+                                    isInlineAutocompleteEnabled =
+                                        FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
                                 )
                             ),
                             isLinkUI = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -85,6 +86,7 @@ internal abstract class BaseSheetViewModel(
             autocompleteConfig = AutocompleteAddressInteractor.Config(
                 googlePlacesApiKey = config.googlePlacesApiKey,
                 autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+                isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
             )
         )
 


### PR DESCRIPTION

# Summary
<!-- Simple summary of what was changed. -->
Add the existing inlineAddressAutocompleteEnabled feature flag to the playground UI settings so it can be toggled for PaymentSheet, FlowController, and Embedded integration types.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The feature flag for inline address autocomplete already exists in `FeatureFlags.kt` but was not wired into the playground settings UI. This change allows developers to toggle the flag from the playground during development and testing.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


