### PR TITLE
Skip existingPaymentMethodRequired in Google Pay test mode

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -129,7 +129,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
     }
 
     suspend fun loadPaymentData(): Task<PaymentData> {
-        check(isReadyToPay()) {
+        check(args.config.environment == GooglePayEnvironment.Test || isReadyToPay()) {
             "Google Pay is unavailable."
         }
         return paymentsClient.loadPaymentData(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayRepositoryFactory.kt
@@ -36,7 +36,7 @@ class DefaultGooglePayRepositoryFactory @Inject constructor(
             appContext,
             environment,
             GooglePayJsonFactory.BillingAddressParameters(),
-            existingPaymentMethodRequired = true,
+            existingPaymentMethodRequired = environment == GooglePayEnvironment.Production,
             allowCreditCards = true,
             errorReporter = errorReporter,
             logger = logger,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -188,6 +188,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     merchantName = this.config.merchantDisplayName,
                     isEmailRequired = args.config.billingDetailsCollectionConfiguration.collectsEmail,
                     billingAddressConfig = args.config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),
+                    existingPaymentMethodRequired = config.environment == PaymentSheet.GooglePayConfiguration.Environment.Production,
                     additionalEnabledNetworks = args.config.googlePay?.additionalEnabledNetworks ?: emptyList()
                 )
             }


### PR DESCRIPTION



Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->
This change skips the `existingPaymentMethodRequired` constraint and the `loadPaymentData` readiness check when the environment is Test, allowing developers to test Google Pay flows without a real card in their wallet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
