### PR TITLE
Add initial analytic events for NFC scanning

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAction.kt
@@ -3,10 +3,13 @@ package com.stripe.android.common.nfcscan
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
 import com.stripe.android.common.taptoadd.TapToButtonUI
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.ui.core.elements.CardDetailsAction
 import com.stripe.android.ui.core.elements.ScannedCardDetails
 
-internal class NfcScanningAction(private val merchantName: String) : CardDetailsAction {
+internal class NfcScanningAction(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+) : CardDetailsAction {
     @Composable
     override fun Content(
         enabled: Boolean,
@@ -25,7 +28,7 @@ internal class NfcScanningAction(private val merchantName: String) : CardDetails
         }
 
         TapToButtonUI(enabled = enabled) {
-            launcher.launch(NfcScanningContract.Args(merchantName))
+            launcher.launch(NfcScanningContract.Args(paymentMethodMetadata))
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
@@ -17,12 +17,23 @@ import kotlinx.coroutines.launch
 import android.graphics.Color as AndroidColor
 
 internal class NfcScanningActivity : AppCompatActivity() {
+    private lateinit var args: NfcScanningContract.Args
+
     private val viewModel by viewModels<NfcScanningViewModel> {
-        NfcScanningViewModel.factory()
+        NfcScanningViewModel.factory { args }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        args = runCatching {
+            requireNotNull(NfcScanningContract.Args.fromIntent(intent)) {
+                "NfcScanningActivity was started without arguments."
+            }
+        }.getOrElse {
+            finishWithResult(NfcScanningContract.Result.Canceled)
+            return
+        }
 
         lifecycleScope.launch {
             viewModel.result.collectLatest { result ->

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningContract.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -17,7 +18,7 @@ internal object NfcScanningContract : ActivityResultContract<NfcScanningContract
 
     @Parcelize
     data class Args(
-        val merchantName: String,
+        val paymentMethodMetadata: PaymentMethodMetadata,
     ) : Parcelable {
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.stripe.android.common.nfcscan.analytics.NfcScanningEventReporter
 import com.stripe.android.common.nfcscan.scanner.NfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.ScannedCardData
 import com.stripe.android.common.nfcscan.tapzone.TapZoneResolver
@@ -26,6 +27,7 @@ internal class NfcScanningViewModel @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     tapZoneResolver: TapZoneResolver,
     private val cardScanner: NfcCardScanner,
+    private val eventReporter: NfcScanningEventReporter,
 ) : ViewModel() {
     private val tapZone = tapZoneResolver.get()
 
@@ -44,6 +46,8 @@ internal class NfcScanningViewModel @Inject constructor(
     private var successShownDispatched = false
 
     init {
+        eventReporter.onNfcScanStarted()
+
         viewModelScope.launch {
             cardScanner.state.collectLatest { state ->
                 when (state) {
@@ -54,8 +58,12 @@ internal class NfcScanningViewModel @Inject constructor(
                                 status = NfcScanningStatus.Scanning,
                             )
                         )
+
+                        eventReporter.onNfcScanAttemptStarted()
                     }
-                    is NfcCardScanner.State.Failed -> Unit
+                    is NfcCardScanner.State.Failed -> {
+                        eventReporter.onNfcScanAttemptFailed()
+                    }
                     is NfcCardScanner.State.Complete -> {
                         _viewState.emit(
                             NfcScanningViewState(
@@ -63,6 +71,8 @@ internal class NfcScanningViewModel @Inject constructor(
                                 status = NfcScanningStatus.Scanned,
                             )
                         )
+
+                        eventReporter.onNfcScanAttemptSucceeded()
 
                         pendingValidCardData = state.cardData
                     }
@@ -79,6 +89,7 @@ internal class NfcScanningViewModel @Inject constructor(
         when (viewAction) {
             is NfcScanningViewAction.Close -> {
                 viewModelScope.launch {
+                    eventReporter.onNfcScanCancelled()
                     _result.emit(NfcScanningContract.Result.Canceled)
                 }
             }
@@ -87,6 +98,7 @@ internal class NfcScanningViewModel @Inject constructor(
                     return
                 }
                 successShownDispatched = true
+                eventReporter.onNfcScanSucceeded()
                 viewModelScope.launch {
                     pendingValidCardData?.let { cardData ->
                         _result.emit(
@@ -108,11 +120,16 @@ internal class NfcScanningViewModel @Inject constructor(
     }
 
     companion object {
-        fun factory(): ViewModelProvider.Factory {
+        fun factory(argsSupplier: () -> NfcScanningContract.Args): ViewModelProvider.Factory {
             return viewModelFactory {
                 initializer<NfcScanningViewModel> {
+                    val args = argsSupplier()
+
                     DaggerNfcScanningViewModelComponent.factory()
-                        .create(requireApplication())
+                        .create(
+                            application = requireApplication(),
+                            paymentMethodMetadata = args.paymentMethodMetadata,
+                        )
                         .viewModel
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.common.nfcscan
 
 import android.app.Application
+import android.content.Context
+import com.stripe.android.common.nfcscan.analytics.NfcScanningEventReporterModule
 import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegateModule
 import com.stripe.android.common.nfcscan.scanner.NfcCardScannerModule
 import com.stripe.android.common.nfcscan.tapzone.TapZoneModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
@@ -23,6 +26,7 @@ internal interface NfcScanningViewModelComponent {
     interface Factory {
         fun create(
             @BindsInstance application: Application,
+            @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
         ): NfcScanningViewModelComponent
     }
 }
@@ -32,6 +36,7 @@ internal interface NfcScanningViewModelComponent {
         CoroutineContextModule::class,
         NfcHardwareDelegateModule::class,
         NfcCardScannerModule::class,
+        NfcScanningEventReporterModule::class,
         TapZoneModule::class,
     ]
 )
@@ -41,4 +46,7 @@ internal object NfcScanningViewModelModule {
     fun provideViewModelScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.Main)
     }
+
+    @Provides
+    fun providesContext(application: Application): Context = application.applicationContext
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/EventPrefix.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/EventPrefix.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import javax.inject.Qualifier
+
+@Qualifier
+internal annotation class EventPrefix

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
@@ -1,0 +1,101 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.core.utils.mapOfDurationInSeconds
+import javax.inject.Inject
+
+internal interface NfcScanningEventReporter {
+    /**
+     * NFC scan flow has been started.
+     */
+    fun onNfcScanStarted()
+
+    /**
+     * User attempts to scan their card using NFC.
+     */
+    fun onNfcScanAttemptStarted()
+
+    /**
+     * User attempt to scan their card with NFC succeeded.
+     */
+    fun onNfcScanAttemptSucceeded()
+
+    /**
+     * User attempt to scan their card with NFC failed.
+     */
+    fun onNfcScanAttemptFailed()
+
+    /**
+     * NFC scan flow completed successfully.
+     */
+    fun onNfcScanSucceeded()
+
+    /**
+     * NFC scan was canceled by the user.
+     */
+    fun onNfcScanCancelled()
+}
+
+internal class DefaultNfcScanningEventReporter @Inject constructor(
+    private val durationProvider: DurationProvider,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequestFactory,
+    @EventPrefix private val eventPrefix: String,
+) : NfcScanningEventReporter {
+    override fun onNfcScanStarted() {
+        durationProvider.start(DurationProvider.Key.NfcScan)
+        fireEvent(eventName = SCAN_STARTED_EVENT_NAME)
+    }
+
+    override fun onNfcScanSucceeded() {
+        val duration = durationProvider.end(DurationProvider.Key.NfcScan)
+        fireEvent(eventName = SCAN_SUCCESS_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
+    }
+
+    override fun onNfcScanAttemptStarted() {
+        durationProvider.start(DurationProvider.Key.NfcScanAttempt)
+        fireEvent(eventName = SCAN_ATTEMPT_STARTED_EVENT_NAME)
+    }
+
+    override fun onNfcScanAttemptSucceeded() {
+        val duration = durationProvider.end(DurationProvider.Key.NfcScanAttempt)
+        fireEvent(eventName = SCAN_ATTEMPT_SUCCEEDED_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
+    }
+
+    override fun onNfcScanAttemptFailed() {
+        val duration = durationProvider.end(DurationProvider.Key.NfcScanAttempt)
+        fireEvent(eventName = SCAN_ATTEMPT_FAILED_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
+    }
+
+    override fun onNfcScanCancelled() {
+        durationProvider.end(DurationProvider.Key.NfcScan)
+        fireEvent(eventName = SCAN_CANCELED_EVENT_NAME)
+    }
+
+    private fun fireEvent(
+        eventName: String,
+        additionalParams: Map<String, Any> = emptyMap()
+    ) {
+        analyticsRequestExecutor.executeAsync(
+            analyticsRequestFactory.createRequest(
+                event = object : AnalyticsEvent {
+                    override val eventName: String
+                        get() = eventPrefix + eventName
+                },
+                additionalParams = additionalParams,
+            )
+        )
+    }
+
+    private companion object {
+        const val SCAN_STARTED_EVENT_NAME = "nfc_scan_started"
+        const val SCAN_SUCCESS_EVENT_NAME = "nfc_scan_success"
+        const val SCAN_CANCELED_EVENT_NAME = "nfc_scan_canceled"
+        const val SCAN_ATTEMPT_STARTED_EVENT_NAME = "nfc_scan_attempt_started"
+        const val SCAN_ATTEMPT_SUCCEEDED_EVENT_NAME = "nfc_scan_attempt_succeeded"
+        const val SCAN_ATTEMPT_FAILED_EVENT_NAME = "nfc_scan_attempt_failed"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.core.utils.DefaultDurationProvider
+import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.BuildConfig
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+
+@Module
+internal interface NfcScanningEventReporterModule {
+    @Binds
+    fun bindsNfcScanningEventReporter(
+        reporter: DefaultNfcScanningEventReporter,
+    ): NfcScanningEventReporter
+
+    @Binds
+    fun bindsAnalyticsRequestFactory(
+        factory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
+
+    @Binds
+    fun bindsAnalyticsRequestExecutor(
+        executor: DefaultAnalyticsRequestExecutor
+    ): AnalyticsRequestExecutor
+
+    companion object {
+        @EventPrefix
+        @Provides
+        fun providesEventPrefix(paymentMethodMetadata: PaymentMethodMetadata): String {
+            return when (paymentMethodMetadata.integrationMetadata) {
+                is IntegrationMetadata.CustomerSheet -> "cs_"
+                else -> "mc_"
+            }
+        }
+
+        @Provides
+        @Named(PUBLISHABLE_KEY)
+        fun providePublishableKey(context: Context): () -> String = {
+            PaymentConfiguration.getInstance(context).publishableKey
+        }
+
+        @Provides
+        fun provideDurationProvider(): DurationProvider {
+            return DefaultDurationProvider.instance
+        }
+
+        @Provides
+        @Named(ENABLE_LOGGING)
+        fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+
+        @Provides
+        @Named(PRODUCT_USAGE)
+        fun providesProductUsage(): Set<String> = emptySet()
+
+        @Provides
+        fun provideLogger(@Named(ENABLE_LOGGING) enabled: Boolean) =
+            Logger.getInstance(enabled)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -212,7 +212,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 paymentMethodMetadata = metadata,
             )
         } else if (metadata.isNfcScanningEnabled) {
-            NfcScanningAction(merchantName = metadata.merchantName)
+            NfcScanningAction(paymentMethodMetadata = metadata)
         } else {
             CardScanAction(
                 isStripeCardScanAllowed = metadata.isStripeCardScanAllowed,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -126,6 +126,8 @@ internal class DefaultEventReporter @Inject internal constructor(
                     // We don't send load timings for these.
                     DurationProvider.Key.Loading,
                     DurationProvider.Key.Checkout,
+                    DurationProvider.Key.NfcScan,
+                    DurationProvider.Key.NfcScanAttempt,
                     DurationProvider.Key.LinkSignup,
                     DurationProvider.Key.ConfirmButtonClicked,
                     DurationProvider.Key.TapToAdd,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActionTest.kt
@@ -16,6 +16,9 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.TAP_TO_BUTTON_UI_TEST_TAG
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.ScannedCardDetails
 import kotlinx.coroutines.test.runTest
@@ -37,7 +40,6 @@ internal class NfcScanningActionTest {
 
     @Test
     fun `when disabled clicking does not launch contract or invoke callback`() = activityResultTest(
-        merchantName = "Cafe Stripe",
         enabled = false,
     ) {
         onLaunchCalls.expectNoEvents()
@@ -46,16 +48,14 @@ internal class NfcScanningActionTest {
 
     @Test
     fun `when enabled click completes forwards scanned card details`() = activityResultTest(
-        merchantName = "River Books",
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFactory.create(),
+        ),
     ) {
         val launch = onLaunchCalls.awaitItem()
 
         assertThat(launch.contract).isEqualTo(NfcScanningContract)
-        assertThat(launch.input).isEqualTo(
-            NfcScanningContract.Args(
-                merchantName = "River Books"
-            )
-        )
+        assertThat(launch.input).isEqualTo(NfcScanningContract.Args(paymentMethodMetadata))
 
         val intent = Intent().apply {
             putExtras(
@@ -96,7 +96,7 @@ internal class NfcScanningActionTest {
     }
 
     private fun activityResultTest(
-        merchantName: String = "Cafe Stripe",
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         enabled: Boolean = true,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
@@ -111,7 +111,7 @@ internal class NfcScanningActionTest {
 
         composeTestRule.setContent {
             CompositionLocalProvider(LocalActivityResultRegistryOwner provides owner) {
-                NfcScanningAction(merchantName = merchantName).Content(
+                NfcScanningAction(paymentMethodMetadata).Content(
                     enabled = enabled,
                     onScannedCard = { details ->
                         onScannedCardCalls.add(OnScannedCall(details))
@@ -126,6 +126,7 @@ internal class NfcScanningActionTest {
 
         block(
             Scenario(
+                paymentMethodMetadata = paymentMethodMetadata,
                 onLaunchCalls = onLaunchCalls,
                 onScannedCalls = onScannedCardCalls,
                 resultDispatcher = registry::dispatchResult,
@@ -137,6 +138,7 @@ internal class NfcScanningActionTest {
     }
 
     private class Scenario(
+        val paymentMethodMetadata: PaymentMethodMetadata,
         val onLaunchCalls: ReceiveTurbine<FakeActivityResultRegistry.OnLaunchCall<*, *>>,
         val onScannedCalls: ReceiveTurbine<OnScannedCall>,
         val resultDispatcher: (requestCode: Int, resultCode: Int, data: Intent?) -> Unit,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.nfcscan
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.nfc.NfcAdapter
 import android.os.Build
@@ -13,6 +14,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -60,6 +62,23 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
+    fun `activity returns canceled result when started without arguments`() {
+        val intent = Intent(context, NfcScanningActivity::class.java)
+
+        ActivityScenario.launchActivityForResult<NfcScanningActivity>(intent).use { scenario ->
+            shadowOf(Looper.getMainLooper()).idle()
+            Espresso.onIdle()
+
+            val result = NfcScanningContract.parseResult(
+                resultCode = scenario.result.resultCode,
+                intent = scenario.result.resultData,
+            )
+
+            assertThat(result).isEqualTo(NfcScanningContract.Result.Canceled)
+        }
+    }
+
+    @Test
     fun `onResume re-registers NFC card scanner when returning from background`() = test {
         waitForIdle()
         assertThat(nfcAdapter?.isInReaderMode).isTrue()
@@ -80,7 +99,9 @@ internal class NfcScanningActivityTest {
 
         val intent = NfcScanningContract.createIntent(
             context = context,
-            input = NfcScanningContract.Args(merchantName = "River Market"),
+            input = NfcScanningContract.Args(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            ),
         )
 
         ActivityScenario.launchActivityForResult<NfcScanningActivity>(intent).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningContractTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -15,14 +16,15 @@ internal class NfcScanningContractTest {
 
     @Test
     fun `createIntent attaches Args so merchant name can be read back`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val intent = NfcScanningContract.createIntent(
             context = context,
-            input = NfcScanningContract.Args(merchantName = "River Market")
+            input = NfcScanningContract.Args(paymentMethodMetadata)
         )
 
         val argsFromIntent = NfcScanningContract.Args.fromIntent(intent)
 
-        assertThat(argsFromIntent?.merchantName).isEqualTo("River Market")
+        assertThat(argsFromIntent?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelStore
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.analytics.FakeNfcScanningEventReporter
 import com.stripe.android.common.nfcscan.scanner.FakeNfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.NfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.ScannedCardData
@@ -46,6 +47,14 @@ internal class NfcScanningViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(NfcScanningContract.Result.Canceled)
         }
+
+        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `card scanner failed reports attempt failed`() = runScenario {
+        scannerState.emit(NfcCardScanner.State.Failed(RuntimeException("test")))
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -64,6 +73,8 @@ internal class NfcScanningViewModelTest {
             scannerState.emit(NfcCardScanner.State.Scanning)
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Scanning)
         }
+
+        assertThat(fakeEventReporter.onNfcScanAttemptStartedCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -83,6 +94,8 @@ internal class NfcScanningViewModelTest {
 
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Scanned)
         }
+
+        assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -110,6 +123,9 @@ internal class NfcScanningViewModelTest {
                 ),
             )
         }
+
+        assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
+        assertThat(fakeEventReporter.onNfcScanSucceededCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -119,6 +135,7 @@ internal class NfcScanningViewModelTest {
             viewModelScope = viewModelScope,
             tapZoneResolver = FakeTapZoneResolver(),
             cardScanner = FakeNfcCardScanner(),
+            eventReporter = FakeNfcScanningEventReporter(),
         )
         val viewModelStore = ViewModelStore().apply {
             put("test", viewModel)
@@ -135,24 +152,31 @@ internal class NfcScanningViewModelTest {
     ) = runTest(dispatcher) {
         val scannerState = MutableSharedFlow<NfcCardScanner.State>()
         val fakeCardScanner = FakeNfcCardScanner(stateFlow = scannerState)
+        val fakeEventReporter = FakeNfcScanningEventReporter()
         val viewModel = NfcScanningViewModel(
             viewModelScope = CoroutineScope(dispatcher),
             tapZoneResolver = FakeTapZoneResolver(tapZone),
             cardScanner = fakeCardScanner,
+            eventReporter = fakeEventReporter,
         )
+
+        assertThat(fakeEventReporter.onNfcScanStartedCalls.awaitItem()).isNotNull()
 
         Scenario(
             viewModel = viewModel,
             fakeCardScanner = fakeCardScanner,
+            fakeEventReporter = fakeEventReporter,
             scannerState = scannerState,
         ).block()
 
         fakeCardScanner.ensureAllEventsConsumed()
+        fakeEventReporter.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val viewModel: NfcScanningViewModel,
         val fakeCardScanner: FakeNfcCardScanner,
+        val fakeEventReporter: FakeNfcScanningEventReporter,
         val scannerState: MutableSharedFlow<NfcCardScanner.State>,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
@@ -1,0 +1,133 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import com.stripe.android.utils.FakeDurationProvider
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class DefaultNfcScanningEventReporterTest {
+    @Test
+    fun `onNfcScanStarted starts duration and fires event`() = runScenario {
+        reporter.onNfcScanStarted()
+
+        assertThat(
+            durationProvider.has(
+                FakeDurationProvider.Call.Start(DurationProvider.Key.NfcScan, reset = true)
+            )
+        ).isTrue()
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_started")
+    }
+
+    @Test
+    fun `onNfcScanSucceeded ends duration and fires event with duration`() = runScenario {
+        durationProvider.start(DurationProvider.Key.NfcScan)
+
+        reporter.onNfcScanSucceeded()
+
+        assertThat(
+            durationProvider.has(
+                FakeDurationProvider.Call.End(DurationProvider.Key.NfcScan)
+            )
+        ).isTrue()
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_success")
+        assertThat(loggedParams).containsEntry("duration", 1.0f)
+    }
+
+    @Test
+    fun `onNfcScanAttemptStarted starts duration and fires event`() = runScenario {
+        reporter.onNfcScanAttemptStarted()
+
+        assertThat(
+            durationProvider.has(
+                FakeDurationProvider.Call.Start(DurationProvider.Key.NfcScanAttempt, reset = true)
+            )
+        ).isTrue()
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_attempt_started")
+    }
+
+    @Test
+    fun `onNfcScanAttemptSucceeded ends duration and fires event with duration`() = runScenario {
+        durationProvider.start(DurationProvider.Key.NfcScanAttempt)
+
+        reporter.onNfcScanAttemptSucceeded()
+
+        assertThat(
+            durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScanAttempt))
+        ).isTrue()
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_attempt_succeeded")
+        assertThat(loggedParams).containsEntry("duration", 1.0f)
+    }
+
+    @Test
+    fun `onNfcScanAttemptFailed ends duration and fires event with duration`() = runScenario {
+        durationProvider.start(DurationProvider.Key.NfcScanAttempt)
+
+        reporter.onNfcScanAttemptFailed()
+
+        assertThat(durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScanAttempt)))
+            .isTrue()
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_attempt_failed")
+        assertThat(loggedParams).containsEntry("duration", 1.0f)
+    }
+
+    @Test
+    fun `onNfcScanCancelled ends duration and fires event`() = runScenario {
+        reporter.onNfcScanCancelled()
+
+        assertThat(
+            durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScan))
+        ).isTrue()
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_canceled")
+        assertThat(loggedParams).doesNotContainKey("duration")
+    }
+
+    private class Scenario(
+        val reporter: NfcScanningEventReporter,
+        val durationProvider: FakeDurationProvider,
+        val executor: FakeAnalyticsRequestExecutor,
+    )
+
+    private fun runScenario(
+        duration: kotlin.time.Duration = 1.seconds,
+        block: Scenario.() -> Unit,
+    ) {
+        val analyticsRequestExecutor = FakeAnalyticsRequestExecutor()
+        val durationProvider = FakeDurationProvider(duration = duration)
+        val reporter = DefaultNfcScanningEventReporter(
+            durationProvider = durationProvider,
+            analyticsRequestExecutor = analyticsRequestExecutor,
+            analyticsRequestFactory = AnalyticsRequestFactory(
+                packageManager = null,
+                packageInfo = null,
+                packageName = "",
+                publishableKeyProvider = { "" },
+                networkTypeProvider = { "" },
+                pluginTypeProvider = { null },
+            ),
+            eventPrefix = "mc_",
+        )
+
+        block(
+            Scenario(
+                reporter = reporter,
+                durationProvider = durationProvider,
+                executor = analyticsRequestExecutor,
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import app.cash.turbine.Turbine
+
+internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
+    val onNfcScanStartedCalls = Turbine<Unit>()
+    val onNfcScanAttemptStartedCalls = Turbine<Unit>()
+    val onNfcScanAttemptSucceededCalls = Turbine<Unit>()
+    val onNfcScanAttemptFailedCalls = Turbine<Unit>()
+    val onNfcScanSucceededCalls = Turbine<Unit>()
+    val onNfcScanCancelledCalls = Turbine<Unit>()
+
+    override fun onNfcScanStarted() {
+        onNfcScanStartedCalls.add(Unit)
+    }
+
+    override fun onNfcScanAttemptStarted() {
+        onNfcScanAttemptStartedCalls.add(Unit)
+    }
+
+    override fun onNfcScanAttemptSucceeded() {
+        onNfcScanAttemptSucceededCalls.add(Unit)
+    }
+
+    override fun onNfcScanAttemptFailed() {
+        onNfcScanAttemptFailedCalls.add(Unit)
+    }
+
+    override fun onNfcScanSucceeded() {
+        onNfcScanSucceededCalls.add(Unit)
+    }
+
+    override fun onNfcScanCancelled() {
+        onNfcScanCancelledCalls.add(Unit)
+    }
+
+    fun ensureAllEventsConsumed() {
+        onNfcScanStartedCalls.ensureAllEventsConsumed()
+        onNfcScanAttemptStartedCalls.ensureAllEventsConsumed()
+        onNfcScanAttemptSucceededCalls.ensureAllEventsConsumed()
+        onNfcScanAttemptFailedCalls.ensureAllEventsConsumed()
+        onNfcScanSucceededCalls.ensureAllEventsConsumed()
+        onNfcScanCancelledCalls.ensureAllEventsConsumed()
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -37,6 +37,8 @@ interface DurationProvider {
         Checkout,
         LinkSignup,
         ConfirmButtonClicked,
+        NfcScan,
+        NfcScanAttempt,
         TapToAdd,
         CardScan,
         Captcha,


### PR DESCRIPTION
# Summary
Add initial analytic events for NFC scanning in the scanner flow
- `nfc_scan_started` to indicate the user has launched the flow. This starts a duration timer for `NfcScan`
- `nfc_attempt_started` to indicate the user is attempting to scan their card. This starts a duration timer for `NfcScanAttempt`.
- `nfc_scan_attempt_succeeded` to indicate the user has successfully scanned their card. THas a `duration` for how long the attempt took before success.
- `nfc_attempt_failed` to indicate the user is attempting to scan their card. Has a `duration` for how long the attempt took before failure.
- `nfc_scan_canceled` to indicate the user cancels scanning their card with NFC. 
- `nfc_scan_success` to indicate the user successfully completed the NFC scan flow.

# Motivation
Helps track usage of NFC scanning flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified