### PR TITLE
Fix isLoading flicker between queued mutations

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
 
 private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
@@ -397,6 +398,7 @@ class Checkout private constructor(
         }
 
     private val mutex = Mutex()
+    private val pendingMutations = AtomicInteger(0)
 
     private val _checkoutSession = MutableStateFlow(
         internalState.asCheckoutSession()
@@ -595,17 +597,25 @@ class Checkout private constructor(
                 )
             )
         }
-        // Run network requests with a mutex to ensure events are processed in order.
-        return mutex.withLock {
+        if (pendingMutations.incrementAndGet() == 1) {
             _isLoading.value = true
-            val result = runCatching {
-                internalState.block(internalState.checkoutSessionResponse.id).getOrThrow()
-            }.map { response ->
-                internalState = internalState.copy(checkoutSessionResponse = response).additionalStateMutations()
-                _checkoutSession.value = internalState.asCheckoutSession()
+        }
+        return try {
+            // Run network requests with a mutex to ensure events are processed in order.
+            mutex.withLock {
+                val result = runCatching {
+                    internalState.block(internalState.checkoutSessionResponse.id).getOrThrow()
+                }.map { response ->
+                    internalState =
+                        internalState.copy(checkoutSessionResponse = response).additionalStateMutations()
+                    _checkoutSession.value = internalState.asCheckoutSession()
+                }
+                result
             }
-            _isLoading.value = false
-            result
+        } finally {
+            if (pendingMutations.decrementAndGet() == 0) {
+                _isLoading.value = false
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -998,6 +998,42 @@ class CheckoutTest {
     }
 
     @Test
+    fun `isLoading stays true while queued mutations are pending`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        val holdFirstResponse = CountDownLatch(1)
+
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+        ) { response ->
+            holdFirstResponse.await(10, TimeUnit.SECONDS)
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "20OFF"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+        val job1 = async { checkout.applyPromotionCode("10OFF") }
+        val job2 = async { checkout.applyPromotionCode("20OFF") }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+
+        holdFirstResponse.countDown()
+        job1.await()
+        job2.await()
+
+        // isLoading should go directly from true to false with no intermediate flicker.
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        isLoadingTurbine.ensureAllEventsConsumed()
+    }
+
+    @Test
     fun `isLoading is false initially`() = runCreateWithStateScenario(
         shouldValidateEvents = false,
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
@@ -1029,6 +1030,46 @@ class CheckoutTest {
         job2.await()
 
         // isLoading should go directly from true to false with no intermediate flicker.
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        isLoadingTurbine.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `isLoading returns to false when queued mutation is cancelled`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        val holdFirstResponse = CountDownLatch(1)
+
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+        ) { response ->
+            holdFirstResponse.await(10, TimeUnit.SECONDS)
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        // No mock for "20OFF": NetworkRule fails unmatched requests, so if the cancelled
+        // mutation's network call fires, the test fails.
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+        val job1 = async { checkout.applyPromotionCode("10OFF") }
+        val job2 = async { checkout.applyPromotionCode("20OFF") }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+
+        // Prove job2 has started and is suspended (waiting for the mutex), not just unstarted.
+        assertThat(job2.isActive).isTrue()
+
+        job2.cancelAndJoin()
+
+        // isLoading should still be true because job1 is in-flight.
+        assertThat(checkout.isLoading.value).isTrue()
+        isLoadingTurbine.expectNoEvents()
+
+        holdFirstResponse.countDown()
+        job1.await()
+
         assertThat(isLoadingTurbine.awaitItem()).isFalse()
         isLoadingTurbine.ensureAllEventsConsumed()
     }


### PR DESCRIPTION
## Summary
- Fixes a bug where `isLoading` briefly flickers to `false` between consecutive queued mutations in the Checkout update queue.
- Uses an `AtomicInteger` counter to track pending mutations. `isLoading` only transitions to `true` on the 0→1 edge (first mutation enqueued) and back to `false` on the 1→0 edge (last mutation completed).
- The counter increments after the `integrationLaunched` guard (rejected calls don't affect loading state) and decrements in a `finally` block (safe against cancellation).

## Context
The proposed Checkout update queue spec requires `isLoading` to stay `true` as long as any mutation is in-flight or queued. Previously, each `mutex.withLock` independently set `isLoading = true` on entry and `false` on exit, causing a brief `false` emission between serialized operations.

### Alternatives considered
A reactive approach (`MutableStateFlow<Int>` + `.map { it > 0 }.stateIn(scope, Eagerly, false)`) was considered but rejected because `Checkout` has no internal `CoroutineScope`, and the synchronous `AtomicInteger` approach is simpler with no lifecycle management needed.

## Test plan
- [x] New test: `isLoading stays true while queued mutations are pending` — holds first response with a latch, enqueues two mutations, asserts only `false → true → false` with no intermediate flicker
- [x] Existing `isLoading` tests pass (single mutation true/false transitions unchanged)
- [x] Full `CheckoutTest` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)