### PR TITLE
[link] Log out correctly in "Not you?" flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NEXT_VERSION_BUMP: PATCH
 ### PaymentSheet
 * [FIXED] Fixed an issue where Klarna billing address fields did not update when the country changed.
 * [FIXED] Fixed an issue where Wero displayed duplicate country fields when collecting a full billing address.
+* [FIXED][13323](https://github.com/stripe/stripe-android/pull/13323) Fixed an issue where selecting "Not you?" during Link 2FA did not fully log out the previous account, preventing subsequent logins.
 
 ## 23.17.0 - 2026-08-24
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -261,6 +261,10 @@ internal class LinkActivityViewModel @Inject constructor(
 
     fun changeEmail() {
         savedStateHandle[SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO] = false
+        viewModelScope.launch {
+            linkAccountManager.logOut()
+        }
+        linkAccountHolder.set(LinkAccountUpdate.Value(null, LoggedOut))
         if (linkScreenState.value is ScreenState.VerificationDialog) {
             linkAccountHolder.set(LinkAccountUpdate.Value(null))
             _linkScreenState.value = ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -190,7 +190,6 @@ internal class LinkActivityViewModel @Inject constructor(
                 linkBrand = linkConfiguration.effectiveLinkBrand(linkAccount),
             )
         }
-
     }
 
     fun moveToWeb(error: Throwable) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -190,6 +190,7 @@ internal class LinkActivityViewModel @Inject constructor(
                 linkBrand = linkConfiguration.effectiveLinkBrand(linkAccount),
             )
         }
+
     }
 
     fun moveToWeb(error: Throwable) {
@@ -264,13 +265,22 @@ internal class LinkActivityViewModel @Inject constructor(
         viewModelScope.launch {
             linkAccountManager.logOut()
         }
-        linkAccountHolder.set(LinkAccountUpdate.Value(null, LoggedOut))
         if (linkScreenState.value is ScreenState.VerificationDialog) {
-            linkAccountHolder.set(LinkAccountUpdate.Value(null))
+            clearAccountAfterChangeEmail(loggedOut = false)
             _linkScreenState.value = ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)
         } else {
+            clearAccountAfterChangeEmail(loggedOut = true)
             navigate(LinkScreen.SignUp, clearStack = true)
         }
+    }
+
+    private fun clearAccountAfterChangeEmail(loggedOut: Boolean) {
+        linkAccountHolder.set(
+            LinkAccountUpdate.Value(
+                account = null,
+                lastUpdateReason = if (loggedOut) LoggedOut else null,
+            )
+        )
     }
 
     fun unregisterActivity() {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -207,7 +207,6 @@ internal class LinkActivityViewModel @Inject constructor(
                 linkBrand = linkConfiguration.effectiveLinkBrand(linkAccount),
             )
         }
