### PR TITLE
Fix NFC scanning lifecycle registration & add NFC permission to `paymentsheet` module.

### DIFF
--- a/paymentsheet/src/main/AndroidManifest.xml
+++ b/paymentsheet/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.NFC" />
 
     <application>
         <activity

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
@@ -24,8 +24,6 @@ internal class NfcScanningActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        viewModel.register(this)
-
         lifecycleScope.launch {
             viewModel.result.collectLatest { result ->
                 finishWithResult(result)
@@ -53,6 +51,11 @@ internal class NfcScanningActivity : AppCompatActivity() {
                 )
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.register(this)
     }
 
     override fun onStop() {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -2,11 +2,13 @@ package com.stripe.android.common.nfcscan
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.Looper
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
@@ -19,6 +21,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNfcAdapter
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
@@ -49,11 +52,31 @@ internal class NfcScanningActivityTest {
         assertThat(getResult()).isEqualTo(NfcScanningContract.Result.Canceled)
     }
 
+    @Test
+    fun `onResume starts NFC card scanner`() = test {
+        waitForIdle()
+
+        assertThat(nfcAdapter?.isInReaderMode).isTrue()
+    }
+
+    @Test
+    fun `onResume re-registers NFC card scanner when returning from background`() = test {
+        waitForIdle()
+        assertThat(nfcAdapter?.isInReaderMode).isTrue()
+
+        moveToState(Lifecycle.State.STARTED)
+        assertThat(nfcAdapter?.isInReaderMode).isFalse()
+
+        moveToState(Lifecycle.State.RESUMED)
+        assertThat(nfcAdapter?.isInReaderMode).isTrue()
+    }
+
     private fun test(
         block: suspend Scenario.() -> Unit,
     ) {
         shadowOf(context.packageManager)
             .setSystemFeature(PackageManager.FEATURE_NFC, true)
+        getNfcAdapter()?.setEnabled(true)
 
         val intent = NfcScanningContract.createIntent(
             context = context,
@@ -63,14 +86,19 @@ internal class NfcScanningActivityTest {
         ActivityScenario.launchActivityForResult<NfcScanningActivity>(intent).use { scenario ->
             scenario.onActivity { activity ->
                 runTest {
+                    val waitForIdle = {
+                        shadowOf(Looper.getMainLooper()).idle()
+                        Espresso.onIdle()
+                        composeRule.waitForIdle()
+                    }
+
                     block(
                         Scenario(
                             activity = activity,
-                            waitForActivityFinish = {
-                                shadowOf(Looper.getMainLooper()).idle()
-                                Espresso.onIdle()
-                                composeRule.waitForIdle()
-                            },
+                            nfcAdapter = getNfcAdapter(),
+                            moveToState = scenario::moveToState,
+                            waitForIdle = waitForIdle,
+                            waitForActivityFinish = waitForIdle,
                             getResult = {
                                 NfcScanningContract.parseResult(
                                     resultCode = scenario.result.resultCode,
@@ -84,8 +112,13 @@ internal class NfcScanningActivityTest {
         }
     }
 
+    private fun getNfcAdapter() = NfcAdapter.getDefaultAdapter(context)?.let { shadowOf(it) }
+
     private class Scenario(
         val activity: NfcScanningActivity,
+        val nfcAdapter: ShadowNfcAdapter?,
+        val moveToState: (Lifecycle.State) -> Unit,
+        val waitForIdle: () -> Unit,
         val waitForActivityFinish: () -> Unit,
         val getResult: () -> NfcScanningContract.Result,
     )


### PR DESCRIPTION
# Summary
Fix NFC scanning lifecycle registration & add NFC permission to `paymentsheet` module.

# Motivation
Ensure NFC scanner is properly registered and is usable.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified