### PR TITLE
Fix cardscan CI flake: clear corrupted orchestrator cache on retry

### DIFF
--- a/scripts/retry_with_emulator_cleanup.sh
+++ b/scripts/retry_with_emulator_cleanup.sh
@@ -3,6 +3,17 @@
 # Retry a command, killing unhealthy emulators between attempts.
 # Usage: ./scripts/retry_with_emulator_cleanup.sh <retries> <command...>
 
+OUTPUT_LOG=$(mktemp)
+trap 'rm -f "$OUTPUT_LOG"' EXIT
+
+function clear_corrupted_orchestrator_cache {
+  if [ -f "$OUTPUT_LOG" ] && grep -qE "Failed to install split APK|Invalid File.*orchestrator" "$OUTPUT_LOG"; then
+    echo "Detected orchestrator APK installation failure. Clearing corrupted cache..."
+    rm -rf ~/.gradle/caches/modules-2/files-2.1/androidx.test/orchestrator/
+    echo "Orchestrator cache cleared. Will re-download on next attempt."
+  fi
+}
+
 function kill_unhealthy_emulators {
   local killed=0
   for device in $(adb devices | grep emulator | cut -f1); do
@@ -23,18 +34,23 @@ function retry {
   shift
 
   local count=0
-  until "$@"; do
-    exit=$?
+  while true; do
+    "$@" 2>&1 | tee "$OUTPUT_LOG"
+    local exit=${PIPESTATUS[0]}
+    if [ $exit -eq 0 ]; then
+      return 0
+    fi
     count=$(($count + 1))
     if [ $count -lt $retries ]; then
-      echo "Retry $count/$retries exited $exit. Checking emulator health..."
+      echo "Retry $count/$retries exited $exit. Checking for known failures..."
+      clear_corrupted_orchestrator_cache
+      echo "Checking emulator health..."
       kill_unhealthy_emulators
     else
       echo "Retry $count/$retries exited $exit, no more retries left."
       return $exit
     fi
   done
-  return 0
 }
 
 retry "$@"


### PR DESCRIPTION
## Summary

Enhance `retry_with_emulator_cleanup.sh` to detect and recover from the intermittent "Failed to install split APK" orchestrator cache corruption.

## Problem

The `run-cardscan-instrumentation-tests` workflow intermittently fails with:
```
Failed to install split APK(s): [~/.gradle/caches/.../orchestrator-1.6.1.apk]
java.lang.IllegalArgumentException: Invalid File: ...orchestrator-1.6.1.apk
```

This happens when Bitrise's gradle cache restore provides a corrupted or incomplete orchestrator APK file. PR #13336 (x-large worker) reduced the frequency but didn't eliminate it.

## Fix

The retry script now:
1. Captures command output to a temp file via `tee` (preserving real-time output)
2. After a failure, checks if the output contains the orchestrator installation error pattern
3. If detected, clears `~/.gradle/caches/modules-2/files-2.1/androidx.test/orchestrator/` so the next retry downloads a fresh copy
4. Continues with the existing emulator health check and retry

The happy path (no corruption) is unaffected. The cache is only cleared when the specific failure pattern is detected.

## Test plan

- [ ] CI passes on this PR (validates the script doesn't break normal flow)
- [ ] Monitor future cardscan instrumentation test runs for reduced flakiness