### PR TITLE
Improve Bitrise CI times on instrumentation tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -17,7 +17,11 @@ pipelines:
       check: { }
       test: { }
       run-instrumentation-tests: { }
-      run-paymentsheet-instrumentation-tests: { }
+      build-paymentsheet-instrumentation-tests: { }
+      run-paymentsheet-instrumentation-tests:
+        parallel: 2
+        depends_on:
+          - build-paymentsheet-instrumentation-tests
       run-financial-connections-instrumentation-tests: { }
       run-connections-e2e-payments-tests-on-push: { }
       run-connections-e2e-token-tests-on-push: { }
@@ -316,6 +320,15 @@ workflows:
           title: Export instrumentation test results
           inputs:
             - test_title: Instrumentation tests
+  build-paymentsheet-instrumentation-tests:
+    before_run:
+      - prepare_all
+    steps:
+      - script@1:
+          title: Compile PaymentSheet instrumentation tests
+          timeout: 1200
+          inputs:
+            - content: ./gradlew :paymentsheet:assembleDebugAndroidTest
   run-paymentsheet-instrumentation-tests:
     before_run:
       - prepare_all
@@ -326,11 +339,17 @@ workflows:
           title: Execute instrumentation tests
           timeout: 1200
           inputs:
-            - content: ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=6 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=6 :paymentsheet:pixel2api33DebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
+            - content: |-
+                #!/usr/bin/env bash
+                set -euo pipefail
+                envman add --key PAYMENTSHEET_INSTRUMENTATION_SHARD_DISPLAY --value "$((BITRISE_IO_PARALLEL_INDEX + 1))"
+                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$BITRISE_IO_PARALLEL_INDEX" --num-shards 2 --test-directory paymentsheet/src/androidTest/java/)
+
+                ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=4 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=4 "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet:pixel2api33DebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
       - bundle::export_instrumentation_test_results:
           title: Export PaymentSheet instrumentation test results
           inputs:
-            - test_title: PaymentSheet instrumentation tests
+            - test_title: "PaymentSheet instrumentation tests (shard $PAYMENTSHEET_INSTRUMENTATION_SHARD_DISPLAY)"
     meta:
       bitrise.io:
         stack: ubuntu-resolute-26.04-bitrise-2026-android
@@ -410,7 +429,7 @@ workflows:
                 #!/usr/bin/env bash
                 set -euo pipefail
                 envman add --key PAYMENTSHEET_E2E_SHARD_DISPLAY --value "$((BITRISE_IO_PARALLEL_INDEX + 1))"
-                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$BITRISE_IO_PARALLEL_INDEX" --num-shards 5)
+                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$BITRISE_IO_PARALLEL_INDEX" --num-shards 5 --test-directory paymentsheet-example/src/androidTest/java/)
 
                 ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=3 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=6 "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33BaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
       - bundle::export_instrumentation_test_results:

--- a/scripts/get_shard_test_classes.py
+++ b/scripts/get_shard_test_classes.py
@@ -39,15 +39,14 @@ def class_names_from_test_files(test_directory, test_file_names):
     return class_names
 
 
-def get_all_test_class_names():
-    directory = 'paymentsheet-example/src/androidTest/java/'
-    _, kotlin_file_names = run_fast_scandir(directory, [".kt"])
+def get_all_test_class_names(test_directory):
+    _, kotlin_file_names = run_fast_scandir(test_directory, [".kt"])
     test_file_names = test_files_from_kotlin_files(kotlin_file_names)
-    return sorted(class_names_from_test_files(directory, test_file_names))
+    return sorted(class_names_from_test_files(test_directory, test_file_names))
 
 
-def get_shard_classes(shard_index, num_shards):
-    all_classes = get_all_test_class_names()
+def get_shard_classes(test_directory, shard_index, num_shards):
+    all_classes = get_all_test_class_names(test_directory)
     return [c for i, c in enumerate(all_classes) if i % num_shards == shard_index]
 
 
@@ -55,9 +54,18 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Get test classes for a given shard.")
     parser.add_argument("--shard-index", type=int, required=True)
     parser.add_argument("--num-shards", type=int, required=True)
+    parser.add_argument(
+        "--test-directory",
+        default="paymentsheet-example/src/androidTest/java/",
+        help="Directory containing android instrumentation test sources",
+    )
     args = parser.parse_args()
 
-    classes = get_shard_classes(args.shard_index, args.num_shards)
+    if not os.path.isdir(args.test_directory):
+        print(f"Test directory not found: {args.test_directory}", file=sys.stderr)
+        sys.exit(1)
+
+    classes = get_shard_classes(args.test_directory, args.shard_index, args.num_shards)
     if not classes:
         print("No test classes found for shard", args.shard_index, file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
# Summary
Improve Bitrise CI times by splitting `paymentsheet-instrumentation-tests` into two pipelines.

# Motivation
Faster CI times on PRs

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified