### PR TITLE
Implement `TapZoneResolver` for resolving exact NFC bias positions.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegate.kt
@@ -1,19 +1,30 @@
 package com.stripe.android.common.nfcscan.hardware
 
-import android.content.Context
+import android.app.Application
 import android.nfc.NfcAdapter
+import android.nfc.NfcAntennaInfo
+import android.os.Build
+import androidx.annotation.RequiresApi
 import javax.inject.Inject
 
 internal interface NfcHardwareDelegate {
     fun isAvailable(): Boolean
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    fun antenna(): NfcAntennaInfo?
 }
 
 internal class DefaultNfcHardwareDelegate @Inject constructor(
-    context: Context
+    application: Application
 ) : NfcHardwareDelegate {
-    private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(context)
+    private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(application)
 
     override fun isAvailable(): Boolean {
         return nfcAdapter?.isEnabled == true
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    override fun antenna(): NfcAntennaInfo? {
+        return nfcAdapter?.nfcAntennaInfo
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/tapzone/TapZoneModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/tapzone/TapZoneModule.kt
@@ -1,10 +1,26 @@
 package com.stripe.android.common.nfcscan.tapzone
 
+import android.os.Build
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 
 @Module
 internal interface TapZoneModule {
     @Binds
     fun bindsTapZoneResolver(resolver: DefaultTapZoneResolver): TapZoneResolver
+
+    companion object {
+        @DeviceManufacturer
+        @Provides
+        fun providesDeviceManufacturer(): String = Build.MANUFACTURER
+
+        @DeviceModel
+        @Provides
+        fun providesDeviceModel(): String = Build.MODEL
+
+        @SdkVersion
+        @Provides
+        fun providesSdkVersion(): Int = Build.VERSION.SDK_INT
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/tapzone/TapZoneQualifiers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/tapzone/TapZoneQualifiers.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.common.nfcscan.tapzone
+
+import javax.inject.Qualifier
+
+@Qualifier
+internal annotation class DeviceManufacturer
+
+@Qualifier
+internal annotation class DeviceModel
+
+@Qualifier
+internal annotation class SdkVersion

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/tapzone/TapZoneResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/tapzone/TapZoneResolver.kt
@@ -1,17 +1,190 @@
 package com.stripe.android.common.nfcscan.tapzone
 
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.RequiresApi
+import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegate
 import javax.inject.Inject
 
 internal interface TapZoneResolver {
     fun get(): TapZone
 }
 
-internal class DefaultTapZoneResolver @Inject constructor() : TapZoneResolver {
+internal class DefaultTapZoneResolver @Inject constructor(
+    private val nfcHardwareDelegate: NfcHardwareDelegate,
+    @DeviceManufacturer private val manufacturer: String,
+    @DeviceModel private val model: String,
+    @SdkVersion private val sdk: Int,
+) : TapZoneResolver {
     override fun get(): TapZone {
-        return DEFAULT
+        val manufacturer = manufacturer.trim().lowercase()
+        val model = standardizeModelName(manufacturer, model)
+
+        return deviceTapZoneMapping[manufacturer]?.get(model) ?: run {
+            if (isAtLeastUpsideDownCake(sdk)) {
+                getTapZoneFromAvailableAntennae()
+            } else {
+                DEFAULT
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getTapZoneFromAvailableAntennae(): TapZone =
+        nfcHardwareDelegate.antenna()?.let { info ->
+            if (info.availableNfcAntennas.isEmpty()) {
+                return DEFAULT
+            } else if (info.deviceWidth == 0 || info.deviceHeight == 0) {
+                return DEFAULT
+            }
+
+            val antenna = info.availableNfcAntennas.first()
+            val xBias = antenna.locationX / info.deviceWidth.toFloat()
+            val yBias = 1 - antenna.locationY / info.deviceHeight.toFloat()
+
+            TapZone(xBias, yBias)
+        } ?: run {
+            DEFAULT
+        }
+
+    private fun standardizeModelName(manufacturer: String, model: String): String {
+        var name = model.trim().lowercase()
+        // Ignore chipset variants
+        when (manufacturer) {
+            "samsung" -> {
+                name = name.take(n = 7)
+
+                if (name.length >= SAMSUNG_REPLACEMENT_INDEX) {
+                    // Samsung will sometimes have this character be '-', '_' or '5'
+                    name = name.replaceRange(startIndex = 2, endIndex = SAMSUNG_REPLACEMENT_INDEX, replacement = "-")
+                }
+            }
+
+            "oneplus" -> {
+                if ("[a-z]\\d+".toRegex().matches(name)) {
+                    // OnePlus 6 and earlier naming scheme is different from literally everything else
+                    name = name.take(n = 4)
+                } else if ("[a-z]{2}\\d+".toRegex().matches(name)) {
+                    // OnePlus's normal naming scheme
+                    name = name.take(n = 5)
+                }
+                // else OnePlus is using Oppo model naming schemes (starting with CPH+)
+            }
+
+            "xiaomi" -> {
+                name = if (name.startsWith("m")) {
+                    name.take(n = 5)
+                } else {
+                    name.take(n = 4)
+                }
+            }
+        }
+        return name
+    }
+
+    @ChecksSdkIntAtLeast(parameter = 0)
+    private fun isAtLeastUpsideDownCake(sdk: Int): Boolean {
+        return sdk >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
     }
 
     private companion object {
+        const val SAMSUNG_REPLACEMENT_INDEX = 3
+
         val DEFAULT = TapZone(xBias = 0.5f, yBias = 0.5f)
+        val deviceTapZoneMapping = mapOf(
+            // Samsung NFC locations are guesstimates based on https://www.samsung.com/hk_en/nfc-support/ or
+            // teardown videos
+            "samsung" to mapOf(
+                // S22+
+                "SM-S906".lowercase() to TapZone(0.5f, 0.5f),
+                // S22
+                "SM-S901".lowercase() to TapZone(0.5f, 0.5f),
+                // S22 ultra
+                "SM-S908".lowercase() to TapZone(0.5f, 0.5f),
+                // S23
+                "SM-S911".lowercase() to TapZone(0.5f, 0.5f),
+                // S23+
+                "SM-S916".lowercase() to TapZone(0.5f, 0.5f),
+                // S23 ultra
+                "SM-S918".lowercase() to TapZone(0.5f, 0.5f),
+                // S24
+                "SM-S921".lowercase() to TapZone(0.5f, 0.22f),
+                // S24+
+                "SM-S926".lowercase() to TapZone(0.5f, 0.22f),
+                // S24 ultra
+                "SM-S928".lowercase() to TapZone(0.5f, 0.22f),
+                // S24 FE
+                "SM-S721".lowercase() to TapZone(0.5f, 0.6f),
+                // A14
+                "SM-A145".lowercase() to TapZone(0.5f, 0.2f),
+                // A14 5G
+                "SM-A146".lowercase() to TapZone(0.5f, 0.2f),
+                // A24 4G
+                "SM-A245".lowercase() to TapZone(0.5f, 0.2f),
+                // A25
+                "SM-A256".lowercase() to TapZone(1f, 0f),
+                // A33 5G
+                "SM-A336".lowercase() to TapZone(1f, 0f),
+                // A34
+                "SM-A346".lowercase() to TapZone(1f, 0f),
+                // A35
+                "SM-A356".lowercase() to TapZone(0.5f, 0.2f),
+                // A53 5G
+                "SM-A536".lowercase() to TapZone(0.5f, 0.2f),
+                // A54
+                "SM-A546".lowercase() to TapZone(0.5f, 0.2f),
+                // A55
+                "SM-A556".lowercase() to TapZone(1f, 0f),
+                // Tab Active5
+                "SM-X300".lowercase() to TapZone(0.25f, 0f),
+                "SM-X306".lowercase() to TapZone(0.25f, 0f),
+                "SM-X308".lowercase() to TapZone(0.25f, 0f),
+            ),
+            "google" to mapOf(
+                "Pixel 6".lowercase() to TapZone(0.5f, 0.4f),
+                "Pixel 6 Pro".lowercase() to TapZone(0.5f, 0.35f),
+                "Pixel 6a".lowercase() to TapZone(0.5f, 0.55f),
+                "Pixel 7".lowercase() to TapZone(0.5f, 0.25f),
+                "Pixel 7 Pro".lowercase() to TapZone(0.5f, 0.25f),
+                "Pixel 7a".lowercase() to TapZone(0.5f, 0.35f),
+                "Pixel 8".lowercase() to TapZone(0.5f, 0.3f),
+                "Pixel 8 Pro".lowercase() to TapZone(0.5f, 0.3f),
+                "Pixel 8a".lowercase() to TapZone(0.5f, 0.4f),
+                "Pixel 9".lowercase() to TapZone(0.5f, 0.31f),
+                "Pixel 9 Pro".lowercase() to TapZone(0.5f, 0.31f),
+                "Pixel 9 Pro XL".lowercase() to TapZone(0.5f, 0.3f)
+            ),
+            // Mostly estimated from teardown or unboxing videos
+            "oneplus" to mapOf(
+                // 10R
+                "CPH2423".lowercase() to TapZone(1f, 0f),
+                // 10 Pro 5G
+                "NE221".lowercase() to TapZone(0.5f, 0.2f),
+                // 11
+                "CPH2449".lowercase() to TapZone(0.5f, 0.2f),
+                "CPH2447".lowercase() to TapZone(0.5f, 0.2f),
+                "CPH2451".lowercase() to TapZone(0.5f, 0.2f),
+                // 11R
+                "CPH2487".lowercase() to TapZone(0.5f, 0.2f),
+            ),
+            /*
+             * A quick note about OPPO:
+             * - Model names that begin with "P" are omitted since they are targeted to Chinese markets
+             * - OPPO does not print the NFC location in their user manuals or on the protective plastic,
+             *   so the only way to figure out where it is is via teardown videos, which are mostly not in English.
+             * - The accuracy of the below tap zones is therefore probably much lower than other OEMs
+             *   with better documentation.
+             */
+            "oppo" to mapOf(
+                // Find X5 Pro
+                "CPH2305".lowercase() to TapZone(0.5f, 0.5f),
+            ),
+            "xiaomi" to mapOf(
+                // Redmi Note 11
+                "2201".lowercase() to TapZone(1f, 0f),
+                // Redmi Note 12
+                "2211".lowercase() to TapZone(1f, 0f),
+            ),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/FakeNfcHardwareDelegate.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/FakeNfcHardwareDelegate.kt
@@ -1,7 +1,12 @@
 package com.stripe.android.common.nfcscan.hardware
 
+import android.nfc.NfcAntennaInfo
+
 internal class FakeNfcHardwareDelegate(
     private val result: Boolean = true,
+    private val antennaInfo: NfcAntennaInfo? = null,
 ) : NfcHardwareDelegate {
     override fun isAvailable(): Boolean = result
+
+    override fun antenna(): NfcAntennaInfo? = antennaInfo
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.common.nfcscan.hardware
 
-import android.content.Context
+import android.app.Application
 import android.content.pm.PackageManager
+import android.nfc.AvailableNfcAntenna
 import android.nfc.NfcAdapter
+import android.nfc.NfcAntennaInfo
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
@@ -10,10 +13,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 internal class NfcHardwareDelegateTest {
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val application: Application = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `isAvailable returns false when device has no NFC hardware`() = test(
@@ -38,23 +42,61 @@ internal class NfcHardwareDelegateTest {
         assertThat(delegate.isAvailable()).isTrue()
     }
 
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `antenna returns null when device has no NFC hardware`() = test(
+        hasNfcFeature = false,
+    ) {
+        assertThat(delegate.antenna()).isNull()
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `antenna returns null when NFC adapter has no antenna info`() = test(
+        hasNfcFeature = true,
+    ) {
+        assertThat(delegate.antenna()).isNull()
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `antenna returns antenna info from NFC adapter`() = test(
+        hasNfcFeature = true,
+        nfcAntennaInfo = NfcAntennaInfo(
+            1000,
+            2000,
+            false,
+            listOf(AvailableNfcAntenna(300, 400)),
+        ),
+    ) {
+        assertThat(delegate.antenna()).isEqualTo(nfcAntennaInfo)
+    }
+
     private fun test(
         hasNfcFeature: Boolean = true,
         isNfcEnabled: Boolean = true,
+        nfcAntennaInfo: NfcAntennaInfo? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        shadowOf(context.packageManager)
+        shadowOf(application.packageManager)
             .setSystemFeature(PackageManager.FEATURE_NFC, hasNfcFeature)
 
         if (hasNfcFeature) {
-            val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+            val nfcAdapter = NfcAdapter.getDefaultAdapter(application)
             shadowOf(nfcAdapter).setEnabled(isNfcEnabled)
+            nfcAntennaInfo?.let { shadowOf(nfcAdapter).setNfcAntennaInfo(it) }
         }
 
-        block(Scenario(DefaultNfcHardwareDelegate(context)))
+        block(
+            Scenario(
+                delegate = DefaultNfcHardwareDelegate(application),
+                nfcAntennaInfo = nfcAntennaInfo,
+            )
+        )
     }
 
     private class Scenario(
         val delegate: NfcHardwareDelegate,
+        val nfcAntennaInfo: NfcAntennaInfo?,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/tapzone/DefaultTapZoneResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/tapzone/DefaultTapZoneResolverTest.kt
@@ -1,0 +1,152 @@
+package com.stripe.android.common.nfcscan.tapzone
+
+import android.nfc.AvailableNfcAntenna
+import android.nfc.NfcAntennaInfo
+import android.os.Build
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.hardware.FakeNfcHardwareDelegate
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultTapZoneResolverTest {
+    @Test
+    fun `get returns mapped tap zone for known samsung device`() = runScenario(
+        manufacturer = "samsung",
+        model = "SM-S921B",
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.22f))
+    }
+
+    @Test
+    fun `get standardizes samsung model name with underscore variant`() = runScenario(
+        manufacturer = "samsung",
+        model = "SM_S906B",
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.5f))
+    }
+
+    @Test
+    fun `get returns mapped tap zone for known google pixel device`() = runScenario(
+        manufacturer = "google",
+        model = "Pixel 7",
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.25f))
+    }
+
+    @Test
+    fun `get returns mapped tap zone for known oneplus device`() = runScenario(
+        manufacturer = "oneplus",
+        model = "NE2215",
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.2f))
+    }
+
+    @Test
+    fun `get returns mapped tap zone for known xiaomi device`() = runScenario(
+        manufacturer = "xiaomi",
+        model = "2201117TG",
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 1f, yBias = 0f))
+    }
+
+    @Test
+    fun `get normalizes manufacturer casing and whitespace`() = runScenario(
+        manufacturer = "  Samsung  ",
+        model = "SM-S921B",
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.22f))
+    }
+
+    @Test
+    fun `get returns default tap zone for unknown device on pre-UPSIDE_DOWN_CAKE sdk`() = runScenario(
+        manufacturer = "unknown",
+        model = "unknown",
+        sdk = Build.VERSION_CODES.TIRAMISU,
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.5f))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    fun `get returns default tap zone when antenna info is unavailable`() = runScenario(
+        manufacturer = "unknown",
+        model = "unknown",
+        sdk = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        antennaInfo = null,
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.5f))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    fun `get returns default tap zone when no antennas are available`() = runScenario(
+        manufacturer = "unknown",
+        model = "unknown",
+        sdk = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        antennaInfo = NfcAntennaInfo(
+            1000,
+            2000,
+            false,
+            emptyList(),
+        ),
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.5f))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    fun `get returns default tap zone when device dimensions are zero`() = runScenario(
+        manufacturer = "unknown",
+        model = "unknown",
+        sdk = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        antennaInfo = NfcAntennaInfo(
+            0,
+            2000,
+            false,
+            listOf(AvailableNfcAntenna(500, 400)),
+        ),
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.5f, yBias = 0.5f))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    fun `get computes tap zone from antenna location for unknown device`() = runScenario(
+        manufacturer = "unknown",
+        model = "unknown",
+        sdk = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        antennaInfo = NfcAntennaInfo(
+            1000,
+            2000,
+            false,
+            listOf(AvailableNfcAntenna(300, 400)),
+        ),
+    ) {
+        assertThat(resolver.get()).isEqualTo(TapZone(xBias = 0.3f, yBias = 0.8f))
+    }
+
+    private fun runScenario(
+        manufacturer: String,
+        model: String,
+        sdk: Int = Build.VERSION_CODES.TIRAMISU,
+        antennaInfo: NfcAntennaInfo? = null,
+        block: Scenario.() -> Unit,
+    ) {
+        val nfcHardwareDelegate = FakeNfcHardwareDelegate(antennaInfo = antennaInfo)
+        val resolver = DefaultTapZoneResolver(
+            nfcHardwareDelegate = nfcHardwareDelegate,
+            manufacturer = manufacturer,
+            model = model,
+            sdk = sdk,
+        )
+
+        block(Scenario(resolver))
+    }
+
+    private class Scenario(
+        val resolver: DefaultTapZoneResolver,
+    )
+}


### PR DESCRIPTION
# Summary
Implement `TapZoneResolver` for resolving exact NFC bias positions.

# Motivation
Ensure NFC coil is rendered properly in the UI.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified