### PR TITLE
Fix HUF currency formatting on Android 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][13311](https://github.com/stripe/stripe-android/pull/13311) Fixed HUF currency amounts displaying incorrectly on Android 17.
+
 ## 23.11.0 - 2026-06-22
 
 ### CryptoOnramp

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentUtils.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import com.stripe.android.uicore.format.CurrencyFormatter
 import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.util.Currency
@@ -36,7 +37,7 @@ object PaymentUtils {
      */
     @JvmSynthetic
     internal fun formatPriceString(amount: Double, currency: Currency): String {
-        val majorUnitAmount = amount / 10.0.pow(currency.defaultFractionDigits.toDouble())
+        val majorUnitAmount = amount / 10.0.pow(CurrencyFormatter.getDefaultDecimalDigits(currency).toDouble())
         val currencyFormat = NumberFormat.getCurrencyInstance()
         return try {
             val decimalFormatSymbols = (currencyFormat as DecimalFormat)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -13,7 +13,7 @@ object CurrencyFormatter {
     private const val MAJOR_UNIT_BASE = 10.0
 
     private val SERVER_DECIMAL_DIGITS = mapOf(
-        setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK", "LAK", "RSD") to 2,
+        setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK", "LAK", "RSD", "HUF") to 2,
     )
 
     fun format(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -102,6 +102,7 @@ class CurrencyFormatterTest {
     @Test
     fun `HUF is effectively 0 decimal places, but Stripe treats it as 2`() {
         val amountCurrency = Currency.getInstance("HUF")
+        assertThat(CurrencyFormatter.getDefaultDecimalDigits(amountCurrency)).isEqualTo(2)
         assertThat(
             CurrencyFormatter.format(
                 123412L,


### PR DESCRIPTION
## Summary
- On Android 17, `Currency.defaultFractionDigits` for HUF changed from 2 to 0, but Stripe's backend still treats HUF as a 2-decimal currency. This caused amounts to display 100x too large (two extra zeros).
- Added HUF to the `SERVER_DECIMAL_DIGITS` override map so the SDK always uses 2 decimal places regardless of platform.
- Updated `PaymentUtils.formatPriceString` to use `CurrencyFormatter.getDefaultDecimalDigits()` instead of the raw platform value.

Fixes #13265

## Test plan
- [x] Existing `CurrencyFormatterTest` passes (HUF formatting test)
- [x] `PayWithGoogleUtilsTest` passes
- [x] `PaymentUtilsTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)