### PR TITLE
[fc] Try scrolling down again in retry block

### DIFF
--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -34,9 +34,13 @@ tags:
     visible: "Select another bank"
     timeout: 30000
 - tapOn: "Select another bank"
-# Assert flow correctly returns to institution picker
+# The retry path resets the picker to the top of the list.
 - extendedWaitUntil:
-    visible: "Down (Unscheduled)"
+    visible: "Select bank"
+    timeout: 30000
+- scrollUntilVisible:
+    element:
+      text: "Down (Unscheduled)"
     timeout: 30000
 - tapOn: "Down (Unscheduled)"
 # Close flow from error page

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-UnplannedDowntime.yaml
@@ -22,7 +22,7 @@ tags:
     id: "consent_cta"
 # Select Down institution
 - extendedWaitUntil:
-    visible: "Select bank"
+    visible: "Search"
     timeout: 30000
 - scrollUntilVisible:
     element:
@@ -34,9 +34,9 @@ tags:
     visible: "Select another bank"
     timeout: 30000
 - tapOn: "Select another bank"
-# The retry path resets the picker to the top of the list.
+# The picker may reopen at the top of the list or stay near the prior position.
 - extendedWaitUntil:
-    visible: "Select bank"
+    visible: "Search"
     timeout: 30000
 - scrollUntilVisible:
     element:


### PR DESCRIPTION
# Summary
More Maestro e2e financial connections fixes. In the retry flow in `Testmode-PaymentIntent-TestInstitution-UnplannedDowntime` the tests are failing with Assertion is false: "Down (Unscheduled)" is visible because you need to scroll down a bit more to see it:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b5d344a4-a422-49a5-b359-01120dc7308d" />

This tries to fix that issue by scrolling down on the retry step

# Motivation
Fix failing maestro tests

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Kicking new Bitrise on this branch

# Screenshots
n/a

# Changelog
n/a