### PR TITLE
Move paymentMethodCode and hasSavedPaymentMethods to create()

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -19,6 +19,7 @@ import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -161,8 +162,13 @@ internal interface EmbeddedActivityModule {
         @Provides
         @Singleton
         fun provideFormInteractor(
-            interactorFactory: EmbeddedFormInteractorFactory
-        ): VerticalModeFormInteractor = interactorFactory.create()
+            interactorFactory: EmbeddedFormInteractorFactory,
+            paymentMethodCode: PaymentMethodCode,
+            hasSavedPaymentMethods: Boolean,
+        ): VerticalModeFormInteractor = interactorFactory.create(
+            paymentMethodCode = paymentMethodCode,
+            hasSavedPaymentMethods = hasSavedPaymentMethods,
+        )
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -24,8 +24,6 @@ import javax.inject.Inject
 
 internal class EmbeddedFormInteractorFactory @Inject constructor(
     private val paymentMethodMetadata: PaymentMethodMetadata,
-    private val paymentMethodCode: PaymentMethodCode,
-    private val hasSavedPaymentMethods: Boolean,
     private val embeddedSelectionHolder: EmbeddedSelectionHolder,
     private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
     @ViewModelScope private val viewModelScope: CoroutineScope,
@@ -34,7 +32,10 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
     private val eventReporter: EventReporter,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
 ) {
-    fun create(): DefaultVerticalModeFormInteractor {
+    fun create(
+        paymentMethodCode: PaymentMethodCode,
+        hasSavedPaymentMethods: Boolean
+    ): DefaultVerticalModeFormInteractor {
         val formHelper = embeddedFormHelperFactory.create(
             coroutineScope = viewModelScope,
             paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -144,8 +144,6 @@ internal class FormActivityScreenShotTest {
         val eventReporter = FakeEventReporter()
         val interactor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
-            paymentMethodCode = "card",
-            hasSavedPaymentMethods = false,
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
@@ -153,7 +151,10 @@ internal class FormActivityScreenShotTest {
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
-        ).create()
+        ).create(
+            paymentMethodCode = "card",
+            hasSavedPaymentMethods = false,
+        )
 
         stateHolder.updateMandate(usBankMandate)
         stateHolder.updateSavedPaymentSelectionToConfirm(savedPaymentMethodSelectionToConfirm)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -274,8 +274,6 @@ internal class DefaultVerticalModeFormInteractorTest {
         val eventReporter = FakeEventReporter()
         val setAsDefaultInteractor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
-            paymentMethodCode = "card",
-            hasSavedPaymentMethods = hasSavedPaymentMethods,
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
@@ -283,7 +281,10 @@ internal class DefaultVerticalModeFormInteractorTest {
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
-        ).create()
+        ).create(
+            paymentMethodCode = "card",
+            hasSavedPaymentMethods = hasSavedPaymentMethods,
+        )
 
         val formElements = setAsDefaultInteractor.state.value.formUiElements
 
@@ -329,8 +330,6 @@ internal class DefaultVerticalModeFormInteractorTest {
         val eventReporter = FakeEventReporter()
         val setAsDefaultInteractor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
-            paymentMethodCode = selectedPaymentMethodCode,
-            hasSavedPaymentMethods = false,
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
@@ -338,7 +337,10 @@ internal class DefaultVerticalModeFormInteractorTest {
             tapToAddHelper = FakeTapToAddHelper.noOp(),
             eventReporter = eventReporter,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
-        ).create()
+        ).create(
+            paymentMethodCode = selectedPaymentMethodCode,
+            hasSavedPaymentMethods = false,
+        )
         block(setAsDefaultInteractor.state.value.formUiElements)
     }
 


### PR DESCRIPTION
Parameterize EmbeddedFormInteractorFactory.create() with paymentMethodCode and hasSavedPaymentMethods instead of injecting them into the constructor. This lets a single factory instance build form interactors for different payment method codes on demand. Behavior is unchanged: provideFormInteractor now passes the same @BindsInstance values into create().

I'm planning some future refactors to enable us to use this for navigating from a payment options list to the form.
