### PR TITLE
Test: switch cardscan emulator to google_apis

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -524,7 +524,7 @@ workflows:
             - profile: "pixel_6"
             - abi: "x86_64"
             - api_level: 33
-            - tag: "google_apis_playstore"
+            - tag: "google_apis"
             - start_command_flags: >
                -camera-back none
                -camera-front none


### PR DESCRIPTION
## Summary

Test whether cardscan instrumentation tests work with `google_apis` instead of `google_apis_playstore` emulator image.

## Context

The `google_apis_playstore` image causes intermittent "Failed to install split APK(s)" errors for the orchestrator APK. If the cardscan tests pass with plain `google_apis`, this is the cleanest fix for the flake.

The concern is that `SSDOcrTest` calls `TfLite.initialize()` which uses Play Services TFLite. The question is whether TFLite's on-demand module delivery requires the Play Store app (only on `google_apis_playstore`) or just the Play Services framework (available on both).

PR #12694 originally switched to `google_apis_playstore` with the note "so that downloading the model works" but it's unclear if that referred to the TFLite runtime module or the ML model file download.

## Test plan

- [ ] If `run-cardscan-instrumentation-tests` passes (specifically `SSDOcrTest`): adopt this as the permanent fix
- [ ] If it fails with TFLite initialization error: close this PR, Play Store IS required