### PR TITLE
[onelink] Clean up use of interpolated brand strings

### DIFF
--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Guardar mis datos para un proceso de compra más rápido con %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Crea una cuenta con un enlace para que el proceso de compra sea más rápido en toda la Web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Crea una cuenta con %s para que el proceso de compra sea más rápido en toda la Web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s de crédito</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Guarda tus datos de pago con Link y efectúa la compra de forma segura en un clic en los sitios que admitan Link</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Paga más rápido en todos los comercios que acepten Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Paga más rápido en todos los comercios que acepten %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Al continuar, aceptas guardar tu información para futuras compras con %s y <link>Link</link> (consulta <terms>Condiciones</terms> y <privacy>Privacidad</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Al continuar, aceptas guardar tu información para futuras compras con %s y <link>Link</link> de acuerdo con las <terms>Condiciones</terms> y <privacy>privacidad</privacy> de Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Al continuar, aceptas guardar tu información para futuras compras con %1$s y <link>%2$s</link> de acuerdo con las <terms>condiciones</terms> y la <privacy>privacidad</privacy> de %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Desa la meva informació per agilitzar el pagament amb %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Creeu un compte amb Link per a una finalització de la compra més ràpida a tot el lloc web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Creeu un compte amb %s per a una finalització de la compra més ràpida a tot el lloc web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s de crèdit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Deseu la vostra informació de pagament amb Link i pagueu amb seguretat en 1 clic als llocs compatibles.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Pagueu més ràpid als llocs on s\'accepta Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Pagueu més ràpid als llocs on s\'accepta %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -151,7 +149,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[En continuar, accepteu desar la vostra informació per a futures compres amb %s i <link>Link</link> (consulteu les <terms>Condicions</terms> i la <privacy>Privacitat</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[En continuar, accepteu desar la vostra informació per a futures compres amb %s i <link>Link,</link> d\'acord amb les <terms>Condicions</terms> i la <privacy>Privacitat</privacy> de Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[En continuar, accepteu desar la vostra informació per a compres futures amb %1$s i <link>%2$s</link> d\'acord amb les <terms>condicions</terms> i la <privacy>privadesa</privacy> de %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Uložit mé údaje pro rychlejší platbu u %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Vytvořte si účet ve službě Link a plaťte na webu rychleji</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Vytvořte si účet u %s a plaťte na webu rychleji</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Kredit %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Uložte si platební údaje u Link a na stránkách podporovaných službou Link se bezpečně odbavte jedním kliknutím.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Plaťte rychleji všude, kde je akceptována služba Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Plaťte rychleji všude, kde je akceptována služba %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Pokračováním vyjadřujete souhlas s uložením vašich informací pro budoucí nákupy pomocí služby %s a pomocí služby <link>Link</link> (viz <terms>Podmínky</terms> a <privacy>Ochrana osobních údajů</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Pokračováním vyjadřujete souhlas s uložením vašich informací pro budoucí nákupy pomocí služby %s a služby <link>Link</link> podle <terms>podmínek</terms> a <privacy>ochrany osobních údajů</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Pokračováním souhlasíte s uložením svých údajů pro budoucí nákupy u %1$s a <link>%2$s</link> v souladu s <terms>podmínkami</terms> a <privacy>zásadami ochrany osobních údajů</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Gem mine oplysninger, så jeg kan betale hurtigere med %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Opret en konto med Link for gøre betaling hurtigere på hele internettet</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Opret en konto med %s, så du kan betale hurtigere på internettet</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Kredit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Gem dine betalingsoplysninger med Link, og betal sikkert med et enkelt klik på sider, der understøtter Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Betal hurtigere alle steder, hvor Link accepteres.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Betal hurtigere alle steder, hvor %s accepteres.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Ved at fortsætte accepterer du at gemme dine oplysninger til senere køb med %s og <link>Link</link> (Se <terms>vilkår</terms> og <privacy>privatlivspolitik</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Ved at fortsætte accepterer du at gemme dine oplysninger til senere køb hos %s og <link>Link</link> ifølge Links <terms>vilkår</terms> og <privacy>privatlivspolitik</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Ved at fortsætte accepterer du at gemme dine oplysninger til fremtidige køb med %1$s og <link>%2$s</link> i henhold til %2$s <terms>vilkår</terms> og <privacy>privatlivspolitik</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Meine Daten zur Beschleunigung des Bezahlvorgangs bei %s speichern</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Für schnelleres Bezahlen überall im Internet ein Konto bei Link erstellen</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Erstellen Sie ein Konto bei %s für schnelleres Bezahlen überall im Netz</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s-Kreditkarte</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Speichern Sie Ihre Zahlungsinformationen bei Link und bezahlen Sie sicher mit einem Klick auf Websites, die Link verwenden.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Schneller bezahlen überall dort, wo Link akzeptiert wird.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Bezahlen Sie schneller überall dort, wo %s akzeptiert wird.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Indem Sie fortfahren, stimmen Sie zu, dass Ihre Informationen für zukünftige Einkäufe bei %s und <link>Link</link> gespeichert werden (siehe <terms>Konditionen</terms> und<privacy>Datenschutz</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Indem Sie fortfahren, stimmen Sie zu, dass Ihre Informationen für zukünftige Einkäufe bei %s und <link>Link</link> gemäß den <terms>Konditionen</terms> und dem <privacy>Datenschutz</privacy> von Link gespeichert werden.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Indem Sie fortfahren, erklären Sie sich mit dem Speichern Ihrer Informationen für zukünftige Käufe bei %1$s und gemäß den <terms>Allgemeinen Geschäftsbedingungen</terms> und der <privacy> Datenschutzerklärung</privacy> von <link>%2$s</link> einverstanden.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Αποθήκευση των στοιχείων μου για ταχύτερη ολοκλήρωση αγοράς με %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Δημιουργήστε λογαριασμό με το Link για ταχύτερη ολοκλήρωση αγοράς σε όλο το διαδίκτυο</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Δημιουργήστε λογαριασμό με το %s για ταχύτερη ολοκλήρωση αγοράς σε όλο το διαδίκτυο</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Πιστωτική κάρτα %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Αποθηκεύστε τα στοιχεία πληρωμής σας με το Link, για ασφαλή ολοκλήρωση αγοράς με 1 κλικ στους ιστότοπους που υποστηρίζονται από το Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Πληρώστε γρηγορότερα όπου γίνεται δεκτό το Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Πληρώστε ταχύτερα οπουδήποτε γίνεται δεκτό το %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Συνεχίζοντας, συμφωνείτε να αποθηκεύσετε τις πληροφορίες σας για μελλοντικές αγορές με το %s και <link>Link</link> (βλέπε <terms>Όρους</terms> και <privacy>Απόρρητο</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Συνεχίζοντας, συμφωνείτε να αποθηκεύσετε τις πληροφορίες σας για μελλοντικές αγορές με το %s και <link>Link</link> σύμφωνα με τους <terms>όρους</terms> και το <privacy>απόρρητο</privacy> του Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Αν συνεχίσετε, συμφωνείτε να αποθηκεύουμε τα στοιχεία σας για μελλοντικές αγορές με %1$s και <link>%2$s</link> σύμφωνα με τους <terms>όρους</terms> και την <privacy>πολιτική απορρήτου</privacy> του %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Save my info for faster checkout with %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Create an account with Link for faster checkout across the web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Create an account with %s for faster checkout across the web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Save your payment information with Link, and securely check out in one click on Link-supported sites.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Pay faster everywhere Link is accepted.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Pay faster everywhere %s is accepted.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> according to %2$s <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Guarda mis datos para un proceso de compra más rápido con %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Crea una cuenta con Link para un proceso de compra más rápido en la web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Crea una cuenta con %s para un proceso de compra más rápido en la web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s de crédito</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Guarda tus datos de pago con Link y efectúa la compra de forma segura en un clic en los establecimientos compatibles con Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Paga más rápido en todos los comercios que acepten Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Paga más rápido en todos los comercios que acepten %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Al hacer clic en continuar, aceptas guardar tu información para futuras compras con %s y <link>Link</link> (consulta <terms>Condiciones</terms> y <privacy>privacidad</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Al hacer clic en continuar, aceptas guardar tu información para futuras compras con %s y <link>Link</link> según los <terms>términos</terms> y condiciones de <privacy>privacidad</privacy> de Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Al continuar, aceptas guardar tu información para futuras compras con %1$s y <link>%2$s</link> de acuerdo con las <terms>condiciones</terms> y <privacy>privacidad</privacy> de %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Salvesta minu info kiiremaks väljamakseks %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Looge Linki konto, et veebis kiiremini maksta</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Looge konto %s-iga, et veebis kiiremini makse lõpule viia</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s krediit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Salvestage oma makseteave Linki ja võimaldage Linki toetusega saitidel turvaline ühe klõpsuga makse lõpuleviimine.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Makske kiiremini kõikjal, kus Link on aktsepteeritud.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Makske kiiremini kõikjal, kus %s on aktsepteeritud.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Jätkates nõustute salvestama oma andmed tulevaste ostude jaoks %s ja <link>Link</link> (vt <terms>Tingimused</terms> ja <privacy>Privaatsus</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Jätkates nõustute salvestama oma andmed tulevaste ostude jaoks %s ja <link>Link</link> vastavalt Linki <terms>tingimustele</terms> ja <privacy>privaatsusele</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Jätkates nõustute, et teie andmed salvestatakse tulevasteks ostudeks teenusepakkujatega %1$s ja <link>%2$s</link> vastavalt %2$s <terms>tingimustele</terms> ja <privacy>privaatsuspoliitikale</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Tallenna tietoni nopeampaa maksamista varten kohteella %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Luo tili Link-palvelulla nopeampaa verkkomaksamista varten</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Luo tili palvelussa %s nopeampaa maksamista varten verkossa</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s-luottokortti</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Tallenna maksutiedot Link-palveluun ja maksa turvallisesti yhdellä napsautuksella Link-palvelun tukemilla sivustoilla.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Maksa nopeammin kaikkialla, missä Link hyväksytään.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Maksa nopeammin kaikkialla, missä %s on hyväksytty.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Jatkamalla hyväksyt, että tietosi tallennetaan tulevia ostoksia varten tahon %s kanssa ja <link>Linkki</link> (katso <terms>Ehdot</terms> ja <privacy>tietosuoja</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Jatkamalla hyväksyt, että tietosi tallennetaan tulevia ostoksia varten tahon %s ja <link>Linkin kanssa</link> Linkin <terms>ehtojen</terms> ja <privacy>tietosuojakäytännön</privacy> mukaisesti.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Jatkamalla hyväksyt tallentavasi tietosi tulevia ostoksia varten kohteilla %1$s ja <link>%2$s</link> %2$s <terms>ehtojen</terms> ja <privacy>tietosuojaselosteen</privacy> mukaisesti.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">I-save ang aking impormasyon para sa mas mabilis na pag-checkout sa %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Gumawa ng account na may Link para sa mas mabilis na pag-checkout sa web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Lumikha ng account sa %s para sa mas mabilis na pag-checkout sa buong web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">I-save ang iyong impormasyon ng pagbabayad sa Link, at ligtas na mag-check out nang 1-click sa mga site na suportado ng Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Magbayad nang mas mabilis kahit saan tinatanggap ang Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Magbayad nang mas mabilis kung saan tinatanggap ang %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Sa pagpapatuloy, sumasang-ayon kang i-save ang iyong impormasyon para sa mga pagbili sa hinaharap sa %s at <link>Link</link> (tingnan ang <terms>Mga Tuntunin</terms> at <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Sa pagpapatuloy, sumasang-ayon kang i-save ang iyong impormasyon para sa mga pagbili sa hinaharap gamit ang %s at <link>Link</link> Ayon sa Link <terms>mga tuntunin</terms> at <privacy>privacy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Sa pagpapatuloy, sumasang-ayon kang i-save ang iyong impormasyon para sa mga pagbili sa hinaharap sa %1$s at <link>%2$s</link> alinsunod sa<terms>mga tuntunin</terms> at <privacy>pagkapribado</privacy> ng %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Enregistrer mes informations pour un paiement plus rapide avec %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Créez un compte avec Link pour un paiement plus rapide sur le Web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Créer un compte avec %s pour un paiement plus rapide sur le web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Carte de crédit %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Enregistrez vos informations de paiement avec Link et payez en un clic et en toute sécurité sur les sites qui proposent Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Payez plus rapidement vos achats partout où Link est accepté.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Payer plus rapidement partout où [ %s] est accepté.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[En continuant, vous acceptez d\'enregistrer vos renseignements pour des achats futurs avec %s et <link>Link</link> (voir <terms>conditions</terms> et <privacy>vie privée</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[En continuant, vous acceptez d\'enregistrer vos renseignements pour des achats futurs avec %s et <link>Link</link> selon les <terms>Conditions de service</terms> et la <privacy>Politique de confidentialité</privacy> de Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[En continuant, vous acceptez d’enregistrer vos informations pour de futurs achats avec %1$s et <link>%2$s</link> selon les <terms>conditions</terms> et la <privacy>politique de confidentialité</privacy> de %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Sauvegardez mes informations pour que je profite d’un processus de paiement plus rapide avec %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Créez un compte avec Link pour un paiement plus rapide sur le Web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Créer un compte avec %s pour profiter d’un processus de paiement plus rapide sur internet</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Carte de crédit %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Enregistrez vos informations de paiement avec Link et payez en un clic et en toute sécurité sur les sites compatibles.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Réglez plus rapidement vos achats partout où Link est accepté.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Réglez vos achats plus rapidement, partout où %s est accepté.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[En continuant, vous acceptez d\'enregistrer vos informations pour de futurs achats avec %s et <link>Link</link> (voir <terms>Conditions</terms> et <privacy>Politique de confidentialité</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[En continuant, vous acceptez d\'enregistrer vos informations pour de futurs achats avec %s et <link>Link</link> conformément aux <terms>conditions</terms> et à la <privacy>confidentialité</privacy> de Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[En continuant, vous acceptez de sauvegarder vos informations pour de futurs achats auprès de %1$s et <link>%2$s</link>, conformément aux <terms>Conditions</terms> et à la <privacy>Politique de confidentialité</privacy> de %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Spremi moje podatke za brže izvršenje plaćanja s %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Stvaranje računa s pomoću Linka za brže izvršenje plaćanja na mreži</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Izradite račun s %s za brže izvršenje plaćanja na mreži</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Kreditna kartica</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Spremite svoje podatke o plaćanju pomoću Linka i sigurno platite jednim klikom na stranicama koje podržavaju Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Plaćajte brže svugdje gdje je Link prihvaćen.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Plaćajte brže svugdje gdje se prihvaća %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Nastavkom pristajete spremiti svoje podatke za buduće kupnje uz %s i <link>Link</link> (pogledajte <terms>Uvjeti</terms> i <privacy>Privatnost</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Nastavkom pristajete spremiti svoje podatke za buduće kupnje uz %s i <link>Link</link> prema <terms>uvjetima</terms> i <privacy>privatnosti</privacy> značajke Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Nastavkom se slažete da ćete spremiti svoje podatke za buduće kupnje s %1$s i <link>%2$s</link> prema %2$s <terms>uvjetima</terms> i <privacy>privatnosti</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Adataim mentése a gyorsabb fizetéshez a következővel: %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Hozzon létre egy fiókot a Link segítségével a gyorsabb fizetéshez az interneten</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Hozzon létre egy számlát a következővel: %s a gyorsabb fizetéshez az interneten</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$sHitel</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Mentse fizetési adatait a Linkbe, hogy biztonságosan fizessen egy kattintással a Link által támogatott oldalakon.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Gyorsabban fizethet mindenhol, ahol a Linket elfogadják.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Gyorsabban fizethet mindenhol, ahol a(z) %s elfogadott.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[A folytatással Ön beleegyezik abba, hogy adatait elmenti a jövőbeni vásárlásokhoz itt: %s és <link>a Linknél</link> (lásd a <terms>feltételeket</terms> és az <privacy>adatvédelmi szabályzatot).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[A folytatással Ön beleegyezik abba, hogy adatait elmenti a jövőbeni vásárlásokhoz itt: %s és <link>a Linknél</link> a Link <terms>feltételei</terms> és <privacy>adatvédelmi szabályzata</privacy> szerint.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Ha folytatja, azzal hozzájárul az adatainak mentéséhez a jövőbeni vásárlásokhoz itt: %1$s és <link>%2$s</link> a %2$s <terms>feltételeknek</terms> és az <privacy>adatvédelmi szabályzatnak</privacy> megfelelően.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Simpan info saya untuk checkout lebih cepat dengan %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Buat rekening dengan Link untuk checkout yang lebih cepat di seluruh web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Buat akun dengan %s agar checkout lebih cepat di seluruh web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Kredit %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Simpan informasi pembayaran Anda dengan Link, dan proses pembayaran secara aman dalam sekali klik pada situs yang didukung Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Bayar lebih cepat di mana saja Link diterima.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Bayar lebih cepat di mana saja %s diterima.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Dengan melanjutkan, Anda menyetujui informasi Anda disimpan untuk pembelian di masa mendatang dengan %s dan <link>Tautan</link> (lihat <terms>Ketentuan</terms> dan <privacy>Privasi</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Dengan melanjutkan, Anda menyetujui informasi Anda disimpan untuk pembelian di masa mendatang dengan %s dan <link>Link</link> sesuai dengan <terms>ketentuan</terms> dan <privacy>privasi</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Dengan melanjutkan, berarti Anda setuju untuk menyimpan informasi untuk pembelian mendatang dengan %1$s dan <link>%2$s</link> sesuai dengan <terms>ketentuan</terms> dan <privacy>privasi</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Salva le mie informazioni per un checkout più veloce con %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Crea un account con Link per un completamento della transazione più veloce sul Web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Crea un account con %s per un checkout più veloce sul web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Carta di credito %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Salva i tuoi dati di pagamento su Link ed effettua il pagamento in modo sicuro con un clic sui siti supportati da Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Paga più velocemente ovunque Link sia accettato.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Paga più velocemente ovunque %s sia accettato.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Continuando, accetti di salvare le tue informazioni per acquisti futuri con %s e <link>Link</link> (consulta <terms>Termini</terms> e <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Continuando, accetti di salvare le tue informazioni per acquisti futuri con %s e <link>Link</link> secondo i <terms>Termini</terms> e la <privacy>privacy</privacy> di Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Continuando, accetti di salvare le tue informazioni per acquisti futuri con %1$s e <link>%2$s</link> in base ai %2$s <terms>Termini</terms> e <privacy>all\'Informativa sulla privacy</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">%s でより迅速に決済できるよう情報を保存</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Link でアカウントを作成すると、ウェブ上で決済を迅速化できます</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">%s でアカウントを作成して、ウェブ全体でより迅速に決済</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s クレジット</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">支払い情報を Link に保存すると、Link に対応したサイトで安全にワンクリックで決済することができます。</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Link に対応している店舗でスピーディーに支払うことができます。</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">%s に対応しているすべての場所で、より迅速に支払い</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[続行することで、今後の購入のために情報を保存することに同意したことになります <link>Link</link> (<terms>利用規約</terms>および<privacy>プライバシー</privacy>を参照)。]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[続行することで、今後の購入のために情報を保存することに同意したことになります <link>Link</link> リンク<terms>規約</terms>および<privacy>プライバシー</privacy>に従うことになります。]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[続行すると、%2$s の<terms>規約</terms>および<privacy>プライバシー</privacy>に従い、今後 %1$s と <link>%2$s</link> で購入できるよう、お客様の情報が保存されることに同意したものとみなされます。]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">%s로 체크아웃을 빠르게 진행하기 위해 내 정보 저장</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Link 계정을 생성하여 웹 전반에서 더 빠르게 체크아웃하세요</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">%s 계정을 생성하여 웹 전반에서 더 빠르게 체크아웃하세요</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s 신용</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Link에서 결제 정보를 저장하고 Link 지원 사이트에서 원클릭으로 안전하게 체크아웃하십시오.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Link가 허용되는 모든 곳에서 더 빠르게 결제하십시오.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">%s가 허용되는 모든 곳에서 더 빠르게 결제하십시오.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[계속 진행하시면, 향후 구매 시 사용하기 위해 귀하의 정보를 %s 및 <link>Link</link> (<terms>약관</terms> 및 <privacy>개인정보 보호</privacy> 참조)에 저장하는 데 동의하시는 것입니다.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[계속 진행하시면, 향후 구매 시 사용하기 위해 귀하의 정보를 %s 및 <link>Link</link> 에 Link <terms>약관</terms> 및 <privacy>개인정보 보호</privacy>에 따라 저장하시는 데 동의하시는 것입니다.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[계속 진행하시면, %2$s의 <terms>약관</terms> 및 <privacy>개인정보정책</privacy>에 따라 향후 %1$s 및 <link>%2$s</link>에서 구매 시 귀하의 정보를 저장하는 데 동의하는 것으로 간주됩니다.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Įrašyti informaciją, kad būtų galima greičiau atsiskaityti su %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Sukurkite paskyrą naudodami „Link”, kad galėtumėte greičiau atsiskaityti žiniatinklyje</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Sukurkite %s paskyrą, kad galėtumėte greičiau atlikti užsakymą visame tinkle</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">„%1$s“ kredito</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Išsaugokite savo mokėjimų informaciją naudodami \"Link\" ir saugiai atsiskaitykite vienu spustelėjimu \"Link\" palaikomose svetainėse.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Mokėkite greičiau visur, kur priimama „Link“.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Mokėti greičiau visur, kur priimama %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Tęsdami sutinkate išsaugoti savo informaciją būsimiems pirkimams naudojant %s ir <link>„Link“</link> (žr. <terms>Sąlygos</terms> ir <privacy>Privatumo politika</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Tęsdami sutinkate išsaugoti savo informaciją būsimiems pirkimams naudojant %s ir <link>„Link“</link> pagal „Link“ <terms>Sąlygas</terms> ir <privacy>Privatumo politiką</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Tęsdami sutinkate, kad laikantis %2$s <terms>sąlygų</terms> ir <privacy>privatumo politikos</privacy> jūsų duomenys būtų išsaugoti būsimų pirkimų su %1$s ir <link>%2$s</link> svetainėse tikslais.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Saglabāt manu informāciju, lai ātrāk norēķinātos ar %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Izveidojiet kontu Link, lai varētu ātrāk veikt apmaksu visā tīmeklī</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Izveidojiet kontu vietnē %s, lai ātrāk norēķinātos tīmeklī</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Kredīta</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Saglabājiet savu maksājuma informāciju ar Link un droši norēķinieties ar 1 klikšķi Link atbalstītās lapas.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Maksājiet ātrāk visur, kur tiek pieņemta saite.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Maksājiet ātrāk visur, kur pieņem %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Turpinot jūs piekrītat saglabāt savu informāciju turpmākiem pirkumiem ar %s un <link>Saite</link> (skatīt <terms>Noteikumi</terms> un <privacy>konfidencialitāte</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Turpinot jūs piekrītat saglabāt savu informāciju turpmākiem pirkumiem ar %s un <link>Saite</link> saskaņā ar saites <terms>noteikumiem</terms> un <privacy>privātumu</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Turpinot, jūs piekrītat saglabāt savu informāciju turpmākiem pirkumiem ar %1$s un <link>%2$s</link> saskaņā ar %2$s <terms>Noteikumi</terms> un <privacy>Konfidencialitāte</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Simpan maklumat saya untuk pembayaran yang lebih pantas dengan %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Buat akaun dengan Link untuk proses bayar dan keluar lebih pantas di seluruh web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Buat akaun dengan %s untuk pembayaran yang lebih pantas merentas web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Kredit %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Simpan maklumat pembayaran anda dengan Link, serta bayar dan keluar dengan sekali klik secara selamat di laman yang disokong oleh Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Bayar dengan lebih pantas di mana-mana sahaja Link diterima.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Bayar lebih pantas di mana-mana sahaja %s diterima.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Dengan meneruskan, anda bersetuju untuk menyimpan maklumat anda bagi pembelian masa hadapan dengan %s dan <link>Link</link> (lihat <terms>Terma</terms> Dan <privacy>Privasi</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Dengan meneruskan, anda bersetuju untuk menyimpan maklumat anda bagi pembelian masa hadapan dengan %s dan <link>Link</link> menurut <terms>terma</terms> Dan <privacy>privasi</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Dengan meneruskan, anda bersetuju untuk menyimpan maklumat anda untuk pembelian masa hadapan dengan %1$s dan <link>%2$s</link> mengikut %2$s <terms>terma</terms> dan <privacy>privasi</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Issejvja l-informazzjoni tiegħi għal checkout aktar malajr ma’ %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Oħloq kont ma’ Link għal pagament aktar mgħaġġel fuq il-web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Oħloq kont ma’ %s għal checkout aktar malajr fuq il-web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Erfa\' l-informazzjoni dwar il-pagament tiegħek permezz ta\' Link u ħallas b\'mod sigur b\'mossa waħda fuq siti tal-internet li jaċċettaw Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Ħallas aktar malajr kullimkien fejn Link huwa aċċettat.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Ħlas aktar malajr kullimkien fejn %s huwa aċċettat.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Billi tkompli, int taqbel li tissejvja l-informazzjoni tiegħek għal xirjiet futuri ma\' %s u <link>Ħolqa</link> (ara t-<terms>Termini</terms> u l-<privacy>Privatezza</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Billi tkompli, int taqbel li tissejvja l-informazzjoni tiegħek għal xirjiet futuri ma\' %s u <link>Ħolqa</link> skont il-Ħolqa <terms>termini</terms> u <privacy>privatezza</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Billi tkompli, qed taqbel li tissejvja l-informazzjoni tiegħek għal xirjiet futuri ma’ %1$s u <link>%2$s</link> skont <terms>it-termini</terms> u <privacy>l-privatezza</privacy> ta’ %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Lagre informasjonen min for raskere betaling med %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Opprett en konto med Link for raskere betaling på nett</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Opprett en konto med %s for raskere betaling på nett</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s -kreditt</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Lagre betalingsinformasjonen din med Link, og sjekk ut sikkert med ett klikk på Link-støttede nettsteder.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Betal raskere overalt hvor Link aksepteres.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Betal raskere overalt hvor %s godtas.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Ved å fortsette godtar du å lagre informasjonen din for fremtidige kjøp med %s og <link>Link</link> (se <terms>vilkår</terms> og <privacy>personvern</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Ved å fortsette godtar du å lagre informasjonen din for fremtidige kjøp med %s og <link>Link</link> ifølge Links <terms>vilkår</terms> og <privacy>personvern</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Når du fortsetter, godtar du at opplysningene dine lagres for fremtidige kjøp med %1$s og <link>%2$s</link> i henhold til <terms>vilkårene</terms> og <privacy>personvernerklæringen</privacy> til %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Bewaar mijn gegevens, zodat ik sneller met %s kan afrekenen</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Maak een account aan bij Link om sneller te kunnen afrekenen op het internet.</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Maak een account bij %s, zodat ik sneller kan afrekenen op internet.</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s creditcard</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Sla je betaalgegevens op met Link, en je kunt veilig met één klik afrekenen op sites die door Link worden ondersteund.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Betaal sneller, overal waar Link wordt geaccepteerd.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Betaal sneller, overal waar %s wordt geaccepteerd.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Door verder te gaan, ga je ermee akkoord dat jouw informatie wordt opgeslagen voor toekomstige aankopen bij %s en <link>Link</link> (zie <terms>Voorwaarden</terms> en <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Door verder te gaan, ga je ermee akkoord dat jouw informatie wordt opgeslagen voor toekomstige aankopen bij %s en <link>Link</link> volgens Link <terms>voorwaarden</terms> en <privacy>privacy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Als je doorgaat, ga je ermee akkoord dat je gegevens worden opgeslagen voor toekomstige aankopen bij %1$s en <link>%2$s</link> volgens de <terms>voorwaarden</terms> en <privacy>privacy</privacy> van %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Zapisz moje dane do szybszej finalizacji za pomocą %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Utwórz konto w usłudze Link, aby przyspieszyć finalizację transakcji online</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Utwórz konto z %s, aby przyspieszyć finalizację transakcji online</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Karta kredytowa %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Zapisz informacje o płatnościach w Link i bezpiecznie finalizuj transakcje jednym kliknięciem na stronach obsługiwanych przez Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Płać szybciej wszędzie tam, gdzie usługa Link jest akceptowana.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Płać szybciej wszędzie tam, gdzie akceptowana jest usługa %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Kontynuując, wyrażasz zgodę na zapisywanie swoich danych na potrzeby przyszłych zakupów w firmie %s i <link>Link</link> (zob. <terms>Warunki</terms> i <privacy>Politykę prywatności</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Kontynuując, wyrażasz zgodę na zapisywanie swoich danych na potrzeby przyszłych zakupów w firmie %s i <link>Link</link> zgodnie z <terms>warunkami</terms> i <privacy>polityką prywatnością</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Kontynuując, wyrażasz zgodę na zachowanie danych do przyszłych zakupów w %1$s i <link>%2$s</link> zgodnie z <terms>warunkami</terms> i <privacy>polityką prywatności</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Salvar meus dados para um checkout mais rápido com %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Crie uma conta com o Link para um checkout mais rápido na web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Criar uma conta com %s para checkout mais rápido na web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Crédito %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Salve seus dados de pagamento com o Link e faça checkout com segurança em 1 clique em sites compatíveis com o Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Pague mais rápido em todos os lugares que aceitam o Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Pague mais rápido em todos os lugares onde %s é aceito.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Ao continuar, você concorda em salvar seus dados para compras futuras com %s e <link>Link</link> (ver <terms>Termos</terms> e <privacy>Privacidade</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Ao continuar, você concorda em salvar seus dados para compras futuras com %s e <link>Link</link> de acordo com os <terms>termos</terms> e a <privacy>privacidade</privacy> do Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Ao continuar, você concorda em salvar suas informações para compras futuras com %1$s e <link>%2$s</link> de acordo com os <terms>termos</terms> e a <privacy>privacidade</privacy> da %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Guardar as minhas informações para uma finalização de compra mais rápida com %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Crie uma conta com o Link para uma finalização de compra mais rápida na Web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Crie uma Conta com %s para uma finalização de compra mais rápida online</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Crédito %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Guarde as suas informações de pagamento com Link, e finalize as suas compras num clique em páginas de Internet que suportam o Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Pague mais rapidamente em todos os locais que aceitam Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Pague mais rapidamente em todos os locais que aceitam %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Ao continuar, concorda guardar as suas informações para compras futuras com %s e <link>Link</link> (ver <terms>Condições</terms> e <privacy>Privacidade</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Ao continuar, concorda guardar as suas informações para compras futuras com %s e <link>Link</link> de acordo com as <terms>condições</terms> e a <privacy>privacidade</privacy> da Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Ao continuar, concorda guardar as suas informações para compras futuras com %1$s e <link>%2$s</link> de acordo com as <terms>Condições</terms> e a <privacy>privacidade</privacy> de %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Salvează-mi datele pentru o finalizare mai rapidă a comenzii cu %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Creați un cont cu Link pentru o finalizare mai rapidă a comenzii online</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Creați un cont cu %s pentru o finalizare mai rapidă a comenzii online</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Salvați-vă informațiile privind plata cu Link și finalizați comanda în siguranță cu un singur clic pe site-urile acceptate de Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Plătiți mai repede oriunde este acceptat Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Plătiți mai repede oriunde este acceptat %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Continuând, sunteți de acord să vă salvați informațiile pentru achiziții viitoare cu %s și <link>Link</link> (consultați <terms>Termeni</terms> și <privacy>Confidențialitate</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Continuând, sunteți de acord să vă salvați informațiile pentru achiziții viitoare cu %s și <link>Link</link> în conformitate cu <terms>Termenii</terms> și <privacy>confidențialitatea</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Continuând, sunteți de acord să vă salvați informațiile pentru achiziții viitoare cu %1$s și <link>%2$s</link>, conform <terms>Termenilor</terms> și <privacy>confidențialității</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ro/strings.xml
+++ b/paymentsheet/res/values-ro/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Salvează-mi datele pentru o finalizare mai rapidă a comenzii cu %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Creați un cont cu Link pentru o finalizare mai rapidă a comenzii online</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Creați un cont cu %s pentru o finalizare mai rapidă a comenzii online</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Salvați-vă informațiile privind plata cu Link și finalizați comanda în siguranță cu un singur clic pe site-urile acceptate de Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Plătiți mai repede oriunde este acceptat Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Plătiți mai repede oriunde este acceptat %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Continuând, sunteți de acord să vă salvați informațiile pentru achiziții viitoare cu %s și <link>Link</link> (consultați <terms>Termeni</terms> și <privacy>Confidențialitate</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Continuând, sunteți de acord să vă salvați informațiile pentru achiziții viitoare cu %s și <link>Link</link> în conformitate cu <terms>Termenii</terms> și <privacy>confidențialitatea</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Continuând, sunteți de acord să vă salvați informațiile pentru achiziții viitoare cu %1$s și <link>%2$s</link>, conform <terms>Termenilor</terms> și <privacy>confidențialității</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Сохранить данные для ускоренной процедуры выписки с помощью %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Создайте учетную запись в Link для более быстрого оформления заказов в Интернете</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Создание учетной записи в %s для ускоренного оформления заказов в интернете</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s кредитная</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Сохраните платежные реквизиты в Link, чтобы безопасно оформлять заказы одним щелчком на всех сайтах, поддерживающих Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Платите быстрее везде, где принимают Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Платите быстрее везде, где принимают %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Продолжая, вы соглашаетесь сохранить вашу информацию для будущих покупок через %s и <link>Ссылка</link> (см. <terms>Условия</terms> и <privacy>Политику конфиденциальности</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Продолжая, вы соглашаетесь сохранить свою информацию для будущих покупок через %s и <link>Link</link> в соответствии с <terms>условиями</terms> и <privacy>политикой конфиденциальности</privacy> Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Продолжая, вы соглашаетесь сохранить свои данные для будущих покупок с помощью %1$s и <link>%2$s</link> согласно <terms>Условиям</terms> и <privacy>Политике конфиденциальности</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Uloženie mojich informácií pre rýchlejšiu platbu pomocou %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Vytvorte si účet pomocou služby Link pre rýchlejšiu platbu na internete</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Vytvorte si účet pomocou %s na rýchlejšiu platbu na internete</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Kreditná karta %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Uložte si svoje platobné údaje pomocou služby Link a bezpečne plaťte jedným kliknutím na stránkach podporovaných službou Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Plaťte rýchlejšie všade tam, kde je akceptovaná služba Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Plaťte rýchlejšie všade tam, kde je akceptovaná služba %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Pokračovaním súhlasíte s uložením svojich údajov pre budúce nákupy v spoločnosti %s a <link>službe Link</link> (pozrite si <terms>podmienky</terms> a <privacy>zásady ochrany osobných údajov</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Pokračovaním súhlasíte s uložením svojich údajov pre budúce nákupy v spoločnosti %s a <link>službe Link</link> podľa <terms>podmienok</terms> a <privacy>zásad ochrany osobných údajov</privacy> služby Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Pokračovaním súhlasíte s uložením svojich informácií pre budúce nákupy v spoločnosti %1$s a <link>%2$s</link> podľa <terms>podmienok</terms> a <privacy>zásad ochrany osobných údajov</privacy> spoločnosti %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Shrani moje podatke za hitrejši nakup z %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Ustvarite račun v storitvi Link za hitrejšo izvedbo plačila na spletu</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Ustvarite račun z %s za hitrejše plačilo na spletu</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">Kreditna kartica %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Shranite svoje podatke o plačilu v storitev Link za varno izvedbo plačila z enim klikom na spletnih mestih, ki podpirajo Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Plačujte hitreje povsod, kjer je sprejeta storitev Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Plačujte hitreje povsod, kjer sprejemajo %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Z nadaljevanjem se strinjate, da se vaši podatki shranijo za prihodnje nakupe pri %s in <link>Link</link> (glejte <terms>Pogoji</terms> in <privacy>Politika o zasebnost</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Z nadaljevanjem se strinjate, da se vaši podatki shranijo za prihodnje nakupe pri %s in <link>Link</link> glede na povezavo <terms>pogoji</terms> in <privacy>zasebnost</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Z nadaljevanjem se strinjate, da se vaši podatki shranijo za prihodnje nakupe z %1$s in <link>%2$s</link> v skladu s <terms>pogoji</terms> in <privacy>zasebnostjo</privacy> %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Spara mina uppgifter för snabbare betalningar i kassan med %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Skapa ett konto med Link för en snabbare kassaupplevelse på webben</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Skapa ett konto hos %s för snabbare betalningar i kassan på nätet</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Kreditkort</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Spara dina betalningsuppgifter med Link och betala på ett säkert sätt med ett klick på webbplatser som erbjuder Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Betala snabbare överallt där Link accepteras.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Betala snabbare överallt där %s accepteras.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Genom att fortsätta godkänner du att dina uppgifter sparas för framtida köp hos %s och <link>Link</link> (se <terms>Villkor</terms> och <privacy>Integritet</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Genom att fortsätta godkänner du att dina uppgifter sparas för framtida köp hos %s och <link>Link</link> enligt Links <terms>villkor</terms> och <privacy>integritetspolicy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Genom att fortsätta samtycker du till att spara dina uppgifter för framtida köp med %1$s och <link>%2$s</link> enligt <terms>villkoren</terms> och <privacy>integritetspolicyn</privacy> för %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">บันทึกข้อมูลของฉันเพื่อให้ดำเนินการชำระเงินด้วย %s ได้รวดเร็วขึ้น</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">สร้างบัญชีด้วย Link เพื่อการชำระเงินบนเว็บที่รวดเร็วขึ้น</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">สร้างบัญชีด้วย %s เพื่อการชำระเงินบนเว็บที่รวดเร็วขึ้น</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">บัตรเครดิต %1$s</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">บันทึกข้อมูลการชำระเงินของคุณด้วย Link แล้วชำระเงินอย่างปลอดภัยในคลิกเดียวบนเว็บไซต์ที่ Link รองรับ</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">ชำระเงินได้รวดเร็วขึ้นในทุกที่ที่รองรับ Link</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">ชำระเงินได้รวดเร็วขึ้นในทุกที่ที่รองรับ %s</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[เมื่อดำเนินการต่อ แสดงว่ายินยอมที่จะบันทึกข้อมูลไว้สำหรับการซื้อด้วย %s ในอนาคต และ <link>Link</link> (ดู<terms>ข้อกำหนด</terms>และ<privacy>ความเป็นส่วนตัว</privacy>)]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[เมื่อดำเนินการต่อ แสดงว่าคุณยินยอมที่จะบันทึกข้อมูลไว้สำหรับการซื้อด้วย %s ในอนาคต และ <link>Link</link> ตาม<terms>ข้อกำหนด</terms>และ<privacy>ความเป็นส่วนตัว</privacy>ของ Link]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[เมื่อดำเนินการต่อ จะถือว่าคุณตกลงที่จะบันทึกข้อมูลของคุณไว้สำหรับการซื้อสินค้าจาก %1$s และ <link>%2$s</link> ในอนาคต โดยเป็นไปตาม<terms>ข้อกำหนด</terms>และ<privacy>ความเป็นส่วนตัว</privacy>ของ %2$s]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">%s ile daha hızlı ödeme yapmak için bilgilerimi kaydet</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Web genelinde daha hızlı ödeme yapmak için Link ile bir hesap oluşturun</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Web genelinde daha hızlı ödeme için %s ile bir hesap oluşturun</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Kredisi</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Bilgilerinizi Link\'e kaydedin ve Link tarafından desteklenen sitelerde 1 tıklamayla güvenle ödeme yapın.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Link\'in kabul edildiği her yerde daha hızlı ödeme yapın.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">%s kabul edildiği her yerde daha hızlı ödeme yapın.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Devam ederek, bilgilerinizi gelecekteki %s satın alımları için kaydetmeyi kabul etmiş olursunuz ve <link>Link</link> (bkz. <terms>Koşullar</terms> ve <privacy>Gizlilik</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Devam ederek, bilgilerinizi gelecekteki %s ve <link>Link satın alımları için</link> Link <terms>koşulları</terms> ve <privacy>gizlilik kuralları</privacy> uyarınca kaydetmeyi kabul etmiş olursunuz.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Devam ederek, %1$s ve <link>%2$s</link> ile gelecekteki satın alımlar için bilgilerinizi %2$s <terms>koşulları</terms> ve <privacy>gizlilik</privacy> şartları uyarınca kaydetmeyi kabul etmiş olursunuz.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Lưu thông tin của tôi để thanh toán nhanh hơn với %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Tạo tài khoản bằng Link để thanh toán nhanh hơn trên web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Tạo tài khoản bằng %s để thanh toán nhanh hơn trên web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Ghi có</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Lưu thông tin thanh toán với Link và thanh toán an toàn bằng 1 cú nhấp chuột trên các trang web có hỗ trợ Link.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Thanh toán nhanh hơn ở mọi nơi chấp nhận Link.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Thanh toán nhanh hơn ở mọi nơi chấp nhận %s.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[Bằng cách tiếp tục, bạn đồng ý lưu thông tin của mình cho các giao dịch mua trong tương lai với %s và <link>Link</link> (xem <terms>Điều khoản</terms> và <privacy>Quyền riêng tư</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[Bằng cách tiếp tục, bạn đồng ý lưu thông tin của mình cho các giao dịch mua trong tương lai với %s và <link>Link</link> theo <terms>điều khoản</terms> và <privacy>quyền riêng tư</privacy> của Link.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[Bằng việc tiếp tục, bạn đồng ý lưu thông tin của mình cho các giao dịch mua trong tương lai với %1$s và <link>%2$s</link> theo <terms>điều khoản</terms> và <privacy>quyền riêng tư</privacy> của %2$s.]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">儲存資訊，以便透過 %s 更快結賬</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">使用 Link 建立帳戶，以便在網站上更快結帳</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">透過 %s 建立賬戶，網上各處享受更快捷的結賬體驗</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s 信用卡</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">用 Link 儲存您的支付資訊，並在支援 Link 的網站上一鍵安全結賬。</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">在接受 Link 的任何地方可以更快速支付。</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">在任何接受 %s 的地方享受更快捷的付款體驗。</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[繼續即表示您同意儲存您的個人資料，以便將來透過 %s 和 <link>Link</link> 進行購物（請參閱<terms>條款</terms>與<privacy>隱私政策</privacy>）。]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[繼續即表示您同意儲存您的個人資料，以便將來根據 <link>Link</link> <terms>條款</terms>與<privacy>私隱政策</privacy> 透過 %s 和 Link 購物]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[繼續操作即表示您同意按照 %2$s 的 <terms>條款</terms> 和 <privacy>隱私政策</privacy>，為供未來在 %1$s 和 <link>%2$s</link> 購物時使用而儲存您的資訊。]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">保存我的信息，以便使用 %s 更快地结账</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">在 Link 创建账户，加快全网结账速度</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">使用 %s 创建账户，以便在全网更快地结账</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s 信用卡</string>
@@ -75,7 +74,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">用 Link 保存您的支付信息，并在支持 Link 的网站上一键安全结账。</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">在接受 Link 的任何地方更快支付。</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">在接受 %s 的任何地方都能更快地支付。</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -153,7 +151,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[继续操作则表示您同意保存您的信息，用于今后在%s和 <link>Link 购物</link> （参见<terms>条款</terms>和<privacy>隐私政策</privacy>）。]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[继续操作则表示您同意保存您的信息，用于今后在%s和 <link>Link 相关的购物</link> 根据 Link <terms>条款</terms>和<privacy>隐私政策</privacy>。]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[继续操作，即表示您同意根据 %2$s 的<terms>条款</terms>和<privacy>隐私</privacy>，将您的信息保存至 %1$s 和 <link>%2$s</link>，以便将来购买。]]></string>
   <!-- Error message displayed when updating a card fails. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -32,7 +32,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_inline_sign_up_header_default_opt_in_with_brand">Save my info for faster checkout with %s</string>
   <!-- Label for a checkbox that when checked allows the payment information
 to be saved and used in future checkout sessions. -->
-  <string name="stripe_inline_sign_up_toggle">Create an account with Link for faster checkout across the web</string>
   <string name="stripe_inline_sign_up_toggle_with_brand">Create an account with %s for faster checkout across the web</string>
   <!-- Label a credit funding source. E.g. in english 'Visa Credit', or in german 'Visa-Kreditkarte' -->
   <string name="stripe_link_card_type_credit">%1$s Credit</string>
@@ -79,7 +78,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Label describing the benefit of signing up for Link. -->
   <string name="stripe_link_sign_up_message">Save your payment information with Link, and securely check out in 1-click on Link-supported sites.</string>
   <!-- Subtitle for the Link signup screen -->
-  <string name="stripe_link_sign_up_message_v2">Pay faster everywhere Link is accepted.</string>
   <!-- Subtitle for the Link signup screen. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_link_sign_up_message_v2_with_brand">Pay faster everywhere %s is accepted.</string>
   <!-- Legal text shown when creating a Link account. -->
@@ -157,7 +155,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v2"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> (see <terms>Terms</terms> and <privacy>Privacy</privacy>).]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. -->
-  <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3"><![CDATA[By continuing, you agree to save your information for future purchases with %s and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Text displayed below a credit card entry form when the card will be saved with the merchant and saved to a non-Link brand. -->
   <string name="stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded"><![CDATA[By continuing, you agree to save your information for future purchases with %1$s and <link>%2$s</link> according to %2$s <terms>terms</terms> and <privacy>privacy</privacy>.]]></string>
   <!-- Error message displayed when updating a card fails. -->
@@ -268,7 +265,6 @@ to be saved and used in future checkout sessions. -->
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="stripe_show_menu">Show menu</string>
   <!-- Title of the sign-out action. -->
-  <string name="stripe_sign_out_link">Sign out of Link</string>
   <!-- Title of the sign-out action. '%s' is a Stripe brand name such as 'Link'. -->
   <string name="stripe_sign_out_with_brand">Sign out of %s</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarMenu.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarMenu.kt
@@ -27,11 +27,7 @@ internal fun LinkAppBarMenu(
 internal data class LogoutMenuItem(
     private val linkBrand: LinkBrand,
 ) : LinkMenuItem {
-    override val text = if (linkBrand == LinkBrand.Link) {
-        R.string.stripe_sign_out_link.resolvableString
-    } else {
-        resolvableString(R.string.stripe_sign_out_with_brand, linkBrand.brandName())
-    }
+    override val text = resolvableString(R.string.stripe_sign_out_with_brand, linkBrand.brandName())
     override val testTag = LOGOUT_MENU_ROW_TAG
     override val isDestructive = true
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -416,11 +416,7 @@ private fun TextWithLinkLogo(
     linkBrand: LinkBrand,
 ) {
     val brandName = linkBrand.brandName()
-    val label = if (linkBrand == LinkBrand.Link) {
-        stringResource(R.string.stripe_inline_sign_up_toggle)
-    } else {
-        stringResource(R.string.stripe_inline_sign_up_toggle_with_brand, brandName)
-    }
+    val label = stringResource(R.string.stripe_inline_sign_up_toggle_with_brand, brandName)
     val painter = painterResource(linkBrand.logoRes(LinkLogoStyle.InlineKnockout))
     // Slightly smaller Link logo for better visual balance
     val logoHeight = style.fontSize * LINK_LOGO_SCALE

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -281,14 +281,10 @@ private fun ColumnScope.SignUpHeader(linkBrand: LinkBrand) {
         color = LinkTheme.colors.textPrimary
     )
     Text(
-        text = if (linkBrand == LinkBrand.Link) {
-            stringResource(R.string.stripe_link_sign_up_message_v2)
-        } else {
-            stringResource(
-                R.string.stripe_link_sign_up_message_v2_with_brand,
-                linkBrand.brandName(),
-            )
-        },
+        text = stringResource(
+            R.string.stripe_link_sign_up_message_v2_with_brand,
+            linkBrand.brandName(),
+        ),
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 4.dp, bottom = 30.dp),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -342,17 +342,10 @@ internal class CombinedLinkMandateElement(
             // when displaying the mandate from Link UI (add card to Link) we always want the
             // non-signup version of the mandate text.
             mandateText = if (linkState?.isExpanded == true && isLinkUI.not()) {
-                if (linkBrand == LinkBrand.Link) {
-                    stringResource(
-                        id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3,
-                        formatArgs = arrayOf(merchantName)
-                    )
-                } else {
-                    stringResource(
-                        id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded,
-                        formatArgs = arrayOf(merchantName, linkBrand.brandName())
-                    )
-                }.replaceHyperlinks(linkBrand)
+                stringResource(
+                    id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_on_v3_branded,
+                    formatArgs = arrayOf(merchantName, linkBrand.brandName())
+                ).replaceHyperlinks(linkBrand)
             } else {
                 stringResource(
                     id = PaymentSheetR.string.stripe_paymentsheet_card_mandate_signup_toggle_off,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/BrandTextUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/BrandTextUtilsTest.kt
@@ -17,7 +17,8 @@ internal class BrandTextUtilsTest {
     fun `inline signup text replaces Link with inline brand icon`() {
         assertThat(
             context.getString(
-                R.string.stripe_inline_sign_up_toggle,
+                R.string.stripe_inline_sign_up_toggle_with_brand,
+                LinkBrand.Link.brandName(),
             ).buildBrandIconAnnotatedString(
                 brandToken = LinkBrand.Link.brandName(),
                 inlineContentId = "brand_icon",


### PR DESCRIPTION
# Summary
Clean up string interpolation of Onelink / Link branded strings now that we have all translated locales

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-866

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
no visual changes - string cleanup

# Changelog
n/a