### PR TITLE
Wire inline address autocomplete into billing address fields for Payment Sheet and Flow Controller.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -600,6 +600,7 @@ internal class CustomerSheetViewModel(
                             IllegalStateException("Unexpected attempt to update default from CustomerSheet.")
                         )
                     },
+                    autocompleteAddressInteractorFactory = null,
                 ),
                 isLiveMode = isLiveMode,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -210,7 +210,8 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                                     isInlineAutocompleteEnabled =
                                         FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-                                )
+                                ),
+                                inlineDependencies = null,
                             ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
@@ -142,7 +142,8 @@ internal fun UpdateCardScreenBodyPreview() {
                     onBrandChoiceChanged = {},
                     onCardUpdateParamsChanged = {},
                     billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(),
-                    requiresModification = true
+                    requiresModification = true,
+                    autocompleteAddressInteractorFactory = null,
                 ),
                 state = UpdateCardScreenState(
                     paymentDetailsId = "card_id_1234",

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -225,7 +225,8 @@ internal class UpdateCardScreenViewModel @Inject constructor(
             onBrandChoiceChanged = ::onBrandChoiceChanged,
             // We prefill in the billing details update flow, so the form might
             // already be complete on first render. The user can submit without modifying.
-            requiresModification = state.value.isBillingDetailsUpdateFlow.not()
+            requiresModification = state.value.isBillingDetailsUpdateFlow.not(),
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -83,6 +83,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             onUpdateSuccess = {
                 embeddedNavigatorProvider.get().performAction(EmbeddedNavigator.Action.Back)
             },
+            autocompleteAddressInteractorFactory = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -52,6 +52,7 @@ import com.stripe.android.paymentsheet.ui.DefaultSelectSavedPaymentMethodsIntera
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -82,7 +83,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
     mode: EventReporter.Mode,
     customerStateHolderFactory: CustomerStateHolder.Factory,
     @ViewModelScope customViewModelScope: CoroutineScope,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    placesClient: PlacesClientProxy?,
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,
@@ -95,6 +97,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     mode = mode,
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
+    placesClient = placesClient,
 ) {
 
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -67,6 +67,7 @@ import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
@@ -103,7 +104,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     mode: EventReporter.Mode,
     customerStateHolderFactory: CustomerStateHolder.Factory,
     @ViewModelScope customViewModelScope: CoroutineScope,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    placesClient: PlacesClientProxy?,
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,
@@ -116,6 +118,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     mode = mode,
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
+    placesClient = placesClient,
 ) {
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -407,6 +407,8 @@ internal class SavedPaymentMethodMutator(
                             removeMessage = paymentMethodMetadata?.customerMetadata?.removePaymentMethod
                                 ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
+                            autocompleteAddressInteractorFactory =
+                                viewModel.autocompleteAddressInteractorFactory,
                         )
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import com.stripe.android.uicore.R
+
 internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "AU",
     "BE",
@@ -22,3 +24,7 @@ internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "US",
     "ZA"
 )
+
+internal val AUTOCOMPLETE_ATTRIBUTION_DRAWABLE: (Boolean) -> Int? = { _ ->
+    R.drawable.stripe_google_maps_logo
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+
+internal class BillingInlineAutocompleteAddressInteractor(
+    placesClient: PlacesClientProxy,
+    override val autocompleteConfig: AutocompleteAddressInteractor.Config,
+    coroutineScope: CoroutineScope,
+) : AutocompleteAddressInteractor {
+    private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
+
+    private val inlineController = InlineAutocompleteController(
+        placesClient = placesClient,
+        config = autocompleteConfig,
+        coroutineScope = coroutineScope,
+        eventListenerProvider = { eventListener },
+    )
+
+    override val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =
+        inlineController.inlinePredictionsState
+
+    override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
+        eventListener = onEvent
+    }
+
+    override fun onAutocomplete(country: String) = Unit
+
+    override fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
+        inlineController.observeQueryChanges(query, country)
+    }
+
+    override fun onPredictionSelected(predictionId: String) {
+        inlineController.onPredictionSelected(predictionId)
+    }
+
+    override fun onDismissed() {
+        inlineController.onDismissed()
+    }
+
+    override fun onEnterManuallyFromInline() {
+        eventListener?.invoke(AutocompleteAddressInteractor.Event.OnExpandForm(null))
+    }
+
+    fun dispose() {
+        inlineController.dispose()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -92,10 +92,6 @@ internal class InlineAutocompleteController(
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
     }
 
-    /**
-     * Cancels all running coroutines. Call when the owning form is discarded so the
-     * long-running [observeQueryChanges] collector does not outlive it on a shared scope.
-     */
     fun dispose() {
         observeJob?.cancel()
         selectionJob?.cancel()
@@ -108,8 +104,9 @@ internal class InlineAutocompleteController(
     }
 
     private suspend fun fetchPredictions(query: String, country: String) {
+        val client = placesClient ?: return
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Loading
-        val result = placesClient!!.findAutocompletePredictions(
+        val result = client.findAutocompletePredictions(
             query = query,
             country = country,
             limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -26,6 +26,7 @@ internal class InlineAutocompleteController(
 ) {
     private var lastPredictionLine1: String? = null
     private var observeJob: Job? = null
+    private var selectionJob: Job? = null
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
         AutocompleteAddressInteractor.InlinePredictionsState.Idle
@@ -58,7 +59,8 @@ internal class InlineAutocompleteController(
 
     fun onPredictionSelected(predictionId: String) {
         if (placesClient == null) return
-        coroutineScope.launch {
+        selectionJob?.cancel()
+        selectionJob = coroutineScope.launch {
             placesClient.fetchPlace(predictionId).fold(
                 onSuccess = { response ->
                     val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
@@ -86,7 +88,17 @@ internal class InlineAutocompleteController(
     }
 
     fun onDismissed() {
+        selectionJob?.cancel()
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+    }
+
+    /**
+     * Cancels all running coroutines. Call when the owning form is discarded so the
+     * long-running [observeQueryChanges] collector does not outlive it on a shared scope.
+     */
+    fun dispose() {
+        observeJob?.cancel()
+        selectionJob?.cancel()
     }
 
     private fun isCountrySupported(country: String): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -73,11 +73,7 @@ internal class InputAddressViewModel @Inject constructor(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
-        getAttributionDrawable = if (isInlineAutocompleteEnabled) {
-            { _ -> com.stripe.android.uicore.R.drawable.stripe_google_maps_logo }
-        } else {
-            null
-        },
+        getAttributionDrawable = if (isInlineAutocompleteEnabled) AUTOCOMPLETE_ATTRIBUTION_DRAWABLE else null,
     )
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
 
 internal class PaymentElementAutocompleteAddressInteractor(
     private val launcher: AutocompleteLauncher,
@@ -42,8 +44,26 @@ internal class PaymentElementAutocompleteAddressInteractor(
     class Factory(
         private val launcher: AutocompleteLauncher,
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
+        private val inlineDependencies: InlineAutocompleteDependencies?,
     ) : AutocompleteAddressInteractor.Factory {
+        // The factory outlives individual forms (it is held for the whole sheet), so it disposes the
+        // previously-created inline interactor before building a new one. Only one address form is
+        // live at a time in this flow, so the prior controller's long-running query collector would
+        // otherwise leak on the shared coroutine scope across form re-creations.
+        private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
+
         override fun create(): AutocompleteAddressInteractor {
+            activeInlineInteractor?.dispose()
+            activeInlineInteractor = null
+
+            val dependencies = inlineDependencies
+            if (dependencies != null) {
+                return BillingInlineAutocompleteAddressInteractor(
+                    placesClient = dependencies.placesClient,
+                    autocompleteConfig = autocompleteConfig,
+                    coroutineScope = dependencies.coroutineScope,
+                ).also { activeInlineInteractor = it }
+            }
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,
                 autocompleteConfig = autocompleteConfig,
@@ -51,3 +71,8 @@ internal class PaymentElementAutocompleteAddressInteractor(
         }
     }
 }
+
+internal data class InlineAutocompleteDependencies(
+    val placesClient: PlacesClientProxy,
+    val coroutineScope: CoroutineScope,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -4,22 +4,40 @@ import android.content.Context
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.uicore.elements.DefaultIsPlacesAvailable
 
-/**
- * Creates a [PlacesClientProxy] for inline address autocomplete, or `null` when the feature is
- * disabled or no Google Places API key is configured.
- */
+internal val cachedIsPlacesAvailable: Boolean by lazy { DefaultIsPlacesAvailable()() }
+
 internal fun createInlineAutocompletePlacesClient(
     context: Context,
     googlePlacesApiKey: String?,
     errorReporter: ErrorReporter,
+    isPlacesAvailable: () -> Boolean,
 ): PlacesClientProxy? {
     if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return null
-    return googlePlacesApiKey?.let { apiKey ->
+    if (!isPlacesAvailable()) return null
+    val apiKey = googlePlacesApiKey ?: return null
+    return LazyPlacesClientProxy {
         PlacesClientProxy.create(
             context = context,
             googlePlacesApiKey = apiKey,
             errorReporter = errorReporter,
         )
     }
+}
+
+private class LazyPlacesClientProxy(
+    factory: () -> PlacesClientProxy,
+) : PlacesClientProxy {
+    private val delegate by lazy(factory)
+
+    override suspend fun findAutocompletePredictions(
+        query: String?,
+        country: String,
+        limit: Int,
+    ): Result<FindAutocompletePredictionsResponse> = delegate.findAutocompletePredictions(query, country, limit)
+
+    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> = delegate.fetchPlace(placeId)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+
+/**
+ * Creates a [PlacesClientProxy] for inline address autocomplete, or `null` when the feature is
+ * disabled or no Google Places API key is configured.
+ */
+internal fun createInlineAutocompletePlacesClient(
+    context: Context,
+    googlePlacesApiKey: String?,
+    errorReporter: ErrorReporter,
+): PlacesClientProxy? {
+    if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return null
+    return googlePlacesApiKey?.let { apiKey ->
+        PlacesClientProxy.create(
+            context = context,
+            googlePlacesApiKey = apiKey,
+            errorReporter = errorReporter,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -65,5 +65,6 @@ internal class PaymentOptionsViewModelModule {
         context = application,
         googlePlacesApiKey = args.configuration.googlePlacesApiKey,
         errorReporter = errorReporter,
+        isPlacesAvailable = { cachedIsPlacesAvailable },
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -53,4 +55,15 @@ internal class PaymentOptionsViewModelModule {
     ): PaymentMethodMessagePromotionsHelper {
         return PrefetchedPaymentMethodMessagePromotionsHelper(args.promotions, eventReporter)
     }
+
+    @Provides
+    fun providePlacesClient(
+        application: Application,
+        args: PaymentOptionContract.Args,
+        errorReporter: ErrorReporter,
+    ): PlacesClientProxy? = createInlineAutocompletePlacesClient(
+        context = application,
+        googlePlacesApiKey = args.configuration.googlePlacesApiKey,
+        errorReporter = errorReporter,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -46,4 +48,15 @@ internal class PaymentSheetViewModelModule {
     fun provideViewModelScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.Main)
     }
+
+    @Provides
+    fun providePlacesClient(
+        appContext: Context,
+        starterArgs: PaymentSheetContract.Args,
+        errorReporter: ErrorReporter,
+    ): PlacesClientProxy? = createInlineAutocompletePlacesClient(
+        context = appContext,
+        googlePlacesApiKey = starterArgs.config.googlePlacesApiKey,
+        errorReporter = errorReporter,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -58,5 +58,6 @@ internal class PaymentSheetViewModelModule {
         context = appContext,
         googlePlacesApiKey = starterArgs.config.googlePlacesApiKey,
         errorReporter = errorReporter,
+        isPlacesAvailable = { cachedIsPlacesAvailable },
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -7,6 +7,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.SectionElement
@@ -25,7 +26,8 @@ internal class BillingDetailsForm(
     private val nameCollection: NameCollection,
     private val collectEmail: Boolean,
     private val collectPhone: Boolean,
-    allowedBillingCountries: Set<String>
+    allowedBillingCountries: Set<String>,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) {
     val nameElement: SimpleTextElement? = if (nameCollection == NameCollection.OutsideBillingDetailsForm) {
         SimpleTextElement(
@@ -53,7 +55,7 @@ internal class BillingDetailsForm(
             collectPhone = collectPhone,
         ),
         rawValuesMap = rawAddressValues(billingDetails),
-        autocompleteAddressInteractorFactory = null,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         shouldHideCountryOnNoAddressCollection = false,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -165,8 +165,6 @@ internal interface EditCardDetailsInteractor {
          *       Depending on this configuration, the interactor may or may not collect billing details.
          * @param onBrandChoiceChanged Callback invoked when the card brand choice changes.
          * @param onCardUpdateParamsChanged Callback invoked when the card update parameters change.
-         * @param autocompleteAddressInteractorFactory Optional factory for inline address autocomplete.
-         *        If null, inline address autocomplete is not used.
          */
         fun create(
             coroutineScope: CoroutineScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.SectionFieldElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -164,6 +165,8 @@ internal interface EditCardDetailsInteractor {
          *       Depending on this configuration, the interactor may or may not collect billing details.
          * @param onBrandChoiceChanged Callback invoked when the card brand choice changes.
          * @param onCardUpdateParamsChanged Callback invoked when the card update parameters change.
+         * @param autocompleteAddressInteractorFactory Optional factory for inline address autocomplete.
+         *        If null, inline address autocomplete is not used.
          */
         fun create(
             coroutineScope: CoroutineScope,
@@ -172,7 +175,8 @@ internal interface EditCardDetailsInteractor {
             payload: EditCardPayload,
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
             onBrandChoiceChanged: CardBrandCallback,
-            onCardUpdateParamsChanged: CardUpdateParamsCallback
+            onCardUpdateParamsChanged: CardUpdateParamsCallback,
+            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
         ): EditCardDetailsInteractor
     }
 }
@@ -187,7 +191,8 @@ internal class DefaultEditCardDetailsInteractor(
     private val requiresModification: Boolean,
     private val coroutineScope: CoroutineScope,
     private val onBrandChoiceChanged: CardBrandCallback,
-    private val onCardUpdateParamsChanged: CardUpdateParamsCallback
+    private val onCardUpdateParamsChanged: CardUpdateParamsCallback,
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) : EditCardDetailsInteractor {
     private val cardDetailsEntry = MutableStateFlow(
         value = cardEditConfiguration?.buildDefaultCardEntry()
@@ -356,6 +361,7 @@ internal class DefaultEditCardDetailsInteractor(
             collectEmail = billingDetailsCollectionConfiguration.collectsEmail,
             collectPhone = billingDetailsCollectionConfiguration.collectsPhone,
             allowedBillingCountries = billingDetailsCollectionConfiguration.allowedBillingCountries,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
     }
 
@@ -388,7 +394,8 @@ internal class DefaultEditCardDetailsInteractor(
             payload: EditCardPayload,
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
             onBrandChoiceChanged: CardBrandCallback,
-            onCardUpdateParamsChanged: CardUpdateParamsCallback
+            onCardUpdateParamsChanged: CardUpdateParamsCallback,
+            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
         ): EditCardDetailsInteractor {
             return DefaultEditCardDetailsInteractor(
                 payload = payload,
@@ -397,7 +404,8 @@ internal class DefaultEditCardDetailsInteractor(
                 coroutineScope = coroutineScope,
                 onBrandChoiceChanged = onBrandChoiceChanged,
                 onCardUpdateParamsChanged = onCardUpdateParamsChanged,
-                requiresModification = requiresModification
+                requiresModification = requiresModification,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.SavedPaymentMethod
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
@@ -124,6 +125,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private val onUpdateSuccess: () -> Unit,
     val editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
         .Factory(),
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) : UpdatePaymentMethodInteractor {
     private val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val error = MutableStateFlow(getInitialError())
@@ -196,7 +198,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
                 name = CollectionMode.Never,
                 allowedCountries = allowedBillingCountries,
             ),
-            requiresModification = true
+            requiresModification = true,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
     }
 
@@ -224,7 +227,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
                 name = CollectionMode.Never,
                 allowedCountries = allowedBillingCountries,
             ),
-            requiresModification = true
+            requiresModification = true,
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -369,6 +369,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             shouldShowSetAsDefaultCheckbox = true,
             isDefaultPaymentMethod = false,
             onUpdateSuccess = {},
+            autocompleteAddressInteractorFactory = null,
         ),
         modifier = Modifier
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -19,9 +19,11 @@ import com.stripe.android.paymentsheet.MandateHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_ATTRIBUTION_DRAWABLE
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
 import com.stripe.android.paymentsheet.addresselement.AutocompleteAppearanceContext
 import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
+import com.stripe.android.paymentsheet.addresselement.InlineAutocompleteDependencies
 import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
@@ -34,6 +36,7 @@ import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
@@ -65,6 +68,7 @@ internal abstract class BaseSheetViewModel(
     val mode: EventReporter.Mode,
     val customerStateHolderFactory: CustomerStateHolder.Factory,
     val customViewModelScope: CoroutineScope,
+    val placesClient: PlacesClientProxy?,
 ) : ViewModel() {
     private val autocompleteLauncher = DefaultAutocompleteLauncher(
         AutocompleteAppearanceContext.PaymentElement(config.appearance)
@@ -87,7 +91,14 @@ internal abstract class BaseSheetViewModel(
                 googlePlacesApiKey = config.googlePlacesApiKey,
                 autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                 isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-            )
+                getAttributionDrawable = AUTOCOMPLETE_ATTRIBUTION_DRAWABLE,
+            ),
+            inlineDependencies = placesClient?.let { client ->
+                InlineAutocompleteDependencies(
+                    placesClient = client,
+                    coroutineScope = viewModelScope,
+                )
+            },
         )
 
     internal val validationRequested = MutableSharedFlow<Unit>()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -91,7 +91,7 @@ internal abstract class BaseSheetViewModel(
                 googlePlacesApiKey = config.googlePlacesApiKey,
                 autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                 isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-                getAttributionDrawable = AUTOCOMPLETE_ATTRIBUTION_DRAWABLE,
+                getAttributionDrawable = if (placesClient != null) AUTOCOMPLETE_ATTRIBUTION_DRAWABLE else null,
             ),
             inlineDependencies = placesClient?.let { client ->
                 InlineAutocompleteDependencies(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -392,6 +392,7 @@ internal class CustomerSheetScreenshotTest {
                 allowedBillingCountries = emptySet(),
                 removeMessage = null,
                 onUpdateSuccess = {},
+                autocompleteAddressInteractorFactory = null,
             ),
             isLiveMode = true,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
@@ -51,6 +51,7 @@ internal class UpdateCardScreenshotTest(
                         billingDetailsCollectionConfiguration = testCase.billingDetailsCollectionConfiguration,
                         onBrandChoiceChanged = {},
                         onCardUpdateParamsChanged = {},
+                        autocompleteAddressInteractorFactory = null,
                     ).apply {
                         if (testCase.validate) {
                             handleViewAction(EditCardDetailsInteractor.ViewAction.Validate)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -175,6 +175,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                placesClient = null,
             )
         }
     }
@@ -226,7 +227,8 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                placesClient = null,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -570,6 +570,7 @@ internal class PaymentOptionsActivityTest {
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                placesClient = null,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1463,7 +1463,8 @@ internal class PaymentOptionsViewModelTest {
                 }
             },
             customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            placesClient = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1368,7 +1368,8 @@ internal class PaymentSheetActivityTest {
                 tapToAddHelperFactory = FakeTapToAddHelper.Factory.noOp(),
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
-                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                placesClient = null,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3492,7 +3492,8 @@ internal class PaymentSheetViewModelTest {
                     }
                 },
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                placesClient = null,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -1,0 +1,90 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// The detailed inline autocomplete behavior (predictions, debouncing, selection,
+// suppression, dismissal) is tested in InlineAutocompleteControllerTest. These tests
+// cover only the wrapper-specific behavior: the two methods this interactor implements
+// directly (onAutocomplete, onEnterManuallyFromInline) and that the registered event
+// listener is wired into the controller.
+@RunWith(RobolectricTestRunner::class)
+class BillingInlineAutocompleteAddressInteractorTest {
+
+    @Test
+    fun `onAutocomplete is a no-op and emits no event`() = runScenario {
+        interactor.onAutocomplete("US")
+
+        eventCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `onEnterManuallyFromInline emits OnExpandForm with null values`() = runScenario {
+        interactor.onEnterManuallyFromInline()
+
+        assertThat(eventCalls.awaitItem())
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `onPredictionSelected forwards the resulting event to the registered listener`() = runScenario {
+        // Address-mapping detail is covered by InlineAutocompleteControllerTest; here we only
+        // verify the event the controller produces reaches the listener wired via register().
+        fakePlacesClient.fetchPlaceResult = Result.success(FetchPlaceResponse(Place(emptyList())))
+
+        interactor.onPredictionSelected("place_1")
+        advanceTimeBy(100)
+
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        assertThat(eventCalls.awaitItem())
+            .isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest(UnconfinedTestDispatcher()) {
+        val fakePlaces = FakePlacesClientProxy()
+        val eventCalls = Turbine<AutocompleteAddressInteractor.Event>()
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test_key",
+            autocompleteCountries = emptySet(),
+            isPlacesAvailable = true,
+            isInlineAutocompleteEnabled = true,
+        )
+        val interactor = BillingInlineAutocompleteAddressInteractor(
+            placesClient = fakePlaces,
+            autocompleteConfig = config,
+            coroutineScope = backgroundScope,
+        )
+        interactor.register { event -> eventCalls.add(event) }
+
+        Scenario(
+            interactor = interactor,
+            fakePlacesClient = fakePlaces,
+            eventCalls = eventCalls,
+            testScope = this,
+        ).apply { block() }
+
+        fakePlaces.ensureAllEventsConsumed()
+        eventCalls.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val interactor: BillingInlineAutocompleteAddressInteractor,
+        val fakePlacesClient: FakePlacesClientProxy,
+        val eventCalls: Turbine<AutocompleteAddressInteractor.Event>,
+        val testScope: TestScope,
+    ) {
+        fun advanceTimeBy(millis: Long) = testScope.advanceTimeBy(millis)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -14,6 +14,7 @@ internal class FakePlacesClientProxy(
         Result.success(FetchPlaceResponse(Place(emptyList()))),
 ) : PlacesClientProxy {
     var onBeforeFindPredictions: (() -> Unit)? = null
+    var onBeforeFetchPlace: (suspend () -> Unit)? = null
 
     data class FindPredictionsCall(
         val query: String?,
@@ -39,6 +40,7 @@ internal class FakePlacesClientProxy(
 
     override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
         _fetchPlaceCalls.add(placeId)
+        onBeforeFetchPlace?.invoke()
         return fetchPlaceResult
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor.InlinePredictionsState
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -249,6 +250,29 @@ class InlineAutocompleteControllerTest {
         }
 
     @Test
+    fun `onDismissed cancels an in-flight prediction selection`() = runScenario {
+        val fetchGate = CompletableDeferred<Unit>()
+        fakePlacesClient.fetchPlaceResult = Result.success(
+            FetchPlaceResponse(Place(emptyList()))
+        )
+        fakePlacesClient.onBeforeFetchPlace = { fetchGate.await() }
+
+        delegate.onPredictionSelected("place_1")
+        advanceTimeBy(100)
+
+        // The selection is suspended in fetchPlace; dismissing must cancel it.
+        delegate.onDismissed()
+
+        // Releasing the gate must not produce an OnValues event, since the job was cancelled.
+        fetchGate.complete(Unit)
+        advanceTimeBy(100)
+
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        eventCalls.expectNoEvents()
+    }
+
+    @Test
     fun `onPredictionSelected suppresses next query matching predicted line1`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
@@ -423,6 +447,21 @@ class InlineAutocompleteControllerTest {
             val call = fakePlacesClient.findPredictionsCalls.awaitItem()
             assertThat(call.query).isEqualTo("second query")
         }
+
+    @Test
+    fun `dispose cancels query observation`() = runScenario {
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(emptyList())
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        delegate.dispose()
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        fakePlacesClient.findPredictionsCalls.expectNoEvents()
+    }
 
     @Test
     fun `null country flow value defaults to empty string`() = runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -5,8 +5,10 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -183,13 +185,88 @@ class PaymentElementAutocompleteAddressInteractorTest {
 
         val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
-            autocompleteConfig = config
+            autocompleteConfig = config,
+            inlineDependencies = null,
         )
 
         val interactor = factory.create()
 
         assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
         assertThat(interactor.autocompleteConfig).isEqualTo(config)
+    }
+
+    @Test
+    fun `Factory creates inline interactor when inline enabled with places client and scope`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US"),
+            isInlineAutocompleteEnabled = true,
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            inlineDependencies = InlineAutocompleteDependencies(
+                placesClient = FakePlacesClientProxy(),
+                coroutineScope = this,
+            ),
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(BillingInlineAutocompleteAddressInteractor::class.java)
+        assertThat(interactor.autocompleteConfig).isEqualTo(config)
+    }
+
+    @Test
+    fun `Factory disposes previously created inline interactor on next create`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US"),
+            isInlineAutocompleteEnabled = true,
+        )
+        val fakePlaces = FakePlacesClientProxy()
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            inlineDependencies = InlineAutocompleteDependencies(
+                placesClient = fakePlaces,
+                coroutineScope = this,
+            ),
+        )
+        val queryFlow = MutableStateFlow("")
+        val countryFlow = MutableStateFlow<String?>("US")
+
+        val first = factory.create()
+        first.observeQueryChanges(queryFlow, countryFlow)
+
+        // Building a new interactor must dispose the previous one's query observation.
+        factory.create()
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        fakePlaces.findPredictionsCalls.expectNoEvents()
+        fakePlaces.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `Factory falls back to launcher when inline enabled but no dependencies`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US"),
+            isInlineAutocompleteEnabled = true,
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            inlineDependencies = null,
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
@@ -116,6 +116,7 @@ internal class BillingDetailsFormTest {
             collectEmail = false,
             collectPhone = false,
             allowedBillingCountries = allowedCountries,
+            autocompleteAddressInteractorFactory = null,
         )
         block(form)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
@@ -85,6 +85,7 @@ internal class BillingDetailsFormUITest {
             collectEmail = false,
             collectPhone = false,
             allowedBillingCountries = emptySet(),
+            autocompleteAddressInteractorFactory = null,
         )
         composeRule.setContent {
             BillingDetailsFormUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
@@ -408,7 +408,8 @@ internal class CardDetailsEditUITest {
                 ),
                 onBrandChoiceChanged = {},
                 onCardUpdateParamsChanged = {},
-                requiresModification = true
+                requiresModification = true,
+                autocompleteAddressInteractorFactory = null,
             )
         composeRule.setContent {
             CardDetailsEditUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -659,6 +659,7 @@ internal class DefaultEditCardDetailsInteractorTest {
             ),
             onBrandChoiceChanged = onBrandChoiceChanged,
             onCardUpdateParamsChanged = onCardUpdateParamsChanged,
+            autocompleteAddressInteractorFactory = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -739,6 +739,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             editCardDetailsInteractorFactory = editCardDetailsInteractorFactory,
             removeMessage = null,
             allowedBillingCountries = allowedBillingCountries,
+            autocompleteAddressInteractorFactory = null,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.CoroutineScope
 
 internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.Factory {
@@ -17,7 +18,8 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
         payload: EditCardPayload,
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         onBrandChoiceChanged: CardBrandCallback,
-        onCardUpdateParamsChanged: CardUpdateParamsCallback
+        onCardUpdateParamsChanged: CardUpdateParamsCallback,
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     ): EditCardDetailsInteractor {
         this.onCardUpdateParamsChanged = onCardUpdateParamsChanged
         this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -64,6 +64,7 @@ internal class FakeUpdatePaymentMethodInteractor(
             ),
             onBrandChoiceChanged = {},
             onCardUpdateParamsChanged = {},
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -53,6 +53,7 @@ internal class FakeBaseSheetViewModel private constructor(
     mode = EventReporter.Mode.Complete,
     customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
     customViewModelScope = customViewModelScope,
+    placesClient = null,
 ) {
     companion object {
         fun create(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -31,7 +31,6 @@ class AutocompleteAddressController(
 
     private val config = interactor.autocompleteConfig
 
-    // Inline autocomplete requires both the feature flag and an available Places SDK.
     private val inlineAutocompleteActive =
         config.isInlineAutocompleteEnabled && config.isPlacesAvailable
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -31,8 +31,12 @@ class AutocompleteAddressController(
 
     private val config = interactor.autocompleteConfig
 
+    // Inline autocomplete requires both the feature flag and an available Places SDK.
+    private val inlineAutocompleteActive =
+        config.isInlineAutocompleteEnabled && config.isPlacesAvailable
+
     private val inlineAutocompleteHandler: InlineAutocompleteHandler? =
-        if (config.isInlineAutocompleteEnabled) {
+        if (inlineAutocompleteActive) {
             object : InlineAutocompleteHandler {
                 override val predictionsState = interactor.inlinePredictionsState
 
@@ -99,7 +103,7 @@ class AutocompleteAddressController(
     }
 
     init {
-        if (config.isInlineAutocompleteEnabled) {
+        if (inlineAutocompleteActive) {
             interactor.observeQueryChanges(inlineQuery, countryDropdownFieldController.rawFieldValue)
         }
 
@@ -163,7 +167,7 @@ class AutocompleteAddressController(
                 nameConfig = nameConfig,
                 emailConfig = emailConfig,
             )
-        } else if (config.isInlineAutocompleteEnabled && !expandForm && values[IdentifierSpec.Line1] == null) {
+        } else if (inlineAutocompleteActive && !expandForm && values[IdentifierSpec.Line1] == null) {
             AddressInputMode.AutocompleteInline(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -172,6 +172,16 @@ class AutocompleteAddressControllerTest {
     )
 
     @Test
+    fun `Element does not use inline autocomplete if Places is not available`() = noAutocompleteTest(
+        autocompleteConfig = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "123",
+            autocompleteCountries = setOf("US"),
+            isPlacesAvailable = false,
+            isInlineAutocompleteEnabled = true,
+        ),
+    )
+
+    @Test
     fun `Element does not use autocomplete if autocomplete country not supported`() = noAutocompleteTest(
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "123",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Wire inline address autocomplete into billing address fields for Payment Sheet and Flow Controller.
When the feature flag is on and a Google Places API key is configured, users see an inline prediction dropdown under the billing address field instead of only the full-screen Places launcher.



# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Inline address autocomplete was previously implemented for the standalone Address Element and extracted into a reusable InlineAutocompleteController in #13306. Payment Sheet billing address fields still passed autocompleteAddressInteractorFactory = null into CardBillingAddressElement, so billing address collection did not benefit from inline predictions even when the feature flag was enabled. This change builds on the shared InlineAutocompleteController from #13306 and connects it to Payment Sheet billing address via the existing AutocompleteAddressInteractor factory pattern, so inline predictions appear directly under the billing address field.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
Gated by feature flag:
New card entry (Payment Sheet complete flow + Flow Controller add-payment-method UI)
Edit/update saved card billing address (Payment Sheet manage payment methods flow)
