### PR TITLE
Add implementation for `NfcTagTransceiver`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
@@ -46,18 +46,23 @@ internal class DefaultNfcCardScanner @Inject constructor(
             viewModelScope.launch(workContext) {
                 _state.emit(NfcCardScanner.State.Scanning)
 
-                transceiver.open()
+                runCatching {
+                    transceiver.open()
 
-                cardReader.readCard(transceiver).fold(
+                    try {
+                        cardReader.readCard(transceiver)
+                            .getOrThrow()
+                    } finally {
+                        transceiver.close()
+                    }
+                }.fold(
                     onSuccess = { cardData ->
                         _state.emit(NfcCardScanner.State.Complete(cardData))
                     },
-                    onFailure = {
-                        _state.emit(NfcCardScanner.State.Failed(it))
-                    },
+                    onFailure = { error ->
+                        _state.emit(NfcCardScanner.State.Failed(error))
+                    }
                 )
-
-                transceiver.close()
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcTagTransceiver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcTagTransceiver.kt
@@ -1,18 +1,19 @@
 package com.stripe.android.common.nfcscan.scanner
 
 import android.nfc.Tag
+import android.nfc.tech.IsoDep
 import java.io.IOException
 import javax.inject.Inject
 import kotlin.jvm.Throws
 
 internal interface NfcTagTransceiver {
-    @Throws(IOException::class)
+    @Throws(IOException::class, SecurityException::class)
     fun open()
 
-    @Throws(IOException::class)
+    @Throws(IOException::class, SecurityException::class)
     fun transceive(data: ByteArray): ByteArray
 
-    @Throws(IOException::class)
+    @Throws(IOException::class, SecurityException::class)
     fun close()
 
     interface Factory {
@@ -20,22 +21,31 @@ internal interface NfcTagTransceiver {
     }
 }
 
-internal class IsoNfcTagTransceiver : NfcTagTransceiver {
+internal class IsoNfcTagTransceiver(
+    private val isoDep: IsoDep,
+) : NfcTagTransceiver {
     override fun open() {
-        // Do nothing
+        isoDep.timeout = TIMEOUT_MS
+        isoDep.connect()
     }
 
     override fun transceive(data: ByteArray): ByteArray {
-        return ByteArray(0x00)
+        return isoDep.transceive(data)
     }
 
     override fun close() {
-        // Do nothing
+        isoDep.close()
     }
 
     class Factory @Inject constructor() : NfcTagTransceiver.Factory {
-        override fun create(tag: Tag): NfcTagTransceiver? {
-            return null
+        override fun create(tag: Tag): IsoNfcTagTransceiver? {
+            return IsoDep.get(tag)?.let {
+                IsoNfcTagTransceiver(it)
+            }
         }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 5000
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import java.io.IOException
 
 internal class DefaultNfcCardScannerTest {
     private val dispatcher = UnconfinedTestDispatcher()
@@ -92,6 +93,59 @@ internal class DefaultNfcCardScannerTest {
         }
 
         assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
+    }
+
+    @Test
+    fun `start emits Failed when transceiver open fails`() = runScenario(
+        openException = IOException("open failed"),
+    ) {
+        scanner.state.test {
+            scanner.start(activity)
+
+            val startCall = fakeHardwareDelegate.startCalls.awaitItem()
+            startCall.onTagDiscovered.invoke(tag)
+
+            assertThat(awaitItem()).isEqualTo(NfcCardScanner.State.Scanning)
+            val failedState = awaitItem() as NfcCardScanner.State.Failed
+            assertThat(failedState.error).isInstanceOf(IOException::class.java)
+            assertThat(failedState.error.message).isEqualTo("open failed")
+        }
+
+        assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
+
+        val transceiver = requireNotNull(fakeTransceiver)
+
+        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `start emits Failed when transceiver close fails`() = runScenario(
+        cardData = ScannedCardData(
+            cardNumber = "4242424242424242",
+            expirationMonth = 12,
+            expirationYear = 2030,
+        ),
+        closeException = IOException("close failed"),
+    ) {
+        scanner.state.test {
+            scanner.start(activity)
+
+            val startCall = fakeHardwareDelegate.startCalls.awaitItem()
+            startCall.onTagDiscovered.invoke(tag)
+
+            assertThat(awaitItem()).isEqualTo(NfcCardScanner.State.Scanning)
+            val failedState = awaitItem() as NfcCardScanner.State.Failed
+            assertThat(failedState.error).isInstanceOf(IOException::class.java)
+            assertThat(failedState.error.message).isEqualTo("close failed")
+        }
+
+        assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
+
+        val transceiver = requireNotNull(fakeTransceiver)
+
+        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
+        assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
+        assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
     }
 
     private fun runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/IsoNfcTagTransceiverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/IsoNfcTagTransceiverTest.kt
@@ -1,0 +1,104 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import android.nfc.Tag
+import android.nfc.tech.IsoDep
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.IOException
+
+internal class IsoNfcTagTransceiverTest {
+    @Test
+    fun `open sets timeout and connects to isoDep`() {
+        val isoDep = mock<IsoDep>()
+        val transceiver = IsoNfcTagTransceiver(isoDep)
+
+        transceiver.open()
+
+        verify(isoDep).timeout = TIMEOUT_MS
+        verify(isoDep).connect()
+    }
+
+    @Test
+    fun `transceive forwards data to isoDep and returns response`() {
+        val isoDep = createIsoDep()
+        val transceiver = IsoNfcTagTransceiver(isoDep)
+
+        val command = byteArrayOf(0x00, 0xA4.toByte(), 0x04, 0x00)
+        val response = byteArrayOf(0x90.toByte(), 0x00)
+
+        whenever(isoDep.transceive(command)).thenReturn(response)
+
+        val result = transceiver.transceive(command)
+
+        assertThat(result).isEqualTo(response)
+        verify(isoDep).transceive(command)
+    }
+
+    @Test
+    fun `close closes isoDep`() {
+        val isoDep = createIsoDep()
+        val transceiver = IsoNfcTagTransceiver(isoDep)
+
+        transceiver.close()
+
+        verify(isoDep).close()
+    }
+
+    @Test(expected = IOException::class)
+    fun `open propagates error from connect`() {
+        val isoDep = createIsoDep(IOException("connect failed"))
+        val transceiver = IsoNfcTagTransceiver(isoDep)
+
+        transceiver.open()
+    }
+
+    @Test
+    fun `factory create returns transceiver when tag supports IsoDep`() {
+        val tag = createTag()
+        val isoDep = createIsoDep()
+
+        mockStatic(IsoDep::class.java).use { mockedIsoDep ->
+            mockedIsoDep.`when`<IsoDep> { IsoDep.get(tag) }.thenReturn(isoDep)
+
+            val transceiver = IsoNfcTagTransceiver.Factory().create(tag)
+
+            assertThat(transceiver).isNotNull()
+            requireNotNull(transceiver).open()
+
+            verify(isoDep).timeout = TIMEOUT_MS
+            verify(isoDep).connect()
+        }
+    }
+
+    @Test
+    fun `factory create returns null when tag does not support IsoDep`() {
+        val tag = createTag()
+
+        mockStatic(IsoDep::class.java).use { mockedIsoDep ->
+            mockedIsoDep.`when`<IsoDep> { IsoDep.get(tag) }.thenReturn(null)
+
+            val transceiver = IsoNfcTagTransceiver.Factory().create(tag)
+
+            assertThat(transceiver).isNull()
+        }
+    }
+
+    private fun createIsoDep(
+        connectFailure: Exception? = null
+    ) = mock<IsoDep> {
+        connectFailure?.let {
+            on { connect() } doThrow it
+        }
+    }
+
+    private fun createTag() = mock<Tag>()
+
+    private companion object {
+        const val TIMEOUT_MS = 5000
+    }
+}


### PR DESCRIPTION
# Summary
Add implementation for `NfcTagTransceiver`.

# Motivation
Allows for communication of NFC tag when scanning cards.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified