### PR TITLE
Extract EmbeddedFormScreenFactory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -23,7 +23,6 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
 import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentelement.embedded.manage.DefaultEmbeddedManageScreenInteractorFactory
@@ -32,9 +31,11 @@ import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInt
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.InitialManageScreenFactory
 import com.stripe.android.paymentelement.embedded.manage.ManageSavedPaymentMethodMutatorFactory
+import com.stripe.android.paymentelement.embedded.sheet.DefaultEmbeddedFormScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityConfirmationHelper
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityRegistrar
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedFormScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmationHelper
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
@@ -48,13 +49,11 @@ import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotio
 import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.verticalmode.DefaultSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
-import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import dagger.Binds
-import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -62,6 +61,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Singleton
 
+@Suppress("TooManyFunctions")
 @Module
 internal interface EmbeddedActivityModule {
     @Binds
@@ -73,6 +73,11 @@ internal interface EmbeddedActivityModule {
     fun bindsEmbeddedUpdateScreenInteractorFactory(
         factory: DefaultEmbeddedUpdateScreenInteractorFactory
     ): EmbeddedUpdateScreenInteractorFactory
+
+    @Binds
+    fun bindsEmbeddedFormScreenFactory(
+        factory: DefaultEmbeddedFormScreenFactory
+    ): EmbeddedFormScreenFactory
 
     @Binds
     fun bindsCardAccountRangeRepositoryFactory(
@@ -129,13 +134,14 @@ internal interface EmbeddedActivityModule {
         @Singleton
         fun provideEmbeddedNavigator(
             launchMode: EmbeddedLaunchMode,
-            formScreen: Lazy<EmbeddedNavigator.Screen.Form>,
+            selectedPaymentMethodCode: PaymentMethodCode,
+            formScreenFactory: EmbeddedFormScreenFactory,
             initialManageScreenFactory: InitialManageScreenFactory,
             @ViewModelScope viewModelScope: CoroutineScope,
             eventReporter: EventReporter,
         ): EmbeddedNavigator {
             val initialScreen = when (launchMode) {
-                EmbeddedLaunchMode.Form -> formScreen.get()
+                EmbeddedLaunchMode.Form -> formScreenFactory.createFormScreen(selectedPaymentMethodCode)
                 EmbeddedLaunchMode.Manage -> initialManageScreenFactory.createInitialScreen()
             }
             return EmbeddedNavigator(
@@ -158,17 +164,6 @@ internal interface EmbeddedActivityModule {
         fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
             return LinkAccountHolder(savedStateHandle)
         }
-
-        @Provides
-        @Singleton
-        fun provideFormInteractor(
-            interactorFactory: EmbeddedFormInteractorFactory,
-            paymentMethodCode: PaymentMethodCode,
-            hasSavedPaymentMethods: Boolean,
-        ): VerticalModeFormInteractor = interactorFactory.create(
-            paymentMethodCode = paymentMethodCode,
-            hasSavedPaymentMethods = hasSavedPaymentMethods,
-        )
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedFormScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedFormScreenFactory.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import javax.inject.Inject
+
+internal fun interface EmbeddedFormScreenFactory {
+    fun createFormScreen(code: PaymentMethodCode): EmbeddedNavigator.Screen.Form
+}
+
+internal class DefaultEmbeddedFormScreenFactory @Inject constructor(
+    private val embeddedFormInteractorFactory: EmbeddedFormInteractorFactory,
+    private val eventReporter: EventReporter,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+    private val confirmationHelper: SheetActivityConfirmationHelper,
+    private val embeddedSelectionHolder: EmbeddedSelectionHolder,
+    private val savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
+    private val customerStateHolder: CustomerStateHolder,
+    private val launchMode: EmbeddedLaunchMode,
+) : EmbeddedFormScreenFactory {
+    override fun createFormScreen(code: PaymentMethodCode): EmbeddedNavigator.Screen.Form {
+        val hasSavedPaymentMethods = customerStateHolder.paymentMethods.value.any { it.type?.code == code }
+        val formInteractor = embeddedFormInteractorFactory.create(code, hasSavedPaymentMethods)
+        return EmbeddedNavigator.Screen.Form(
+            formInteractor = formInteractor,
+            eventReporter = eventReporter,
+            sheetActivityStateHolder = sheetActivityStateHolder,
+            confirmationHelper = confirmationHelper,
+            embeddedSelectionHolder = embeddedSelectionHolder,
+            savedPaymentMethodConfirmInteractorFactory = savedPaymentMethodConfirmInteractorFactory,
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.Closeable
-import javax.inject.Inject
 
 internal class EmbeddedNavigator private constructor(
     private val eventReporter: EventReporter,
@@ -158,7 +157,7 @@ internal class EmbeddedNavigator private constructor(
             }
         }
 
-        class Form @Inject constructor(
+        class Form(
             private val formInteractor: VerticalModeFormInteractor,
             private val eventReporter: EventReporter,
             private val sheetActivityStateHolder: SheetActivityStateHolder,


### PR DESCRIPTION
Introduce EmbeddedFormScreenFactory / DefaultEmbeddedFormScreenFactory so the Form screen can be built on demand for a given payment method code, rather than via a Dagger-injected EmbeddedNavigator.Screen.Form singleton.

- Screen.Form loses @Inject; it is now constructed by the factory.
- provideEmbeddedNavigator builds the initial Form screen through the factory using the injected selectedPaymentMethodCode.
- provideFormInteractor is removed; the factory creates the interactor.

Behavior is unchanged for Form and Manage launch modes: the factory derives hasSavedPaymentMethods the same way the launch site previously did (paymentMethods.any { it.type?.code == code }).

I plan to follow this up with a new screen for displaying a list of payment options, and when clicking an item, we'll need to create this form screen with the selected code, not the one that was supplied at construction time (blank string/null).