### PR TITLE
Add `SelectApplication` & `ReadRecord` APDU commands and use in `ApduCardReader`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.common.nfcscan.scanner
 
+import com.stripe.android.common.nfcscan.scanner.apdu.ReadRecordCommand
+import com.stripe.android.common.nfcscan.scanner.apdu.SelectApplicationCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
 import com.stripe.android.core.injection.IOContext
 import kotlinx.coroutines.withContext
@@ -17,9 +19,29 @@ internal class ApduCardReader @Inject constructor(
         transceiver: NfcTagTransceiver
     ): Result<ScannedCardData> = withContext(workContext) {
         runCatching {
-            SelectPpseCommand.transceiveWith(transceiver).getOrThrow()
+            val applicationIdentifier = SelectPpseCommand.transceiveWith(transceiver).getOrThrow()
+            SelectApplicationCommand(applicationIdentifier).transceiveWith(transceiver)
+
+            val records = mutableMapOf<String, ByteArray>()
+
+            for (sfi in PROBE_SFIS) {
+                for (record in 1..MAX_RECORDS_PER_SFI) {
+                    val result = ReadRecordCommand(record, sfi)
+                        .transceiveWith(transceiver)
+
+                    if (result.isFailure) continue
+
+                    records += result.getOrThrow()
+                }
+            }
 
             throw IllegalStateException("Could not parse card data from NFC tag")
         }
+    }
+
+    private companion object {
+        // SFIs 1-3 cover virtually all Visa/Mastercard/Amex/Discover payment records.
+        val PROBE_SFIS = 1..3
+        const val MAX_RECORDS_PER_SFI = 8
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommand.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+/**
+ * An APDU command for reading records from an ISO 7816-4 card application.
+ */
+internal data class ReadRecordCommand(
+    val recordNumber: Int,
+    val shortFileIdentifier: Int,
+) : ApduCommand<Map<String, ByteArray>>() {
+    /*
+     * Interindustry standardized command for ISO 7816-4
+     */
+    override val classByte = 0x00.toByte()
+
+    /*
+     * READ RECORD command instruction
+     */
+    override val instructionByte = 0xB2.toByte()
+
+    /*
+     * Record number to retrieve
+     */
+    override val firstParameterByte = recordNumber.toByte()
+
+    /*
+     * File to retrieve using short file identifier
+     */
+    override val secondParameterByte = ((shortFileIdentifier shl 3) or 4).toByte()
+    override val dataArray = null
+
+    override fun responseData(tlv: Map<String, ByteArray>): Map<String, ByteArray> = tlv
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommand.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+/**
+ * An APDU command for selecting the payment application on the credit card chip
+ */
+internal data class SelectApplicationCommand(
+    val aid: ApplicationIdentifier,
+) : ApduCommand<Unit>() {
+    /*
+     * Interindustry standardized command for ISO 7816-4
+     */
+    override val classByte = 0x00.toByte()
+
+    /*
+     * SELECT command instruction
+     */
+    override val instructionByte = 0xA4.toByte()
+
+    /*
+     * Select by name
+     */
+    override val firstParameterByte = 0x04.toByte()
+
+    /*
+     * First or only occurrence
+     */
+    override val secondParameterByte = 0x00.toByte()
+
+    /*
+     * Application identifier value
+     */
+    override val dataArray = aid.value.hexToByteArray()
+
+    override fun responseData(tlv: Map<String, ByteArray>) {
+        // No-op
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommand.kt
@@ -3,7 +3,7 @@ package com.stripe.android.common.nfcscan.scanner.apdu
 import com.stripe.android.model.CardBrand
 
 /**
- * An APDU command for selecting the first payment application on the credit card chip
+ * An APDU command for retrieving the payment application on the credit card chip
  */
 internal data object SelectPpseCommand : ApduCommand<ApplicationIdentifier>() {
     /*

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -1,0 +1,159 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.scanner.apdu.ApduResponseError
+import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
+import com.stripe.android.common.nfcscan.scanner.apdu.tlv
+import com.stripe.android.isInstanceOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class ApduCardReaderTest {
+    @Test
+    fun `readCard selects PPSE then application then probes records`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalStateException>()
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+
+        assertReadRecordProbes()
+    }
+
+    @Test
+    fun `readCard continues probing when read record commands fail`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalStateException>()
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+
+        assertReadRecordProbes()
+    }
+
+    @Test
+    fun `readCard propagates PPSE selection failure`() = runScenario(
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf<ApduResponseError.Command>()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+    }
+
+    private fun runScenario(
+        transceiveResult: ByteArray = apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+        transceiveResults: List<ByteArray> = emptyList(),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val fakeTransceiver = FakeNfcTagTransceiver(
+            transceiveResult = transceiveResult,
+            transceiveResults = transceiveResults,
+        )
+        val reader = ApduCardReader(
+            workContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        Scenario(
+            cardReader = reader,
+            transceiver = fakeTransceiver,
+        ).apply { block() }
+
+        fakeTransceiver.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val cardReader: ApduCardReader,
+        val transceiver: FakeNfcTagTransceiver,
+    ) {
+        suspend fun assertReadRecordProbes() {
+            for (expectedRequest in READ_RECORD_REQUESTS) {
+                assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(expectedRequest)
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_RECORDS_PER_SFI = 8
+
+        val READ_RECORD_REQUESTS = buildList {
+            for (sfi in 1..3) {
+                val shortFileIdentifierByte = ((sfi shl 3) or 4).toByte()
+                for (record in 1..MAX_RECORDS_PER_SFI) {
+                    add(
+                        byteArrayOf(
+                            0x00,
+                            0xB2.toByte(),
+                            record.toByte(),
+                            shortFileIdentifierByte,
+                            0x00,
+                        ),
+                    )
+                }
+            }
+        }
+
+        val VISA_AID = byteArrayOf(
+            0xA0.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x03,
+            0x10,
+            0x10,
+        )
+        val RECORD_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x83.toByte())
+        val SELECT_PPSE_REQUEST = byteArrayOf(
+            0x00,
+            0xA4.toByte(),
+            0x04,
+            0x00,
+            0x0E,
+            0x32,
+            0x50,
+            0x41,
+            0x59,
+            0x2E,
+            0x53,
+            0x59,
+            0x53,
+            0x2E,
+            0x44,
+            0x44,
+            0x46,
+            0x30,
+            0x31,
+            0x00,
+        )
+        val SELECT_VISA_APPLICATION_REQUEST = byteArrayOf(
+            0x00,
+            0xA4.toByte(),
+            0x04,
+            0x00,
+            0x07,
+            0xA0.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x03,
+            0x10,
+            0x10,
+            0x00,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcTagTransceiver.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcTagTransceiver.kt
@@ -8,11 +8,14 @@ internal class FakeNfcTagTransceiver(
     private val openException: Throwable? = null,
     private val closeException: Throwable? = null,
     private val transceiveResult: ByteArray = byteArrayOf(),
+    private val transceiveResults: List<ByteArray> = emptyList(),
     private val transceiveException: Throwable? = null,
 ) : NfcTagTransceiver {
     val openCalls = Turbine<Unit>()
     val closeCalls = Turbine<Unit>()
     val transceiveCalls = Turbine<ByteArray>()
+
+    private var transceiveResultIndex = 0
 
     override fun open() {
         openCalls.add(Unit)
@@ -22,7 +25,11 @@ internal class FakeNfcTagTransceiver(
     override fun transceive(data: ByteArray): ByteArray {
         transceiveCalls.add(data)
         transceiveException?.let { throw it as IOException }
-        return transceiveResult
+        return if (transceiveResultIndex < transceiveResults.size) {
+            transceiveResults[transceiveResultIndex++]
+        } else {
+            transceiveResult
+        }
     }
 
     override fun close() {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommandTest.kt
@@ -1,0 +1,76 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.scanner.FakeNfcTagTransceiver
+import com.stripe.android.isInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class ReadRecordCommandTest {
+    @Test
+    fun `transceiveWith sends READ RECORD command with encoded short file identifier`() = test(
+        transceiveResult = apduSuccessResponse(byteArrayOf()),
+    ) {
+        ReadRecordCommand(recordNumber = 5, shortFileIdentifier = 2)
+            .transceiveWith(transceiver)
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(
+            byteArrayOf(0x00, 0xB2.toByte(), 0x05, 0x14, 0x00),
+        )
+    }
+
+    @Test
+    fun `transceiveWith returns parsed TLV data on success`() = test(
+        transceiveResult = apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
+    ) {
+        val result = ReadRecordCommand(recordNumber = 1, shortFileIdentifier = 1)
+            .transceiveWith(transceiver)
+
+        assertThat(result.isSuccess).isTrue()
+
+        val tlvData = result.getOrNull()
+
+        assertThat(tlvData).containsKey("57")
+        assertThat(tlvData?.getValue("57")?.contentEquals(TRACK_2_DATA)).isTrue()
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `transceiveWith returns Command error when record is not found`() = test(
+        transceiveResult = byteArrayOf(0x6A.toByte(), 0x83.toByte()),
+    ) {
+        val result = ReadRecordCommand(recordNumber = 1, shortFileIdentifier = 1)
+            .transceiveWith(transceiver)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf<ApduResponseError.Command>()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    private fun test(
+        transceiveResult: ByteArray,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val fakeTransceiver = FakeNfcTagTransceiver(
+            transceiveResult = transceiveResult,
+        )
+
+        block(Scenario(fakeTransceiver))
+
+        fakeTransceiver.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val transceiver: FakeNfcTagTransceiver,
+    )
+
+    private companion object {
+        val TRACK_2_DATA = byteArrayOf(
+            0x12,
+            0x34,
+            0x56,
+            0x78,
+            0x90.toByte(),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommandTest.kt
@@ -1,0 +1,84 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.scanner.FakeNfcTagTransceiver
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class SelectApplicationCommandTest {
+    @Test
+    fun `transceiveWith sends SELECT application command`() = test(
+        transceiveResult = apduSuccessResponse(byteArrayOf()),
+    ) {
+        SelectApplicationCommand(ApplicationIdentifier(VISA_AID.toHexString()))
+            .transceiveWith(transceiver)
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+    }
+
+    @Test
+    fun `transceiveWith returns success when status word is 9000`() = test(
+        transceiveResult = apduSuccessResponse(byteArrayOf()),
+    ) {
+        val result = SelectApplicationCommand(ApplicationIdentifier(VISA_AID.toHexString()))
+            .transceiveWith(transceiver)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `transceiveWith returns Command error when status word is not 9000`() = test(
+        transceiveResult = byteArrayOf(0x6A.toByte(), 0x82.toByte()),
+    ) {
+        val result = SelectApplicationCommand(ApplicationIdentifier(VISA_AID.toHexString()))
+            .transceiveWith(transceiver)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    private fun test(
+        transceiveResult: ByteArray,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val fakeTransceiver = FakeNfcTagTransceiver(
+            transceiveResult = transceiveResult,
+        )
+
+        block(Scenario(fakeTransceiver))
+
+        fakeTransceiver.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val transceiver: FakeNfcTagTransceiver,
+    )
+
+    private companion object {
+        val VISA_AID = byteArrayOf(
+            0xA0.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x03,
+            0x10,
+            0x10,
+        )
+        val SELECT_VISA_APPLICATION_REQUEST = byteArrayOf(
+            0x00,
+            0xA4.toByte(),
+            0x04,
+            0x00,
+            0x07,
+            0xA0.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x03,
+            0x10,
+            0x10,
+            0x00,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Add `SelectApplication` & `ReadRecord` APDU commands and use in `ApduCardReader`

# Motivation
Support remaining APDU operations in `ApduCardReader`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified