### PR TITLE
Fix CustomerSheet sending 'unknown' as preferred network on card edit 🪿✨

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsEntry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsEntry.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.model.Address
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CardUpdateParams
 
@@ -48,7 +49,7 @@ internal fun toUpdateParams(
     billingDetailsEntry: BillingDetailsEntry?,
 ): CardUpdateParams {
     return CardUpdateParams(
-        cardBrand = cardDetailsEntry?.cardBrandChoice?.brand,
+        cardBrand = cardDetailsEntry?.cardBrandChoice?.brand?.takeIf { it != CardBrand.Unknown },
         expiryMonth = cardDetailsEntry?.expiryDateState?.expiryMonth,
         expiryYear = cardDetailsEntry?.expiryDateState?.expiryYear,
         billingDetails = createBillingDetails(billingDetailsEntry)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEntryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEntryTest.kt
@@ -166,6 +166,23 @@ internal class CardDetailsEntryTest {
     }
 
     @Test
+    fun `toUpdateParams() should treat CardBrand Unknown as null preferred network`() {
+        val cardBrandChoice = CardBrandChoice(CardBrand.Unknown, true)
+        val cardDetailsEntry = createEntry(
+            cardBrandChoice = cardBrandChoice,
+            expMonth = 12,
+            expYear = 2030
+        )
+
+        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry())
+
+        assertThat(params.cardBrand).isNull()
+        assertThat(params.expiryMonth).isEqualTo(12)
+        assertThat(params.expiryYear).isEqualTo(2030)
+        assertThat(params.billingDetails).isEqualTo(BILLING_DETAILS_FORM_DETAILS)
+    }
+
+    @Test
     fun `toUpdateParams() should correctly convert to CardUpdateParams`() {
         val cardBrandChoice = CardBrandChoice(CardBrand.Visa, true)
         val cardDetailsEntry = createEntry(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -277,6 +277,31 @@ internal class DefaultEditCardDetailsInteractorTest {
     }
 
     @Test
+    fun cardUpdateParamsHasNullCardBrandWhenDisplayBrandIsNull() {
+        var capturedCardUpdateParams: CardUpdateParams? = null
+        val cardWithNoDisplayBrand = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+            displayBrand = null,
+        )
+        val handler = handler(
+            card = cardWithNoDisplayBrand,
+            onCardUpdateParamsChanged = {
+                capturedCardUpdateParams = it
+            }
+        )
+
+        handler.handleViewAction(
+            EditCardDetailsInteractor.ViewAction.BillingDetailsChanged(
+                PaymentSheetFixtures.billingDetailsFormState(
+                    postalCode = FormFieldEntry("90211", isComplete = true),
+                )
+            )
+        )
+
+        assertThat(capturedCardUpdateParams?.billingDetails?.address?.postalCode).isEqualTo("90211")
+        assertThat(capturedCardUpdateParams?.cardBrand).isNull()
+    }
+
+    @Test
     fun cardUpdateParamsIsUpdatedForValidExpDateUpdate() {
         var capturedCardUpdateParams: CardUpdateParams? = null
         val handler = handler(


### PR DESCRIPTION
[Minion run](https://agents.corp.stripe.com/sessions/b406a7cc-44cd-4b92-9b73-9428a0651839)

# Summary
<!-- Simple summary of what was changed. -->

Filter `CardBrand.Unknown` to `null` in `toUpdateParams()` so that saved-card edits without a recognized display brand omit `card[networks][preferred]` instead of sending `preferred=unknown`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When editing a saved Diners Club or Discover card on Android `CustomerSheet` (e.g., changing only the postal code), the update request includes `card[networks][preferred]=unknown` and fails. iOS omits the field for the same edit and succeeds.

The cause: `CardBrand.fromCode(displayBrand)` returns `CardBrand.Unknown` when `displayBrand` is null, and `toUpdateParams()` passes it through unconditionally. `CustomerSheetViewModel` then serializes it as `Networks(preferred = "unknown")`.

Reported in https://github.com/stripe/stripe-react-native/issues/2494.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A | N/A |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] CustomerSheet no longer sends `unknown` as the preferred network when editing a saved card without a recognized display brand.