### PR TITLE
Add `NfcCardDataParser` to support parsing out card details

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
@@ -1,0 +1,101 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import javax.inject.Inject
+import kotlin.collections.joinToString
+
+internal interface NfcCardDataParser {
+    fun parse(records: Map<String, ByteArray>): ScannedCardData?
+}
+
+internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParser {
+    override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
+        // Tag 0x57 — Track 2 Equivalent Data. Preferred when present because it encodes PAN and
+        // expiry together in the same format used on magnetic-stripe Track 2.
+        records[TAG_TRACK2]?.let {
+            return parseFromTrack2(it)
+        }
+
+        // Fall back to separate PAN and expiry tags when Track 2 is unavailable.
+        val panBytes = records[TAG_PAN] ?: return null
+        val pan = panBytes.toReadableString()
+            // Cards pad odd-length numbers with trailing 'F'.
+            .trimEnd(*PAN_TRAILING_CHARS)
+
+        val expiryBytes = records[TAG_EXPIRY] ?: return null
+        val (month, year) = parseExpiry(expiryBytes) ?: return null
+
+        return ScannedCardData(
+            cardNumber = pan,
+            expirationMonth = month,
+            expirationYear = year,
+        )
+    }
+
+    private fun parseFromTrack2(bytes: ByteArray): ScannedCardData? {
+        val hex = bytes.toReadableString()
+
+        // Get the separator between the PAN and expiration date
+        val sep = hex.indexOf(TRACK2_SEPARATOR).takeIf { it >= 0 } ?: return null
+
+        val pan = hex.substring(0, sep)
+
+        if (hex.length < sep + TRACK2_EXPIRY_MONTH_END_OFFSET) return null
+
+        val year = hex.substring(
+            startIndex = sep + TRACK2_EXPIRY_YEAR_START_OFFSET,
+            endIndex = sep + TRACK2_EXPIRY_MONTH_START_OFFSET,
+        ).toIntOrNull() ?: return null
+
+        val month = hex.substring(
+            sep + TRACK2_EXPIRY_MONTH_START_OFFSET,
+            sep + TRACK2_EXPIRY_MONTH_END_OFFSET,
+        ).toIntOrNull() ?: return null
+
+        return ScannedCardData(
+            cardNumber = pan,
+            expirationMonth = month,
+            expirationYear = EXPIRATION_YEAR_START + year,
+        )
+    }
+
+    private fun parseExpiry(bytes: ByteArray): Pair<Int, Int>? {
+        if (bytes.size < EXPIRATION_DATE_MIN_LENGTH) return null
+
+        val yearBcd = bytes[0].toSingleByte()
+        val monthBcd = bytes[1].toSingleByte()
+
+        val year = EXPIRATION_YEAR_START + yearBcd.toTwoDigitNumber()
+        val month = monthBcd.toTwoDigitNumber()
+
+        return month to year
+    }
+
+    private fun ByteArray.toReadableString(): String {
+        return joinToString("") { "%02X".format(it) }
+    }
+
+    private fun Byte.toSingleByte() = toInt() and BYTE_MASK
+    private fun Int.toTwoDigitNumber() =
+        (this shr FIRST_DIGIT_SHIFT) * FIRST_DIGIT_MULTIPLIER + (this and LAST_DIGIT_MASK)
+
+    private companion object {
+        const val TAG_TRACK2 = "57"
+        const val TAG_PAN = "5A"
+        const val TAG_EXPIRY = "5F24"
+
+        const val TRACK2_SEPARATOR = 'D'
+        const val EXPIRATION_YEAR_START = 2000
+
+        const val TRACK2_EXPIRY_YEAR_START_OFFSET = 1
+        const val TRACK2_EXPIRY_MONTH_START_OFFSET = 3
+        const val TRACK2_EXPIRY_MONTH_END_OFFSET = 5
+
+        const val EXPIRATION_DATE_MIN_LENGTH = 3
+        const val BYTE_MASK = 0xFF
+        const val LAST_DIGIT_MASK = 0x0F
+        const val FIRST_DIGIT_SHIFT = 4
+        const val FIRST_DIGIT_MULTIPLIER = 10
+
+        val PAN_TRAILING_CHARS = charArrayOf('F', 'f')
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -14,6 +14,7 @@ internal interface NfcCardReader {
 
 internal class ApduCardReader @Inject constructor(
     @IOContext private val workContext: CoroutineContext,
+    private val cardDataParser: NfcCardDataParser,
 ) : NfcCardReader {
     override suspend fun readCard(
         transceiver: NfcTagTransceiver
@@ -35,7 +36,8 @@ internal class ApduCardReader @Inject constructor(
                 }
             }
 
-            throw IllegalStateException("Could not parse card data from NFC tag")
+            cardDataParser.parse(records)
+                ?: throw IllegalStateException("Could not parse card data from NFC tag")
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScannerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScannerModule.kt
@@ -15,4 +15,7 @@ internal interface NfcCardScannerModule {
 
     @Binds
     fun bindsNfcCardReader(reader: ApduCardReader): NfcCardReader
+
+    @Binds
+    fun bindsNfcCardDataParser(parser: DefaultNfcCardDataParser): NfcCardDataParser
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -26,6 +26,8 @@ internal class ApduCardReaderTest {
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
 
         assertReadRecordProbes()
+
+        assertThat(cardDataParser.parseCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -44,6 +46,8 @@ internal class ApduCardReaderTest {
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
 
         assertReadRecordProbes()
+
+        assertThat(cardDataParser.parseCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -56,40 +60,131 @@ internal class ApduCardReaderTest {
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
     }
 
+    @Test
+    fun `readCard returns parsed card data when parser succeeds`() = runScenario(
+        parseResult = SCANNED_CARD_DATA,
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result.getOrNull()).isEqualTo(SCANNED_CARD_DATA)
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
+
+        assertReadRecordProbes(startingAtIndex = 1)
+        assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
+    }
+
+    @Test
+    fun `readCard merges tlv records from successful read record commands`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
+            apduSuccessResponse(tlv(tag = 0x5A, value = PAN_DATA)),
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalStateException>()
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS[1])
+
+        assertReadRecordProbes(startingAtIndex = 2)
+
+        val parsedRecords = cardDataParser.parseCalls.awaitItem()
+        assertThat(parsedRecords).containsKey("57")
+        assertThat(parsedRecords.getValue("57").contentEquals(TRACK_2_DATA)).isTrue()
+        assertThat(parsedRecords).containsKey("5A")
+        assertThat(parsedRecords.getValue("5A").contentEquals(PAN_DATA)).isTrue()
+    }
+
     private fun runScenario(
         transceiveResult: ByteArray = apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
         transceiveResults: List<ByteArray> = emptyList(),
+        parseResult: ScannedCardData? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val fakeTransceiver = FakeNfcTagTransceiver(
             transceiveResult = transceiveResult,
             transceiveResults = transceiveResults,
         )
+        val fakeCardDataParser = FakeNfcCardDataParser(
+            parseResult = parseResult,
+        )
         val reader = ApduCardReader(
             workContext = UnconfinedTestDispatcher(testScheduler),
+            cardDataParser = fakeCardDataParser,
         )
 
         Scenario(
             cardReader = reader,
             transceiver = fakeTransceiver,
+            cardDataParser = fakeCardDataParser,
         ).apply { block() }
 
         fakeTransceiver.ensureAllEventsConsumed()
+        fakeCardDataParser.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val cardReader: ApduCardReader,
         val transceiver: FakeNfcTagTransceiver,
+        val cardDataParser: FakeNfcCardDataParser,
     ) {
-        suspend fun assertReadRecordProbes() {
-            for (expectedRequest in READ_RECORD_REQUESTS) {
-                assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(expectedRequest)
+        suspend fun assertReadRecordProbes(startingAtIndex: Int = 0) {
+            for (index in startingAtIndex until READ_RECORD_REQUESTS.size) {
+                assertThat(transceiver.transceiveCalls.awaitItem())
+                    .isEqualTo(READ_RECORD_REQUESTS[index])
             }
         }
     }
 
     private companion object {
         const val MAX_RECORDS_PER_SFI = 8
+
+        val SCANNED_CARD_DATA = ScannedCardData(
+            cardNumber = "4111111111111111",
+            expirationMonth = 12,
+            expirationYear = 2025,
+        )
+
+        val TRACK_2_DATA = byteArrayOf(
+            0x41,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0xD2.toByte(),
+            0x51,
+            0x21,
+            0x01,
+        )
+
+        val PAN_DATA = byteArrayOf(
+            0x41,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+        )
 
         val READ_RECORD_REQUESTS = buildList {
             for (sfi in 1..3) {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
@@ -1,0 +1,149 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class DefaultNfcCardDataParserTest {
+    private val parser = DefaultNfcCardDataParser()
+
+    @Test
+    fun `parse returns card data from Track 2 equivalent data when available, preferring it over PAN & expiry tags`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111D2512101"),
+                TAG_PAN to hexToBytes("5555555555554444F"),
+                TAG_EXPIRY to byteArrayOf(0x30, 0x06, 0x01),
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            ScannedCardData(
+                cardNumber = "4111111111111111",
+                expirationMonth = 12,
+                expirationYear = 2025,
+            ),
+        )
+    }
+
+    @Test
+    fun `parse returns null when Track 2 is missing field separator`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111"),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse returns null when Track 2 expiry is truncated`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111D25"),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse returns null when Track 2 expiry is not numeric`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111DAA12100"),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse returns card data from separate PAN and expiry tags`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_PAN to hexToBytes("4111111111111111"),
+                TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            ScannedCardData(
+                cardNumber = "4111111111111111",
+                expirationMonth = 12,
+                expirationYear = 2025,
+            ),
+        )
+    }
+
+    @Test
+    fun `parse trims trailing F padding from PAN`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_PAN to hexToBytes("411111111111111F"),
+                TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            ScannedCardData(
+                cardNumber = "411111111111111",
+                expirationMonth = 12,
+                expirationYear = 2025,
+            ),
+        )
+    }
+
+    @Test
+    fun `parse returns null when PAN tag is missing`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse returns null when expiry tag is missing`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_PAN to hexToBytes("4111111111111111"),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse returns null when expiry data is too short`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_PAN to hexToBytes("4111111111111111"),
+                TAG_EXPIRY to byteArrayOf(0x25, 0x12),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parse returns null when no recognized tags are present`() {
+        val result = parser.parse(emptyMap())
+
+        assertThat(result).isNull()
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        return hex.chunked(2)
+            .map { it.toInt(16).toByte() }
+            .toByteArray()
+    }
+
+    private companion object {
+        const val TAG_TRACK2 = "57"
+        const val TAG_PAN = "5A"
+        const val TAG_EXPIRY = "5F24"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import app.cash.turbine.Turbine
+
+internal class FakeNfcCardDataParser(
+    private val parseResult: ScannedCardData? = null,
+) : NfcCardDataParser {
+    val parseCalls = Turbine<Map<String, ByteArray>>()
+
+    override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
+        parseCalls.add(records)
+        return parseResult
+    }
+
+    fun ensureAllEventsConsumed() {
+        parseCalls.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary
Add `NfcCardDataParser` to support parsing out card details from the APDU commands in `NfcCardScanner`. It has the ability to create the raw card number PAN and expiration date from the records fetched from the credit card chip.

# Motivation
Return readable card data from the `NfcCardScanner`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified