### PR TITLE
Make checkout session customer_email authoritative for Google Pay

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -260,7 +260,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         isElements: Boolean = false,
         publishableKey: String? = null,
         displayItems: List<com.stripe.android.GooglePayJsonFactory.DisplayItem> = emptyList(),
-        billingEmailFallback: String? = null,
+        billingEmailOverride: String? = null,
     ) {
         check(skipReadyCheck || isReady) {
             "present() may only be called when Google Pay is available on this device."
@@ -279,7 +279,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
                 isElements = isElements,
                 publishableKey = publishableKey,
                 displayItems = displayItems,
-                billingEmailFallback = billingEmailFallback,
+                billingEmailOverride = billingEmailOverride,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -59,7 +59,7 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val isElements: Boolean = false,
         internal val publishableKey: String? = null,
         internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
-        internal val billingEmailFallback: String? = null,
+        internal val billingEmailOverride: String? = null,
     ) : Parcelable {
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -145,7 +145,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
         val params = PaymentMethodCreateParams.createFromGooglePay(
             googlePayPaymentData = paymentDataJson,
             clientAttributionMetadata = args.clientAttributionMetadata,
-            billingEmailFallback = args.billingEmailFallback,
+            billingEmailOverride = args.billingEmailOverride,
         )
 
         return stripeRepository.createPaymentMethod(params, requestOptions).fold(

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1047,7 +1047,7 @@ constructor(
             return createFromGooglePay(
                 googlePayPaymentData = googlePayPaymentData,
                 clientAttributionMetadata = null,
-                billingEmailFallback = null,
+                billingEmailOverride = null,
             )
         }
 
@@ -1055,7 +1055,7 @@ constructor(
         fun createFromGooglePay(
             googlePayPaymentData: JSONObject,
             clientAttributionMetadata: ClientAttributionMetadata?,
-            billingEmailFallback: String?,
+            billingEmailOverride: String?,
         ): PaymentMethodCreateParams {
             val googlePayResult = GooglePayResult.fromJson(googlePayPaymentData)
             val token = googlePayResult.token
@@ -1069,7 +1069,7 @@ constructor(
                 billingDetails = PaymentMethod.BillingDetails(
                     address = googlePayResult.address,
                     name = googlePayResult.name,
-                    email = googlePayResult.email ?: billingEmailFallback,
+                    email = billingEmailOverride ?: googlePayResult.email,
                     phone = googlePayResult.phoneNumber
                 ),
                 allowRedisplay = null,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -100,12 +100,12 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     @Test
-    fun `createPaymentMethod() uses billingEmailFallback when Google Pay has no email`() = runTest {
+    fun `createPaymentMethod() uses billingEmailOverride when Google Pay has no email`() = runTest {
         val viewModelWithEmail = GooglePayPaymentMethodLauncherViewModel(
             ApplicationProvider.getApplicationContext(),
             paymentsClient,
             REQUEST_OPTIONS,
-            ARGS.copy(billingEmailFallback = "checkout@example.com"),
+            ARGS.copy(billingEmailOverride = "checkout@example.com"),
             stripeRepository,
             googlePayJsonFactory,
             googlePayRepository,
@@ -123,12 +123,12 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     @Test
-    fun `createPaymentMethod() prefers Google Pay email over billingEmailFallback`() = runTest {
+    fun `createPaymentMethod() prefers billingEmailOverride over Google Pay email`() = runTest {
         val viewModelWithEmail = GooglePayPaymentMethodLauncherViewModel(
             ApplicationProvider.getApplicationContext(),
             paymentsClient,
             REQUEST_OPTIONS,
-            ARGS.copy(billingEmailFallback = "checkout@example.com"),
+            ARGS.copy(billingEmailOverride = "checkout@example.com"),
             stripeRepository,
             googlePayJsonFactory,
             googlePayRepository,
@@ -141,8 +141,10 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             )
         )
 
+        // The Checkout Session email must win over whatever Google Pay returned, otherwise the
+        // backend rejects the confirmation with a customer_email mismatch.
         assertThat(stripeRepository.getCreateParams()?.billingDetails?.email)
-            .isEqualTo("stripe@example.com")
+            .isEqualTo("checkout@example.com")
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -26,6 +26,40 @@ class PaymentMethodCreateParamsTest {
     }
 
     @Test
+    fun createFromGooglePay_withBillingEmailOverride_overridesGooglePayEmail() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = "checkout@example.com",
+        )
+
+        // The override must win over Google Pay's own email (Checkout Session requirement).
+        assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun createFromGooglePay_withBillingEmailOverride_usedWhenGooglePayHasNoEmail() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = "checkout@example.com",
+        )
+
+        assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun createFromGooglePay_withNullOverride_keepsGooglePayEmail() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = null,
+        )
+
+        assertThat(params.billingDetails?.email).isEqualTo("stripe@example.com")
+    }
+
+    @Test
     fun createFromGooglePay_withFullBillingAddress() {
         assertThat(
             PaymentMethodCreateParams.createFromGooglePay(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -427,6 +427,8 @@ internal class PlaygroundTestDriver(
         Espresso.onIdle()
         composeTestRule.waitForIdle()
 
+        resultCountDownLatch = testParameters.countDownLatch()
+
         selectors.playgroundBuyButton.waitForEnabled()
         selectors.playgroundBuyButton.click()
 
@@ -443,6 +445,13 @@ internal class PlaygroundTestDriver(
 
         Espresso.onIdle()
         composeTestRule.waitForIdle()
+
+        // Confirmation must actually succeed. Without this the test passes even when the backend
+        // rejects the payment (e.g. a customer_email mismatch surfaces as a failure result here).
+        resultCountDownLatch?.let {
+            assertThat(it.await(5, TimeUnit.SECONDS)).isTrue()
+        }
+        assertThat(resultValue).isEqualTo(SUCCESS_RESULT)
 
         teardown()
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
@@ -280,10 +280,12 @@ internal class FlowControllerCheckoutSessionTest {
         )
 
     @Test
-    fun testDefaultBillingEmailTakesPrecedenceOverCheckoutSessionEmail() =
+    fun testCheckoutSessionEmailTakesPrecedenceOverDefaultBillingEmail() =
         runCheckoutSessionEmailPrecedenceTest(
             defaultEmail = "merchant@example.com",
-            expectedEmail = "merchant@example.com",
+            // customer_email is authoritative: the backend rejects confirmation if the payment
+            // method email differs from it, so it must win over a merchant-provided default.
+            expectedEmail = "session@example.com",
         )
 
     private fun runCheckoutSessionEmailPrecedenceTest(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
@@ -64,7 +64,11 @@ private fun mergeCheckoutSessionData(
     return MergedDetails(
         billingDetails = PaymentSheet.BillingDetails(
             address = existingBillingDetails?.address ?: state.billingAddress?.asPaymentSheetAddress(),
-            email = existingBillingDetails?.email ?: response.customerEmail,
+            // The Checkout Session's customer_email is authoritative: the backend rejects
+            // confirmation if the payment method email differs from it. So it must win over a
+            // merchant-provided default email, falling back to the default only when the session
+            // has no customer_email.
+            email = response.customerEmail ?: existingBillingDetails?.email,
             name = existingBillingDetails?.name ?: state.billingName,
             phone = existingBillingDetails?.phone ?: state.billingPhoneNumber,
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -21,6 +21,9 @@ internal fun PaymentSelection.toConfirmationOption(
     cardFundingFilter: CardFundingFilter,
     googlePayDisplayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
     googlePayIsEmailRequired: Boolean = configuration.billingDetailsCollectionConfiguration.collectsEmail,
+    // In a Checkout Session this MUST be supplied via GooglePayBillingEmailOverrideProvider: the
+    // backend rejects confirmation if the Google Pay payment method email differs from the session's
+    // customer_email. The null default is only correct for non-Checkout-Session flows.
     googlePayBillingEmailOverride: String? = null,
 ): ConfirmationHandler.Option? {
     return when (this) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -21,6 +21,7 @@ internal fun PaymentSelection.toConfirmationOption(
     cardFundingFilter: CardFundingFilter,
     googlePayDisplayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
     googlePayIsEmailRequired: Boolean = configuration.billingDetailsCollectionConfiguration.collectsEmail,
+    googlePayBillingEmailOverride: String? = null,
 ): ConfirmationHandler.Option? {
     return when (this) {
         is PaymentSelection.Saved -> toConfirmationOption(linkConfiguration)
@@ -34,6 +35,7 @@ internal fun PaymentSelection.toConfirmationOption(
             cardFundingFilter,
             googlePayDisplayItems,
             isEmailRequired = googlePayIsEmailRequired,
+            billingEmailOverride = googlePayBillingEmailOverride,
         )
         is PaymentSelection.Link -> toConfirmationOption(linkConfiguration)
     }
@@ -127,6 +129,7 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
     cardFundingFilter: CardFundingFilter,
     displayItems: List<GooglePayJsonFactory.DisplayItem>,
     isEmailRequired: Boolean,
+    billingEmailOverride: String?,
 ): GooglePayConfirmationOption? {
     return configuration.googlePay?.let { googlePay ->
         GooglePayConfirmationOption(
@@ -143,7 +146,7 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
                 cardFundingFilter = cardFundingFilter,
                 displayItems = displayItems,
                 isEmailRequired = isEmailRequired,
-                billingEmailFallback = configuration.defaultBillingDetails?.email,
+                billingEmailOverride = billingEmailOverride,
             ),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProvider.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+
+/**
+ * Computes the billing email to force onto the Google Pay payment method, scoped to Checkout
+ * Sessions. The Checkout Session's customer_email (merged into [CommonConfiguration.defaultBillingDetails]
+ * by the checkout configuration merger) is authoritative: the backend rejects confirmation if the
+ * payment method email differs from it, so it must override whatever email Google Pay returns.
+ *
+ * Returns null outside of Checkout Sessions so normal Google Pay flows keep Google Pay's own email.
+ */
+internal object GooglePayBillingEmailOverrideProvider {
+
+    fun get(
+        configuration: CommonConfiguration,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): String? {
+        if (paymentMethodMetadata.integrationMetadata !is IntegrationMetadata.CheckoutSession) {
+            return null
+        }
+
+        return configuration.defaultBillingDetails?.email
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -100,7 +100,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             clientAttributionMetadata = confirmationArgs.paymentMethodMetadata.clientAttributionMetadata,
             isElements = true,
             displayItems = config.displayItems,
-            billingEmailFallback = config.billingEmailFallback,
+            billingEmailOverride = config.billingEmailOverride,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -26,6 +26,6 @@ internal data class GooglePayConfirmationOption(
         val additionalEnabledNetworks: List<String> = emptyList(),
         val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
         val isEmailRequired: Boolean = billingDetailsCollectionConfiguration.collectsEmail,
-        val billingEmailFallback: String? = null,
+        val billingEmailOverride: String? = null,
     ) : Parcelable
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
@@ -58,6 +59,10 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
             linkConfiguration = confirmationState.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = confirmationState.paymentMethodMetadata.cardFundingFilter,
             googlePayDisplayItems = GooglePayDisplayItemsFactory.create(confirmationState.paymentMethodMetadata),
+            googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
+                configuration = confirmationState.configuration.asCommonConfiguration(),
+                paymentMethodMetadata = confirmationState.paymentMethodMetadata,
+            ),
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -71,6 +72,10 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
             linkConfiguration = paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
             googlePayDisplayItems = GooglePayDisplayItemsFactory.create(paymentMethodMetadata),
+            googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
+                configuration = configuration.asCommonConfiguration(),
+                paymentMethodMetadata = paymentMethodMetadata,
+            ),
         ) ?: return null
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -36,6 +36,7 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
@@ -575,6 +576,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                         linkConfiguration = linkHandler.linkConfiguration.value,
                         cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
                         googlePayDisplayItems = GooglePayDisplayItemsFactory.create(paymentMethodMetadata),
+                        googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
+                            configuration = config.asCommonConfiguration(),
+                            paymentMethodMetadata = paymentMethodMetadata,
+                        ),
                     )
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -584,6 +585,10 @@ internal class DefaultFlowController @Inject internal constructor(
                 linkConfiguration = state.linkConfiguration,
                 cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
                 googlePayDisplayItems = GooglePayDisplayItemsFactory.create(state.paymentMethodMetadata),
+                googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
+                    configuration = state.config,
+                    paymentMethodMetadata = state.paymentMethodMetadata,
+                ),
             )
 
             confirmationOption?.let { option ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -47,10 +47,10 @@ import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayIsEmailRequiredProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
@@ -329,6 +330,10 @@ internal class DefaultWalletButtonsInteractor constructor(
             cardFundingFilter = arguments.paymentMethodMetadata.cardFundingFilter,
             googlePayDisplayItems = GooglePayDisplayItemsFactory.create(arguments.paymentMethodMetadata),
             googlePayIsEmailRequired = GooglePayIsEmailRequiredProvider.get(
+                configuration = arguments.configuration,
+                paymentMethodMetadata = arguments.paymentMethodMetadata,
+            ),
+            googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = arguments.configuration,
                 paymentMethodMetadata = arguments.paymentMethodMetadata,
             ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -28,8 +28,8 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayIsEmailRequiredProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
@@ -22,11 +22,25 @@ class CheckoutConfigurationMergerTest {
     }
 
     @Test
-    fun `embedded - preserves merchant email when already set`() {
+    fun `embedded - checkout session email overrides merchant email when both set`() {
         val config = embeddedConfiguration(
             defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
         )
         val state = state(customerEmail = "checkout@example.com")
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        // customer_email is authoritative; the backend rejects a mismatched PM email, so it must
+        // win over a merchant-provided default rather than fall back to it.
+        assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `embedded - preserves merchant email when checkout session has no customer email`() {
+        val config = embeddedConfiguration(
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
+        )
+        val state = state(customerEmail = null)
 
         val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
 
@@ -263,11 +277,24 @@ class CheckoutConfigurationMergerTest {
     }
 
     @Test
-    fun `paymentSheet - preserves merchant email when already set`() {
+    fun `paymentSheet - checkout session email overrides merchant email when both set`() {
         val config = paymentSheetConfiguration(
             defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
         )
         val state = state(customerEmail = "checkout@example.com")
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        // customer_email is authoritative; it must win over a merchant-provided default.
+        assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `paymentSheet - preserves merchant email when checkout session has no customer email`() {
+        val config = paymentSheetConfiguration(
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
+        )
+        val state = state(customerEmail = null)
 
         val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -3,9 +3,6 @@ package com.stripe.android.paymentelement.confirmation
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.checkout.Checkout
-import com.stripe.android.checkout.CheckoutConfigurationMerger
-import com.stripe.android.checkout.InternalState
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
@@ -27,7 +24,6 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
 import com.stripe.android.paymentelement.confirmation.cpms.CustomPaymentMethodConfirmationOption
@@ -40,7 +36,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.BankFormScreenStateFactory
@@ -395,39 +390,52 @@ class ConfirmationHandlerOptionKtxTest {
         ).isEmpty()
     }
 
-    @OptIn(CheckoutSessionPreview::class)
     @Test
-    fun `On Google Pay selection, customerEmail from response flows through merger to billingEmailFallback`() {
-        val response = CheckoutSessionResponseFactory.create(
-            customerEmail = "checkout@example.com",
-        )
-        val state = InternalState(
-            key = "test",
-            configuration = Checkout.Configuration().build(),
-            checkoutSessionResponse = response,
-            flagImages = null,
-        )
-        val mergedConfig = CheckoutConfigurationMerger.EmbeddedConfiguration(
-            EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").apply {
-                googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
-                        countryCode = "US",
-                        currencyCode = "USD",
-                    )
+    fun `On Google Pay selection, googlePayBillingEmailOverride flows through to the config`() {
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").apply {
+            googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
+                    countryCode = "US",
+                    currencyCode = "USD",
                 )
-            }.build()
-        ).forCheckoutSession(state).asCommonConfiguration()
+            )
+        }.build().asCommonConfiguration()
 
         val confirmationOption = PaymentSelection.GooglePay.toConfirmationOption(
-            configuration = mergedConfig,
+            configuration = configuration,
+            linkConfiguration = null,
+            cardFundingFilter = DefaultCardFundingFilter,
+            googlePayBillingEmailOverride = "checkout@example.com",
+        )
+
+        assertThat(
+            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.billingEmailOverride
+        ).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `On Google Pay selection, billingEmailOverride is null when none is provided`() {
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").apply {
+            defaultBillingDetails(PaymentSheet.BillingDetails(email = "merchant@example.com"))
+            googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
+                    countryCode = "US",
+                    currencyCode = "USD",
+                )
+            )
+        }.build().asCommonConfiguration()
+
+        val confirmationOption = PaymentSelection.GooglePay.toConfirmationOption(
+            configuration = configuration,
             linkConfiguration = null,
             cardFundingFilter = DefaultCardFundingFilter,
         )
 
         assertThat(
-            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.billingEmailFallback
-        ).isEqualTo("checkout@example.com")
+            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.billingEmailOverride
+        ).isNull()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProviderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProviderTest.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.CommonConfigurationFactory
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Test
+
+class GooglePayBillingEmailOverrideProviderTest {
+
+    @Test
+    fun `returns checkout session email when integration is a checkout session`() {
+        val result = billingEmailOverride(
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "checkout@example.com"),
+            integrationMetadata = checkoutSessionMetadata(),
+        )
+
+        assertThat(result).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `returns null when checkout session has no email`() {
+        val result = billingEmailOverride(
+            defaultBillingDetails = PaymentSheet.BillingDetails(),
+            integrationMetadata = checkoutSessionMetadata(),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null outside of a checkout session even when a default email is present`() {
+        val result = billingEmailOverride(
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "merchant@example.com"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_1234"),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    private fun billingEmailOverride(
+        defaultBillingDetails: PaymentSheet.BillingDetails? = null,
+        integrationMetadata: IntegrationMetadata,
+    ): String? {
+        return GooglePayBillingEmailOverrideProvider.get(
+            configuration = CommonConfigurationFactory.create(
+                defaultBillingDetails = defaultBillingDetails,
+            ),
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                integrationMetadata = integrationMetadata,
+            ),
+        )
+    }
+
+    private fun checkoutSessionMetadata(): IntegrationMetadata.CheckoutSession {
+        return IntegrationMetadata.CheckoutSession(
+            id = "cs_test_123",
+            instancesKey = "checkout_instances_123",
+        )
+    }
+}


### PR DESCRIPTION
go/o/req_okIbxf1vrqEN1w

# Summary
In a Stripe Checkout Session, the payment method's billing email is now the session's `customer_email` (authoritative), rather than a merchant-provided default. Google Pay's returned email is overridden with the session email, scoped to checkout sessions only.

Builds on #13363 and supersedes #13372 (which accumulated a lot of exploratory history; this is the clean, minimal version incorporating the review feedback there and the alignment reached with @amk-stripe in Slack).

# Motivation
Confirming a payment in a Checkout Session could fail with:

```
`customer_email` was provided when creating the Checkout Session, but a different email was provided on confirmation.
```

Root cause: `CheckoutConfigurationMerger` merged the billing email as `existingBillingDetails?.email ?: customerEmail`, so a merchant-provided default email won over the session's `customer_email`. The backend requires the PM email to equal `customer_email`, so the merged default produced an invalid PM. This surfaced on Google Pay (the merchant/playground default `email@example.com` reached the PM), but the same applies to cards via `attachDefaultsToPaymentMethod`.

Verified on-device that the merged default was the source: `billingEmailOverride=email@email.com` while the session's `customer_email` was `test@example.com`.

## Changes
1. **`CheckoutConfigurationMerger`**: flip email precedence to `customerEmail ?: existingBillingDetails?.email` — `customer_email` is authoritative, falling back to the merchant default only when the session has no `customer_email`. This mirrors stripe-js EwCS (which seeds the Payment Element's default email from `customer_email`). iOS's `applyAddressOverrides` is being aligned separately by @porter.
2. **`createFromGooglePay`**: rename `billingEmailFallback` → `billingEmailOverride` and flip precedence to `billingEmailOverride ?: googlePayResult.email`, so the session email wins over Google Pay's returned email.
3. **`GooglePayBillingEmailOverrideProvider`** (new): computes the override scoped to `IntegrationMetadata.CheckoutSession`, threaded through the confirmation-option callers alongside the existing `GooglePayIsEmailRequiredProvider`. Non-checkout Google Pay flows are unaffected. This resolves @amk-stripe's review note on #13372: the logic lives at config creation (via a provider), not in the confirmation definition.

### Why not touch `isEmailRequired`
With override precedence, correctness no longer depends on suppressing Google Pay email collection (the override discards any Google Pay email anyway), so `GooglePayIsEmailRequiredProvider` is left as-is.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

- `CheckoutConfigurationMergerTest`: `customer_email` overrides a merchant default when both set; preserves the merchant default when the session has no `customer_email` (PaymentSheet + Embedded).
- `PaymentMethodCreateParamsTest`: override precedence for `createFromGooglePay`.
- `GooglePayBillingEmailOverrideProviderTest` (new): CS returns the session email; non-CS returns null; CS-without-email returns null.
- `ConfirmationHandlerOptionKtxTest`: the override param flows to the config; null when not provided.
- `GooglePayPaymentMethodLauncherViewModelTest`: override wins over Google Pay email; used when Google Pay has none.
- **Instrumentation**: `FlowControllerCheckoutSessionTest#testCheckoutSessionEmailTakesPrecedenceOverDefaultBillingEmail` (renamed from the old `testDefaultBillingEmail...` which asserted the pre-flip behavior) — verified passing on the emulator.
- **Test-quality fix**: `confirmGooglePayWithCheckoutSession` now asserts `SUCCESS_RESULT`; it previously returned without checking the confirmation result, so it passed even when confirmation failed.

# Changelog
N/A — Checkout Sessions is a preview feature; this fixes unreleased behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)