### PR TITLE
Prep for wiring inline autocomplete into billing address fields

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -600,6 +600,7 @@ internal class CustomerSheetViewModel(
                             IllegalStateException("Unexpected attempt to update default from CustomerSheet.")
                         )
                     },
+                    autocompleteAddressInteractorFactory = null,
                 ),
                 isLiveMode = isLiveMode,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
@@ -142,7 +142,8 @@ internal fun UpdateCardScreenBodyPreview() {
                     onBrandChoiceChanged = {},
                     onCardUpdateParamsChanged = {},
                     billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(),
-                    requiresModification = true
+                    requiresModification = true,
+                    autocompleteAddressInteractorFactory = null,
                 ),
                 state = UpdateCardScreenState(
                     paymentDetailsId = "card_id_1234",

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -225,7 +225,8 @@ internal class UpdateCardScreenViewModel @Inject constructor(
             onBrandChoiceChanged = ::onBrandChoiceChanged,
             // We prefill in the billing details update flow, so the form might
             // already be complete on first render. The user can submit without modifying.
-            requiresModification = state.value.isBillingDetailsUpdateFlow.not()
+            requiresModification = state.value.isBillingDetailsUpdateFlow.not(),
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -83,6 +83,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             onUpdateSuccess = {
                 embeddedNavigatorProvider.get().performAction(EmbeddedNavigator.Action.Back)
             },
+            autocompleteAddressInteractorFactory = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -407,6 +407,8 @@ internal class SavedPaymentMethodMutator(
                             removeMessage = paymentMethodMetadata?.customerMetadata?.removePaymentMethod
                                 ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
+                            autocompleteAddressInteractorFactory =
+                                null,
                         )
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -407,8 +407,7 @@ internal class SavedPaymentMethodMutator(
                             removeMessage = paymentMethodMetadata?.customerMetadata?.removePaymentMethod
                                 ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
-                            autocompleteAddressInteractorFactory =
-                                null,
+                            autocompleteAddressInteractorFactory = null,
                         )
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentsheet.addresselement
 
-import com.stripe.android.uicore.R
-
 internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "AU",
     "BE",
@@ -24,7 +22,3 @@ internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "US",
     "ZA"
 )
-
-internal val AUTOCOMPLETE_ATTRIBUTION_DRAWABLE: (Boolean) -> Int? = { _ ->
-    R.drawable.stripe_google_maps_logo
-}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import com.stripe.android.uicore.R
+
 internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "AU",
     "BE",
@@ -22,3 +24,7 @@ internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "US",
     "ZA"
 )
+
+internal val AUTOCOMPLETE_ATTRIBUTION_DRAWABLE: (Boolean) -> Int? = { _ ->
+    R.drawable.stripe_google_maps_logo
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -26,6 +26,7 @@ internal class InlineAutocompleteController(
 ) {
     private var lastPredictionLine1: String? = null
     private var observeJob: Job? = null
+    private var selectionJob: Job? = null
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
         AutocompleteAddressInteractor.InlinePredictionsState.Idle
@@ -58,7 +59,8 @@ internal class InlineAutocompleteController(
 
     fun onPredictionSelected(predictionId: String) {
         if (placesClient == null) return
-        coroutineScope.launch {
+        selectionJob?.cancel()
+        selectionJob = coroutineScope.launch {
             placesClient.fetchPlace(predictionId).fold(
                 onSuccess = { response ->
                     val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
@@ -86,7 +88,13 @@ internal class InlineAutocompleteController(
     }
 
     fun onDismissed() {
+        selectionJob?.cancel()
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+    }
+
+    fun dispose() {
+        observeJob?.cancel()
+        selectionJob?.cancel()
     }
 
     private fun isCountrySupported(country: String): Boolean {
@@ -96,8 +104,9 @@ internal class InlineAutocompleteController(
     }
 
     private suspend fun fetchPredictions(query: String, country: String) {
+        val client = placesClient ?: return
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Loading
-        val result = placesClient!!.findAutocompletePredictions(
+        val result = client.findAutocompletePredictions(
             query = query,
             country = country,
             limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -73,11 +73,7 @@ internal class InputAddressViewModel @Inject constructor(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
-        getAttributionDrawable = if (isInlineAutocompleteEnabled) {
-            { _ -> com.stripe.android.uicore.R.drawable.stripe_google_maps_logo }
-        } else {
-            null
-        },
+        getAttributionDrawable = if (isInlineAutocompleteEnabled) AUTOCOMPLETE_ATTRIBUTION_DRAWABLE else null,
     )
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -73,7 +74,7 @@ internal class InputAddressViewModel @Inject constructor(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
-        getAttributionDrawable = if (isInlineAutocompleteEnabled) AUTOCOMPLETE_ATTRIBUTION_DRAWABLE else null,
+        getAttributionDrawable = if (isInlineAutocompleteEnabled) { _ -> R.drawable.stripe_google_maps_logo } else null,
     )
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -7,6 +7,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.SectionElement
@@ -25,7 +26,8 @@ internal class BillingDetailsForm(
     private val nameCollection: NameCollection,
     private val collectEmail: Boolean,
     private val collectPhone: Boolean,
-    allowedBillingCountries: Set<String>
+    allowedBillingCountries: Set<String>,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) {
     val nameElement: SimpleTextElement? = if (nameCollection == NameCollection.OutsideBillingDetailsForm) {
         SimpleTextElement(
@@ -53,7 +55,7 @@ internal class BillingDetailsForm(
             collectPhone = collectPhone,
         ),
         rawValuesMap = rawAddressValues(billingDetails),
-        autocompleteAddressInteractorFactory = null,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         shouldHideCountryOnNoAddressCollection = false,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.SectionFieldElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -172,7 +173,8 @@ internal interface EditCardDetailsInteractor {
             payload: EditCardPayload,
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
             onBrandChoiceChanged: CardBrandCallback,
-            onCardUpdateParamsChanged: CardUpdateParamsCallback
+            onCardUpdateParamsChanged: CardUpdateParamsCallback,
+            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
         ): EditCardDetailsInteractor
     }
 }
@@ -187,7 +189,8 @@ internal class DefaultEditCardDetailsInteractor(
     private val requiresModification: Boolean,
     private val coroutineScope: CoroutineScope,
     private val onBrandChoiceChanged: CardBrandCallback,
-    private val onCardUpdateParamsChanged: CardUpdateParamsCallback
+    private val onCardUpdateParamsChanged: CardUpdateParamsCallback,
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) : EditCardDetailsInteractor {
     private val cardDetailsEntry = MutableStateFlow(
         value = cardEditConfiguration?.buildDefaultCardEntry()
@@ -356,6 +359,7 @@ internal class DefaultEditCardDetailsInteractor(
             collectEmail = billingDetailsCollectionConfiguration.collectsEmail,
             collectPhone = billingDetailsCollectionConfiguration.collectsPhone,
             allowedBillingCountries = billingDetailsCollectionConfiguration.allowedBillingCountries,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
     }
 
@@ -388,7 +392,8 @@ internal class DefaultEditCardDetailsInteractor(
             payload: EditCardPayload,
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
             onBrandChoiceChanged: CardBrandCallback,
-            onCardUpdateParamsChanged: CardUpdateParamsCallback
+            onCardUpdateParamsChanged: CardUpdateParamsCallback,
+            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
         ): EditCardDetailsInteractor {
             return DefaultEditCardDetailsInteractor(
                 payload = payload,
@@ -397,7 +402,8 @@ internal class DefaultEditCardDetailsInteractor(
                 coroutineScope = coroutineScope,
                 onBrandChoiceChanged = onBrandChoiceChanged,
                 onCardUpdateParamsChanged = onCardUpdateParamsChanged,
-                requiresModification = requiresModification
+                requiresModification = requiresModification,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.SavedPaymentMethod
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
@@ -124,6 +125,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private val onUpdateSuccess: () -> Unit,
     val editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
         .Factory(),
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) : UpdatePaymentMethodInteractor {
     private val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val error = MutableStateFlow(getInitialError())
@@ -196,7 +198,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
                 name = CollectionMode.Never,
                 allowedCountries = allowedBillingCountries,
             ),
-            requiresModification = true
+            requiresModification = true,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
     }
 
@@ -224,7 +227,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
                 name = CollectionMode.Never,
                 allowedCountries = allowedBillingCountries,
             ),
-            requiresModification = true
+            requiresModification = true,
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -369,6 +369,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             shouldShowSetAsDefaultCheckbox = true,
             isDefaultPaymentMethod = false,
             onUpdateSuccess = {},
+            autocompleteAddressInteractorFactory = null,
         ),
         modifier = Modifier
     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -392,6 +392,7 @@ internal class CustomerSheetScreenshotTest {
                 allowedBillingCountries = emptySet(),
                 removeMessage = null,
                 onUpdateSuccess = {},
+                autocompleteAddressInteractorFactory = null,
             ),
             isLiveMode = true,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
@@ -51,6 +51,7 @@ internal class UpdateCardScreenshotTest(
                         billingDetailsCollectionConfiguration = testCase.billingDetailsCollectionConfiguration,
                         onBrandChoiceChanged = {},
                         onCardUpdateParamsChanged = {},
+                        autocompleteAddressInteractorFactory = null,
                     ).apply {
                         if (testCase.validate) {
                             handleViewAction(EditCardDetailsInteractor.ViewAction.Validate)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -14,6 +14,7 @@ internal class FakePlacesClientProxy(
         Result.success(FetchPlaceResponse(Place(emptyList()))),
 ) : PlacesClientProxy {
     var onBeforeFindPredictions: (() -> Unit)? = null
+    var onBeforeFetchPlace: (suspend () -> Unit)? = null
 
     data class FindPredictionsCall(
         val query: String?,
@@ -39,6 +40,7 @@ internal class FakePlacesClientProxy(
 
     override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
         _fetchPlaceCalls.add(placeId)
+        onBeforeFetchPlace?.invoke()
         return fetchPlaceResult
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor.InlinePredictionsState
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -249,6 +250,29 @@ class InlineAutocompleteControllerTest {
         }
 
     @Test
+    fun `onDismissed cancels an in-flight prediction selection`() = runScenario {
+        val fetchGate = CompletableDeferred<Unit>()
+        fakePlacesClient.fetchPlaceResult = Result.success(
+            FetchPlaceResponse(Place(emptyList()))
+        )
+        fakePlacesClient.onBeforeFetchPlace = { fetchGate.await() }
+
+        delegate.onPredictionSelected("place_1")
+        advanceTimeBy(100)
+
+        // The selection is suspended in fetchPlace; dismissing must cancel it.
+        delegate.onDismissed()
+
+        // Releasing the gate must not produce an OnValues event, since the job was cancelled.
+        fetchGate.complete(Unit)
+        advanceTimeBy(100)
+
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        eventCalls.expectNoEvents()
+    }
+
+    @Test
     fun `onPredictionSelected suppresses next query matching predicted line1`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
@@ -423,6 +447,21 @@ class InlineAutocompleteControllerTest {
             val call = fakePlacesClient.findPredictionsCalls.awaitItem()
             assertThat(call.query).isEqualTo("second query")
         }
+
+    @Test
+    fun `dispose cancels query observation`() = runScenario {
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(emptyList())
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        delegate.dispose()
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        fakePlacesClient.findPredictionsCalls.expectNoEvents()
+    }
 
     @Test
     fun `null country flow value defaults to empty string`() = runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
@@ -116,6 +116,7 @@ internal class BillingDetailsFormTest {
             collectEmail = false,
             collectPhone = false,
             allowedBillingCountries = allowedCountries,
+            autocompleteAddressInteractorFactory = null,
         )
         block(form)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
@@ -85,6 +85,7 @@ internal class BillingDetailsFormUITest {
             collectEmail = false,
             collectPhone = false,
             allowedBillingCountries = emptySet(),
+            autocompleteAddressInteractorFactory = null,
         )
         composeRule.setContent {
             BillingDetailsFormUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
@@ -408,7 +408,8 @@ internal class CardDetailsEditUITest {
                 ),
                 onBrandChoiceChanged = {},
                 onCardUpdateParamsChanged = {},
-                requiresModification = true
+                requiresModification = true,
+                autocompleteAddressInteractorFactory = null,
             )
         composeRule.setContent {
             CardDetailsEditUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -659,6 +659,7 @@ internal class DefaultEditCardDetailsInteractorTest {
             ),
             onBrandChoiceChanged = onBrandChoiceChanged,
             onCardUpdateParamsChanged = onCardUpdateParamsChanged,
+            autocompleteAddressInteractorFactory = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -739,6 +739,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             editCardDetailsInteractorFactory = editCardDetailsInteractorFactory,
             removeMessage = null,
             allowedBillingCountries = allowedBillingCountries,
+            autocompleteAddressInteractorFactory = null,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.CoroutineScope
 
 internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.Factory {
@@ -17,7 +18,8 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
         payload: EditCardPayload,
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         onBrandChoiceChanged: CardBrandCallback,
-        onCardUpdateParamsChanged: CardUpdateParamsCallback
+        onCardUpdateParamsChanged: CardUpdateParamsCallback,
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     ): EditCardDetailsInteractor {
         this.onCardUpdateParamsChanged = onCardUpdateParamsChanged
         this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -64,6 +64,7 @@ internal class FakeUpdatePaymentMethodInteractor(
             ),
             onBrandChoiceChanged = {},
             onCardUpdateParamsChanged = {},
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -31,8 +31,11 @@ class AutocompleteAddressController(
 
     private val config = interactor.autocompleteConfig
 
+    private val inlineAutocompleteActive =
+        config.isInlineAutocompleteEnabled && config.isPlacesAvailable
+
     private val inlineAutocompleteHandler: InlineAutocompleteHandler? =
-        if (config.isInlineAutocompleteEnabled) {
+        if (inlineAutocompleteActive) {
             object : InlineAutocompleteHandler {
                 override val predictionsState = interactor.inlinePredictionsState
 
@@ -99,7 +102,7 @@ class AutocompleteAddressController(
     }
 
     init {
-        if (config.isInlineAutocompleteEnabled) {
+        if (inlineAutocompleteActive) {
             interactor.observeQueryChanges(inlineQuery, countryDropdownFieldController.rawFieldValue)
         }
 
@@ -163,7 +166,7 @@ class AutocompleteAddressController(
                 nameConfig = nameConfig,
                 emailConfig = emailConfig,
             )
-        } else if (config.isInlineAutocompleteEnabled && !expandForm && values[IdentifierSpec.Line1] == null) {
+        } else if (inlineAutocompleteActive && !expandForm && values[IdentifierSpec.Line1] == null) {
             AddressInputMode.AutocompleteInline(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -172,6 +172,16 @@ class AutocompleteAddressControllerTest {
     )
 
     @Test
+    fun `Element does not use inline autocomplete if Places is not available`() = noAutocompleteTest(
+        autocompleteConfig = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "123",
+            autocompleteCountries = setOf("US"),
+            isPlacesAvailable = false,
+            isInlineAutocompleteEnabled = true,
+        ),
+    )
+
+    @Test
     fun `Element does not use autocomplete if autocomplete country not supported`() = noAutocompleteTest(
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "123",


### PR DESCRIPTION
## Summary


This a pre-work PR for wiring inline autocomplete into billing address fields. Fixes lifecycle issues in InlineAutocompleteController and adds an autocompleteAddressInteractorFactory parameter to billing form classes.

## Motivation

Inline address autocomplete was extracted into a reusable `InlineAutocompleteController` in #13306. Before wiring it into Payment Sheet billing fields, the controller needs improvements (job cancellation on dismiss/dispose, null-safety) and the billing form classes need a factory parameter to accept an autocomplete interactor. This PR splits out the prep work,accounting for controller edge cases (cancel jobs on dismiss/dispose, null-safety) and parameter plumbing. The follow-up PR will connect inline autocomplete to Payment Sheet and Flow Controller billing fields. 


## Testing
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

New tests:
- `InlineAutocompleteControllerTest`: onDismissed cancels an in-flight prediction selection, dispose cancels query observation
- `AutocompleteAddressControllerTest`: Element does not use inline autocomplete if Places is not available

## Changelog
