### PR TITLE
StripeCryptoOnramp: Faster E2E Test Implementation

### DIFF
--- a/crypto-onramp-example/build.gradle
+++ b/crypto-onramp-example/build.gradle
@@ -57,4 +57,5 @@ dependencies {
     androidTestImplementation testLibs.androidx.coreKtx
     androidTestImplementation testLibs.androidx.testRules
     androidTestImplementation testLibs.androidx.truth
+    androidTestImplementation testLibs.espresso.core
 }

--- a/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
+++ b/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
@@ -186,4 +186,4 @@ class OnrampFlowTest {
 }
 
 private const val EXTRA_SCROLL_DISTANCE = 72f
-private const val EXTRA_SCROLL_DURATION_MILLIS = 100L
+private const val EXTRA_SCROLL_DURATION_MILLIS = 50L

--- a/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
+++ b/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
@@ -9,9 +9,12 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -149,10 +152,38 @@ class OnrampFlowTest {
 
     private fun performClickOnNode(tag: String, timeoutMs: Long = defaultTimeout.inWholeMilliseconds) {
         waitForTag(tag = tag, timeoutMs = timeoutMs)
-        waitForSnackbarToHide()
 
         val node = composeRule.onNodeWithTag(tag)
         runCatching { node.performScrollTo() }
+        scrollContentUp()
+        if (snackbarOverlaps(node)) {
+            waitForSnackbarToHide()
+        }
         node.performClick()
     }
+
+    private fun scrollContentUp() {
+        runCatching {
+            composeRule.onRoot().performTouchInput {
+                val scrollCenterY = centerY
+                swipeUp(
+                    startY = scrollCenterY + EXTRA_SCROLL_DISTANCE,
+                    endY = scrollCenterY - EXTRA_SCROLL_DISTANCE,
+                    durationMillis = EXTRA_SCROLL_DURATION_MILLIS
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun snackbarOverlaps(node: SemanticsNodeInteraction): Boolean {
+        val snackbar = composeRule.onAllNodes(hasTestTag(SNACKBAR_TAG))
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .firstOrNull() ?: return false
+
+        return snackbar.boundsInRoot.overlaps(node.fetchSemanticsNode().boundsInRoot)
+    }
 }
+
+private const val EXTRA_SCROLL_DISTANCE = 72f
+private const val EXTRA_SCROLL_DURATION_MILLIS = 100L


### PR DESCRIPTION
# Summary
Updated the `OnrampFlowTest` implementation to scroll to nodes better to avoid waiting for the snackbar to dismiss. Previously we were waiting so that if the snackbar overlaps a node, we wouldn't fail to find it. Now we:
1. Scroll extra distance to decrease the chance of an overlap.
2. Only wait for it to disappear if we can't find the node (due to an overlap).

# Motivation
Improves test speed for CI / manual runs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img width="994" height="128" alt="Screenshot 2026-07-09 at 1 14 38 PM" src="https://github.com/user-attachments/assets/c6e5072a-0656-476c-8318-410df0efea89" /> |  <img width="995" height="125" alt="Screenshot 2026-07-09 at 1 10 29 PM" src="https://github.com/user-attachments/assets/a39ae9e1-8498-4d34-ac60-a3e9c8ac57a4" /> |