-
     }
 
     fun moveToWeb(error: Throwable) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -278,8 +278,10 @@ internal class LinkActivityViewModel @Inject constructor(
 
     fun changeEmail() {
         savedStateHandle[SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO] = false
-        viewModelScope.launch {
-            linkAccountManager.logOut()
+        linkAccount?.let { linkAccount ->
+            viewModelScope.launch {
+                linkAccountManager.logOut(linkAccount)
+            }
         }
         if (linkScreenState.value is ScreenState.VerificationDialog) {
             clearAccountAfterChangeEmail(loggedOut = false)

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -207,6 +207,7 @@ internal class LinkActivityViewModel @Inject constructor(
                 linkBrand = linkConfiguration.effectiveLinkBrand(linkAccount),
             )
         }
+
     }
 
     fun moveToWeb(error: Throwable) {
@@ -281,13 +282,22 @@ internal class LinkActivityViewModel @Inject constructor(
         viewModelScope.launch {
             linkAccountManager.logOut()
         }
-        linkAccountHolder.set(LinkAccountUpdate.Value(null, LoggedOut))
         if (linkScreenState.value is ScreenState.VerificationDialog) {
-            linkAccountHolder.set(LinkAccountUpdate.Value(null))
+            clearAccountAfterChangeEmail(loggedOut = false)
             _linkScreenState.value = ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)
         } else {
+            clearAccountAfterChangeEmail(loggedOut = true)
             navigate(LinkScreen.SignUp, clearStack = true)
         }
+    }
+
+    private fun clearAccountAfterChangeEmail(loggedOut: Boolean) {
+        linkAccountHolder.set(
+            LinkAccountUpdate.Value(
+                account = null,
+                lastUpdateReason = if (loggedOut) LoggedOut else null,
+            )
+        )
     }
 
     fun unregisterActivity() {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -278,6 +278,10 @@ internal class LinkActivityViewModel @Inject constructor(
 
     fun changeEmail() {
         savedStateHandle[SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO] = false
+        viewModelScope.launch {
+            linkAccountManager.logOut()
+        }
+        linkAccountHolder.set(LinkAccountUpdate.Value(null, LoggedOut))
         if (linkScreenState.value is ScreenState.VerificationDialog) {
             linkAccountHolder.set(LinkAccountUpdate.Value(null))
             _linkScreenState.value = ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -120,21 +120,25 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return runCatching {
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->
-            runCatching {
-                linkRepository.logOut(
-                    consumerSessionClientSecret = account.clientSecret,
-                    consumerAccountPublishableKey = account.consumerPublishableKey,
-                ).getOrThrow()
-            }.onSuccess {
-                errorReporter.report(ErrorReporter.SuccessEvent.LINK_LOG_OUT_SUCCESS)
-                Logger.getInstance(BuildConfig.DEBUG).debug("Logged out of Link successfully")
-            }.onFailure { error ->
-                errorReporter.report(
-                    ErrorReporter.ExpectedErrorEvent.LINK_LOG_OUT_FAILURE,
-                    StripeException.create(error)
-                )
-                Logger.getInstance(BuildConfig.DEBUG).warning("Failed to log out of Link: $error")
-            }.getOrThrow()
+            logOut(account).getOrThrow()
+        }
+    }
+
+    override suspend fun logOut(linkAccount: LinkAccount): Result<ConsumerSession> {
+        return runCatching {
+            linkRepository.logOut(
+                consumerSessionClientSecret = linkAccount.clientSecret,
+                consumerAccountPublishableKey = linkAccount.consumerPublishableKey,
+            ).getOrThrow()
+        }.onSuccess {
+            errorReporter.report(ErrorReporter.SuccessEvent.LINK_LOG_OUT_SUCCESS)
+            Logger.getInstance(BuildConfig.DEBUG).debug("Logged out of Link successfully")
+        }.onFailure { error ->
+            errorReporter.report(
+                ErrorReporter.ExpectedErrorEvent.LINK_LOG_OUT_FAILURE,
+                StripeException.create(error)
+            )
+            Logger.getInstance(BuildConfig.DEBUG).warning("Failed to log out of Link: $error")
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -108,6 +108,8 @@ internal interface LinkAccountManager {
 
     suspend fun logOut(): Result<ConsumerSession>
 
+    suspend fun logOut(linkAccount: LinkAccount): Result<ConsumerSession>
+
     suspend fun createPaymentMethod(
         linkPaymentMethod: LinkPaymentMethod
     ): Result<PaymentMethod>

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.stripe.android.link.LinkAccountUpdate
@@ -149,10 +151,13 @@ private fun Screens(
             )
         }
 
-        composable(LinkScreen.Verification.route) {
+        composable(LinkScreen.Verification.route) { backStackEntry ->
             // Keep height fixed to reduce animations caused by IME toggling on both
             // this screen and SignUp screen.
-            val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
+            val linkAccount = rememberRouteLinkAccount(
+                backStackEntry = backStackEntry,
+                getLinkAccount = getLinkAccount,
+            ) ?: return@composable dismissWithResult(noLinkAccountResult())
             MinScreenHeightBox(screenHeightPercentage = if (initialDestination == LinkScreen.SignUp) 1f else 0f) {
                 VerificationRoute(
                     linkAccount = linkAccount,
@@ -163,8 +168,11 @@ private fun Screens(
             }
         }
 
-        composable(LinkScreen.Wallet.route) {
-            val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
+        composable(LinkScreen.Wallet.route) { backStackEntry ->
+            val linkAccount = rememberRouteLinkAccount(
+                backStackEntry = backStackEntry,
+                getLinkAccount = getLinkAccount,
+            ) ?: return@composable dismissWithResult(noLinkAccountResult())
 
             WalletRoute(
                 linkAccount = linkAccount,
@@ -176,22 +184,39 @@ private fun Screens(
             )
         }
 
-        composable(LinkScreen.PaymentMethod.route) {
-            val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
+        composable(LinkScreen.PaymentMethod.route) { backStackEntry ->
+            val linkAccount = rememberRouteLinkAccount(
+                backStackEntry = backStackEntry,
+                getLinkAccount = getLinkAccount,
+            ) ?: return@composable dismissWithResult(noLinkAccountResult())
             PaymentMethodRoute(
                 linkAccount = linkAccount,
                 dismissWithResult = dismissWithResult,
             )
         }
 
-        composable(LinkScreen.OAuthConsent.route) {
-            val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
+        composable(LinkScreen.OAuthConsent.route) { backStackEntry ->
+            val linkAccount = rememberRouteLinkAccount(
+                backStackEntry = backStackEntry,
+                getLinkAccount = getLinkAccount,
+            ) ?: return@composable dismissWithResult(noLinkAccountResult())
             OAuthConsentRoute(
                 linkAccount = linkAccount,
                 dismissWithResult = dismissWithResult,
             )
         }
     }
+}
+
+@Composable
+private fun rememberRouteLinkAccount(
+    backStackEntry: NavBackStackEntry,
+    getLinkAccount: () -> LinkAccount?,
+): LinkAccount? {
+    val initialLinkAccount = remember(backStackEntry) {
+        getLinkAccount()
+    }
+    return getLinkAccount() ?: initialLinkAccount
 }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -228,9 +228,6 @@ internal class VerificationViewModel @Inject constructor(
     fun onChangeEmailButtonClicked() {
         clearError()
         onChangeEmailRequested()
-        viewModelScope.launch {
-            linkAccountManager.logOut()
-        }
     }
 
     fun onFocusRequested() {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -721,18 +721,58 @@ internal class LinkActivityViewModelTest {
     }
 
     @Test
-    fun `change email should navigate to email route and update savedStateHandle`() {
-        val navigationManager = TestNavigationManager()
+    fun `change email from verification dialog should log out and transition to full screen SignUp`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val savedStateHandle = SavedStateHandle()
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
         val viewModel = createViewModel(
-            navigationManager = navigationManager,
-            savedStateHandle = savedStateHandle
+            linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
+            savedStateHandle = savedStateHandle,
+            linkExpressMode = LinkExpressMode.ENABLED,
+        )
+        linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification())
+        viewModel.onCreate(mock())
+        advanceUntilIdle()
+
+        assertThat(viewModel.linkScreenState.value).isEqualTo(
+            ScreenState.VerificationDialog(TestFactory.LINK_ACCOUNT)
         )
 
         viewModel.changeEmail()
 
+        linkAccountManager.awaitLogoutCall()
         assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
+        assertThat(viewModel.linkScreenState.value).isEqualTo(
+            ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)
+        )
+    }
 
+    @Test
+    fun `change email from full screen should log out and navigate to SignUp`() = runTest {
+        val navigationManager = TestNavigationManager()
+        val linkAccountManager = FakeLinkAccountManager()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val savedStateHandle = SavedStateHandle()
+        val viewModel = createViewModel(
+            navigationManager = navigationManager,
+            linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
+            savedStateHandle = savedStateHandle,
+        )
+
+        viewModel.changeEmail()
+
+        linkAccountManager.awaitLogoutCall()
+        assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
         navigationManager.assertNavigatedTo(
             route = LinkScreen.SignUp.route,
             popUpTo = PopUpToBehavior.Start

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -746,7 +746,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.awaitLogoutCall()
         assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
         assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
-            LinkAccountUpdate.Value(null, LoggedOut)
+            LinkAccountUpdate.Value(null)
         )
         assertThat(viewModel.linkScreenState.value).isEqualTo(
             ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)
@@ -756,9 +756,10 @@ internal class LinkActivityViewModelTest {
     @Test
     fun `change email from full screen should log out and navigate to SignUp`() = runTest {
         val navigationManager = TestNavigationManager()
-        val linkAccountManager = FakeLinkAccountManager()
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val linkAccountManager = FakeLinkAccountManager(linkAccountHolder = linkAccountHolder)
         val savedStateHandle = SavedStateHandle()
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
         val viewModel = createViewModel(
             navigationManager = navigationManager,
             linkAccountManager = linkAccountManager,
@@ -776,6 +777,48 @@ internal class LinkActivityViewModelTest {
         navigationManager.assertNavigatedTo(
             route = LinkScreen.SignUp.route,
             popUpTo = PopUpToBehavior.Start
+        )
+    }
+
+    @Test
+    fun `change email clears linkAccountHolder immediately for full-screen flow`() = runTest {
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val linkAccountManager = FakeLinkAccountManager(linkAccountHolder = linkAccountHolder)
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        val viewModel = createViewModel(
+            linkAccountHolder = linkAccountHolder,
+            linkAccountManager = linkAccountManager,
+        )
+
+        viewModel.changeEmail()
+        linkAccountManager.awaitLogoutCall()
+
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
+    }
+
+    @Test
+    fun `change email clears linkAccountHolder without LoggedOut for verification dialog flow`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        val viewModel = createViewModel(
+            linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
+            linkExpressMode = LinkExpressMode.ENABLED,
+        )
+        linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification())
+        viewModel.onCreate(mock())
+        advanceUntilIdle()
+
+        viewModel.changeEmail()
+        linkAccountManager.awaitLogoutCall()
+
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null)
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -788,18 +788,58 @@ internal class LinkActivityViewModelTest {
     }
 
     @Test
-    fun `change email should navigate to email route and update savedStateHandle`() {
-        val navigationManager = TestNavigationManager()
+    fun `change email from verification dialog should log out and transition to full screen SignUp`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val savedStateHandle = SavedStateHandle()
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
         val viewModel = createViewModel(
-            navigationManager = navigationManager,
-            savedStateHandle = savedStateHandle
+            linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
+            savedStateHandle = savedStateHandle,
+            linkExpressMode = LinkExpressMode.ENABLED,
+        )
+        linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification())
+        viewModel.onCreate(mock())
+        advanceUntilIdle()
+
+        assertThat(viewModel.linkScreenState.value).isEqualTo(
+            ScreenState.VerificationDialog(TestFactory.LINK_ACCOUNT)
         )
 
         viewModel.changeEmail()
 
+        linkAccountManager.awaitLogoutCall()
         assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
+        assertThat(viewModel.linkScreenState.value).isEqualTo(
+            ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)
+        )
+    }
 
+    @Test
+    fun `change email from full screen should log out and navigate to SignUp`() = runTest {
+        val navigationManager = TestNavigationManager()
+        val linkAccountManager = FakeLinkAccountManager()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val savedStateHandle = SavedStateHandle()
+        val viewModel = createViewModel(
+            navigationManager = navigationManager,
+            linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
+            savedStateHandle = savedStateHandle,
+        )
+
+        viewModel.changeEmail()
+
+        linkAccountManager.awaitLogoutCall()
+        assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
         navigationManager.assertNavigatedTo(
             route = LinkScreen.SignUp.route,
             popUpTo = PopUpToBehavior.Start

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -52,10 +52,14 @@ import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.uicore.navigation.NavBackStackEntryUpdate
 import com.stripe.android.uicore.navigation.NavigationManager
 import com.stripe.android.uicore.navigation.PopUpToBehavior
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -864,6 +868,30 @@ internal class LinkActivityViewModelTest {
         assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
             LinkAccountUpdate.Value(null, LoggedOut)
         )
+    }
+
+    @Test
+    fun `change email logs out captured account after clearing linkAccountHolder`() = runTest {
+        val queuedDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(queuedDispatcher)
+
+        try {
+            val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+            val linkAccountManager = FakeLinkAccountManager(linkAccountHolder = linkAccountHolder)
+            linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+            val viewModel = createViewModel(
+                linkAccountHolder = linkAccountHolder,
+                linkAccountManager = linkAccountManager,
+            )
+
+            viewModel.changeEmail()
+            assertThat(linkAccountHolder.linkAccountInfo.value.account).isNull()
+
+            runCurrent()
+            assertThat(linkAccountManager.awaitLogoutCallAccount()).isEqualTo(TestFactory.LINK_ACCOUNT)
+        } finally {
+            Dispatchers.setMain(dispatcher)
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -813,7 +813,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.awaitLogoutCall()
         assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
         assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
-            LinkAccountUpdate.Value(null, LoggedOut)
+            LinkAccountUpdate.Value(null)
         )
         assertThat(viewModel.linkScreenState.value).isEqualTo(
             ScreenState.FullScreen(initialDestination = LinkScreen.SignUp)
@@ -823,9 +823,10 @@ internal class LinkActivityViewModelTest {
     @Test
     fun `change email from full screen should log out and navigate to SignUp`() = runTest {
         val navigationManager = TestNavigationManager()
-        val linkAccountManager = FakeLinkAccountManager()
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val linkAccountManager = FakeLinkAccountManager(linkAccountHolder = linkAccountHolder)
         val savedStateHandle = SavedStateHandle()
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
         val viewModel = createViewModel(
             navigationManager = navigationManager,
             linkAccountManager = linkAccountManager,
@@ -843,6 +844,48 @@ internal class LinkActivityViewModelTest {
         navigationManager.assertNavigatedTo(
             route = LinkScreen.SignUp.route,
             popUpTo = PopUpToBehavior.Start
+        )
+    }
+
+    @Test
+    fun `change email clears linkAccountHolder immediately for full-screen flow`() = runTest {
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val linkAccountManager = FakeLinkAccountManager(linkAccountHolder = linkAccountHolder)
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        val viewModel = createViewModel(
+            linkAccountHolder = linkAccountHolder,
+            linkAccountManager = linkAccountManager,
+        )
+
+        viewModel.changeEmail()
+        linkAccountManager.awaitLogoutCall()
+
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
+    }
+
+    @Test
+    fun `change email clears linkAccountHolder without LoggedOut for verification dialog flow`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        linkAccountManager.setLinkAccount(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        val viewModel = createViewModel(
+            linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
+            linkExpressMode = LinkExpressMode.ENABLED,
+        )
+        linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification())
+        viewModel.onCreate(mock())
+        advanceUntilIdle()
+
+        viewModel.changeEmail()
+        linkAccountManager.awaitLogoutCall()
+
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null)
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -139,7 +139,7 @@ internal open class FakeLinkAccountManager(
 
     val confirmVerificationTurbine = Turbine<String>()
 
-    private val logoutCall = Turbine<Unit>()
+    private val logoutCall = Turbine<LinkAccount?>()
 
     fun setConsumerPaymentDetails(consumerPaymentDetails: ConsumerPaymentDetails?) {
         _consumerState.value = consumerPaymentDetails?.toLinkPaymentMethod()?.let {
@@ -209,7 +209,12 @@ internal open class FakeLinkAccountManager(
     }
 
     override suspend fun logOut(): Result<ConsumerSession> {
-        logoutCall.add(Unit)
+        logoutCall.add(linkAccountHolder.linkAccountInfo.value.account)
+        return logOutResult
+    }
+
+    override suspend fun logOut(linkAccount: LinkAccount): Result<ConsumerSession> {
+        logoutCall.add(linkAccount)
         return logOutResult
     }
 
@@ -323,6 +328,10 @@ internal open class FakeLinkAccountManager(
     }
 
     suspend fun awaitLogoutCall() {
+        logoutCall.awaitItem()
+    }
+
+    suspend fun awaitLogoutCallAccount(): LinkAccount? {
         return logoutCall.awaitItem()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -121,7 +121,7 @@ internal class VerificationViewModelTest {
     }
 
     @Test
-    fun `onChangeEmailClicked triggers logout`() = runTest(dispatcher) {
+    fun `onChangeEmailClicked delegates to onChangeEmailRequested without logging out`() = runTest(dispatcher) {
         val linkAccountManager = object : FakeLinkAccountManager() {
             var callCount = 0
             override suspend fun logOut(): Result<ConsumerSession> {
@@ -140,7 +140,7 @@ internal class VerificationViewModelTest {
             onChangeEmailRequested = ::onChangeEmailRequested,
         ).onChangeEmailButtonClicked()
 
-        assertThat(linkAccountManager.callCount).isEqualTo(1)
+        assertThat(linkAccountManager.callCount).isEqualTo(0)
         assertThat(onChangeEmailRequestedCalls).containsExactly(Unit)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -125,7 +125,7 @@ internal class VerificationViewModelTest {
     }
 
     @Test
-    fun `onChangeEmailClicked triggers logout`() = runTest(dispatcher) {
+    fun `onChangeEmailClicked delegates to onChangeEmailRequested without logging out`() = runTest(dispatcher) {
         val linkAccountManager = object : FakeLinkAccountManager() {
             var callCount = 0
             override suspend fun logOut(): Result<ConsumerSession> {
@@ -144,7 +144,7 @@ internal class VerificationViewModelTest {
             onChangeEmailRequested = ::onChangeEmailRequested,
         ).onChangeEmailButtonClicked()
 
-        assertThat(linkAccountManager.callCount).isEqualTo(1)
+        assertThat(linkAccountManager.callCount).isEqualTo(0)
         assertThat(onChangeEmailRequestedCalls).containsExactly(Unit)
     }
 


### PR DESCRIPTION
# Summary
Log out when clicking "Not you?" during 2FA flow with Link. Previously, this incorrectly retained a stale reference to the previous account when clicking "Not you?", and then if you try to use that stale logged-in account, subsequent logins don't work. See repro steps below for more info.

# Motivation
https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-9

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Manual repro instructions:

1. native link in MPE
2. confirm it's you --> X out of 2FA prompt
3. re-click Link
4. click "not you?"
5. X out --> `email@email.com` no longer shows as logged-in user

# Screenshots
Before:

https://github.com/user-attachments/assets/31df2844-f2b4-4425-94d5-9a8000285371

After:

https://github.com/user-attachments/assets/6865914b-8c6a-4f26-be01-92f627870ccd

# Changelog

- [ ] TODO - update changelog for this fix