### PR TITLE
Enforce single Checkout instance per key

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -121,10 +121,7 @@ class Checkout private constructor(
         }
 
         /**
-         * Recreates a [Checkout] from a previously saved [State], such as after process death.
-         *
-         * If a live instance already exists for the same key, it is returned directly and the
-         * provided [state] is ignored.
+         * Returns the existing [Checkout] if one is still alive, or creates a new one from [state].
          */
         fun createWithState(
             context: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -78,15 +78,18 @@ class Checkout private constructor(
                 adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
             ).map { response ->
                 val flagImages = prefetchFlagImages(context, response, component)
-                Checkout(
-                    internalState = InternalState(
-                        key = UUID.randomUUID().toString(),
-                        configuration = configurationState,
-                        checkoutSessionResponse = response,
-                        flagImages = flagImages,
-                    ),
-                    component = component,
-                )
+                val key = UUID.randomUUID().toString()
+                CheckoutInstances.getOrCreate(key) {
+                    Checkout(
+                        internalState = InternalState(
+                            key = key,
+                            configuration = configurationState,
+                            checkoutSessionResponse = response,
+                            flagImages = flagImages,
+                        ),
+                        component = component,
+                    )
+                }
             }
         }
 
@@ -410,10 +413,6 @@ class Checkout private constructor(
      * Whether a mutation is currently in progress.
      */
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-
-    init {
-        CheckoutInstances.add(internalState.key, this)
-    }
 
     /**
      * Applies a promotion code to the checkout session.

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -124,8 +124,7 @@ class Checkout private constructor(
          * Recreates a [Checkout] from a previously saved [State], such as after process death.
          *
          * If a live instance already exists for the same key, it is returned directly and the
-         * provided [state] is ignored. This ensures a single [Checkout] object per session key
-         * across Activity boundaries, so mutations are serialized and observable from all holders.
+         * provided [state] is ignored.
          */
         fun createWithState(
             context: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -122,17 +122,23 @@ class Checkout private constructor(
 
         /**
          * Recreates a [Checkout] from a previously saved [State], such as after process death.
+         *
+         * If a live instance already exists for the same key, it is returned directly and the
+         * provided [state] is ignored. This ensures a single [Checkout] object per session key
+         * across Activity boundaries, so mutations are serialized and observable from all holders.
          */
         fun createWithState(
             context: Context,
             state: State,
         ): Checkout {
-            val application = context.applicationContext as Application
-            val component = DaggerCheckoutComponent.factory().create(application)
-            return Checkout(
-                internalState = state.internalState,
-                component = component,
-            )
+            return CheckoutInstances.getOrCreate(state.internalState.key) {
+                val application = context.applicationContext as Application
+                val component = DaggerCheckoutComponent.factory().create(application)
+                Checkout(
+                    internalState = state.internalState,
+                    component = component,
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -25,12 +25,6 @@ internal object CheckoutInstances {
         return checkout
     }
 
-    @VisibleForTesting
-    @Synchronized
-    fun add(key: String, checkout: Checkout) {
-        instanceMap[key] = WeakReference(checkout)
-    }
-
     @Synchronized
     fun ensureNoMutationInFlight(key: String) {
         this[key]?.ensureNoMutationInFlight()

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -8,31 +8,42 @@ import java.lang.ref.WeakReference
 
 @OptIn(CheckoutSessionPreview::class)
 internal object CheckoutInstances {
-    private val instanceMap = mutableMapOf<String, MutableList<WeakReference<Checkout>>>()
+    private val instanceMap = mutableMapOf<String, WeakReference<Checkout>>()
 
-    operator fun get(key: String): List<Checkout> {
-        val refs = instanceMap[key] ?: return emptyList()
-        val live = refs.mapNotNull { it.get() }
-        if (live.isEmpty()) {
-            instanceMap.remove(key)
-        } else if (live.size != refs.size) {
-            // Prune stale references
-            refs.clear()
-            refs.addAll(live.map { WeakReference(it) })
-        }
-        return live
+    @Synchronized
+    operator fun get(key: String): Checkout? {
+        val checkout = instanceMap[key]?.get()
+        if (checkout == null) instanceMap.remove(key)
+        return checkout
     }
 
+    // The factory runs under this lock. Checkout's init block calls add() which re-acquires the
+    // same monitor (reentrant). This is intentional: it keeps the check-then-create atomic so two
+    // concurrent callers cannot both create an instance for the same key.
+    @Synchronized
+    fun getOrCreate(key: String, factory: () -> Checkout): Checkout {
+        this[key]?.let { return it }
+        return factory()
+    }
+
+    @Synchronized
+    fun add(key: String, checkout: Checkout) {
+        instanceMap[key] = WeakReference(checkout)
+    }
+
+    @Synchronized
     fun ensureNoMutationInFlight(key: String) {
-        this[key].forEach { it.ensureNoMutationInFlight() }
+        this[key]?.ensureNoMutationInFlight()
     }
 
+    @Synchronized
     fun markIntegrationLaunched(key: String) {
-        this[key].forEach { it.markIntegrationLaunched() }
+        this[key]?.markIntegrationLaunched()
     }
 
+    @Synchronized
     fun markIntegrationDismissed(key: String) {
-        this[key].forEach { it.markIntegrationDismissed() }
+        this[key]?.markIntegrationDismissed()
     }
 
     fun markIntegrationDismissed(paymentMethodMetadata: PaymentMethodMetadata?) {
@@ -41,16 +52,13 @@ internal object CheckoutInstances {
         markIntegrationDismissed(checkoutSession.instancesKey)
     }
 
-    fun add(key: String, checkout: Checkout) {
-        val refs = instanceMap.getOrPut(key) { mutableListOf() }
-        refs.add(WeakReference(checkout))
-    }
-
+    @Synchronized
     fun remove(key: String) {
         instanceMap.remove(key)
     }
 
     @VisibleForTesting
+    @Synchronized
     fun clear() {
         instanceMap.clear()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -52,6 +52,7 @@ internal object CheckoutInstances {
         markIntegrationDismissed(checkoutSession.instancesKey)
     }
 
+    @VisibleForTesting
     @Synchronized
     fun remove(key: String) {
         instanceMap.remove(key)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -17,15 +17,15 @@ internal object CheckoutInstances {
         return checkout
     }
 
-    // The factory runs under this lock. Checkout's init block calls add() which re-acquires the
-    // same monitor (reentrant). This is intentional: it keeps the check-then-create atomic so two
-    // concurrent callers cannot both create an instance for the same key.
     @Synchronized
     fun getOrCreate(key: String, factory: () -> Checkout): Checkout {
         this[key]?.let { return it }
-        return factory()
+        val checkout = factory()
+        instanceMap[key] = WeakReference(checkout)
+        return checkout
     }
 
+    @VisibleForTesting
     @Synchronized
     fun add(key: String, checkout: Checkout) {
         instanceMap[key] = WeakReference(checkout)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -54,12 +54,6 @@ internal object CheckoutInstances {
 
     @VisibleForTesting
     @Synchronized
-    fun remove(key: String) {
-        instanceMap.remove(key)
-    }
-
-    @VisibleForTesting
-    @Synchronized
     fun clear() {
         instanceMap.clear()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -14,7 +14,7 @@ internal object GooglePayDisplayItemsFactory {
         val checkoutSessionMetadata = paymentMethodMetadata.integrationMetadata
             as? IntegrationMetadata.CheckoutSession ?: return emptyList()
 
-        val checkout = CheckoutInstances[checkoutSessionMetadata.instancesKey].firstOrNull()
+        val checkout = CheckoutInstances[checkoutSessionMetadata.instancesKey]
             ?: return emptyList()
 
         val checkoutSession = checkout.checkoutSession.value

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -143,9 +143,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     private fun handleConfirmResponse(
         response: CheckoutSessionResponse,
     ): ConfirmationDefinition.Action<Args> {
-        CheckoutInstances[integrationMetadata.instancesKey].forEach { checkout ->
-            checkout.updateWithResponse(response)
-        }
+        CheckoutInstances[integrationMetadata.instancesKey]?.updateWithResponse(response)
 
         val intent: StripeIntent = response.paymentIntent ?: response.setupIntent
             ?: run {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -7,8 +7,8 @@ import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.PaymentConfigurationTestRule
-import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import android.app.Application
+import app.cash.turbine.test
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.checkoutUpdate
@@ -194,16 +195,20 @@ class CheckoutInstancesTest {
             response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
         }
 
-        val job = async { checkoutB.removePromotionCode() }
-        testScheduler.advanceUntilIdle()
+        checkoutA.isLoading.test {
+            assertThat(awaitItem()).isFalse()
 
-        // A observes isLoading because it's the same instance as B
-        assertThat(checkoutA.isLoading.value).isTrue()
+            val job = async { checkoutB.removePromotionCode() }
+            testScheduler.advanceUntilIdle()
 
-        holdResponse.countDown()
-        job.await()
+            assertThat(awaitItem()).isTrue()
 
-        assertThat(checkoutA.isLoading.value).isFalse()
+            holdResponse.countDown()
+            job.await()
+
+            assertThat(awaitItem()).isFalse()
+        }
+
         assertThat(checkoutA.checkoutSession.value).isEqualTo(checkoutB.checkoutSession.value)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -81,7 +81,7 @@ class CheckoutInstancesTest {
 
         networkRule.checkoutUpdate { response ->
             requestArrived.countDown()
-            holdResponse.await()
+            holdResponse.await(10, TimeUnit.SECONDS)
             response.setBody("{}")
         }
 
@@ -191,7 +191,7 @@ class CheckoutInstancesTest {
         val holdResponse = CountDownLatch(1)
 
         networkRule.checkoutUpdate { response ->
-            holdResponse.await()
+            holdResponse.await(10, TimeUnit.SECONDS)
             response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
         }
 
@@ -224,7 +224,7 @@ class CheckoutInstancesTest {
         val secondRequestArrived = CountDownLatch(1)
 
         networkRule.checkoutUpdate { response ->
-            holdFirstResponse.await()
+            holdFirstResponse.await(10, TimeUnit.SECONDS)
             response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.checkout
 
 import android.app.Application
-import app.cash.turbine.test
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
@@ -46,26 +46,11 @@ class CheckoutInstancesTest {
     }
 
     @Test
-    fun `add and get round-trips single instance`() {
-        val checkout = createCheckout(key = "key1")
-        CheckoutInstances.clear()
-
-        CheckoutInstances.add("key1", checkout)
-
-        assertThat(CheckoutInstances["key1"]).isSameInstanceAs(checkout)
-    }
-
-    @Test
-    fun `multiple keys coexist independently`() {
+    fun `different keys produce different instances`() {
         val checkout1 = createCheckout(key = "key1")
         val checkout2 = createCheckout(key = "key2")
-        CheckoutInstances.clear()
 
-        CheckoutInstances.add("key1", checkout1)
-        CheckoutInstances.add("key2", checkout2)
-
-        assertThat(CheckoutInstances["key1"]).isSameInstanceAs(checkout1)
-        assertThat(CheckoutInstances["key2"]).isSameInstanceAs(checkout2)
+        assertThat(checkout1).isNotSameInstanceAs(checkout2)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -38,8 +38,6 @@ class CheckoutInstancesTest {
         CheckoutInstances.clear()
     }
 
-    // --- Registry basics (single entry per key) ---
-
     @Test
     fun `get returns null for unknown key`() {
         assertThat(CheckoutInstances["unknown-key"]).isNull()
@@ -95,8 +93,6 @@ class CheckoutInstancesTest {
         assertThat(CheckoutInstances["key2"]).isSameInstanceAs(checkout2)
     }
 
-    // --- ensureNoMutationInFlight ---
-
     @Test
     fun `ensureNoMutationInFlight does not throw for unknown key`() {
         CheckoutInstances.ensureNoMutationInFlight("unknown-key")
@@ -132,8 +128,6 @@ class CheckoutInstancesTest {
         }
     }
 
-    // --- markIntegrationLaunched/Dismissed ---
-
     @Test
     fun `markIntegrationLaunched blocks mutations`() = runTest {
         val checkout = createCheckout(key = "key1")
@@ -161,8 +155,6 @@ class CheckoutInstancesTest {
         assertThat(result.isFailure).isTrue()
         assertThat(result.exceptionOrNull()).isNotInstanceOf(IllegalStateException::class.java)
     }
-
-    // --- Dedup behavior (createWithState) ---
 
     @Test
     fun `createWithState returns same instance when checkout exists for key`() {
@@ -300,8 +292,6 @@ class CheckoutInstancesTest {
             jobA.join()
         }
     }
-
-    // --- getOrCreate ---
 
     @Test
     fun `getOrCreate returns existing instance without calling factory`() {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -54,18 +54,6 @@ class CheckoutInstancesTest {
     }
 
     @Test
-    fun `remove clears instance for a key`() {
-        val checkout = createCheckout(key = "key1")
-        CheckoutInstances.clear()
-
-        CheckoutInstances.add("key1", checkout)
-        assertThat(CheckoutInstances["key1"]).isNotNull()
-
-        CheckoutInstances.remove("key1")
-        assertThat(CheckoutInstances["key1"]).isNull()
-    }
-
-    @Test
     fun `clear empties the map`() {
         val checkout1 = createCheckout(key = "key1")
         val checkout2 = createCheckout(key = "key2")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -38,9 +38,11 @@ class CheckoutInstancesTest {
         CheckoutInstances.clear()
     }
 
+    // --- Registry basics (single entry per key) ---
+
     @Test
-    fun `get returns empty list for unknown key`() {
-        assertThat(CheckoutInstances["unknown-key"]).isEmpty()
+    fun `get returns null for unknown key`() {
+        assertThat(CheckoutInstances["unknown-key"]).isNull()
     }
 
     @Test
@@ -50,31 +52,19 @@ class CheckoutInstancesTest {
 
         CheckoutInstances.add("key1", checkout)
 
-        assertThat(CheckoutInstances["key1"]).containsExactly(checkout)
+        assertThat(CheckoutInstances["key1"]).isSameInstanceAs(checkout)
     }
 
     @Test
-    fun `add multiple instances with same key returns all`() {
-        val checkout1 = createCheckout(key = "key1")
-        val checkout2 = createCheckout(key = "key1")
-        CheckoutInstances.clear()
-
-        CheckoutInstances.add("key1", checkout1)
-        CheckoutInstances.add("key1", checkout2)
-
-        assertThat(CheckoutInstances["key1"]).containsExactly(checkout1, checkout2)
-    }
-
-    @Test
-    fun `remove clears all instances for a key`() {
+    fun `remove clears instance for a key`() {
         val checkout = createCheckout(key = "key1")
         CheckoutInstances.clear()
 
         CheckoutInstances.add("key1", checkout)
-        assertThat(CheckoutInstances["key1"]).isNotEmpty()
+        assertThat(CheckoutInstances["key1"]).isNotNull()
 
         CheckoutInstances.remove("key1")
-        assertThat(CheckoutInstances["key1"]).isEmpty()
+        assertThat(CheckoutInstances["key1"]).isNull()
     }
 
     @Test
@@ -88,9 +78,24 @@ class CheckoutInstancesTest {
 
         CheckoutInstances.clear()
 
-        assertThat(CheckoutInstances["key1"]).isEmpty()
-        assertThat(CheckoutInstances["key2"]).isEmpty()
+        assertThat(CheckoutInstances["key1"]).isNull()
+        assertThat(CheckoutInstances["key2"]).isNull()
     }
+
+    @Test
+    fun `multiple keys coexist independently`() {
+        val checkout1 = createCheckout(key = "key1")
+        val checkout2 = createCheckout(key = "key2")
+        CheckoutInstances.clear()
+
+        CheckoutInstances.add("key1", checkout1)
+        CheckoutInstances.add("key2", checkout2)
+
+        assertThat(CheckoutInstances["key1"]).isSameInstanceAs(checkout1)
+        assertThat(CheckoutInstances["key2"]).isSameInstanceAs(checkout2)
+    }
+
+    // --- ensureNoMutationInFlight ---
 
     @Test
     fun `ensureNoMutationInFlight does not throw for unknown key`() {
@@ -127,64 +132,201 @@ class CheckoutInstancesTest {
         }
     }
 
+    // --- markIntegrationLaunched/Dismissed ---
+
     @Test
-    fun `markIntegrationLaunched marks all instances for a key`() = runTest {
-        val checkout1 = createCheckout(key = "key1")
-        val checkout2 = createCheckout(key = "key1")
-        CheckoutInstances.clear()
-        CheckoutInstances.add("key1", checkout1)
-        CheckoutInstances.add("key1", checkout2)
+    fun `markIntegrationLaunched blocks mutations`() = runTest {
+        val checkout = createCheckout(key = "key1")
 
         CheckoutInstances.markIntegrationLaunched("key1")
 
-        // Both instances should return failure because integrationLaunched is set.
-        val result1 = checkout1.applyPromotionCode("code")
-        assertThat(result1.isFailure).isTrue()
-        assertThat(result1.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
-        val result2 = checkout2.applyPromotionCode("code")
-        assertThat(result2.isFailure).isTrue()
-        assertThat(result2.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        val result = checkout.applyPromotionCode("code")
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
     }
 
     @Test
-    fun `markIntegrationDismissed clears the flag for all instances`() = runTest {
-        val checkout1 = createCheckout(key = "key1")
-        val checkout2 = createCheckout(key = "key1")
-        CheckoutInstances.clear()
-        CheckoutInstances.add("key1", checkout1)
-        CheckoutInstances.add("key1", checkout2)
+    fun `markIntegrationDismissed unblocks mutations`() = runTest {
+        val checkout = createCheckout(key = "key1")
 
         CheckoutInstances.markIntegrationLaunched("key1")
         CheckoutInstances.markIntegrationDismissed("key1")
 
-        // After dismissing, mutations should not throw the integrationLaunched error.
-        // They will fail for other reasons (network), but they won't throw IllegalStateException.
-        networkRule.checkoutUpdate { response ->
-            response.setResponseCode(400)
-            response.setBody("""{"error": {"message": "error"}}""")
-        }
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "error"}}""")
         }
 
-        val result1 = checkout1.applyPromotionCode("code")
-        assertThat(result1.isFailure).isTrue()
-        val result2 = checkout2.applyPromotionCode("code")
-        assertThat(result2.isFailure).isTrue()
+        val result = checkout.applyPromotionCode("code")
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isNotInstanceOf(IllegalStateException::class.java)
+    }
+
+    // --- Dedup behavior (createWithState) ---
+
+    @Test
+    fun `createWithState returns same instance when checkout exists for key`() {
+        val checkoutA = createCheckout(key = "key1")
+        val stateA = checkoutA.state
+
+        val checkoutB = Checkout.createWithState(
+            context = applicationContext,
+            state = stateA,
+        )
+
+        assertThat(checkoutB).isSameInstanceAs(checkoutA)
     }
 
     @Test
-    fun `multiple keys coexist independently`() {
-        val checkout1 = createCheckout(key = "key1")
-        val checkout2 = createCheckout(key = "key2")
+    fun `createWithState creates fresh instance when registry is empty`() {
+        val state = CheckoutStateFactory.create(key = "key1")
+
         CheckoutInstances.clear()
 
-        CheckoutInstances.add("key1", checkout1)
-        CheckoutInstances.add("key2", checkout2)
+        val checkout = Checkout.createWithState(
+            context = applicationContext,
+            state = state,
+        )
 
-        assertThat(CheckoutInstances["key1"]).containsExactly(checkout1)
-        assertThat(CheckoutInstances["key2"]).containsExactly(checkout2)
+        assertThat(checkout).isNotNull()
+        assertThat(CheckoutInstances["key1"]).isSameInstanceAs(checkout)
+    }
+
+    @Test
+    fun `live instance wins over provided state`() = runTest {
+        val checkout = createCheckout(key = "key1")
+
+        networkRule.checkoutUpdate { response ->
+            response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
+        }
+        checkout.removePromotionCode()
+
+        val liveSession = checkout.checkoutSession.value
+
+        val staleState = CheckoutStateFactory.create(key = "key1")
+        val restored = Checkout.createWithState(
+            context = applicationContext,
+            state = staleState,
+        )
+
+        assertThat(restored).isSameInstanceAs(checkout)
+        assertThat(restored.checkoutSession.value).isEqualTo(liveSession)
+    }
+
+    @Test
+    fun `shared instance emits isLoading and checkoutSession across callers`() {
+        val checkoutA = createCheckout(key = "key1")
+        val checkoutB = Checkout.createWithState(
+            context = applicationContext,
+            state = checkoutA.state,
+        )
+
+        val requestArrived = CountDownLatch(1)
+        val holdResponse = CountDownLatch(1)
+
+        networkRule.checkoutUpdate { response ->
+            requestArrived.countDown()
+            holdResponse.await()
+            response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
+        }
+
+        runBlocking {
+            val job = launch(Dispatchers.IO) {
+                checkoutB.removePromotionCode()
+            }
+
+            assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+
+            // A observes isLoading = true (because same instance)
+            assertThat(checkoutA.isLoading.value).isTrue()
+
+            holdResponse.countDown()
+            job.join()
+
+            // After completion, A observes isLoading = false
+            assertThat(checkoutA.isLoading.value).isFalse()
+
+            // A and B share the same checkoutSession
+            assertThat(checkoutA.checkoutSession.value).isEqualTo(checkoutB.checkoutSession.value)
+        }
+    }
+
+    @Test
+    fun `concurrent mutations on shared instance are queued`() {
+        val checkoutA = createCheckout(key = "key1")
+        val checkoutB = Checkout.createWithState(
+            context = applicationContext,
+            state = checkoutA.state,
+        )
+
+        val firstRequestArrived = CountDownLatch(1)
+        val holdFirstResponse = CountDownLatch(1)
+        val secondRequestArrived = CountDownLatch(1)
+
+        networkRule.checkoutUpdate { response ->
+            firstRequestArrived.countDown()
+            holdFirstResponse.await()
+            response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
+        }
+
+        networkRule.checkoutUpdate { response ->
+            secondRequestArrived.countDown()
+            response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
+        }
+
+        runBlocking {
+            val jobB = launch(Dispatchers.IO) {
+                checkoutB.applyPromotionCode("B_CODE")
+            }
+
+            assertThat(firstRequestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+
+            val jobA = launch(Dispatchers.IO) {
+                checkoutA.applyPromotionCode("A_CODE")
+            }
+
+            // Give A time to reach the mutex
+            Thread.sleep(100)
+
+            // Second request should NOT have arrived yet (A is queued behind B)
+            assertThat(secondRequestArrived.count).isEqualTo(1)
+
+            // Release B's response
+            holdFirstResponse.countDown()
+            jobB.join()
+
+            // Now A should proceed
+            assertThat(secondRequestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+            jobA.join()
+        }
+    }
+
+    // --- getOrCreate ---
+
+    @Test
+    fun `getOrCreate returns existing instance without calling factory`() {
+        val checkout = createCheckout(key = "key1")
+
+        var factoryCalled = false
+        val result = CheckoutInstances.getOrCreate("key1") {
+            factoryCalled = true
+            createCheckout(key = "key1")
+        }
+
+        assertThat(result).isSameInstanceAs(checkout)
+        assertThat(factoryCalled).isFalse()
+    }
+
+    @Test
+    fun `getOrCreate calls factory and returns new instance when none exists`() {
+        CheckoutInstances.clear()
+
+        val result = CheckoutInstances.getOrCreate("key1") {
+            createCheckout(key = "key1")
+        }
+
+        assertThat(result).isNotNull()
+        assertThat(CheckoutInstances["key1"]).isSameInstanceAs(result)
     }
 
     private fun createCheckout(key: String): Checkout {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -51,21 +52,6 @@ class CheckoutInstancesTest {
         CheckoutInstances.add("key1", checkout)
 
         assertThat(CheckoutInstances["key1"]).isSameInstanceAs(checkout)
-    }
-
-    @Test
-    fun `clear empties the map`() {
-        val checkout1 = createCheckout(key = "key1")
-        val checkout2 = createCheckout(key = "key2")
-        CheckoutInstances.clear()
-
-        CheckoutInstances.add("key1", checkout1)
-        CheckoutInstances.add("key2", checkout2)
-
-        CheckoutInstances.clear()
-
-        assertThat(CheckoutInstances["key1"]).isNull()
-        assertThat(CheckoutInstances["key2"]).isNull()
     }
 
     @Test
@@ -194,57 +180,45 @@ class CheckoutInstancesTest {
     }
 
     @Test
-    fun `shared instance emits isLoading and checkoutSession across callers`() {
+    fun `shared instance emits isLoading and checkoutSession across callers`() = runTest {
         val checkoutA = createCheckout(key = "key1")
         val checkoutB = Checkout.createWithState(
             context = applicationContext,
             state = checkoutA.state,
         )
 
-        val requestArrived = CountDownLatch(1)
         val holdResponse = CountDownLatch(1)
 
         networkRule.checkoutUpdate { response ->
-            requestArrived.countDown()
             holdResponse.await()
             response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
         }
 
-        runBlocking {
-            val job = launch(Dispatchers.IO) {
-                checkoutB.removePromotionCode()
-            }
+        val job = async { checkoutB.removePromotionCode() }
+        testScheduler.advanceUntilIdle()
 
-            assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+        // A observes isLoading because it's the same instance as B
+        assertThat(checkoutA.isLoading.value).isTrue()
 
-            // A observes isLoading = true (because same instance)
-            assertThat(checkoutA.isLoading.value).isTrue()
+        holdResponse.countDown()
+        job.await()
 
-            holdResponse.countDown()
-            job.join()
-
-            // After completion, A observes isLoading = false
-            assertThat(checkoutA.isLoading.value).isFalse()
-
-            // A and B share the same checkoutSession
-            assertThat(checkoutA.checkoutSession.value).isEqualTo(checkoutB.checkoutSession.value)
-        }
+        assertThat(checkoutA.isLoading.value).isFalse()
+        assertThat(checkoutA.checkoutSession.value).isEqualTo(checkoutB.checkoutSession.value)
     }
 
     @Test
-    fun `concurrent mutations on shared instance are queued`() {
+    fun `concurrent mutations on shared instance are queued`() = runTest {
         val checkoutA = createCheckout(key = "key1")
         val checkoutB = Checkout.createWithState(
             context = applicationContext,
             state = checkoutA.state,
         )
 
-        val firstRequestArrived = CountDownLatch(1)
         val holdFirstResponse = CountDownLatch(1)
         val secondRequestArrived = CountDownLatch(1)
 
         networkRule.checkoutUpdate { response ->
-            firstRequestArrived.countDown()
             holdFirstResponse.await()
             response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
         }
@@ -254,45 +228,31 @@ class CheckoutInstancesTest {
             response.setBody("""{"id": "cs_123", "line_items": [], "status": "open"}""")
         }
 
-        runBlocking {
-            val jobB = launch(Dispatchers.IO) {
-                checkoutB.applyPromotionCode("B_CODE")
-            }
+        val jobB = async { checkoutB.applyPromotionCode("B_CODE") }
+        testScheduler.advanceUntilIdle()
 
-            assertThat(firstRequestArrived.await(5, TimeUnit.SECONDS)).isTrue()
+        val jobA = async { checkoutA.applyPromotionCode("A_CODE") }
+        testScheduler.advanceUntilIdle()
 
-            val jobA = launch(Dispatchers.IO) {
-                checkoutA.applyPromotionCode("A_CODE")
-            }
+        // A's request should not arrive while B holds the mutex
+        assertThat(secondRequestArrived.count).isEqualTo(1)
 
-            // Give A time to reach the mutex
-            Thread.sleep(100)
+        holdFirstResponse.countDown()
+        jobB.await()
+        jobA.await()
 
-            // Second request should NOT have arrived yet (A is queued behind B)
-            assertThat(secondRequestArrived.count).isEqualTo(1)
-
-            // Release B's response
-            holdFirstResponse.countDown()
-            jobB.join()
-
-            // Now A should proceed
-            assertThat(secondRequestArrived.await(5, TimeUnit.SECONDS)).isTrue()
-            jobA.join()
-        }
+        assertThat(secondRequestArrived.count).isEqualTo(0)
     }
 
     @Test
     fun `getOrCreate returns existing instance without calling factory`() {
         val checkout = createCheckout(key = "key1")
 
-        var factoryCalled = false
         val result = CheckoutInstances.getOrCreate("key1") {
-            factoryCalled = true
-            createCheckout(key = "key1")
+            error("factory should not be called")
         }
 
         assertThat(result).isSameInstanceAs(checkout)
-        assertThat(factoryCalled).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -199,7 +199,7 @@ class GooglePayDisplayItemsFactoryTest {
         lineItems: List<CheckoutSessionResponse.LineItem>,
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
     ): List<GooglePayJsonFactory.DisplayItem> {
-        val checkout = Checkout.createWithState(
+        Checkout.createWithState(
             context = applicationContext,
             state = CheckoutStateFactory.create(
                 key = INSTANCES_KEY,
@@ -209,7 +209,6 @@ class GooglePayDisplayItemsFactoryTest {
                 ),
             ),
         )
-        CheckoutInstances.add(INSTANCES_KEY, checkout)
 
         val metadata = PaymentMethodMetadataFactory.create(
             integrationMetadata = IntegrationMetadata.CheckoutSession(


### PR DESCRIPTION
## Summary
- Simplifies `CheckoutInstances` from `Map<String, MutableList<WeakReference<Checkout>>>` to `Map<String, WeakReference<Checkout>>`
- Adds `@Synchronized` `getOrCreate(key, factory)` for atomic check-then-create
- `Checkout.createWithState` returns the existing live instance if one exists for the key, ensuring cross-Activity mutation serialization and shared `StateFlow` observation
- Updates callers (`CheckoutSessionConfirmationInterceptor`, `GooglePayDisplayItemsFactory`) for `Checkout?` return type

## Motivation
When Activity A creates a Checkout and passes `checkout.state` via Intent to Activity B, calling `createWithState` previously created a separate object. This caused:
- Mutations from B not observable by A (separate `StateFlow` instances)
- Concurrent mutations not serialized (separate `Mutex` instances)

Now both activities share the same `Checkout` object, so mutations queue via the internal `Mutex` and state changes propagate to all holders.

## Test plan
- [x] New unit tests: dedup identity, fresh-from-empty (process death), live-instance-wins-over-stale-state, shared `isLoading` observation, queued concurrent mutations, `getOrCreate` contract
- [x] Full `:paymentsheet:testDebugUnitTest` passes with zero regressions
- [ ] E2e cross-Activity tests deferred until checkout playground is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)