### PR TITLE
Fix checkout session Google Pay confirmation by making customer_email authoritative

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -260,7 +260,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         isElements: Boolean = false,
         publishableKey: String? = null,
         displayItems: List<com.stripe.android.GooglePayJsonFactory.DisplayItem> = emptyList(),
-        billingEmailFallback: String? = null,
+        billingEmailOverride: String? = null,
     ) {
         check(skipReadyCheck || isReady) {
             "present() may only be called when Google Pay is available on this device."
@@ -279,7 +279,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
                 isElements = isElements,
                 publishableKey = publishableKey,
                 displayItems = displayItems,
-                billingEmailFallback = billingEmailFallback,
+                billingEmailOverride = billingEmailOverride,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -59,7 +59,7 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val isElements: Boolean = false,
         internal val publishableKey: String? = null,
         internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
-        internal val billingEmailFallback: String? = null,
+        internal val billingEmailOverride: String? = null,
     ) : Parcelable {
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -145,7 +145,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
         val params = PaymentMethodCreateParams.createFromGooglePay(
             googlePayPaymentData = paymentDataJson,
             clientAttributionMetadata = args.clientAttributionMetadata,
-            billingEmailFallback = args.billingEmailFallback,
+            billingEmailOverride = args.billingEmailOverride,
         )
 
         return stripeRepository.createPaymentMethod(params, requestOptions).fold(

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1047,7 +1047,7 @@ constructor(
             return createFromGooglePay(
                 googlePayPaymentData = googlePayPaymentData,
                 clientAttributionMetadata = null,
-                billingEmailFallback = null,
+                billingEmailOverride = null,
             )
         }
 
@@ -1055,7 +1055,7 @@ constructor(
         fun createFromGooglePay(
             googlePayPaymentData: JSONObject,
             clientAttributionMetadata: ClientAttributionMetadata?,
-            billingEmailFallback: String?,
+            billingEmailOverride: String?,
         ): PaymentMethodCreateParams {
             val googlePayResult = GooglePayResult.fromJson(googlePayPaymentData)
             val token = googlePayResult.token
@@ -1069,7 +1069,7 @@ constructor(
                 billingDetails = PaymentMethod.BillingDetails(
                     address = googlePayResult.address,
                     name = googlePayResult.name,
-                    email = googlePayResult.email ?: billingEmailFallback,
+                    email = billingEmailOverride ?: googlePayResult.email,
                     phone = googlePayResult.phoneNumber
                 ),
                 allowRedisplay = null,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -100,12 +100,12 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     @Test
-    fun `createPaymentMethod() uses billingEmailFallback when Google Pay has no email`() = runTest {
+    fun `createPaymentMethod() uses billingEmailOverride when Google Pay has no email`() = runTest {
         val viewModelWithEmail = GooglePayPaymentMethodLauncherViewModel(
             ApplicationProvider.getApplicationContext(),
             paymentsClient,
             REQUEST_OPTIONS,
-            ARGS.copy(billingEmailFallback = "checkout@example.com"),
+            ARGS.copy(billingEmailOverride = "checkout@example.com"),
             stripeRepository,
             googlePayJsonFactory,
             googlePayRepository,
@@ -123,12 +123,12 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     @Test
-    fun `createPaymentMethod() prefers Google Pay email over billingEmailFallback`() = runTest {
+    fun `createPaymentMethod() prefers billingEmailOverride over Google Pay email`() = runTest {
         val viewModelWithEmail = GooglePayPaymentMethodLauncherViewModel(
             ApplicationProvider.getApplicationContext(),
             paymentsClient,
             REQUEST_OPTIONS,
-            ARGS.copy(billingEmailFallback = "checkout@example.com"),
+            ARGS.copy(billingEmailOverride = "checkout@example.com"),
             stripeRepository,
             googlePayJsonFactory,
             googlePayRepository,
@@ -141,6 +141,21 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             )
         )
 
+        // The Checkout Session email must win over whatever Google Pay returned, otherwise the
+        // backend rejects the confirmation with a customer_email mismatch.
+        assertThat(stripeRepository.getCreateParams()?.billingDetails?.email)
+            .isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `createPaymentMethod() uses Google Pay email when no billingEmailOverride`() = runTest {
+        val result = viewModel.createPaymentMethod(
+            PaymentData.fromJson(
+                GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS.toString()
+            )
+        )
+
+        assertThat(result).isInstanceOf(GooglePayPaymentMethodLauncher.Result.Completed::class.java)
         assertThat(stripeRepository.getCreateParams()?.billingDetails?.email)
             .isEqualTo("stripe@example.com")
     }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -54,6 +54,40 @@ class PaymentMethodCreateParamsTest {
     }
 
     @Test
+    fun createFromGooglePay_withBillingEmailOverride_overridesGooglePayEmail() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = "checkout@example.com",
+        )
+
+        // The override must win over Google Pay's own email (Checkout Session requirement).
+        assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun createFromGooglePay_withBillingEmailOverride_usedWhenGooglePayHasNoEmail() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = "checkout@example.com",
+        )
+
+        assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun createFromGooglePay_withNullOverride_keepsGooglePayEmail() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = null,
+        )
+
+        assertThat(params.billingDetails?.email).isEqualTo("stripe@example.com")
+    }
+
+    @Test
     fun createCardParams() {
         assertThat(
             PaymentMethodCreateParamsFixtures.CARD.toParamMap()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -427,6 +427,8 @@ internal class PlaygroundTestDriver(
         Espresso.onIdle()
         composeTestRule.waitForIdle()
 
+        resultCountDownLatch = testParameters.countDownLatch()
+
         selectors.playgroundBuyButton.waitForEnabled()
         selectors.playgroundBuyButton.click()
 
@@ -443,6 +445,13 @@ internal class PlaygroundTestDriver(
 
         Espresso.onIdle()
         composeTestRule.waitForIdle()
+
+        // Confirmation must actually succeed. Without this the test passes even when the backend
+        // rejects the payment (e.g. a customer_email mismatch surfaces as a failure result here).
+        resultCountDownLatch?.let {
+            assertThat(it.await(5, TimeUnit.SECONDS)).isTrue()
+        }
+        assertThat(resultValue).isEqualTo(SUCCESS_RESULT)
 
         teardown()
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
@@ -280,10 +280,12 @@ internal class FlowControllerCheckoutSessionTest {
         )
 
     @Test
-    fun testDefaultBillingEmailTakesPrecedenceOverCheckoutSessionEmail() =
+    fun testCheckoutSessionEmailTakesPrecedenceOverDefaultBillingEmail() =
         runCheckoutSessionEmailPrecedenceTest(
             defaultEmail = "merchant@example.com",
-            expectedEmail = "merchant@example.com",
+            // customer_email is authoritative: the backend rejects confirmation if the payment
+            // method email differs from it, so it must win over a merchant-provided default.
+            expectedEmail = "session@example.com",
         )
 
     private fun runCheckoutSessionEmailPrecedenceTest(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
@@ -64,7 +64,10 @@ private fun mergeCheckoutSessionData(
     return MergedDetails(
         billingDetails = PaymentSheet.BillingDetails(
             address = existingBillingDetails?.address ?: state.billingAddress?.asPaymentSheetAddress(),
-            email = existingBillingDetails?.email ?: response.customerEmail,
+            // The Checkout Session's customer_email is authoritative: the backend rejects
+            // confirmation if the payment method email differs from it. So it must win over a
+            // merchant-provided default email, not merely fall back to it.
+            email = response.customerEmail ?: existingBillingDetails?.email,
             name = existingBillingDetails?.name ?: state.billingName,
             phone = existingBillingDetails?.phone ?: state.billingPhoneNumber,
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -139,7 +139,7 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
                 cardFundingFilter = cardFundingFilter,
                 displayItems = displayItems,
-                billingEmailFallback = configuration.defaultBillingDetails?.email,
+                billingEmailOverride = configuration.defaultBillingDetails?.email,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -8,6 +8,7 @@ import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
@@ -81,11 +82,14 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
     ) {
         val config = confirmationOption.config
         val intent = confirmationArgs.intent
+        val isCheckoutSession = confirmationArgs.paymentMethodMetadata.integrationMetadata is
+            IntegrationMetadata.CheckoutSession
         val googlePayLauncher = createGooglePayLauncher(
             factory = googlePayPaymentMethodLauncherFactory,
             activityLauncher = launcher,
             config = confirmationOption.config,
             confirmationArgs = confirmationArgs,
+            isCheckoutSession = isCheckoutSession,
         )
 
         googlePayLauncher.present(
@@ -100,7 +104,10 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             clientAttributionMetadata = confirmationArgs.paymentMethodMetadata.clientAttributionMetadata,
             isElements = true,
             displayItems = config.displayItems,
-            billingEmailFallback = config.billingEmailFallback,
+            // Checkout Sessions require the payment method email to match the session's
+            // customer_email. Override Google Pay's returned email with it, mirroring
+            // stripe-js's __billingDetailsEmailOverride. Non-checkout flows keep Google Pay's email.
+            billingEmailOverride = config.billingEmailOverride.takeIf { isCheckoutSession },
         )
     }
 
@@ -147,6 +154,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
         activityLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
         config: GooglePayConfirmationOption.Config,
         confirmationArgs: ConfirmationHandler.Args,
+        isCheckoutSession: Boolean,
     ): GooglePayPaymentMethodLauncher {
         return factory.create(
             lifecycleScope = CoroutineScope(Dispatchers.Default),
@@ -158,7 +166,10 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                 merchantCountryCode = config.merchantCountryCode,
                 merchantName = confirmationArgs.paymentMethodMetadata.sellerBusinessName
                     ?: config.merchantName,
-                isEmailRequired = config.billingDetailsCollectionConfiguration.collectsEmail,
+                // In a Checkout Session the email is overridden with the session's customer_email,
+                // so we don't request it from Google Pay (matching stripe-js, which sets
+                // requestPayerEmail=false whenever __billingDetailsEmailOverride is provided).
+                isEmailRequired = !isCheckoutSession && config.billingDetailsCollectionConfiguration.collectsEmail,
                 billingAddressConfig = config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),
                 additionalEnabledNetworks = config.additionalEnabledNetworks
             ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -25,6 +25,6 @@ internal data class GooglePayConfirmationOption(
         val cardFundingFilter: CardFundingFilter,
         val additionalEnabledNetworks: List<String> = emptyList(),
         val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
-        val billingEmailFallback: String? = null,
+        val billingEmailOverride: String? = null,
     ) : Parcelable
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
@@ -22,11 +22,25 @@ class CheckoutConfigurationMergerTest {
     }
 
     @Test
-    fun `embedded - preserves merchant email when already set`() {
+    fun `embedded - checkout session email overrides merchant email when both set`() {
         val config = embeddedConfiguration(
             defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
         )
         val state = state(customerEmail = "checkout@example.com")
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        // customer_email is authoritative; the backend rejects a mismatched PM email, so it must
+        // win over a merchant-provided default rather than fall back to it.
+        assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `embedded - preserves merchant email when checkout session has no customer email`() {
+        val config = embeddedConfiguration(
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
+        )
+        val state = state(customerEmail = null)
 
         val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
 
@@ -263,11 +277,24 @@ class CheckoutConfigurationMergerTest {
     }
 
     @Test
-    fun `paymentSheet - preserves merchant email when already set`() {
+    fun `paymentSheet - checkout session email overrides merchant email when both set`() {
         val config = paymentSheetConfiguration(
             defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
         )
         val state = state(customerEmail = "checkout@example.com")
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        // customer_email is authoritative; it must win over a merchant-provided default.
+        assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `paymentSheet - preserves merchant email when checkout session has no customer email`() {
+        val config = paymentSheetConfiguration(
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
+        )
+        val state = state(customerEmail = null)
 
         val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -397,7 +397,7 @@ class ConfirmationHandlerOptionKtxTest {
 
     @OptIn(CheckoutSessionPreview::class)
     @Test
-    fun `On Google Pay selection, customerEmail from response flows through merger to billingEmailFallback`() {
+    fun `On Google Pay selection, customerEmail from response flows through merger to billingEmailOverride`() {
         val response = CheckoutSessionResponseFactory.create(
             customerEmail = "checkout@example.com",
         )
@@ -426,7 +426,7 @@ class ConfirmationHandlerOptionKtxTest {
         )
 
         assertThat(
-            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.billingEmailFallback
+            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.billingEmailOverride
         ).isEqualTo("checkout@example.com")
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -536,6 +537,99 @@ class GooglePayConfirmationDefinitionTest {
                 clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                 isElements = true,
                 displayItems = displayItems,
+            )
+        }
+    }
+
+    @Test
+    fun `On 'launch' for checkout session, overrides email and does not request it from Google Pay`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                        ),
+                        billingEmailOverride = "checkout@example.com",
+                    ),
+                ),
+                confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                        stripeIntent = PAYMENT_INTENT.copy(currency = "USD"),
+                        integrationMetadata = IntegrationMetadata.CheckoutSession(
+                            id = "cs_123",
+                            instancesKey = "key",
+                        ),
+                    ),
+                ),
+                arguments = EmptyConfirmationLauncherArgs,
+                launcher = launcher,
+            )
+
+            val createGooglePayLauncherCall = createGooglePayPaymentMethodLauncherCalls.awaitItem()
+
+            // Matches stripe-js: don't request the wallet email when we're going to override it.
+            assertThat(createGooglePayLauncherCall.config.isEmailRequired).isFalse()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "USD",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = null,
+                clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
+                isElements = true,
+                displayItems = emptyList(),
+                billingEmailOverride = "checkout@example.com",
+            )
+        }
+    }
+
+    @Test
+    fun `On 'launch' outside checkout session, does not override email even when configured`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                        ),
+                        billingEmailOverride = "checkout@example.com",
+                    ),
+                ),
+                confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                        stripeIntent = PAYMENT_INTENT.copy(currency = "USD"),
+                    ),
+                ),
+                arguments = EmptyConfirmationLauncherArgs,
+                launcher = launcher,
+            )
+
+            val createGooglePayLauncherCall = createGooglePayPaymentMethodLauncherCalls.awaitItem()
+
+            assertThat(createGooglePayLauncherCall.config.isEmailRequired).isTrue()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "USD",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = null,
+                clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
+                isElements = true,
+                displayItems = emptyList(),
+                billingEmailOverride = null,
             )
         }
     }


### PR DESCRIPTION
# Summary
Confirming a payment in a Stripe Checkout Session could fail with a `customer_email` mismatch. The root cause is in `CheckoutConfigurationMerger`: it merged the billing email as `existingBillingDetails?.email ?: customerEmail`, so a merchant-provided default billing email won over the session's `customer_email`. Since the backend requires the payment method email to equal the session's `customer_email`, the merged default produced an invalid PM.

This makes the session's `customer_email` authoritative for the email field, and layers Google Pay handling on top to match stripe-js's Elements-with-Checkout-Sessions behavior.

# Motivation
Reported failure (Google Pay):

```
com.stripe.android.core.exception.APIException: `customer_email` was provided when creating the
Checkout Session, but a different email was provided on confirmation.
```

Verified on-device: session `customer_email = test@example.com`, but the PM went out with the merchant default `email@email.com`. Debug logging confirmed the checkout-session branch was hit correctly (`isCheckoutSession=true`) but the override value itself was the merchant default, because the merger preferred it over `customer_email`.

## Changes
1. **`CheckoutConfigurationMerger` (root cause):** flip email precedence to `customerEmail ?: existingBillingDetails?.email`, so `customer_email` wins when present and falls back to the merchant default only when the session has none. This fixes **all** payment methods in checkout sessions (cards attach the merged email via `attachDefaultsToPaymentMethod`, Google Pay via its override).
2. **`PaymentMethodCreateParams.createFromGooglePay`:** renamed `billingEmailFallback` -> `billingEmailOverride` and flipped precedence to `billingEmailOverride ?: googlePayResult.email` (mirrors stripe-js `__billingDetailsEmailOverride`).
3. **`GooglePayConfirmationDefinition`:** scoped the override and forced `isEmailRequired = false` to the checkout-session flow only (gated on `IntegrationMetadata.CheckoutSession`), so normal Google Pay flows are unchanged.
4. **Test driver:** `confirmGooglePayWithCheckoutSession` now asserts `SUCCESS_RESULT`. Previously it returned to the playground without checking the result, so it passed even when confirmation failed (which is why #13362 looked green).

### Design note
Only the email field is made session-authoritative. The Checkout Session response exposes `customer_email` only (no session-level name/phone), and the backend constraint is email-specific, so name/phone/address intentionally remain merchant-default-first. Please don't symmetrize this.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

- `CheckoutConfigurationMergerTest`: `customer_email` overrides a merchant default when both set; preserves merchant default when the session has no `customer_email` (both PaymentSheet and Embedded).
- `PaymentMethodCreateParamsTest`: override precedence for `createFromGooglePay`.
- `GooglePayConfirmationDefinitionTest`: checkout session applies the override + forces `isEmailRequired=false`; non-checkout applies neither.
- `GooglePayPaymentMethodLauncherViewModelTest`: rewrote the test that encoded the old fallback behavior.
- `ConfirmationHandlerOptionKtxTest`: updated for the rename.
- **On-device:** `TestGooglePay#testCheckoutSessionWithFlowController` now PASSES on a physical tablet (previously failed once the result assertion was added).

### Follow-up
Add a unit test asserting a **card** PM in a checkout session (with a conflicting merchant default email set) attaches `customer_email` to the created params. This is the other half of the merger fix; currently covered end-to-end on-device but not at the unit level.

# Changelog
N/A — Checkout Sessions is a preview feature; this fixes unreleased behavior from #13362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)