### PR TITLE
Use x-large worker for CardScan instrumentation tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -383,6 +383,10 @@ workflows:
           title: Export CardScan instrumentation test results
           inputs:
             - test_title: CardScan instrumentation tests
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   build-paymentsheet-e2e:
     before_run:
       - prepare_all


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Use x-large worker for CardScan instrumentation tests

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Attempt to fix flakiness in this bitrise workflow.
- Example failure: https://app.bitrise.io/app/f5b7f5379a28eb07/build/73785071-9083-487d-a588-0fe0511530ce
- Previous PR which fixed this type of failure: https://github.com/stripe/stripe-android/pull/13285
