### PR TITLE
Wire inline address autocomplete into Payment Sheet and Flow Controll…

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -210,7 +210,8 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                                     isInlineAutocompleteEnabled =
                                         FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-                                )
+                                ),
+                                inlineDependencies = null,
                             ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -212,7 +212,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                         FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
                                 ),
                                 placesClient = null,
-                                coroutineScope = parentComponent.viewModel.viewModelScope,
+                                coroutineScope = null,
                             ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -27,7 +27,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
-import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractorFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -203,7 +203,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             eventReporter = parentComponent.eventReporter,
                             savedStateHandle = parentComponent.viewModel.savedStateHandle,
                             autocompleteAddressInteractorFactory =
-                            PaymentElementAutocompleteAddressInteractor.Factory(
+                            PaymentElementAutocompleteAddressInteractorFactory(
                                 launcher = parentComponent.autocompleteLauncher,
                                 autocompleteConfig = AutocompleteAddressInteractor.Config(
                                     googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -27,7 +27,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
-import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractorFactory
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -203,7 +203,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             eventReporter = parentComponent.eventReporter,
                             savedStateHandle = parentComponent.viewModel.savedStateHandle,
                             autocompleteAddressInteractorFactory =
-                            PaymentElementAutocompleteAddressInteractorFactory(
+                            PaymentElementAutocompleteAddressInteractor.Factory(
                                 launcher = parentComponent.autocompleteLauncher,
                                 autocompleteConfig = AutocompleteAddressInteractor.Config(
                                     googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
@@ -211,7 +211,8 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     isInlineAutocompleteEnabled =
                                         FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
                                 ),
-                                inlineDependencies = null,
+                                placesClient = null,
+                                coroutineScope = parentComponent.viewModel.viewModelScope,
                             ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -52,6 +52,7 @@ import com.stripe.android.paymentsheet.ui.DefaultSelectSavedPaymentMethodsIntera
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -82,7 +83,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
     mode: EventReporter.Mode,
     customerStateHolderFactory: CustomerStateHolder.Factory,
     @ViewModelScope customViewModelScope: CoroutineScope,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    placesClient: PlacesClientProxy?,
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,
@@ -95,6 +97,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     mode = mode,
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
+    placesClient = placesClient,
 ) {
 
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -67,6 +67,7 @@ import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
@@ -103,7 +104,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     mode: EventReporter.Mode,
     customerStateHolderFactory: CustomerStateHolder.Factory,
     @ViewModelScope customViewModelScope: CoroutineScope,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    placesClient: PlacesClientProxy?,
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,
@@ -116,6 +118,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     mode = mode,
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
+    placesClient = placesClient,
 ) {
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -411,7 +411,7 @@ internal class SavedPaymentMethodMutator(
                             removeMessage = paymentMethodMetadata?.customerMetadata?.removePaymentMethod
                                 ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
-                            autocompleteAddressInteractorFactory = null,
+                            autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
                         )
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+
+internal class BillingInlineAutocompleteAddressInteractor(
+    placesClient: PlacesClientProxy,
+    override val autocompleteConfig: AutocompleteAddressInteractor.Config,
+    coroutineScope: CoroutineScope,
+) : AutocompleteAddressInteractor {
+    private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
+
+    private val inlineController = InlineAutocompleteController(
+        placesClient = placesClient,
+        config = autocompleteConfig,
+        coroutineScope = coroutineScope,
+        eventListenerProvider = { eventListener },
+    )
+
+    override val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =
+        inlineController.inlinePredictionsState
+
+    override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
+        eventListener = onEvent
+    }
+
+    override fun onAutocomplete(country: String) = Unit
+
+    override fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
+        inlineController.observeQueryChanges(query, country)
+    }
+
+    override fun onPredictionSelected(predictionId: String) {
+        inlineController.onPredictionSelected(predictionId)
+    }
+
+    override fun onDismissed() {
+        inlineController.onDismissed()
+    }
+
+    override fun onEnterManuallyFromInline() {
+        eventListener?.invoke(AutocompleteAddressInteractor.Event.OnExpandForm(null))
+    }
+
+    fun dispose() {
+        inlineController.dispose()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -43,8 +43,4 @@ internal class BillingInlineAutocompleteAddressInteractor(
     override fun onEnterManuallyFromInline() {
         eventListener?.invoke(AutocompleteAddressInteractor.Event.OnExpandForm(null))
     }
-
-    fun dispose() {
-        inlineController.dispose()
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -43,4 +43,8 @@ internal class BillingInlineAutocompleteAddressInteractor(
     override fun onEnterManuallyFromInline() {
         eventListener?.invoke(AutocompleteAddressInteractor.Event.OnExpandForm(null))
     }
+
+    fun dispose() {
+        inlineController.dispose()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -40,7 +39,6 @@ internal class InlineAutocompleteController(
         observeJob?.cancel()
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
-                .drop(1)
                 .debounce(AutocompleteViewModel.SEARCH_DEBOUNCE_MS)
                 .collectLatest { (q, c) ->
                     if (q == lastPredictionLine1) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -47,6 +47,7 @@ internal class InlineAutocompleteController(
                         return@collectLatest
                     }
                     if (q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE || !isCountrySupported(c)) {
+                        lastPredictionLine1 = null
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                         return@collectLatest
                     }
@@ -63,7 +64,7 @@ internal class InlineAutocompleteController(
                 onSuccess = { response ->
                     val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
                     val address = response.place.transformGoogleToStripeAddress(locale)
-                    lastPredictionLine1 = address.line1
+                    address.line1?.let { lastPredictionLine1 = it }
                     _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                     eventListenerProvider()?.invoke(
                         AutocompleteAddressInteractor.Event.OnValues(
@@ -87,6 +88,7 @@ internal class InlineAutocompleteController(
 
     fun onDismissed() {
         selectionJob?.cancel()
+        lastPredictionLine1 = null
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -64,7 +64,7 @@ internal class InlineAutocompleteController(
                 onSuccess = { response ->
                     val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
                     val address = response.place.transformGoogleToStripeAddress(locale)
-                    address.line1?.let { lastPredictionLine1 = it }
+                    lastPredictionLine1 = address.line1
                     _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                     eventListenerProvider()?.invoke(
                         AutocompleteAddressInteractor.Event.OnValues(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -74,7 +74,11 @@ internal class InputAddressViewModel @Inject constructor(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
-        getAttributionDrawable = if (isInlineAutocompleteEnabled) { _ -> R.drawable.stripe_google_maps_logo } else null,
+        getAttributionDrawable = if (isInlineAutocompleteEnabled && placesClient != null) {
+            { _ -> R.drawable.stripe_google_maps_logo }
+        } else {
+            null
+        },
     )
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -74,11 +73,6 @@ internal class InputAddressViewModel @Inject constructor(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
-        getAttributionDrawable = if (isInlineAutocompleteEnabled && placesClient != null) {
-            { _ -> R.drawable.stripe_google_maps_logo }
-        } else {
-            null
-        },
     )
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
 
 internal class PaymentElementAutocompleteAddressInteractor(
     private val launcher: AutocompleteLauncher,
@@ -42,8 +44,26 @@ internal class PaymentElementAutocompleteAddressInteractor(
     class Factory(
         private val launcher: AutocompleteLauncher,
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
+        private val inlineDependencies: InlineAutocompleteDependencies?,
     ) : AutocompleteAddressInteractor.Factory {
+        // The factory outlives individual forms (it is held for the whole sheet), so it disposes the
+        // previously-created inline interactor before building a new one. Only one address form is
+        // live at a time in this flow, so the prior controller's long-running query collector would
+        // otherwise leak on the shared coroutine scope across form re-creations.
+        private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
+
         override fun create(): AutocompleteAddressInteractor {
+            activeInlineInteractor?.dispose()
+            activeInlineInteractor = null
+
+            val dependencies = inlineDependencies
+            if (dependencies != null) {
+                return BillingInlineAutocompleteAddressInteractor(
+                    placesClient = dependencies.placesClient,
+                    autocompleteConfig = autocompleteConfig,
+                    coroutineScope = dependencies.coroutineScope,
+                ).also { activeInlineInteractor = it }
+            }
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,
                 autocompleteConfig = autocompleteConfig,
@@ -51,3 +71,8 @@ internal class PaymentElementAutocompleteAddressInteractor(
         }
     }
 }
+
+internal data class InlineAutocompleteDependencies(
+    val placesClient: PlacesClientProxy,
+    val coroutineScope: CoroutineScope,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -40,34 +40,25 @@ internal class PaymentElementAutocompleteAddressInteractor(
             eventListener?.invoke(it)
         }
     }
-}
 
-internal class PaymentElementAutocompleteAddressInteractorFactory(
-    private val launcher: AutocompleteLauncher,
-    private val autocompleteConfig: AutocompleteAddressInteractor.Config,
-    private val inlineDependencies: InlineAutocompleteDependencies?,
-) : AutocompleteAddressInteractor.Factory {
-    override fun create(): AutocompleteAddressInteractor {
-        val dependencies = inlineDependencies
-        if (dependencies != null && autocompleteConfig.isInlineAutocompleteEnabled) {
-            // The shared factory can be reused while an existing form is still on screen. The
-            // form/controller that created an inline interactor owns its lifecycle and disposes it
-            // when that controller goes away; disposing previous interactors here can tear down the
-            // active dropdown observer during unrelated form-model rebuilds.
-            return BillingInlineAutocompleteAddressInteractor(
-                placesClient = dependencies.placesClient,
+    class Factory(
+        private val launcher: AutocompleteLauncher,
+        private val autocompleteConfig: AutocompleteAddressInteractor.Config,
+        private val placesClient: PlacesClientProxy?,
+        private val coroutineScope: CoroutineScope,
+    ) : AutocompleteAddressInteractor.Factory {
+        override fun create(): AutocompleteAddressInteractor {
+            if (placesClient != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+                return BillingInlineAutocompleteAddressInteractor(
+                    placesClient = placesClient,
+                    autocompleteConfig = autocompleteConfig,
+                    coroutineScope = coroutineScope,
+                )
+            }
+            return PaymentElementAutocompleteAddressInteractor(
+                launcher = launcher,
                 autocompleteConfig = autocompleteConfig,
-                coroutineScope = dependencies.coroutineScope,
             )
         }
-        return PaymentElementAutocompleteAddressInteractor(
-            launcher = launcher,
-            autocompleteConfig = autocompleteConfig,
-        )
     }
 }
-
-internal data class InlineAutocompleteDependencies(
-    val placesClient: PlacesClientProxy,
-    val coroutineScope: CoroutineScope,
-)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -40,35 +40,30 @@ internal class PaymentElementAutocompleteAddressInteractor(
             eventListener?.invoke(it)
         }
     }
+}
 
-    class Factory(
-        private val launcher: AutocompleteLauncher,
-        private val autocompleteConfig: AutocompleteAddressInteractor.Config,
-        private val inlineDependencies: InlineAutocompleteDependencies?,
-    ) : AutocompleteAddressInteractor.Factory {
-        // The factory outlives individual forms (it is held for the whole sheet), so it disposes the
-        // previously-created inline interactor before building a new one. Only one address form is
-        // live at a time in this flow, so the prior controller's long-running query collector would
-        // otherwise leak on the shared coroutine scope across form re-creations.
-        private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
-
-        override fun create(): AutocompleteAddressInteractor {
-            activeInlineInteractor?.dispose()
-            activeInlineInteractor = null
-
-            val dependencies = inlineDependencies
-            if (dependencies != null) {
-                return BillingInlineAutocompleteAddressInteractor(
-                    placesClient = dependencies.placesClient,
-                    autocompleteConfig = autocompleteConfig,
-                    coroutineScope = dependencies.coroutineScope,
-                ).also { activeInlineInteractor = it }
-            }
-            return PaymentElementAutocompleteAddressInteractor(
-                launcher = launcher,
+internal class PaymentElementAutocompleteAddressInteractorFactory(
+    private val launcher: AutocompleteLauncher,
+    private val autocompleteConfig: AutocompleteAddressInteractor.Config,
+    private val inlineDependencies: InlineAutocompleteDependencies?,
+) : AutocompleteAddressInteractor.Factory {
+    override fun create(): AutocompleteAddressInteractor {
+        val dependencies = inlineDependencies
+        if (dependencies != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+            // The shared factory can be reused while an existing form is still on screen. The
+            // form/controller that created an inline interactor owns its lifecycle and disposes it
+            // when that controller goes away; disposing previous interactors here can tear down the
+            // active dropdown observer during unrelated form-model rebuilds.
+            return BillingInlineAutocompleteAddressInteractor(
+                placesClient = dependencies.placesClient,
                 autocompleteConfig = autocompleteConfig,
+                coroutineScope = dependencies.coroutineScope,
             )
         }
+        return PaymentElementAutocompleteAddressInteractor(
+            launcher = launcher,
+            autocompleteConfig = autocompleteConfig,
+        )
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -45,15 +45,18 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private val launcher: AutocompleteLauncher,
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
         private val placesClient: PlacesClientProxy?,
-        private val coroutineScope: CoroutineScope,
+        private val coroutineScope: CoroutineScope?,
     ) : AutocompleteAddressInteractor.Factory {
+        private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
+
         override fun create(): AutocompleteAddressInteractor {
-            if (placesClient != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+            if (placesClient != null && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+                activeInlineInteractor?.dispose()
                 return BillingInlineAutocompleteAddressInteractor(
                     placesClient = placesClient,
                     autocompleteConfig = autocompleteConfig,
                     coroutineScope = coroutineScope,
-                )
+                ).also { activeInlineInteractor = it }
             }
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.uicore.elements.DefaultIsPlacesAvailable
+
+internal val cachedIsPlacesAvailable: Boolean by lazy { DefaultIsPlacesAvailable()() }
+
+internal fun createInlineAutocompletePlacesClient(
+    context: Context,
+    googlePlacesApiKey: String?,
+    errorReporter: ErrorReporter,
+    isPlacesAvailable: () -> Boolean,
+): PlacesClientProxy? {
+    if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return null
+    if (!isPlacesAvailable()) return null
+    val apiKey = googlePlacesApiKey ?: return null
+    return LazyPlacesClientProxy {
+        PlacesClientProxy.create(
+            context = context,
+            googlePlacesApiKey = apiKey,
+            errorReporter = errorReporter,
+        )
+    }
+}
+
+private class LazyPlacesClientProxy(
+    factory: () -> PlacesClientProxy,
+) : PlacesClientProxy {
+    private val delegate by lazy(factory)
+
+    override suspend fun findAutocompletePredictions(
+        query: String?,
+        country: String,
+        limit: Int,
+    ): Result<FindAutocompletePredictionsResponse> = delegate.findAutocompletePredictions(query, country, limit)
+
+    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> = delegate.fetchPlace(placeId)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -11,10 +11,10 @@ internal fun createInlineAutocompletePlacesClient(
     context: Context,
     googlePlacesApiKey: String?,
     errorReporter: ErrorReporter,
-    isPlacesAvailable: () -> Boolean,
+    isPlacesAvailable: Boolean,
 ): PlacesClientProxy? {
     if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return null
-    if (!isPlacesAvailable()) return null
+    if (!isPlacesAvailable) return null
     val apiKey = googlePlacesApiKey ?: return null
     return LazyPlacesClientProxy {
         PlacesClientProxy.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -6,9 +6,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.uicore.elements.DefaultIsPlacesAvailable
-
-internal val cachedIsPlacesAvailable: Boolean by lazy { DefaultIsPlacesAvailable()() }
 
 internal fun createInlineAutocompletePlacesClient(
     context: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.elements.DefaultIsPlacesAvailable
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -58,13 +59,13 @@ internal class PaymentOptionsViewModelModule {
 
     @Provides
     fun providePlacesClient(
-        application: Application,
+        appContext: Context,
         args: PaymentOptionContract.Args,
         errorReporter: ErrorReporter,
     ): PlacesClientProxy? = createInlineAutocompletePlacesClient(
-        context = application,
+        context = appContext,
         googlePlacesApiKey = args.configuration.googlePlacesApiKey,
         errorReporter = errorReporter,
-        isPlacesAvailable = { cachedIsPlacesAvailable },
+        isPlacesAvailable = { DefaultIsPlacesAvailable()() },
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -53,4 +55,16 @@ internal class PaymentOptionsViewModelModule {
     ): PaymentMethodMessagePromotionsHelper {
         return PrefetchedPaymentMethodMessagePromotionsHelper(args.promotions, eventReporter)
     }
+
+    @Provides
+    fun providePlacesClient(
+        application: Application,
+        args: PaymentOptionContract.Args,
+        errorReporter: ErrorReporter,
+    ): PlacesClientProxy? = createInlineAutocompletePlacesClient(
+        context = application,
+        googlePlacesApiKey = args.configuration.googlePlacesApiKey,
+        errorReporter = errorReporter,
+        isPlacesAvailable = { cachedIsPlacesAvailable },
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -66,6 +66,6 @@ internal class PaymentOptionsViewModelModule {
         context = appContext,
         googlePlacesApiKey = args.configuration.googlePlacesApiKey,
         errorReporter = errorReporter,
-        isPlacesAvailable = { DefaultIsPlacesAvailable()() },
+        isPlacesAvailable = DefaultIsPlacesAvailable()(),
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -46,4 +48,16 @@ internal class PaymentSheetViewModelModule {
     fun provideViewModelScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.Main)
     }
+
+    @Provides
+    fun providePlacesClient(
+        appContext: Context,
+        starterArgs: PaymentSheetContract.Args,
+        errorReporter: ErrorReporter,
+    ): PlacesClientProxy? = createInlineAutocompletePlacesClient(
+        context = appContext,
+        googlePlacesApiKey = starterArgs.config.googlePlacesApiKey,
+        errorReporter = errorReporter,
+        isPlacesAvailable = { cachedIsPlacesAvailable },
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -59,6 +59,6 @@ internal class PaymentSheetViewModelModule {
         context = appContext,
         googlePlacesApiKey = starterArgs.config.googlePlacesApiKey,
         errorReporter = errorReporter,
-        isPlacesAvailable = { DefaultIsPlacesAvailable()() },
+        isPlacesAvailable = DefaultIsPlacesAvailable()(),
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.elements.DefaultIsPlacesAvailable
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -58,6 +59,6 @@ internal class PaymentSheetViewModelModule {
         context = appContext,
         googlePlacesApiKey = starterArgs.config.googlePlacesApiKey,
         errorReporter = errorReporter,
-        isPlacesAvailable = { cachedIsPlacesAvailable },
+        isPlacesAvailable = { DefaultIsPlacesAvailable()() },
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -22,8 +22,7 @@ import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
 import com.stripe.android.paymentsheet.addresselement.AutocompleteAppearanceContext
 import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
-import com.stripe.android.paymentsheet.addresselement.InlineAutocompleteDependencies
-import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractorFactory
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -85,7 +84,7 @@ internal abstract class BaseSheetViewModel(
     }
 
     val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory =
-        PaymentElementAutocompleteAddressInteractorFactory(
+        PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = autocompleteLauncher,
             autocompleteConfig = AutocompleteAddressInteractor.Config(
                 googlePlacesApiKey = config.googlePlacesApiKey,
@@ -94,12 +93,8 @@ internal abstract class BaseSheetViewModel(
                 getAttributionDrawable =
                     if (placesClient != null) { _ -> R.drawable.stripe_google_maps_logo } else null,
             ),
-            inlineDependencies = placesClient?.let { client ->
-                InlineAutocompleteDependencies(
-                    placesClient = client,
-                    coroutineScope = viewModelScope,
-                )
-            },
+            placesClient = placesClient,
+            coroutineScope = viewModelScope,
         )
 
     internal val validationRequested = MutableSharedFlow<Unit>()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
 import com.stripe.android.paymentsheet.addresselement.AutocompleteAppearanceContext
 import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
+import com.stripe.android.paymentsheet.addresselement.InlineAutocompleteDependencies
 import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
@@ -34,6 +35,8 @@ import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
@@ -65,6 +68,7 @@ internal abstract class BaseSheetViewModel(
     val mode: EventReporter.Mode,
     val customerStateHolderFactory: CustomerStateHolder.Factory,
     val customViewModelScope: CoroutineScope,
+    val placesClient: PlacesClientProxy?,
 ) : ViewModel() {
     private val autocompleteLauncher = DefaultAutocompleteLauncher(
         AutocompleteAppearanceContext.PaymentElement(config.appearance)
@@ -87,7 +91,15 @@ internal abstract class BaseSheetViewModel(
                 googlePlacesApiKey = config.googlePlacesApiKey,
                 autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                 isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-            )
+                getAttributionDrawable =
+                    if (placesClient != null) { _ -> R.drawable.stripe_google_maps_logo } else null,
+            ),
+            inlineDependencies = placesClient?.let { client ->
+                InlineAutocompleteDependencies(
+                    placesClient = client,
+                    coroutineScope = viewModelScope,
+                )
+            },
         )
 
     internal val validationRequested = MutableSharedFlow<Unit>()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -35,7 +35,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
@@ -90,8 +89,6 @@ internal abstract class BaseSheetViewModel(
                 googlePlacesApiKey = config.googlePlacesApiKey,
                 autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                 isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-                getAttributionDrawable =
-                    if (placesClient != null) { _ -> R.drawable.stripe_google_maps_logo } else null,
             ),
             placesClient = placesClient,
             coroutineScope = viewModelScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -23,7 +23,7 @@ import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNT
 import com.stripe.android.paymentsheet.addresselement.AutocompleteAppearanceContext
 import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
 import com.stripe.android.paymentsheet.addresselement.InlineAutocompleteDependencies
-import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractorFactory
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -84,8 +84,8 @@ internal abstract class BaseSheetViewModel(
         analyticsListener.reportPaymentSheetHidden(poppedScreen)
     }
 
-    val autocompleteAddressInteractorFactory: PaymentElementAutocompleteAddressInteractor.Factory =
-        PaymentElementAutocompleteAddressInteractor.Factory(
+    val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory =
+        PaymentElementAutocompleteAddressInteractorFactory(
             launcher = autocompleteLauncher,
             autocompleteConfig = AutocompleteAddressInteractor.Config(
                 googlePlacesApiKey = config.googlePlacesApiKey,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -175,6 +175,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                placesClient = null,
             )
         }
     }
@@ -226,7 +227,8 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                placesClient = null,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -570,6 +570,7 @@ internal class PaymentOptionsActivityTest {
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                placesClient = null,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1463,7 +1463,8 @@ internal class PaymentOptionsViewModelTest {
                 }
             },
             customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            placesClient = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1368,7 +1368,8 @@ internal class PaymentSheetActivityTest {
                 tapToAddHelperFactory = FakeTapToAddHelper.Factory.noOp(),
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
-                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                placesClient = null,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3492,7 +3492,8 @@ internal class PaymentSheetViewModelTest {
                     }
                 },
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                placesClient = null,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -13,11 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-// The detailed inline autocomplete behavior (predictions, debouncing, selection,
-// suppression, dismissal) is tested in InlineAutocompleteControllerTest. These tests
-// cover only the wrapper-specific behavior: the two methods this interactor implements
-// directly (onAutocomplete, onEnterManuallyFromInline) and that the registered event
-// listener is wired into the controller.
+// Wrapper-specific behavior only — controller logic is tested in InlineAutocompleteControllerTest.
 @RunWith(RobolectricTestRunner::class)
 class BillingInlineAutocompleteAddressInteractorTest {
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -1,0 +1,90 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// The detailed inline autocomplete behavior (predictions, debouncing, selection,
+// suppression, dismissal) is tested in InlineAutocompleteControllerTest. These tests
+// cover only the wrapper-specific behavior: the two methods this interactor implements
+// directly (onAutocomplete, onEnterManuallyFromInline) and that the registered event
+// listener is wired into the controller.
+@RunWith(RobolectricTestRunner::class)
+class BillingInlineAutocompleteAddressInteractorTest {
+
+    @Test
+    fun `onAutocomplete is a no-op and emits no event`() = runScenario {
+        interactor.onAutocomplete("US")
+
+        eventCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `onEnterManuallyFromInline emits OnExpandForm with null values`() = runScenario {
+        interactor.onEnterManuallyFromInline()
+
+        assertThat(eventCalls.awaitItem())
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `onPredictionSelected forwards the resulting event to the registered listener`() = runScenario {
+        // Address-mapping detail is covered by InlineAutocompleteControllerTest; here we only
+        // verify the event the controller produces reaches the listener wired via register().
+        fakePlacesClient.fetchPlaceResult = Result.success(FetchPlaceResponse(Place(emptyList())))
+
+        interactor.onPredictionSelected("place_1")
+        advanceTimeBy(100)
+
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        assertThat(eventCalls.awaitItem())
+            .isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest(UnconfinedTestDispatcher()) {
+        val fakePlaces = FakePlacesClientProxy()
+        val eventCalls = Turbine<AutocompleteAddressInteractor.Event>()
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test_key",
+            autocompleteCountries = emptySet(),
+            isPlacesAvailable = true,
+            isInlineAutocompleteEnabled = true,
+        )
+        val interactor = BillingInlineAutocompleteAddressInteractor(
+            placesClient = fakePlaces,
+            autocompleteConfig = config,
+            coroutineScope = backgroundScope,
+        )
+        interactor.register { event -> eventCalls.add(event) }
+
+        Scenario(
+            interactor = interactor,
+            fakePlacesClient = fakePlaces,
+            eventCalls = eventCalls,
+            testScope = this,
+        ).apply { block() }
+
+        fakePlaces.ensureAllEventsConsumed()
+        eventCalls.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val interactor: BillingInlineAutocompleteAddressInteractor,
+        val fakePlacesClient: FakePlacesClientProxy,
+        val eventCalls: Turbine<AutocompleteAddressInteractor.Event>,
+        val testScope: TestScope,
+    ) {
+        fun advanceTimeBy(millis: Long) = testScope.advanceTimeBy(millis)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -432,7 +432,7 @@ class InlineAutocompleteControllerTest {
     @Test
     fun `prediction selected with null line1 does not block subsequent fetches`() =
         runScenario {
-            // Place with no street components produces a null line1 from transformGoogleToStripeAddress.
+            // Place with no street components produces null line1 — no suppression is set.
             fakePlacesClient.fetchPlaceResult = Result.success(
                 FetchPlaceResponse(Place(emptyList()))
             )
@@ -447,8 +447,54 @@ class InlineAutocompleteControllerTest {
             fakePlacesClient.fetchPlaceCalls.awaitItem()
             eventCalls.awaitItem()
 
-            // With null line1, lastPredictionLine1 was not set, so the next query must fetch.
+            // lastPredictionLine1 was not set, so the next query must still fetch predictions.
             queryFlow.value = "123 Main"
+            advanceTimeBy(500)
+
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+        }
+
+    @Test
+    fun `null line1 after prior non-null selection does not leave stale suppression`() =
+        runScenario {
+            // First selection: place with line1="123 Main St" — sets lastPredictionLine1.
+            fakePlacesClient.fetchPlaceResult = Result.success(
+                FetchPlaceResponse(
+                    Place(
+                        listOf(
+                            AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
+                            AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
+                            AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
+                        )
+                    )
+                )
+            )
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            delegate.onPredictionSelected("place_1")
+            advanceTimeBy(100)
+
+            fakePlacesClient.fetchPlaceCalls.awaitItem()
+            eventCalls.awaitItem()
+
+            // Second selection: place with no street components → line1 is null.
+            // This must clear lastPredictionLine1 so the previous value doesn't
+            // suppress a future fetch for "123 Main St".
+            fakePlacesClient.fetchPlaceResult = Result.success(
+                FetchPlaceResponse(Place(emptyList()))
+            )
+
+            delegate.onPredictionSelected("place_2")
+            advanceTimeBy(100)
+
+            fakePlacesClient.fetchPlaceCalls.awaitItem()
+            eventCalls.awaitItem()
+
+            // Typing "123 Main St" must now fetch predictions — not be suppressed.
+            queryFlow.value = "123 Main St"
             advanceTimeBy(500)
 
             fakePlacesClient.findPredictionsCalls.awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -362,6 +362,99 @@ class InlineAutocompleteControllerTest {
         }
 
     @Test
+    fun `onDismissed clears suppression - typing previously-selected address fetches normally`() =
+        runScenario {
+            fakePlacesClient.fetchPlaceResult = Result.success(
+                FetchPlaceResponse(
+                    Place(
+                        listOf(
+                            AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
+                            AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
+                            AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
+                        )
+                    )
+                )
+            )
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            delegate.onPredictionSelected("place_1")
+            advanceTimeBy(100)
+
+            fakePlacesClient.fetchPlaceCalls.awaitItem()
+            eventCalls.awaitItem()
+
+            delegate.onDismissed()
+
+            queryFlow.value = "123 Main Street"
+            advanceTimeBy(500)
+
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+        }
+
+    @Test
+    fun `query dropping below minimum chars clears suppression - re-typing fetches normally`() =
+        runScenario {
+            fakePlacesClient.fetchPlaceResult = Result.success(
+                FetchPlaceResponse(
+                    Place(
+                        listOf(
+                            AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
+                            AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
+                            AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
+                        )
+                    )
+                )
+            )
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            delegate.onPredictionSelected("place_1")
+            advanceTimeBy(100)
+
+            fakePlacesClient.fetchPlaceCalls.awaitItem()
+            eventCalls.awaitItem()
+
+            // Query drops below the minimum — suppression guard should be cleared.
+            queryFlow.value = "1"
+            advanceTimeBy(500)
+
+            queryFlow.value = "123 Main Street"
+            advanceTimeBy(500)
+
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+        }
+
+    @Test
+    fun `prediction selected with null line1 does not block subsequent fetches`() =
+        runScenario {
+            // Place with no street components produces a null line1 from transformGoogleToStripeAddress.
+            fakePlacesClient.fetchPlaceResult = Result.success(
+                FetchPlaceResponse(Place(emptyList()))
+            )
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            delegate.onPredictionSelected("place_1")
+            advanceTimeBy(100)
+
+            fakePlacesClient.fetchPlaceCalls.awaitItem()
+            eventCalls.awaitItem()
+
+            // With null line1, lastPredictionLine1 was not set, so the next query must fetch.
+            queryFlow.value = "123 Main"
+            advanceTimeBy(500)
+
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+        }
+
+    @Test
     fun `onDismissed resets state to Idle`() = runScenario {
         fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -201,6 +201,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test-key",
             autocompleteCountries = setOf("US"),
+            isPlacesAvailable = true,
             isInlineAutocompleteEnabled = true,
         )
 
@@ -218,10 +219,11 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
-    fun `Factory does not dispose previously created inline interactor on next create`() = test { scenario ->
+    fun `Factory disposes previously created inline interactor on next create`() = test { scenario ->
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test-key",
             autocompleteCountries = setOf("US"),
+            isPlacesAvailable = true,
             isInlineAutocompleteEnabled = true,
         )
         val fakePlaces = FakePlacesClientProxy()
@@ -237,16 +239,13 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val first = factory.create()
         first.observeQueryChanges(queryFlow, countryFlow)
 
-        // Building a new interactor must not tear down the previous controller's observation,
-        // because the shared factory can be reused while the original form is still on screen.
+        // Creating a new interactor disposes the previous one, so its observation is cancelled.
         factory.create()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
 
-        val call = fakePlaces.findPredictionsCalls.awaitItem()
-        assertThat(call.query).isEqualTo("123 Main")
-        assertThat(call.country).isEqualTo("US")
+        // No predictions are fetched because the first interactor was disposed.
         fakePlaces.ensureAllEventsConsumed()
     }
 
@@ -255,6 +254,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test-key",
             autocompleteCountries = setOf("US"),
+            isPlacesAvailable = true,
             isInlineAutocompleteEnabled = true,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -183,7 +183,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteCountries = setOf("US")
         )
 
-        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+        val factory = PaymentElementAutocompleteAddressInteractorFactory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
             inlineDependencies = null,
@@ -203,7 +203,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             isInlineAutocompleteEnabled = true,
         )
 
-        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+        val factory = PaymentElementAutocompleteAddressInteractorFactory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
             inlineDependencies = InlineAutocompleteDependencies(
@@ -219,14 +219,14 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
-    fun `Factory disposes previously created inline interactor on next create`() = test { scenario ->
+    fun `Factory does not dispose previously created inline interactor on next create`() = test { scenario ->
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test-key",
             autocompleteCountries = setOf("US"),
             isInlineAutocompleteEnabled = true,
         )
         val fakePlaces = FakePlacesClientProxy()
-        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+        val factory = PaymentElementAutocompleteAddressInteractorFactory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
             inlineDependencies = InlineAutocompleteDependencies(
@@ -240,13 +240,16 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val first = factory.create()
         first.observeQueryChanges(queryFlow, countryFlow)
 
-        // Building a new interactor must dispose the previous one's query observation.
+        // Building a new interactor must not tear down the previous controller's observation,
+        // because the shared factory can be reused while the original form is still on screen.
         factory.create()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
 
-        fakePlaces.findPredictionsCalls.expectNoEvents()
+        val call = fakePlaces.findPredictionsCalls.awaitItem()
+        assertThat(call.query).isEqualTo("123 Main")
+        assertThat(call.country).isEqualTo("US")
         fakePlaces.ensureAllEventsConsumed()
     }
 
@@ -258,7 +261,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             isInlineAutocompleteEnabled = true,
         )
 
-        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+        val factory = PaymentElementAutocompleteAddressInteractorFactory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
             inlineDependencies = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -5,8 +5,10 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -183,13 +185,88 @@ class PaymentElementAutocompleteAddressInteractorTest {
 
         val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
-            autocompleteConfig = config
+            autocompleteConfig = config,
+            inlineDependencies = null,
         )
 
         val interactor = factory.create()
 
         assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
         assertThat(interactor.autocompleteConfig).isEqualTo(config)
+    }
+
+    @Test
+    fun `Factory creates inline interactor when inline enabled with places client and scope`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US"),
+            isInlineAutocompleteEnabled = true,
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            inlineDependencies = InlineAutocompleteDependencies(
+                placesClient = FakePlacesClientProxy(),
+                coroutineScope = this,
+            ),
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(BillingInlineAutocompleteAddressInteractor::class.java)
+        assertThat(interactor.autocompleteConfig).isEqualTo(config)
+    }
+
+    @Test
+    fun `Factory disposes previously created inline interactor on next create`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US"),
+            isInlineAutocompleteEnabled = true,
+        )
+        val fakePlaces = FakePlacesClientProxy()
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            inlineDependencies = InlineAutocompleteDependencies(
+                placesClient = fakePlaces,
+                coroutineScope = this,
+            ),
+        )
+        val queryFlow = MutableStateFlow("")
+        val countryFlow = MutableStateFlow<String?>("US")
+
+        val first = factory.create()
+        first.observeQueryChanges(queryFlow, countryFlow)
+
+        // Building a new interactor must dispose the previous one's query observation.
+        factory.create()
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        fakePlaces.findPredictionsCalls.expectNoEvents()
+        fakePlaces.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `Factory falls back to launcher when inline enabled but no dependencies`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US"),
+            isInlineAutocompleteEnabled = true,
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            inlineDependencies = null,
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -231,7 +231,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteConfig = config,
             inlineDependencies = InlineAutocompleteDependencies(
                 placesClient = fakePlaces,
-                coroutineScope = this,
+                coroutineScope = backgroundScope,
             ),
         )
         val queryFlow = MutableStateFlow("")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -183,10 +183,11 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteCountries = setOf("US")
         )
 
-        val factory = PaymentElementAutocompleteAddressInteractorFactory(
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
-            inlineDependencies = null,
+            placesClient = null,
+            coroutineScope = this,
         )
 
         val interactor = factory.create()
@@ -203,13 +204,11 @@ class PaymentElementAutocompleteAddressInteractorTest {
             isInlineAutocompleteEnabled = true,
         )
 
-        val factory = PaymentElementAutocompleteAddressInteractorFactory(
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
-            inlineDependencies = InlineAutocompleteDependencies(
-                placesClient = FakePlacesClientProxy(),
-                coroutineScope = this,
-            ),
+            placesClient = FakePlacesClientProxy(),
+            coroutineScope = this,
         )
 
         val interactor = factory.create()
@@ -226,13 +225,11 @@ class PaymentElementAutocompleteAddressInteractorTest {
             isInlineAutocompleteEnabled = true,
         )
         val fakePlaces = FakePlacesClientProxy()
-        val factory = PaymentElementAutocompleteAddressInteractorFactory(
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
-            inlineDependencies = InlineAutocompleteDependencies(
-                placesClient = fakePlaces,
-                coroutineScope = backgroundScope,
-            ),
+            placesClient = fakePlaces,
+            coroutineScope = backgroundScope,
         )
         val queryFlow = MutableStateFlow("")
         val countryFlow = MutableStateFlow<String?>("US")
@@ -254,17 +251,18 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
-    fun `Factory falls back to launcher when inline enabled but no dependencies`() = test { scenario ->
+    fun `Factory falls back to launcher when inline enabled but placesClient is null`() = test { scenario ->
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test-key",
             autocompleteCountries = setOf("US"),
             isInlineAutocompleteEnabled = true,
         )
 
-        val factory = PaymentElementAutocompleteAddressInteractorFactory(
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
-            inlineDependencies = null,
+            placesClient = null,
+            coroutineScope = this,
         )
 
         val interactor = factory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.C
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updateCardBrandErrorMessage
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updatesFailedErrorMessage
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertThrows
@@ -683,6 +684,22 @@ class DefaultUpdatePaymentMethodInteractorTest {
         }
     }
 
+    @Test
+    fun editCardDetailsInteractorFactory_forwardsAutocompleteAddressInteractorFactory() {
+        val fakeEditCardFactory = FakeEditCardDetailsInteractorFactory()
+        val fakeAutocompleteFactory = AutocompleteAddressInteractor.Factory {
+            error("not expected to be called")
+        }
+        runScenario(
+            editCardDetailsInteractorFactory = fakeEditCardFactory,
+            autocompleteAddressInteractorFactory = fakeAutocompleteFactory,
+        ) {
+            interactor.editCardDetailsInteractor
+            assertThat(fakeEditCardFactory.autocompleteAddressInteractorFactory)
+                .isSameInstanceAs(fakeAutocompleteFactory)
+        }
+    }
+
     private fun updateCardAndDefaultPaymentMethod(
         interactor: UpdatePaymentMethodInteractor,
     ) {
@@ -717,6 +734,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
             .Factory(),
         onBrandChoiceSelected: (CardBrand) -> Unit = {},
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
         testBlock: suspend TestParams.() -> Unit
     ) {
         val onUpdateSuccessTurbine = Turbine<Unit>()
@@ -739,7 +757,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             editCardDetailsInteractorFactory = editCardDetailsInteractorFactory,
             removeMessage = null,
             allowedBillingCountries = allowedBillingCountries,
-            autocompleteAddressInteractorFactory = null,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
@@ -11,6 +11,9 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
     var onCardUpdateParamsChanged: CardUpdateParamsCallback? = null
         private set
 
+    var autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null
+        private set
+
     override fun create(
         coroutineScope: CoroutineScope,
         cardEditConfiguration: CardEditConfiguration?,
@@ -23,6 +26,7 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
     ): EditCardDetailsInteractor {
         this.onCardUpdateParamsChanged = onCardUpdateParamsChanged
         this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
+        this.autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory
         return FakeEditCardDetailsInteractor(
             payload = payload,
             shouldShowCardBrandDropdown = cardEditConfiguration?.isCbcModifiable ?: false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -53,6 +53,7 @@ internal class FakeBaseSheetViewModel private constructor(
     mode = EventReporter.Mode.Complete,
     customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
     customViewModelScope = customViewModelScope,
+    placesClient = null,
 ) {
     companion object {
         fun create(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
@@ -52,7 +53,7 @@ class AutocompleteAddressController(
                 }
 
                 override fun getAttributionDrawable(isDarkTheme: Boolean): Int? {
-                    return config.getAttributionDrawable?.invoke(isDarkTheme)
+                    return R.drawable.stripe_google_maps_logo
                 }
             }
         } else {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
@@ -32,7 +32,6 @@ interface AutocompleteAddressInteractor {
         val autocompleteCountries: Set<String>,
         val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
         val isInlineAutocompleteEnabled: Boolean = false,
-        val getAttributionDrawable: ((isDarkTheme: Boolean) -> Int?)? = null,
     )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InlineAddressPredictionsUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InlineAddressPredictionsUI.kt
@@ -44,12 +44,8 @@ fun InlineAddressPredictionsUI(
     onClear: () -> Unit,
     onEnterManually: (() -> Unit)? = null,
 ) {
-    val loading = state is AutocompleteAddressInteractor.InlinePredictionsState.Loading
-    val results = state as? AutocompleteAddressInteractor.InlinePredictionsState.Results
-    val expanded = loading || (results != null && results.predictions.isNotEmpty())
-
     DropdownMenu(
-        expanded = expanded,
+        expanded = shouldShowPredictionsDropdown(state),
         onDismissRequest = onDismiss,
         offset = DpOffset(x = (-1).dp, y = 0.dp),
         modifier = if (fieldWidthDp > 0.dp) {
@@ -227,4 +223,14 @@ private fun buildQueryRegex(query: String): Regex? {
 private fun applyBoldMatches(primaryText: String, queryRegex: Regex?): String {
     if (queryRegex == null) return primaryText
     return queryRegex.replace(primaryText) { "<b>${it.value}</b>" }
+}
+
+internal fun shouldShowPredictionsDropdown(
+    state: AutocompleteAddressInteractor.InlinePredictionsState
+): Boolean {
+    return when (state) {
+        AutocompleteAddressInteractor.InlinePredictionsState.Idle -> false
+        AutocompleteAddressInteractor.InlinePredictionsState.Loading -> true
+        is AutocompleteAddressInteractor.InlinePredictionsState.Results -> true
+    }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
@@ -89,6 +89,27 @@ class AddressTextFieldControllerTest {
         }
     }
 
+    @Test
+    fun `predictions dropdown is hidden when state is idle`() {
+        assertThat(
+            shouldShowPredictionsDropdown(
+                AutocompleteAddressInteractor.InlinePredictionsState.Idle
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `predictions dropdown remains shown when results are empty`() {
+        assertThat(
+            shouldShowPredictionsDropdown(
+                AutocompleteAddressInteractor.InlinePredictionsState.Results(
+                    query = "123 Main",
+                    predictions = emptyList()
+                )
+            )
+        ).isTrue()
+    }
+
     private fun createAddressController(isInlineAutocompleteEnabled: Boolean = false): AddressTextFieldController {
         return AddressTextFieldController(
             label = resolvableString(value = "Name"),


### PR DESCRIPTION
…er billing address

# Summary
<!-- Simple summary of what was changed. -->
Enable inline address autocomplete on billing address fields in Payment Sheet and Flow Controller.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

#13330 prepared billing address forms to accept an autocomplete factory, but they still used the launcher-only interactor. Billing address fields did not show the inline prediction dropdown even when inline autocomplete was enabled for Address Element.

This PR completes the integration so users collecting billing address during new card entry (Payment Sheet + Flow Controller) or when editing a saved card see inline predictions under the address field, matching Address Element behavior.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

Added Tests:
BillingInlineAutocompleteAddressInteractorTest: checks the billing wrapper forwards events correctly and that onAutocomplete does nothing
PaymentElementAutocompleteAddressInteractorTest: checks the factory picks inline vs launcher interactor and cleans up the old one when recreated

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Recording



https://github.com/user-attachments/assets/11a50adb-412c-4552-bb60-42e7394b37a3



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
