### PR TITLE
Remove stale link module from translations job and harden empty-download guard

### DIFF
--- a/scripts/localization_vars.sh
+++ b/scripts/localization_vars.sh
@@ -2,7 +2,6 @@
 
 MODULES=(
   "connect"
-  "link"
   "paymentsheet"
   "payments-core"
   "payments-ui-core"

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -101,8 +101,19 @@ do
     # actually produced strings for this module. An empty download here would
     # otherwise delete every existing strings.xml and replace it with nothing.
     if [ -z "$(find android/$MODULE -type f -name strings.xml 2>/dev/null)" ]; then
-        echo "ERROR: no strings downloaded for $MODULE; aborting before removing existing translations."
-        exit 1
+        if [ -d "../$MODULE/res" ]; then
+            # A maintained module with existing translations returned nothing.
+            # Abort rather than wipe them (this is what produced the
+            # all-deletions PRs).
+            echo "ERROR: no strings downloaded for $MODULE but ../$MODULE/res exists; aborting before removing existing translations."
+            exit 1
+        else
+            # No local module to update — e.g. a module that was removed or
+            # merged elsewhere but is still listed here. Nothing to wipe, so
+            # skip it instead of failing the whole job.
+            echo "WARNING: no strings downloaded for $MODULE and no ../$MODULE/res directory; skipping."
+            continue
+        fi
     fi
 
     #There is a command line switch that might be better than this, see: --language-mapping


### PR DESCRIPTION
# Summary

Follow-up to the tap-trust fix (#13358). Testing that fix on a real runner (`workflow_dispatch` run `28817910180`) confirmed it works — lokalise2 now installs (`Trusted tap: lokalise/cli-2`, no more "Refusing to load"/"command not found") and downloads succeed — but it surfaced the **next** blocker.

## Problem

The run failed with:

```
Downloading strings for link/strings.xml
Error: Download failed: No keys for export with current export settings
ERROR: no strings downloaded for link; aborting before removing existing translations.
```

The `link` module was folded into `paymentsheet` in #9771 ("Move link into paymentsheet"), but it was never removed from the localization `MODULES` list. There's no `link/res` directory in the repo and Lokalise returns no keys for `link/strings.xml`. This was silently tolerated before (the old script skipped it, and more recently the whole job was failing on the lokalise2 install anyway); now that the install is fixed, the empty `link` export trips the new guard and aborts the entire job.

## Fix

- Remove the stale `link` entry from `scripts/localization_vars.sh` — its strings live in `paymentsheet` now.
- Harden the guard in `localize.sh`: a module with no local `res/` directory is skipped with a warning (nothing to wipe), while a *maintained* module that unexpectedly returns no strings still aborts before any deletion. This preserves the anti-wipe protection while surviving future module cleanups.

## Verification

- `bash -n` passes on both scripts.
- After merge, a re-run of the workflow is expected to install lokalise2, download all remaining modules, and open a normal additions/modifications translations PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
