### PR TITLE
[fc] Hide ANRs error dialogs in E2E tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -245,6 +245,13 @@ workflows:
                 adb logcat > /tmp/logcat.txt 2>&1 &
                 echo $! > /tmp/logcat.pid
       - script@1:
+          title: Set up emulator for Maestro tests
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # Suppress ANR/crash dialogs that can interrupt Maestro test flows.
+                adb shell settings put global hide_error_dialogs 1
+      - script@1:
           title: Execute Maestro tests
           inputs:
             - content: |-


### PR DESCRIPTION
# Summary
Prior art: https://chromium.googlesource.com/chromium/src/+/8839cf4898d5714727530f6e8a840ba53230a341%5E%21/

# Motivation
[RUN_LINK_MOBILE-193](https://go/jira/RUN_LINK_MOBILE-193)

# Testing
Run CI multiple times