### PR TITLE
Consolidate saved payment method modifiable checks

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.isModifiable
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
@@ -145,10 +146,8 @@ internal fun isModifiable(
     cbcEligibility: CardBrandChoiceEligibility,
     canUpdateFullPaymentMethodDetails: Boolean
 ): Boolean {
-    if (canUpdateFullPaymentMethodDetails && paymentMethod.card != null) return true
-    val hasMultipleNetworks = paymentMethod.card?.networks?.available?.let { available ->
-        available.size > 1
-    } ?: false
-
-    return cbcEligibility is CardBrandChoiceEligibility.Eligible && hasMultipleNetworks
+    return paymentMethod.isModifiable(
+        canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
+        isCbcEligible = cbcEligibility is CardBrandChoiceEligibility.Eligible,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.DateUtils
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
@@ -27,34 +26,6 @@ internal data class DisplayableSavedPaymentMethod private constructor(
             is SavedPaymentMethod.USBankAccount,
             SavedPaymentMethod.Unexpected -> false
         }
-
-    fun canChangeCbc(): Boolean {
-        return when (savedPaymentMethod) {
-            is SavedPaymentMethod.Card -> {
-                val hasMultipleNetworks = savedPaymentMethod.card.networks?.available?.let { available ->
-                    available.size > 1
-                } ?: false
-
-                return isCbcEligible && hasMultipleNetworks
-            }
-            is SavedPaymentMethod.SepaDebit,
-            is SavedPaymentMethod.USBankAccount,
-            is SavedPaymentMethod.Link,
-            SavedPaymentMethod.Unexpected -> false
-        }
-    }
-
-    fun isModifiable(canUpdateFullPaymentMethodDetails: Boolean): Boolean {
-        return when (savedPaymentMethod) {
-            is SavedPaymentMethod.Card -> {
-                canUpdateFullPaymentMethodDetails || (savedPaymentMethod.isExpired().not() && canChangeCbc())
-            }
-            is SavedPaymentMethod.SepaDebit,
-            is SavedPaymentMethod.USBankAccount,
-            is SavedPaymentMethod.Link,
-            SavedPaymentMethod.Unexpected -> false
-        }
-    }
 
     fun getDescription() = when (savedPaymentMethod) {
         is SavedPaymentMethod.Card -> {
@@ -172,15 +143,7 @@ internal sealed interface SavedPaymentMethod {
         val billingDetails: PaymentMethod.BillingDetails?
     ) : SavedPaymentMethod {
         fun isExpired(): Boolean {
-            val cardExpiryMonth = card.expiryMonth
-            val cardExpiryYear = card.expiryYear
-            // If the card's expiration dates are missing, we can't conclude that it is expired, so we don't want to
-            // show the user an expired card error.
-            return cardExpiryMonth != null && cardExpiryYear != null &&
-                !DateUtils.isExpiryDataValid(
-                    expiryMonth = cardExpiryMonth,
-                    expiryYear = cardExpiryYear,
-                )
+            return card.isExpired()
         }
     }
     data class USBankAccount(val usBankAccount: PaymentMethod.USBankAccount) : SavedPaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -38,10 +38,6 @@ sealed class PaymentOptionsItem {
         val displayName = displayableSavedPaymentMethod.displayName
         val paymentMethod = displayableSavedPaymentMethod.paymentMethod
 
-        fun isModifiable(canUpdateFullPaymentMethodDetails: Boolean): Boolean {
-            return displayableSavedPaymentMethod.isModifiable(canUpdateFullPaymentMethodDetails)
-        }
-
         override val isEnabledDuringEditing: Boolean = true
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodEditability.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodEditability.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.core.utils.DateUtils
+import com.stripe.android.model.PaymentMethod
+
+internal fun PaymentMethod.isModifiable(
+    canUpdateFullPaymentMethodDetails: Boolean,
+    isCbcEligible: Boolean,
+): Boolean {
+    val card = editableSavedCard() ?: return false
+
+    return canUpdateFullPaymentMethodDetails || (card.isExpired().not() && canChangeCbc(isCbcEligible))
+}
+
+internal fun PaymentMethod.canChangeCbc(isCbcEligible: Boolean): Boolean {
+    val card = editableSavedCard() ?: return false
+    val hasMultipleNetworks = card.networks?.available?.let { available ->
+        available.size > 1
+    } ?: false
+
+    return isCbcEligible && hasMultipleNetworks
+}
+
+internal fun PaymentMethod.Card.isExpired(): Boolean {
+    val cardExpiryMonth = expiryMonth
+    val cardExpiryYear = expiryYear
+    // If the card's expiration dates are missing, we can't conclude that it is expired, so we don't want to
+    // show the user an expired card error.
+    return cardExpiryMonth != null && cardExpiryYear != null &&
+        !DateUtils.isExpiryDataValid(
+            expiryMonth = cardExpiryMonth,
+            expiryYear = cardExpiryYear,
+        )
+}
+
+private fun PaymentMethod.editableSavedCard(): PaymentMethod.Card? {
+    return card.takeIf {
+        type == PaymentMethod.Type.Card && isLinkPaymentMethod.not()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -95,7 +95,11 @@ internal class SavedPaymentMethodMutator(
         paymentOptionsItems
     ) { canRemove, items ->
         canRemove || items.filterIsInstance<PaymentOptionsItem.SavedPaymentMethod>().any { item ->
-            item.isModifiable(customerStateHolder.canUpdateFullPaymentMethodDetails.value)
+            val displayableSavedPaymentMethod = item.displayableSavedPaymentMethod
+            displayableSavedPaymentMethod.paymentMethod.isModifiable(
+                canUpdateFullPaymentMethodDetails = customerStateHolder.canUpdateFullPaymentMethodDetails.value,
+                isCbcEligible = displayableSavedPaymentMethod.isCbcEligible,
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -15,6 +15,8 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.SavedPaymentMethod
+import com.stripe.android.paymentsheet.canChangeCbc
+import com.stripe.android.paymentsheet.isModifiable
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -140,7 +142,10 @@ internal class DefaultUpdatePaymentMethodInteractor(
         displayableSavedPaymentMethod
     )
     override val isModifiablePaymentMethod: Boolean
-        get() = displayableSavedPaymentMethod.isModifiable(canUpdateFullPaymentMethodDetails)
+        get() = displayableSavedPaymentMethod.paymentMethod.isModifiable(
+            canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
+            isCbcEligible = displayableSavedPaymentMethod.isCbcEligible,
+        )
 
     override val topBarState: PaymentSheetTopBarState = PaymentSheetTopBarStateFactory.create(
         isLiveMode = isLiveMode,
@@ -175,11 +180,16 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private fun createEditCardDetailsInteractorForCard(
         savedPaymentMethodCard: SavedPaymentMethod.Card,
     ): EditCardDetailsInteractor {
-        val isModifiable = displayableSavedPaymentMethod.isModifiable(canUpdateFullPaymentMethodDetails)
+        val isModifiable = displayableSavedPaymentMethod.paymentMethod.isModifiable(
+            canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
+            isCbcEligible = displayableSavedPaymentMethod.isCbcEligible,
+        )
         val payload = EditCardPayload.create(savedPaymentMethodCard.card, savedPaymentMethodCard.billingDetails)
         val cardEditConfiguration = CardEditConfiguration(
             cardBrandFilter = cardBrandFilter,
-            isCbcModifiable = isModifiable && displayableSavedPaymentMethod.canChangeCbc(),
+            isCbcModifiable = isModifiable && displayableSavedPaymentMethod.paymentMethod.canChangeCbc(
+                displayableSavedPaymentMethod.isCbcEligible
+            ),
             areExpiryDateAndAddressModificationSupported = isModifiable && canUpdateFullPaymentMethodDetails,
         )
         return editCardDetailsInteractorFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -31,6 +31,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.SavedPaymentMethod
+import com.stripe.android.paymentsheet.canChangeCbc
 import com.stripe.android.paymentsheet.utils.testMetadata
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
@@ -48,7 +49,9 @@ internal fun UpdatePaymentMethodUI(interactor: UpdatePaymentMethodInteractor, mo
     val horizontalPadding = StripeTheme.getOuterFormInsets()
     val state by interactor.state.collectAsState()
     val shouldShowCardBrandDropdown = interactor.isModifiablePaymentMethod &&
-        interactor.displayableSavedPaymentMethod.canChangeCbc()
+        interactor.displayableSavedPaymentMethod.paymentMethod.canChangeCbc(
+            interactor.displayableSavedPaymentMethod.isCbcEligible
+        )
 
     Column(
         modifier = modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.isModifiable
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
@@ -528,7 +529,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         savedPaymentMethod: DisplayableSavedPaymentMethod?,
         canUpdateFullPaymentMethodDetails: Boolean,
     ): PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction {
-        return if (savedPaymentMethod?.isModifiable(canUpdateFullPaymentMethodDetails) == true || canRemove) {
+        val canUpdatePaymentMethod = savedPaymentMethod?.paymentMethod?.isModifiable(
+            canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
+            isCbcEligible = savedPaymentMethod.isCbcEligible,
+        ) == true
+        return if (canUpdatePaymentMethod || canRemove) {
             PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ONE
         } else {
             PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.NONE

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+import com.stripe.android.model.PaymentMethodFixtures.EXPIRED_CARD_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT
 import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT_VERIFIED
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
@@ -621,6 +622,32 @@ class CustomerSheetViewModelTest {
                 viewState = awaitViewState()
                 assertThat(viewState.isEditing).isTrue()
                 assertThat(viewState.topBarState {}.showEditMenu).isTrue()
+            }
+        }
+
+    @Test
+    fun `When canUpdateFullPaymentMethodDetails=false, expired card is cbc eligible, showEditMenu should be false`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                customerPaymentMethods = listOf(EXPIRED_CARD_PAYMENT_METHOD),
+                customerPermissions = CustomerPermissions(
+                    removePaymentMethod = PaymentMethodRemovePermission.None,
+                    canRemoveLastPaymentMethod = false,
+                    canUpdateFullPaymentMethodDetails = false,
+                ),
+                cbcEligibility = CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = listOf(CardBrand.CartesBancaires)
+                ),
+            )
+            viewModel.viewState.test {
+                val viewState = awaitViewState<SelectPaymentMethod>()
+                assertThat(viewState.isEditing).isFalse()
+                assertThat(viewState.topBarState {}.showEditMenu).isFalse()
+
+                viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
+
+                ensureAllEventsConsumed()
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -133,8 +133,13 @@ class PaymentOptionsStateFactoryTest {
             defaultPaymentMethodId = null,
         )
 
+        val displayableSavedPaymentMethod = (state.items.last() as PaymentOptionsItem.SavedPaymentMethod)
+            .displayableSavedPaymentMethod
         assertThat(
-            (state.items.last() as PaymentOptionsItem.SavedPaymentMethod).isModifiable(canUpdatePaymentMethod)
+            displayableSavedPaymentMethod.paymentMethod.isModifiable(
+                canUpdateFullPaymentMethodDetails = canUpdatePaymentMethod,
+                isCbcEligible = displayableSavedPaymentMethod.isCbcEligible,
+            )
         ).isEqualTo(expectedResult)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodEditabilityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodEditabilityTest.kt
@@ -1,42 +1,37 @@
 package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.strings.resolvableString
+import com.google.common.truth.Truth.assertWithMessage
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
-import junit.framework.TestCase.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class DisplayableSavedPaymentMethodModifiableTest(private val params: IsModifiableParams) {
+class SavedPaymentMethodEditabilityTest(private val params: IsModifiableParams) {
 
     @Test
     fun `test isModifiable logic`() {
-        val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
-            displayName = "unused".resolvableString,
-            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-                card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
-                    networks = PaymentMethod.Card.Networks(params.availableNetworks),
-                    expiryYear = if (params.cardExpired) 2005 else 2099
-                )
-            ),
-            isCbcEligible = params.isCbcEligible,
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                networks = PaymentMethod.Card.Networks(params.availableNetworks),
+                expiryYear = if (params.cardExpired) 2005 else 2099
+            )
         )
 
-        assertEquals(
-            "Expected isModifiable to be ${params.expectedResult} for parameters: " +
+        assertWithMessage(
+            "Expected isModifiable for parameters: " +
                 "canUpdatePaymentMethod=${params.canUpdatePaymentMethod}, " +
                 "isCbcEligible=${params.isCbcEligible}, " +
                 "availableNetworks=${params.availableNetworks}, " +
-                "cardExpired=${params.cardExpired}",
-            params.expectedResult,
-            displayableSavedPaymentMethod.isModifiable(params.canUpdatePaymentMethod)
-        )
-
-        assertThat(displayableSavedPaymentMethod.isModifiable(params.canUpdatePaymentMethod))
-            .isEqualTo(params.expectedResult)
+                "cardExpired=${params.cardExpired}"
+        ).that(
+            paymentMethod.isModifiable(
+                canUpdateFullPaymentMethodDetails = params.canUpdatePaymentMethod,
+                isCbcEligible = params.isCbcEligible,
+            )
+        ).isEqualTo(params.expectedResult)
     }
 
     data class IsModifiableParams(
@@ -108,5 +103,60 @@ class DisplayableSavedPaymentMethodModifiableTest(private val params: IsModifiab
                 expectedResult = false
             )
         )
+    }
+}
+
+class SavedPaymentMethodEditabilityStandaloneTest {
+    @Test
+    fun `canChangeCbc returns false for single network card when cbc eligible`() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                networks = PaymentMethod.Card.Networks(setOf("visa"))
+            )
+        )
+
+        assertThat(paymentMethod.canChangeCbc(isCbcEligible = true)).isFalse()
+    }
+
+    @Test
+    fun `canChangeCbc returns false for multiple network card when cbc not eligible`() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                networks = PaymentMethod.Card.Networks(setOf("visa", "cartes_bancaires"))
+            )
+        )
+
+        assertThat(paymentMethod.canChangeCbc(isCbcEligible = false)).isFalse()
+    }
+
+    @Test
+    fun `canChangeCbc returns true for multiple network card when cbc eligible`() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card?.copy(
+                networks = PaymentMethod.Card.Networks(setOf("visa", "cartes_bancaires"))
+            )
+        )
+
+        assertThat(paymentMethod.canChangeCbc(isCbcEligible = true)).isTrue()
+    }
+
+    @Test
+    fun `canChangeCbc returns false for non-card payment methods`() {
+        assertThat(PaymentMethodFixtures.US_BANK_ACCOUNT.canChangeCbc(isCbcEligible = true)).isFalse()
+    }
+
+    @Test
+    fun `isModifiable returns false for non-card payment methods`() {
+        listOf(
+            PaymentMethodFixtures.LINK_PAYMENT_METHOD,
+            PaymentMethodFixtures.US_BANK_ACCOUNT,
+        ).forEach { paymentMethod ->
+            assertThat(
+                paymentMethod.isModifiable(
+                    canUpdateFullPaymentMethodDetails = true,
+                    isCbcEligible = true,
+                )
+            ).isFalse()
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -9,6 +9,8 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.ViewActionRecorder
+import com.stripe.android.paymentsheet.canChangeCbc
+import com.stripe.android.paymentsheet.isModifiable
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,13 +47,17 @@ internal class FakeUpdatePaymentMethodInteractor(
         displayableSavedPaymentMethod
     )
     override val editCardDetailsInteractor: EditCardDetailsInteractor by lazy {
-        val isModifiable =
-            displayableSavedPaymentMethod.isModifiable(canUpdateFullPaymentMethodDetails)
+        val isModifiable = displayableSavedPaymentMethod.paymentMethod.isModifiable(
+            canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
+            isCbcEligible = displayableSavedPaymentMethod.isCbcEligible,
+        )
         editCardDetailsInteractorFactory.create(
             coroutineScope = TestScope(),
             cardEditConfiguration = CardEditConfiguration(
                 cardBrandFilter = cardBrandFilter,
-                isCbcModifiable = isModifiable && displayableSavedPaymentMethod.canChangeCbc(),
+                isCbcModifiable = isModifiable && displayableSavedPaymentMethod.paymentMethod.canChangeCbc(
+                    displayableSavedPaymentMethod.isCbcEligible
+                ),
                 areExpiryDateAndAddressModificationSupported = isModifiable && canUpdateFullPaymentMethodDetails
             ),
             requiresModification = true,


### PR DESCRIPTION
## Summary
- Extract saved card editability checks into raw `PaymentMethod` helpers
- Remove the `PaymentOptionsItem.SavedPaymentMethod.isModifiable` and `DisplayableSavedPaymentMethod` editability wrappers
- Route PaymentSheet and CustomerSheet editability checks through the shared `PaymentMethod.isModifiable` helper
- Keep expired CBC-only cards behind the shared guard

## Verification
- `./gradlew :paymentsheet:apiCheck :paymentsheet:detekt`
- Pre-push hook passed: `./gradlew :paymentsheet:apiCheck :paymentsheet:detekt`

This is pre-pre-work for #13344.