### PR TITLE
Fix CustomerSheet edit screen: use locale country for cards with no billing details

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheetViewState.AddPaymentMethod
 import com.stripe.android.customersheet.CustomerSheetViewState.SelectPaymentMethod
+import com.stripe.android.model.Address
 import com.stripe.android.customersheet.analytics.CustomerSheetEvent
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.data.CustomerSheetDataResult
@@ -70,6 +71,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+import java.util.Locale
 import kotlin.coroutines.coroutineContext
 import kotlin.test.assertFailsWith
 import com.stripe.android.ui.core.R as UiCoreR
@@ -2809,6 +2811,97 @@ class CustomerSheetViewModelTest {
                 source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
                 selectedBrand = CardBrand.Visa
             )
+        }
+    }
+
+    @Test
+    fun `Edit screen uses locale country when saved card has no billing details, not merchant defaultBillingDetails`() = runTest(testDispatcher) {
+        val savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+        try {
+            val cardWithNoBillingDetails = CARD_PAYMENT_METHOD.copy(billingDetails = null)
+
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                customerPaymentMethods = listOf(cardWithNoBillingDetails),
+                configuration = CustomerSheet.Configuration.builder("Example")
+                    .defaultBillingDetails(
+                        PaymentSheet.BillingDetails(
+                            address = PaymentSheet.Address(country = "CA")
+                        )
+                    )
+                    .build(),
+            )
+
+            viewModel.viewState.test {
+                assertThat(awaitItem()).isInstanceOf<SelectPaymentMethod>()
+
+                viewModel.handleViewAction(
+                    CustomerSheetViewAction.OnModifyItem(
+                        cardWithNoBillingDetails.toDisplayableSavedPaymentMethod()
+                    )
+                )
+
+                val editViewState = awaitViewState<CustomerSheetViewState.UpdatePaymentMethod>()
+                val billingDetailsForm = editViewState.updatePaymentMethodInteractor
+                    .editCardDetailsInteractor
+                    .state.value
+                    .billingDetailsForm
+
+                assertThat(billingDetailsForm).isNotNull()
+
+                billingDetailsForm!!.formFieldsState.test {
+                    val formState = awaitItem()
+                    // Country should be the locale default (US), not the merchant-configured default (CA)
+                    assertThat(formState.country?.value).isEqualTo("US")
+                }
+            }
+        } finally {
+            Locale.setDefault(savedLocale)
+        }
+    }
+
+    @Test
+    fun `Edit screen shows real saved billing country from the payment method`() = runTest(testDispatcher) {
+        val savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+        try {
+            val cardWithSavedBillingCountry = CARD_PAYMENT_METHOD.copy(
+                billingDetails = PaymentMethod.BillingDetails(
+                    address = Address(country = "CA")
+                )
+            )
+
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                customerPaymentMethods = listOf(cardWithSavedBillingCountry),
+            )
+
+            viewModel.viewState.test {
+                assertThat(awaitItem()).isInstanceOf<SelectPaymentMethod>()
+
+                viewModel.handleViewAction(
+                    CustomerSheetViewAction.OnModifyItem(
+                        cardWithSavedBillingCountry.toDisplayableSavedPaymentMethod()
+                    )
+                )
+
+                val editViewState = awaitViewState<CustomerSheetViewState.UpdatePaymentMethod>()
+                val billingDetailsForm = editViewState.updatePaymentMethodInteractor
+                    .editCardDetailsInteractor
+                    .state.value
+                    .billingDetailsForm
+
+                assertThat(billingDetailsForm).isNotNull()
+
+                billingDetailsForm!!.formFieldsState.test {
+                    val formState = awaitItem()
+                    // Country should be the saved billing country (CA), not the locale default (US)
+                    assertThat(formState.country?.value).isEqualTo("CA")
+                }
+            }
+        } finally {
+            Locale.setDefault(savedLocale)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -24,6 +24,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultEditCardDetailsInteractorTest {
@@ -372,6 +373,30 @@ internal class DefaultEditCardDetailsInteractorTest {
         assertThat(cardUpdateParams).isNotNull()
         assertThat(cardUpdateParams?.cardBrand).isEqualTo(CardBrand.Visa)
         assertThat(cardUpdateParams?.billingDetails).isNull()
+    }
+
+    @Test
+    fun whenBillingDetailsIsNullThenInitialCountryIsLocaleDefault() = runTest {
+        val savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+        try {
+            val handler = handler(
+                addressCollectionMode = AddressCollectionMode.Automatic,
+                billingDetails = null,
+            )
+
+            val billingDetailsForm = handler.uiState.billingDetailsForm
+            assertThat(billingDetailsForm).isNotNull()
+
+            billingDetailsForm!!.formFieldsState.test {
+                val formState = awaitItem()
+                // When there are no saved billing details, the country should default to the
+                // device locale, not to any merchant-configured defaultBillingDetails value.
+                assertThat(formState.country?.value).isEqualTo("US")
+            }
+        } finally {
+            Locale.setDefault(savedLocale)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

When a saved payment method has no billing details stored, the edit/update screen in CustomerSheet should fall back to the device locale country — not to the merchant-provided defaultBillingDetails country from the configuration.

Investigation confirmed that the existing code already correctly threads saved-PM billing details through the edit path (DisplayableSavedPaymentMethod -> SavedPaymentMethod.Card.billingDetails -> EditCardPayload -> BillingDetailsForm), and when those billing details are absent, the country field defaults to the locale automatically via DropdownFieldController.

## Changes

- Added regression tests in CustomerSheetViewModelTest to verify:
  1. Edit screen uses the device locale country (not the merchant-configured defaultBillingDetails.country) when the saved card has no billing details.
  2. Edit screen correctly prefills the real saved billing country when the payment method does have billing details stored.
- Added a lower-level unit test in DefaultEditCardDetailsInteractorTest confirming that a null billing details payload produces the locale-default country in the initial form state.

## Testing

Tests verify the two key scenarios:
- Saved PM with billingDetails = null + config with defaultBillingDetails.address.country = CA -> edit form shows locale default (US), not CA
- Saved PM with billingDetails.address.country = CA -> edit form shows CA