### PR TITLE
Queue mutations behind an in-flight checkout session confirmation 🪿✨

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
@@ -57,6 +57,7 @@ internal class FlowControllerCheckoutSessionTest {
     @Test
     fun testSuccessfulCardSetupWithCheckoutSession() = runFlowControllerTest(
         networkRule = networkRule,
+        callConfirmOnPaymentOptionCallback = false,
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.checkoutInit { response ->
@@ -76,10 +77,7 @@ internal class FlowControllerCheckoutSessionTest {
             response.testBodyFromFile("checkout-session-confirm-setup.json")
         }
 
-        page.clickPrimaryButton()
-
-        testContext.consumePaymentOptionEventForFlowController("card", "4242")
-        testContext.consumeNullPaymentOptionEventForFlowController()
+        confirmAfterPaymentOptionsDismissed(testContext)
     }
 
     /**
@@ -95,6 +93,7 @@ internal class FlowControllerCheckoutSessionTest {
     @Test
     fun testSuccessfulCardPaymentWithCheckoutSession() = runFlowControllerTest(
         networkRule = networkRule,
+        callConfirmOnPaymentOptionCallback = false,
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.checkoutInit { response ->
@@ -113,9 +112,24 @@ internal class FlowControllerCheckoutSessionTest {
             response.testBodyFromFile("checkout-session-confirm.json")
         }
 
+        confirmAfterPaymentOptionsDismissed(testContext)
+    }
+
+    /**
+     * Drives the shared "select then confirm" tail of the checkout confirm tests: observes
+     * PaymentOptionsActivity destruction, clicks the primary button to dismiss the sheet, and only
+     * confirms once the sheet is gone (so integrationLaunched is cleared) — matching real usage.
+     */
+    private suspend fun confirmAfterPaymentOptionsDismissed(testContext: FlowControllerTestRunnerContext) {
+        val destroyHandle = testContext.observePaymentOptionsActivityDestroyed()
+
         page.clickPrimaryButton()
 
         testContext.consumePaymentOptionEventForFlowController("card", "4242")
+
+        destroyHandle.await()
+        testContext.flowController.confirm()
+
         testContext.consumeNullPaymentOptionEventForFlowController()
     }
 
@@ -223,6 +237,7 @@ internal class FlowControllerCheckoutSessionTest {
         expectedAllowRedisplay: String,
     ) = runFlowControllerTest(
         networkRule = networkRule,
+        callConfirmOnPaymentOptionCallback = false,
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.checkoutInit { response ->
@@ -258,10 +273,7 @@ internal class FlowControllerCheckoutSessionTest {
             response.testBodyFromFile(confirmFile)
         }
 
-        page.clickPrimaryButton()
-
-        testContext.consumePaymentOptionEventForFlowController("card", "4242")
-        testContext.consumeNullPaymentOptionEventForFlowController()
+        confirmAfterPaymentOptionsDismissed(testContext)
     }
 
     // region customer_email billing details tests
@@ -292,6 +304,7 @@ internal class FlowControllerCheckoutSessionTest {
         expectedEmail: String,
     ) = runFlowControllerTest(
         networkRule = networkRule,
+        callConfirmOnPaymentOptionCallback = false,
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.checkoutInit { response ->
@@ -337,10 +350,7 @@ internal class FlowControllerCheckoutSessionTest {
             response.testBodyFromFile("checkout-session-confirm.json")
         }
 
-        page.clickPrimaryButton()
-
-        testContext.consumePaymentOptionEventForFlowController("card", "4242")
-        testContext.consumeNullPaymentOptionEventForFlowController()
+        confirmAfterPaymentOptionsDismissed(testContext)
     }
 
     // endregion

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.paymentsheet.utils
 
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
@@ -37,6 +41,44 @@ internal class FlowControllerTestRunnerContext(
             flowController.block()
         }
         activityLaunchObserver.awaitLaunch()
+    }
+
+    /**
+     * Starts observing the destruction of [PaymentOptionsActivity], returning a handle whose
+     * [PaymentOptionsActivityDestroyHandle.await] blocks until it is destroyed.
+     *
+     * Call this BEFORE the action that dismisses the options sheet (e.g. clicking the primary
+     * button), then [PaymentOptionsActivityDestroyHandle.await] before
+     * [PaymentSheet.FlowController.confirm]. This makes the confirm run after the sheet is gone —
+     * mirroring real usage, where the merchant confirms as a separate action once the options
+     * sheet has been dismissed. Registering after the dismissal could miss the destroy event.
+     */
+    fun observePaymentOptionsActivityDestroyed(): PaymentOptionsActivityDestroyHandle {
+        val destroyed = CountDownLatch(1)
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val callbacks = object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityDestroyed(activity: Activity) {
+                if (activity is PaymentOptionsActivity) {
+                    destroyed.countDown()
+                    application.unregisterActivityLifecycleCallbacks(this)
+                }
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+            override fun onActivityStarted(activity: Activity) = Unit
+            override fun onActivityResumed(activity: Activity) = Unit
+            override fun onActivityPaused(activity: Activity) = Unit
+            override fun onActivityStopped(activity: Activity) = Unit
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+        }
+        application.registerActivityLifecycleCallbacks(callbacks)
+        return PaymentOptionsActivityDestroyHandle(destroyed)
+    }
+
+    internal class PaymentOptionsActivityDestroyHandle(private val destroyed: CountDownLatch) {
+        fun await() {
+            assertThat(destroyed.await(5, TimeUnit.SECONDS)).isTrue()
+        }
     }
 
     suspend fun consumePaymentOptionEventForFlowController(paymentMethodType: String, label: String) {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -592,9 +592,9 @@ class Checkout private constructor(
     internal suspend fun <T> withConfirmation(
         block: suspend () -> T,
     ): T {
-        // Confirmation is blocked while a payment flow is presented, just like mutations
-        // (see withInternalState). Omitting this guard would allow a confirm to run on top of
-        // a presented sheet.
+        // Confirmation, like mutations, is blocked while a payment flow is presented. The
+        // integration is marked dismissed when the presenting sheet returns its result (e.g.
+        // DefaultFlowController.onPaymentOptionResult), which precedes the confirm() call.
         if (internalState.integrationLaunched) {
             throw IllegalStateException(
                 "Cannot confirm checkout session while a payment flow is presented."

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -582,8 +582,8 @@ class Checkout private constructor(
     }
 
     /**
-     * Runs a confirmation [block] while holding the mutation queue, so that any mutations
-     * triggered during confirmation are serialized behind it instead of running concurrently.
+     * Runs a confirmation [block] while holding the mutation queue. A mutation triggered during
+     * confirmation waits until the confirmation completes, so the two never overlap.
      *
      * Fails fast with [CheckoutConfirmationBlockedException] if a payment flow is presented, or
      * if a mutation (or another confirmation) is already in flight: a confirmation may only be

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -585,9 +585,9 @@ class Checkout private constructor(
      * Runs a confirmation [block] while holding the mutation queue. A mutation triggered during
      * confirmation waits until the confirmation completes, so the two never overlap.
      *
-     * Fails fast with [CheckoutConfirmationBlockedException] if a payment flow is presented, or
-     * if a mutation (or another confirmation) is already in flight: a confirmation may only be
-     * enqueued when the queue is empty.
+     * Fails fast with [IllegalStateException] if a payment flow is presented, or if a mutation
+     * (or another confirmation) is already in flight: a confirmation may only be enqueued when
+     * the queue is empty.
      */
     internal suspend fun <T> withConfirmation(
         block: suspend () -> T,
@@ -596,7 +596,7 @@ class Checkout private constructor(
         // (see withInternalState). Omitting this guard would allow a confirm to run on top of
         // a presented sheet.
         if (internalState.integrationLaunched) {
-            throw CheckoutConfirmationBlockedException(
+            throw IllegalStateException(
                 "Cannot confirm checkout session while a payment flow is presented."
             )
         }
@@ -605,7 +605,7 @@ class Checkout private constructor(
         // confirmation never waits for the lock (it fails fast instead), so it is always the
         // 0 -> 1 transition and we increment the pending counter only after acquiring.
         if (!mutex.tryLock()) {
-            throw CheckoutConfirmationBlockedException(
+            throw IllegalStateException(
                 "Cannot confirm while a checkout session mutation is in flight."
             )
         }
@@ -707,11 +707,3 @@ class Checkout private constructor(
         }
     }
 }
-
-/**
- * Thrown by [Checkout.withConfirmation] when a confirmation cannot be enqueued: either a payment
- * flow is presented, or a mutation/confirmation is already in flight. Distinct from other
- * [IllegalStateException]s so callers can map only the queue-precondition failure without
- * miscategorizing exceptions thrown from inside the confirmation itself.
- */
-internal class CheckoutConfirmationBlockedException(message: String) : IllegalStateException(message)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -585,14 +585,27 @@ class Checkout private constructor(
      * Runs a confirmation [block] while holding the mutation queue, so that any mutations
      * triggered during confirmation are serialized behind it instead of running concurrently.
      *
-     * Fails fast with [IllegalStateException] if a mutation (or another confirmation) is already
-     * in flight: a confirmation may only be enqueued when the queue is empty.
+     * Fails fast with [CheckoutConfirmationBlockedException] if a payment flow is presented, or
+     * if a mutation (or another confirmation) is already in flight: a confirmation may only be
+     * enqueued when the queue is empty.
      */
     internal suspend fun <T> withConfirmation(
         block: suspend () -> T,
     ): T {
+        // Confirmation is blocked while a payment flow is presented, just like mutations
+        // (see withInternalState). Omitting this guard would allow a confirm to run on top of
+        // a presented sheet.
+        if (internalState.integrationLaunched) {
+            throw CheckoutConfirmationBlockedException(
+                "Cannot confirm checkout session while a payment flow is presented."
+            )
+        }
+        // A confirmation may only be enqueued when the queue is empty. tryLock atomically
+        // checks-and-acquires, so there is no check-then-acquire race. Unlike mutations a
+        // confirmation never waits for the lock (it fails fast instead), so it is always the
+        // 0 -> 1 transition and we increment the pending counter only after acquiring.
         if (!mutex.tryLock()) {
-            throw IllegalStateException(
+            throw CheckoutConfirmationBlockedException(
                 "Cannot confirm while a checkout session mutation is in flight."
             )
         }
@@ -694,3 +707,11 @@ class Checkout private constructor(
         }
     }
 }
+
+/**
+ * Thrown by [Checkout.withConfirmation] when a confirmation cannot be enqueued: either a payment
+ * flow is presented, or a mutation/confirmation is already in flight. Distinct from other
+ * [IllegalStateException]s so callers can map only the queue-precondition failure without
+ * miscategorizing exceptions thrown from inside the confirmation itself.
+ */
+internal class CheckoutConfirmationBlockedException(message: String) : IllegalStateException(message)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -581,6 +581,34 @@ class Checkout private constructor(
         }
     }
 
+    /**
+     * Runs a confirmation [block] while holding the mutation queue, so that any mutations
+     * triggered during confirmation are serialized behind it instead of running concurrently.
+     *
+     * Fails fast with [IllegalStateException] if a mutation (or another confirmation) is already
+     * in flight: a confirmation may only be enqueued when the queue is empty.
+     */
+    internal suspend fun <T> withConfirmation(
+        block: suspend () -> T,
+    ): T {
+        if (!mutex.tryLock()) {
+            throw IllegalStateException(
+                "Cannot confirm while a checkout session mutation is in flight."
+            )
+        }
+        if (pendingMutations.incrementAndGet() == 1) {
+            _isLoading.value = true
+        }
+        return try {
+            block()
+        } finally {
+            if (pendingMutations.decrementAndGet() == 0) {
+                _isLoading.value = false
+            }
+            mutex.unlock()
+        }
+    }
+
     internal fun updateWithResponse(response: CheckoutSessionResponse) {
         internalState = internalState.copy(checkoutSessionResponse = response)
         _checkoutSession.value = internalState.asCheckoutSession()

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -35,6 +35,12 @@ internal object CheckoutInstances {
         return if (checkout != null) {
             checkout.withConfirmation(block)
         } else {
+            // No live instance for this key. Instances are held by WeakReference, and an
+            // in-flight mutation keeps its Checkout strongly reachable (it is the receiver of
+            // the suspending mutation call), so a missing instance means no mutation can be in
+            // flight. There is therefore nothing to serialize against, and running the
+            // confirmation directly is safe — and avoids failing a legitimate payment just
+            // because the merchant's Checkout reference was garbage collected.
             block()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -30,6 +30,15 @@ internal object CheckoutInstances {
         this[key]?.ensureNoMutationInFlight()
     }
 
+    suspend fun <T> withConfirmation(key: String, block: suspend () -> T): T {
+        val checkout = this[key]
+        return if (checkout != null) {
+            checkout.withConfirmation(block)
+        } else {
+            block()
+        }
+    }
+
     @Synchronized
     fun markIntegrationLaunched(key: String) {
         this[key]?.markIntegrationLaunched()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -139,15 +139,6 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                 message = e.stripeErrorMessage(),
                 errorType = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
             )
-        } catch (e: IllegalStateException) {
-            // Any other IllegalStateException originates from the confirmation itself, not the
-            // queue precondition, so it is a payment failure. CancellationException is not an
-            // IllegalStateException, so coroutine cancellation still propagates.
-            ConfirmationDefinition.Action.Fail(
-                cause = e,
-                message = e.stripeErrorMessage(),
-                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -139,6 +139,15 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                 message = e.stripeErrorMessage(),
                 errorType = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
             )
+        } catch (e: IllegalStateException) {
+            // Any other IllegalStateException originates from the confirmation itself, not the
+            // queue precondition, so it is a payment failure. CancellationException is not an
+            // IllegalStateException, so coroutine cancellation still propagates.
+            ConfirmationDefinition.Action.Fail(
+                cause = e,
+                message = e.stripeErrorMessage(),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import android.content.Context
-import com.stripe.android.checkout.CheckoutConfirmationBlockedException
 import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.networking.ApiRequest
@@ -133,7 +132,11 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     }
                 )
             }
-        } catch (e: CheckoutConfirmationBlockedException) {
+        } catch (e: IllegalStateException) {
+            // withConfirmation throws when the queue precondition fails (a payment flow is
+            // presented, or a mutation/confirmation is already in flight). Repository/confirm
+            // failures arrive as Result.failure and are mapped to Payment above, so they do not
+            // reach here.
             ConfirmationDefinition.Action.Fail(
                 cause = e,
                 message = e.stripeErrorMessage(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import android.content.Context
+import com.stripe.android.checkout.CheckoutConfirmationBlockedException
 import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.networking.ApiRequest
@@ -132,7 +133,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     }
                 )
             }
-        } catch (e: IllegalStateException) {
+        } catch (e: CheckoutConfirmationBlockedException) {
             ConfirmationDefinition.Action.Fail(
                 cause = e,
                 message = e.stripeErrorMessage(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -116,28 +116,29 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     private suspend fun confirmCheckoutSession(
         params: ConfirmCheckoutSessionParams,
     ): ConfirmationDefinition.Action<Args> {
-        try {
-            CheckoutInstances.ensureNoMutationInFlight(integrationMetadata.instancesKey)
+        return try {
+            CheckoutInstances.withConfirmation(integrationMetadata.instancesKey) {
+                checkoutSessionRepository.confirm(
+                    id = integrationMetadata.id,
+                    params = params,
+                ).fold(
+                    onSuccess = ::handleConfirmResponse,
+                    onFailure = { error ->
+                        ConfirmationDefinition.Action.Fail(
+                            cause = error,
+                            message = error.stripeErrorMessage(),
+                            errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                        )
+                    }
+                )
+            }
         } catch (e: IllegalStateException) {
-            return ConfirmationDefinition.Action.Fail(
+            ConfirmationDefinition.Action.Fail(
                 cause = e,
                 message = e.stripeErrorMessage(),
                 errorType = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
             )
         }
-        return checkoutSessionRepository.confirm(
-            id = integrationMetadata.id,
-            params = params,
-        ).fold(
-            onSuccess = ::handleConfirmResponse,
-            onFailure = { error ->
-                ConfirmationDefinition.Action.Fail(
-                    cause = error,
-                    message = error.stripeErrorMessage(),
-                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-                )
-            }
-        )
     }
 
     private fun handleConfirmResponse(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFacto
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelAndJoin
@@ -1069,6 +1070,139 @@ class CheckoutTest {
 
         holdFirstResponse.countDown()
         job1.await()
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        isLoadingTurbine.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `mutation runs after withConfirmation completes`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        val holdConfirmation = CompletableDeferred<Unit>()
+        val confirmJob = async {
+            checkout.withConfirmation { holdConfirmation.await() }
+        }
+        testScheduler.advanceUntilIdle()
+
+        val mutationJob = async { checkout.applyPromotionCode("10OFF") }
+        testScheduler.advanceUntilIdle()
+
+        // Negative: the mutation is queued behind the in-flight confirmation.
+        assertThat(mutationJob.isActive).isTrue()
+
+        holdConfirmation.complete(Unit)
+        confirmJob.await()
+
+        // Positive: once confirmation releases the queue, the mutation runs.
+        val result = mutationJob.await()
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `withConfirmation fails when a mutation is in flight`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        val holdResponse = CountDownLatch(1)
+        networkRule.checkoutUpdate { response ->
+            holdResponse.await(10, TimeUnit.SECONDS)
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        // Start a mutation that holds the mutex (its network response is held open).
+        val mutationJob = async { checkout.applyPromotionCode("10OFF") }
+        testScheduler.advanceUntilIdle()
+
+        val error = runCatching {
+            checkout.withConfirmation { error("block should not run when a mutation is in flight") }
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+        assertThat(error).hasMessageThat()
+            .isEqualTo("Cannot confirm while a checkout session mutation is in flight.")
+
+        holdResponse.countDown()
+        mutationJob.await()
+    }
+
+    @Test
+    fun `withConfirmation fails a second confirmation while the first is in flight`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        val holdFirstConfirmation = CompletableDeferred<Unit>()
+        val firstConfirm = async {
+            checkout.withConfirmation { holdFirstConfirmation.await() }
+        }
+        testScheduler.advanceUntilIdle()
+
+        val error = runCatching {
+            checkout.withConfirmation { error("second confirmation should not run") }
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+        assertThat(error).hasMessageThat()
+            .isEqualTo("Cannot confirm while a checkout session mutation is in flight.")
+
+        holdFirstConfirmation.complete(Unit)
+        firstConfirm.await()
+    }
+
+    @Test
+    fun `isLoading is true during withConfirmation`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+        val holdConfirmation = CompletableDeferred<Unit>()
+        val confirmJob = async {
+            checkout.withConfirmation { holdConfirmation.await() }
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+
+        holdConfirmation.complete(Unit)
+        confirmJob.await()
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        isLoadingTurbine.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `isLoading stays true while a mutation is queued behind confirmation`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-apply-discount.json")
+        }
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+        val holdConfirmation = CompletableDeferred<Unit>()
+        val confirmJob = async {
+            checkout.withConfirmation { holdConfirmation.await() }
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+
+        val mutationJob = async { checkout.applyPromotionCode("10OFF") }
+        testScheduler.advanceUntilIdle()
+
+        // No flicker: isLoading stays true while the mutation is queued behind confirmation.
+        isLoadingTurbine.expectNoEvents()
+
+        holdConfirmation.complete(Unit)
+        confirmJob.await()
+        mutationJob.await()
 
         assertThat(isLoadingTurbine.awaitItem()).isFalse()
         isLoadingTurbine.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -1111,10 +1111,12 @@ class CheckoutTest {
     ) {
         checkout.markIntegrationLaunched()
 
+        var blockRan = false
         val error = runCatching {
-            checkout.withConfirmation { error("block should not run when a payment flow is presented") }
+            checkout.withConfirmation { blockRan = true }
         }.exceptionOrNull()
 
+        assertThat(blockRan).isFalse()
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
         assertThat(error).hasMessageThat()
             .isEqualTo("Cannot confirm checkout session while a payment flow is presented.")
@@ -1134,10 +1136,12 @@ class CheckoutTest {
         val mutationJob = async { checkout.applyPromotionCode("10OFF") }
         testScheduler.advanceUntilIdle()
 
+        var blockRan = false
         val error = runCatching {
-            checkout.withConfirmation { error("block should not run when a mutation is in flight") }
+            checkout.withConfirmation { blockRan = true }
         }.exceptionOrNull()
 
+        assertThat(blockRan).isFalse()
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
         assertThat(error).hasMessageThat()
             .isEqualTo("Cannot confirm while a checkout session mutation is in flight.")
@@ -1156,10 +1160,12 @@ class CheckoutTest {
         }
         testScheduler.advanceUntilIdle()
 
+        var secondBlockRan = false
         val error = runCatching {
-            checkout.withConfirmation { error("second confirmation should not run") }
+            checkout.withConfirmation { secondBlockRan = true }
         }.exceptionOrNull()
 
+        assertThat(secondBlockRan).isFalse()
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
         assertThat(error).hasMessageThat()
             .isEqualTo("Cannot confirm while a checkout session mutation is in flight.")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -18,9 +18,9 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelAndJoin
@@ -1103,6 +1103,21 @@ class CheckoutTest {
         // Positive: once confirmation releases the queue, the mutation runs.
         val result = mutationJob.await()
         assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `withConfirmation fails when integrationLaunched is true`() = runCreateWithStateScenario(
+        shouldValidateEvents = false,
+    ) {
+        checkout.markIntegrationLaunched()
+
+        val error = runCatching {
+            checkout.withConfirmation { error("block should not run when a payment flow is presented") }
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+        assertThat(error).hasMessageThat()
+            .isEqualTo("Cannot confirm checkout session while a payment flow is presented.")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -436,7 +436,7 @@ class CheckoutSessionConfirmationInterceptorTest {
         val failAction = result as ConfirmationDefinition.Action.Fail
         assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
         assertThat(failAction.cause.message)
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
+            .isEqualTo("Cannot confirm while a checkout session mutation is in flight.")
         assertThat(failAction.errorType)
             .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
 
@@ -470,7 +470,7 @@ class CheckoutSessionConfirmationInterceptorTest {
         val failAction = result as ConfirmationDefinition.Action.Fail
         assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
         assertThat(failAction.cause.message)
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
+            .isEqualTo("Cannot confirm while a checkout session mutation is in flight.")
         assertThat(failAction.errorType)
             .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
 


### PR DESCRIPTION
[Minion run](https://agents.corp.stripe.com/sessions/18379c5f-245f-4e4f-bf3e-0cf3c6d6e1e2)

# Summary
<!-- Simple summary of what was changed. -->
Adds `Checkout.withConfirmation`, which acquires the mutation `Mutex` for the duration of a confirmation call so that mutations arriving during confirmation queue behind it instead of racing with it. Routes `CheckoutSessionConfirmationInterceptor` through this new method, replacing the point-in-time `ensureNoMutationInFlight` check that left the mutex unguarded for the rest of the confirm network call.

A confirmation fails fast (the interceptor maps it to a `MerchantIntegration` failure) when a payment flow is presented (`integrationLaunched`) or a mutation/confirmation is already in flight — i.e. it may only be enqueued when the queue is empty.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The previous confirm path called `ensureNoMutationInFlight` (fails if the mutex is locked at that instant) and then confirmed without holding the mutex. A mutation started _after_ the check would run concurrently with the in-flight confirm, which could observe a stale session state. This change adds the complementary direction to PR #13259: while confirmation is in flight, mutations wait at the mutex rather than racing.

`Checkout.withConfirmation` rejects confirmation while a payment flow is presented (the same `integrationLaunched` guard mutations use), then uses `mutex.tryLock()` to fail fast if the queue is occupied (a mutation or another confirm already in flight), then participates in `pendingMutations`/`isLoading` so the loading indicator behaves correctly for both the confirmation and any queued mutations. `CheckoutInstances.withConfirmation` runs the block directly when no instance is registered: instances are held by `WeakReference`, and an in-flight mutation keeps its `Checkout` strongly reachable, so a missing instance means no mutation can be in flight and there is nothing to serialize against — matching the previous no-op behavior and avoiding failing a legitimate payment.

The `integrationLaunched` guard is safe for the real confirm flow: in FlowController the merchant confirms as a separate action after the payment options sheet is dismissed, so `integrationLaunched` is already cleared by then. No production change to the dismissal lifecycle was needed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

Added `CheckoutTest` cases: a mutation queues behind an in-flight confirmation; `withConfirmation` fails when `integrationLaunched` is true, when a mutation is in flight, and for a second concurrent confirmation; and `isLoading` stays true (no flicker) while a mutation is queued behind a confirmation. Updated the two `CheckoutSessionConfirmationInterceptorTest` "mutation in flight" cases to assert the new failure message.

`FlowControllerCheckoutSessionTest` (16 instrumentation tests) confirm via FlowController. They were auto-confirming inside `paymentOptionCallback` (which fires before `PaymentOptionsActivity.onDestroy`), a timing that never occurs in real usage. Converted them to confirm after the options sheet is dismissed — via a new `FlowControllerTestRunnerContext.observePaymentOptionsActivityDestroyed()` helper that awaits the activity's destruction before `confirm()` — so the guard sees `integrationLaunched == false`, matching production. Verified 16/16 on a local emulator.

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
No changelog entry — this is an internal concurrency fix on the `@CheckoutSessionPreview` (`@RestrictTo`) API surface with no change to the public API.
