### PR TITLE
Use more powerful machines for backend-triggered FC tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -166,16 +166,28 @@ workflows:
       - MAESTRO_TAGS: testmode-payments
     before_run:
       - _run-connections-e2e-tests
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   run-connections-e2e-data-tests:
     envs:
       - MAESTRO_TAGS: testmode-data
     before_run:
       - _run-connections-e2e-tests
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   run-connections-e2e-token-tests:
     envs:
       - MAESTRO_TAGS: testmode-token
     before_run:
       - _run-connections-e2e-tests
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   run-connections-e2e-payments-tests-on-push:
     envs:
       - MAESTRO_TAGS: testmode-payments
@@ -214,6 +226,10 @@ workflows:
       - MAESTRO_TAGS: livemode-data
     before_run:
       - _run-connections-e2e-tests
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   _run-connect-e2e-tests:
     before_run:
       - build-connect-debug


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request switches the backend-triggered FC tests to use beefier machines, aligning them with tests triggered on push.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
