### PR TITLE
Fix translations job wiping all strings when lokalise2 fails to install

### DIFF
--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -26,7 +26,22 @@ fi
 if [[ -z $(which lokalise2) ]]; then
     echo "Installing lokalise2 via homebrew..."
     brew tap lokalise/cli-2
+    # Homebrew now requires third-party taps to be explicitly trusted before
+    # their formulae will load. Without this, `brew install` silently refuses
+    # to install lokalise2 and downloads below produce zero files. If trust
+    # fails, we let the install fail rather than reaching for the (deprecated)
+    # HOMEBREW_NO_REQUIRE_TAP_TRUST escape hatch; the lokalise2 check below
+    # then aborts before any translations are removed.
+    brew trust lokalise/cli-2
     brew install lokalise2
+fi
+
+# Fail loudly if lokalise2 is still unavailable. Otherwise every download below
+# produces nothing, and the "remove existing strings" step wipes all
+# translations, opening a PR that deletes every strings.xml.
+if [[ -z $(which lokalise2) ]]; then
+    echo "ERROR: lokalise2 is not installed; aborting before any strings are removed."
+    exit 1
 fi
 
 if [[ -z $(which recode) ]]; then
@@ -81,6 +96,14 @@ do
           --original-filenames=false \
           --bundle-structure "android/$MODULE/values-%LANG_ISO%/strings.xml" \
           --async
+
+    # Guard: only proceed to the destructive remove/copy below if the download
+    # actually produced strings for this module. An empty download here would
+    # otherwise delete every existing strings.xml and replace it with nothing.
+    if [ -z "$(find android/$MODULE -type f -name strings.xml 2>/dev/null)" ]; then
+        echo "ERROR: no strings downloaded for $MODULE; aborting before removing existing translations."
+        exit 1
+    fi
 
     #There is a command line switch that might be better than this, see: --language-mapping
     if [ "$FETCH_ALL_LANGUAGES" = true ]; then


### PR DESCRIPTION
# Summary

The scheduled **Update translations** job has been opening PRs that delete every `strings.xml` — e.g. #13356 removed 369 files with zero additions.

## Root cause

From the July 6 workflow run log (which misleadingly reported ✅ success):

```
==> Tapping lokalise/cli-2
##[error]Refusing to load formula lokalise/cli-2/lokalise2 from untrusted tap lokalise/cli-2.
./localize.sh: line 57: lokalise2: command not found
cp: android/connect/*: No such file or directory
```

1. Homebrew now requires third-party taps to be **trusted**, so `brew install lokalise2` refused to install the formula from the untrusted `lokalise/cli-2` tap.
2. With `lokalise2` missing, every download produced **zero files**.
3. `localize.sh` has no `set -e`, so it still ran the "remove existing strings" step (deleting existing translations) and then copied nothing in — wiping all strings.
4. The script exited 0, so the job reported success and opened the deletion PR.

(The `--async` flag from #12918 is unrelated — a red herring.)

## Fix

- `brew trust lokalise/cli-2` so the formula actually installs (and fail if trust fails, rather than using the deprecated `HOMEBREW_NO_REQUIRE_TAP_TRUST` escape hatch).
- Abort with a clear error if `lokalise2` is still unavailable, **before any strings are removed**.
- Per-module guard: abort if a module's download produced no `strings.xml`, so an empty download can never wipe existing translations again.

## Follow-ups

- #13356 should be **closed, not merged** — its diff is the all-deletions snapshot.
- Re-run the Fetch Lokalize translations workflow after this merges to land the pending (onelink cleanup) translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
