### PR TITLE
[fc] Speculative fix for OTPElementUI stack overflow

### DIFF
--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -9,7 +9,6 @@
     <ID>CyclomaticComplexMethod:StripeTheme.kt:@Composable @ReadOnlyComposable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun StripeTypography.toComposeTypography: Typography</ID>
     <ID>EmptyFunctionBlock:DrawablePainter.kt:EmptyPainter${}</ID>
     <ID>ForEachOnRange:OTPController.kt:OTPController$0 until inputLength</ID>
-    <ID>ForEachOnRange:OTPElementUI.kt:0 until inputLength</ID>
     <ID>FunctionParameterNaming:IdentifierSpec.kt:IdentifierSpec.Companion$_value: String</ID>
     <ID>LargeClass:AutocompleteAddressControllerTest.kt:AutocompleteAddressControllerTest</ID>
     <ID>LongMethod:Html.kt:@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource: AnnotatedString</ID>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -225,10 +225,11 @@ private fun OTPInputBox(
     BasicTextField(
         value = value,
         onValueChange = { newValue ->
-            val stringChangedSinceLastInvocation = lastTextValue != newValue
+            val prevLastTextValue = lastTextValue
+            val stringChangedSinceLastInvocation = prevLastTextValue != newValue
             lastTextValue = newValue
 
-            if (stringChangedSinceLastInvocation || newValue.length == 1) {
+            if (stringChangedSinceLastInvocation || (newValue.length == 1 && newValue != value)) {
                 // If the OTPInputBox already has a value, it would be the first character of it.text
                 // remove it before passing it to the controller.
                 val newValue =
@@ -237,11 +238,14 @@ private fun OTPInputBox(
                     } else {
                         newValue
                     }
-                val inputLength = element.controller.onValueChanged(index, newValue)
-                if (inputLength > 0) {
-                    focusRequesters.requestFocusSafely(
-                        minOf(index + inputLength, focusRequesters.lastIndex)
-                    )
+                val isSpuriousImeFlush = newValue.isEmpty() && prevLastTextValue.length > 1
+                if (!isSpuriousImeFlush) {
+                    val inputLength = element.controller.onValueChanged(index, newValue)
+                    if (inputLength > 0) {
+                        focusRequesters.requestFocusSafely(
+                            minOf(index + inputLength, focusRequesters.lastIndex)
+                        )
+                    }
                 }
             }
         },

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -30,8 +30,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -41,7 +39,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentType
 import androidx.compose.ui.semantics.onAutofillText
@@ -58,7 +55,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBorderStrokeWidth
-import com.stripe.android.uicore.moveFocusSafely
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
 
@@ -112,7 +108,13 @@ fun OTPElementUI(
     selectedStrokeWidth: Dp = 2.dp,
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
-    val focusManager = LocalFocusManager.current
+    val focusRequesters = remember(focusRequester, element.controller.otpLength) {
+        if (element.controller.otpLength <= 0) {
+            emptyList()
+        } else {
+            listOf(focusRequester) + List(element.controller.otpLength - 1) { FocusRequester() }
+        }
+    }
     Row(
         modifier = modifier.fillMaxWidth(),
     ) {
@@ -149,6 +151,7 @@ fun OTPElementUI(
 
                 var textFieldModifier = Modifier
                     .height(56.dp)
+                    .focusRequester(focusRequesters[index])
                     .onFocusChanged { focusState ->
                         if (focusState.isFocused) {
                             focusedElementIndex = index
@@ -163,7 +166,7 @@ fun OTPElementUI(
                             value.isEmpty()
                         ) {
                             // If the current field is empty, move to the previous one and delete
-                            focusManager.moveFocusSafely(FocusDirection.Previous)
+                            focusRequesters.requestFocusSafely(index - 1)
                             element.controller.onValueChanged(index - 1, "")
                             return@onPreviewKeyEvent true
                         }
@@ -177,7 +180,6 @@ fun OTPElementUI(
 
                 if (index == 0) {
                     textFieldModifier = textFieldModifier
-                        .focusRequester(focusRequester)
                         .semantics {
                             onAutofillText {
                                 element.controller.onAutofillDigit(it.text)
@@ -191,7 +193,7 @@ fun OTPElementUI(
                     isSelected = isSelected,
                     element = element,
                     index = index,
-                    focusManager = focusManager,
+                    focusRequesters = focusRequesters,
                     modifier = textFieldModifier,
                     placeholder = otpInputPlaceholder,
                     textStyle = boxTextStyle,
@@ -210,7 +212,7 @@ private fun OTPInputBox(
     textStyle: TextStyle,
     element: OTPElement,
     index: Int,
-    focusManager: FocusManager,
+    focusRequesters: List<FocusRequester>,
     modifier: Modifier,
     enabled: Boolean,
     colors: OTPElementColors,
@@ -236,7 +238,11 @@ private fun OTPInputBox(
                         newValue
                     }
                 val inputLength = element.controller.onValueChanged(index, newValue)
-                (0 until inputLength).forEach { _ -> focusManager.moveFocusSafely(FocusDirection.Next) }
+                if (inputLength > 0) {
+                    focusRequesters.requestFocusSafely(
+                        minOf(index + inputLength, focusRequesters.lastIndex)
+                    )
+                }
             }
         },
         modifier = modifier,
@@ -247,12 +253,21 @@ private fun OTPInputBox(
             keyboardType = element.controller.keyboardType
         ),
         keyboardActions = KeyboardActions(
-            onNext = { focusManager.moveFocusSafely(FocusDirection.Next) },
-            onDone = { focusManager.clearFocus(true) }
+            onNext = { focusRequesters.requestFocusSafely(index + 1) }
         ),
         singleLine = true,
         decorationBox = OTPInputDecorationBox(value, isSelected, placeholder, enabled, colors)
     )
+}
+
+private fun List<FocusRequester>.requestFocusSafely(index: Int) {
+    val focusRequester = getOrNull(index) ?: return
+
+    try {
+        focusRequester.requestFocus()
+    } catch (_: IllegalStateException) {
+        // Ignore requests made before the next field has attached to the focus tree.
+    }
 }
 
 @Composable

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUITest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUITest.kt
@@ -1,0 +1,99 @@
+package com.stripe.android.uicore.elements
+
+import android.os.Build
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.pressKey
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class OTPElementUITest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `single digit advances focus`() {
+        val element = testElement()
+
+        composeTestRule.setContent {
+            OTPElementUI(
+                enabled = true,
+                element = element,
+            )
+        }
+
+        otpNode(0).requestFocus()
+        otpNode(0).performTextInput("1")
+
+        otpNode(1).assertIsFocused()
+    }
+
+    @Test
+    fun `pasting full otp jumps focus to last box`() {
+        val element = testElement()
+
+        composeTestRule.setContent {
+            OTPElementUI(
+                enabled = true,
+                element = element,
+            )
+        }
+
+        otpNode(0).requestFocus()
+        otpNode(0).performTextReplacement("123456")
+
+        otpNode(5).assertIsFocused()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `backspace on empty box retreats focus`() {
+        val element = testElement()
+
+        composeTestRule.setContent {
+            OTPElementUI(
+                enabled = true,
+                element = element,
+            )
+        }
+
+        otpNode(0).requestFocus()
+        otpNode(0).performTextInput("1")
+
+        otpNode(1).assertIsFocused()
+        otpNode(1).performKeyInput {
+            pressKey(Key.Backspace)
+        }
+
+        otpNode(0).assertIsFocused()
+    }
+
+    private fun otpNode(index: Int): SemanticsNodeInteraction {
+        return composeTestRule.onNodeWithTag("OTP-$index")
+    }
+
+    private fun testElement(): OTPElement {
+        return OTPElement(
+            identifier = IdentifierSpec.Generic("otp"),
+            controller = OTPController(),
+        )
+    }
+}
+
+private fun SemanticsNodeInteraction.requestFocus() {
+    performSemanticsAction(SemanticsActions.RequestFocus)
+}


### PR DESCRIPTION
Fix OTPElementUI stack overflow and first-digit paste display bug.

Previously, `OTPElementUI` advanced focus by calling `FocusManager.moveFocus(FocusDirection.Next)` in a loop after each character was entered. This triggered Compose's recursive focus traversal search, which combined with the Android autofill stack depth can cause a `StackOverflowError` on some devices. This is a speculative fix that should resolve the recursion when moving focus in the `OTPElementUI`.

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-201

# How has this been tested?
- [x] Automated
- [ ] Manual

# Reproducible test instructions

(note: couldn't repo the stack overflow myself, so the below is 🤖 speculation)

1. Open the Financial Connections OTP screen and paste a 6-digit code — confirm all 6 boxes fill correctly, including the first
2. Type digits one at a time — confirm focus advances to the next box after each entry
3. Press backspace on an empty box — confirm focus retreats to the previous box and clears it
4. Verify the `StackOverflowError` from the original report no longer occurs on a device with autofill enabled

https://github.com/user-attachments/assets/90f1b19c-6ab8-47b2-bd44-c1847e7e8b51

https://github.com/user-attachments/assets/c9f53797-0490-49a6-baad-097de180089b

RTL language:

https://github.com/user-attachments/assets/90b8d558-c539-4afa-8c35-88166210de2b
