### PR TITLE
Fix PersonTokenParams.Verification sending documents under swapped API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### Payments
+* [FIXED][13354](https://github.com/stripe/stripe-android/pull/13354) Fixed an issue where `PersonTokenParams.Verification` sent the `document` and `additionalDocument` fields to the Stripe API under each other's keys.
+
 ## 23.11.1 - 2026-06-30
 
 ### PaymentSheet

--- a/payments-core/src/main/java/com/stripe/android/model/PersonTokenParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PersonTokenParams.kt
@@ -305,8 +305,8 @@ class PersonTokenParams(
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
             return listOf(
-                PARAM_ADDITIONAL_DOCUMENT to document?.toParamMap(),
-                PARAM_DOCUMENT to additionalDocument?.toParamMap()
+                PARAM_ADDITIONAL_DOCUMENT to additionalDocument?.toParamMap(),
+                PARAM_DOCUMENT to document?.toParamMap()
             ).fold(emptyMap()) { acc, (key, value) ->
                 acc.plus(
                     value?.let { mapOf(key to it) }.orEmpty()

--- a/payments-core/src/test/java/com/stripe/android/model/PersonTokenParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PersonTokenParamsTest.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class PersonTokenParamsTest {
+
+    @Test
+    fun `Verification toParamMap maps document and additionalDocument to their own API keys`() {
+        val document = PersonTokenParams.Document(front = "id_front", back = "id_back")
+        val additionalDocument = PersonTokenParams.Document(front = "proof_front", back = "proof_back")
+
+        val verification = PersonTokenParams.Verification(
+            document = document,
+            additionalDocument = additionalDocument
+        )
+
+        assertThat(verification.toParamMap()).isEqualTo(
+            mapOf(
+                "document" to document.toParamMap(),
+                "additional_document" to additionalDocument.toParamMap()
+            )
+        )
+    }
+
+    @Test
+    fun `Verification toParamMap with only document set emits the document key`() {
+        val document = PersonTokenParams.Document(front = "id_front", back = "id_back")
+
+        val verification = PersonTokenParams.Verification(document = document)
+
+        assertThat(verification.toParamMap()).isEqualTo(
+            mapOf("document" to document.toParamMap())
+        )
+    }
+
+    @Test
+    fun `Verification toParamMap with only additionalDocument set emits the additional_document key`() {
+        val additionalDocument = PersonTokenParams.Document(front = "proof_front", back = "proof_back")
+
+        val verification = PersonTokenParams.Verification(additionalDocument = additionalDocument)
+
+        assertThat(verification.toParamMap()).isEqualTo(
+            mapOf("additional_document" to additionalDocument.toParamMap())
+        )
+    }
+}


### PR DESCRIPTION
# Summary

`PersonTokenParams.Verification.toParamMap()` serialized its two documents under each other's Stripe API keys:

- `document` was sent under `additional_document`
- `additionalDocument` was sent under `document`

```kotlin
// before
return listOf(
    PARAM_ADDITIONAL_DOCUMENT to document?.toParamMap(),
    PARAM_DOCUMENT to additionalDocument?.toParamMap()
)
```

# Motivation

When creating a person token, `Verification.document` is the identifying document (passport / local ID) and must be sent as [`person.verification.document`](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-verification-document), while `Verification.additionalDocument` is the proof-of-address document and must be sent as [`person.verification.additional_document`](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-verification-additional_document) — as the fields' own KDoc documents.

Because both fields default to `null` and the `fold` drops `null`/empty inner maps, a caller who set **only** `document` produced a request containing an `additional_document` entry and **no `document`** at all: the identifying document was sent under the wrong field and the intended one was silently absent.

The equivalent `AccountParams.BusinessTypeParams.Individual.Verification.toParamMap()` — same fields, same KDoc, same param constants — already maps them correctly:

```kotlin
// AccountParams.kt (correct)
return listOf(
    PARAM_ADDITIONAL_DOCUMENT to additionalDocument?.toParamMap(),
    PARAM_DOCUMENT to document?.toParamMap()
)
```

This change swaps the two values in `PersonTokenParams` so the keys line up with the fields, matching that sibling and the `create_person` API contract.

# Testing

- [x] Added tests

Added `PersonTokenParamsTest`, which asserts `document` is emitted under `document`, `additionalDocument` under `additional_document`, and each field in isolation. The tests fail before this change and pass after.

```
./gradlew :payments-core:testDebugUnitTest --tests "com.stripe.android.model.PersonTokenParamsTest"
./gradlew :payments-core:detekt
```

Both pass. No public API / ABI change (only the method body changed).

# Changelog

Added a `[FIXED]` entry under **Payments**.
