### PR TITLE
Remove repetitive inline comments from #13387

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -141,8 +141,6 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             )
         )
 
-        // The Checkout Session email must win over whatever Google Pay returned, otherwise the
-        // backend rejects the confirmation with a customer_email mismatch.
         assertThat(stripeRepository.getCreateParams()?.billingDetails?.email)
             .isEqualTo("checkout@example.com")
     }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -33,7 +33,6 @@ class PaymentMethodCreateParamsTest {
             billingEmailOverride = "checkout@example.com",
         )
 
-        // The override must win over Google Pay's own email (Checkout Session requirement).
         assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -446,8 +446,6 @@ internal class PlaygroundTestDriver(
         Espresso.onIdle()
         composeTestRule.waitForIdle()
 
-        // Confirmation must actually succeed. Without this the test passes even when the backend
-        // rejects the payment (e.g. a customer_email mismatch surfaces as a failure result here).
         resultCountDownLatch?.let {
             assertThat(it.await(5, TimeUnit.SECONDS)).isTrue()
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerCheckoutSessionTest.kt
@@ -283,8 +283,6 @@ internal class FlowControllerCheckoutSessionTest {
     fun testCheckoutSessionEmailTakesPrecedenceOverDefaultBillingEmail() =
         runCheckoutSessionEmailPrecedenceTest(
             defaultEmail = "merchant@example.com",
-            // customer_email is authoritative: the backend rejects confirmation if the payment
-            // method email differs from it, so it must win over a merchant-provided default.
             expectedEmail = "session@example.com",
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
@@ -64,10 +64,7 @@ private fun mergeCheckoutSessionData(
     return MergedDetails(
         billingDetails = PaymentSheet.BillingDetails(
             address = existingBillingDetails?.address ?: state.billingAddress?.asPaymentSheetAddress(),
-            // The Checkout Session's customer_email is authoritative: the backend rejects
-            // confirmation if the payment method email differs from it. So it must win over a
-            // merchant-provided default email, falling back to the default only when the session
-            // has no customer_email.
+            // customer_email is authoritative; fall back to the merchant default only when absent.
             email = response.customerEmail ?: existingBillingDetails?.email,
             name = existingBillingDetails?.name ?: state.billingName,
             phone = existingBillingDetails?.phone ?: state.billingPhoneNumber,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -21,9 +21,6 @@ internal fun PaymentSelection.toConfirmationOption(
     cardFundingFilter: CardFundingFilter,
     googlePayDisplayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
     googlePayIsEmailRequired: Boolean = configuration.billingDetailsCollectionConfiguration.collectsEmail,
-    // In a Checkout Session this MUST be supplied via GooglePayBillingEmailOverrideProvider: the
-    // backend rejects confirmation if the Google Pay payment method email differs from the session's
-    // customer_email. The null default is only correct for non-Checkout-Session flows.
     googlePayBillingEmailOverride: String? = null,
 ): ConfirmationHandler.Option? {
     return when (this) {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
@@ -30,8 +30,6 @@ class CheckoutConfigurationMergerTest {
 
         val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
 
-        // customer_email is authoritative; the backend rejects a mismatched PM email, so it must
-        // win over a merchant-provided default rather than fall back to it.
         assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
     }
 
@@ -285,7 +283,6 @@ class CheckoutConfigurationMergerTest {
 
         val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
 
-        // customer_email is authoritative; it must win over a merchant-provided default.
         assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
     }
 


### PR DESCRIPTION
# Summary
Follow-up to #13387 addressing @amk-stripe's review feedback: remove the AI-added inline comments that duplicated the same explanation across production code and tests. Those comments risk going stale, add maintenance burden, and the content was repeated in many places.

# Changes
- **`ConfirmationOptionKtx.kt`**: removed the `googlePayBillingEmailOverride` comment. This is already documented in `GooglePayBillingEmailOverrideProvider`, and documenting it at the call site is confusing since other callers could set the value differently.
- **`CheckoutConfigurationMerger.kt`**: collapsed the 4-line comment into a single concise line.
- **Tests** (`GooglePayPaymentMethodLauncherViewModelTest`, `PaymentMethodCreateParamsTest`, `PlaygroundTestDriver`, `FlowControllerCheckoutSessionTest`, `CheckoutConfigurationMergerTest`): removed the repeated explanatory comments.

The KDoc on `GooglePayBillingEmailOverrideProvider` remains the single source of truth for why `customer_email` is authoritative.

No code logic changed (comments only).

# Changelog
N/A — comment cleanup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)