### PR TITLE
Improve network response logging

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultStripeNetworkClient.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultStripeNetworkClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
+import java.net.URI
 import kotlin.coroutines.CoroutineContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -62,29 +63,29 @@ class DefaultStripeNetworkClient @JvmOverloads constructor(
     private fun makeRequest(
         request: StripeRequest
     ): StripeResponse<String> {
-        return parseResponse(connectionFactory.create(request), request.url)
+        return parseResponse(connectionFactory.create(request), request)
     }
 
     private fun makeRequestForFile(
         request: StripeRequest,
         outputFile: File
     ): StripeResponse<File> {
-        return parseResponse(connectionFactory.createForFile(request, outputFile), request.url)
+        return parseResponse(connectionFactory.createForFile(request, outputFile), request)
     }
 
     private fun <BodyType> parseResponse(
         connection: StripeConnection<BodyType>,
-        baseUrl: String?
+        request: StripeRequest
     ): StripeResponse<BodyType> =
         runCatching {
             val stripeResponse = connection.response
-            logger.info(stripeResponse.toString())
+            logger.info(stripeResponse.toLogString(request))
             stripeResponse
         }.getOrElse { error ->
             logger.error("Exception while making Stripe API request", error)
 
             throw when (error) {
-                is IOException -> APIConnectionException.create(error, baseUrl)
+                is IOException -> APIConnectionException.create(error, request.url)
                 else -> error
             }
         }
@@ -97,3 +98,56 @@ class DefaultStripeNetworkClient @JvmOverloads constructor(
         private const val DEFAULT_MAX_RETRIES = 3
     }
 }
+
+private fun <BodyType> StripeResponse<BodyType>.toLogString(
+    request: StripeRequest
+): String {
+    return "Request: ${request.method.code} ${request.sanitizedLogTarget()}, " +
+        "${StripeResponse.HEADER_REQUEST_ID}: ${requestId?.value ?: "absent"}, " +
+        "Status Code: $code"
+}
+
+private fun StripeRequest.sanitizedLogTarget(): String {
+    val uri = runCatching {
+        URI(url)
+    }.getOrNull()
+
+    val host = uri?.host
+    val path = uri?.rawPath
+        ?.takeIf { it.isNotBlank() }
+        ?.redactSensitivePathSegments()
+        ?: "/"
+
+    return if (host == null || host == "api.stripe.com") {
+        path
+    } else {
+        "$host$path"
+    }
+}
+
+private fun String.redactSensitivePathSegments(): String {
+    return split("/")
+        .joinToString("/") { segment ->
+            if (segment.shouldRedactPathSegment()) {
+                REDACTED_PATH_SEGMENT
+            } else {
+                segment
+            }
+        }
+}
+
+private fun String.shouldRedactPathSegment(): Boolean {
+    return STRIPE_ID_PATH_SEGMENT_REGEX.matches(this) ||
+        HIGH_ENTROPY_PATH_SEGMENT_REGEX.matches(this)
+}
+
+private const val REDACTED_PATH_SEGMENT = "[redacted]"
+
+private val STRIPE_ID_PATH_SEGMENT_REGEX = Regex(
+    pattern = "^(acct|ba|btok|card|cn|cs|ct|ctoken|cus|cvsess|ephkey|es|fca|fcsess|" +
+        "in|link|pi|pm|req|seti|si|src|tok)_[A-Za-z0-9_]+$"
+)
+
+private val HIGH_ENTROPY_PATH_SEGMENT_REGEX = Regex(
+    pattern = "^(?=.*\\d)[A-Za-z0-9_-]{16,}$"
+)

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
@@ -56,10 +56,58 @@ internal class DefaultStripeNetworkClientTest {
                 workContext = testDispatcher,
                 connectionFactory = okConnectionFactory
             )
-            assertThat(executor.executeRequest(mock())).isSameInstanceAs(
+            assertThat(executor.executeRequest(FakeStripeRequest())).isSameInstanceAs(
                 okResponseWithString
             )
         }
+
+    @Test
+    fun `executeRequest should log sanitized request target status and absent request id`() = runTest {
+        val client = DefaultStripeNetworkClient(
+            workContext = testDispatcher,
+            connectionFactory = okConnectionFactory,
+            logger = mockLogger,
+        )
+
+        client.executeRequest(
+            FakeStripeRequest(
+                method = StripeRequest.Method.GET,
+                url = "https://q.stripe.com?event=mc_complete&client_secret=pi_secret",
+            )
+        )
+
+        verify(mockLogger).info(
+            "Request: GET q.stripe.com/, Request-Id: absent, Status Code: 200"
+        )
+    }
+
+    @Test
+    fun `executeRequest should log sanitized API path and request id`() = runTest {
+        val connectionFactory = RetryCountConnectionFactory(
+            ResponseConnection(
+                StripeResponse(
+                    code = HttpURLConnection.HTTP_OK,
+                    body = "response_string",
+                    headers = mapOf(StripeResponse.HEADER_REQUEST_ID to listOf("req_123"))
+                )
+            )
+        )
+        val client = DefaultStripeNetworkClient(
+            workContext = testDispatcher,
+            connectionFactory = connectionFactory,
+            logger = mockLogger,
+        )
+
+        client.executeRequest(
+            FakeStripeRequest(
+                url = "https://api.stripe.com/v1/payment_pages/cs_test_123/init?expand[]=elements_session",
+            )
+        )
+
+        verify(mockLogger).info(
+            "Request: POST /v1/payment_pages/[redacted]/init, Request-Id: req_123, Status Code: 200"
+        )
+    }
 
     @Test
     fun `executeRequestForFile should return StripeResponse with File`() =
@@ -68,7 +116,7 @@ internal class DefaultStripeNetworkClientTest {
                 workContext = testDispatcher,
                 connectionFactory = okConnectionFactory
             )
-            assertThat(executor.executeRequestForFile(mock(), mock())).isSameInstanceAs(
+            assertThat(executor.executeRequestForFile(FakeStripeRequest(), mock())).isSameInstanceAs(
                 okResponseWithFile
             )
         }
@@ -222,8 +270,7 @@ internal class DefaultStripeNetworkClientTest {
                 throw error
             }
 
-        override fun close() {
-        }
+        override fun close() = Unit
 
         override fun createBodyFromResponseStream(responseStream: InputStream?): String? = null
     }
@@ -237,8 +284,20 @@ internal class DefaultStripeNetworkClientTest {
                 body = null
             )
 
-        override fun close() {
-        }
+        override fun close() = Unit
+
+        override fun createBodyFromResponseStream(responseStream: InputStream?): String? = null
+    }
+
+    private class ResponseConnection(
+        private val stripeResponse: StripeResponse<String>
+    ) : StripeConnection<String> {
+        override val responseCode: Int = stripeResponse.code
+
+        override val response: StripeResponse<String>
+            get() = stripeResponse
+
+        override fun close() = Unit
 
         override fun createBodyFromResponseStream(responseStream: InputStream?): String? = null
     }


### PR DESCRIPTION
## Summary
- Include request method and sanitized request target in Stripe network response logs
- Show missing request IDs as "absent" instead of "null"
- Drop query params and redact sensitive or high-entropy path segments before logging

## Motivation
When debugging e2e integration, I constantly need to find the corresponding confirm/creation api calls. Without the path getting logged, it's harder to identify the req_id I need.

## Testing
- ./gradlew :stripe-core:apiCheck :stripe-core:detekt