### PR TITLE
Only send card brand in updates when it is editable

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsEntry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsEntry.kt
@@ -42,14 +42,17 @@ internal data class CardDetailsEntry(
 /**
  * Builds [CardUpdateParams] from the provided [CardDetailsEntry] and [BillingDetailsEntry].
  *
- * @return CardUpdateParams containing the updated card and billing information.
+ * @param includeCardBrand whether to include the selected card brand; only true when the brand is
+ * editable (CBC modifiable).
  */
 internal fun toUpdateParams(
     cardDetailsEntry: CardDetailsEntry?,
     billingDetailsEntry: BillingDetailsEntry?,
+    includeCardBrand: Boolean,
 ): CardUpdateParams {
     return CardUpdateParams(
-        cardBrand = cardDetailsEntry?.cardBrandChoice?.brand?.takeIf { it != CardBrand.Unknown },
+        cardBrand = cardDetailsEntry?.cardBrandChoice?.brand
+            ?.takeIf { includeCardBrand && it != CardBrand.Unknown },
         expiryMonth = cardDetailsEntry?.expiryDateState?.expiryMonth,
         expiryYear = cardDetailsEntry?.expiryDateState?.expiryYear,
         billingDetails = createBillingDetails(billingDetailsEntry)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -235,7 +235,13 @@ internal class DefaultEditCardDetailsInteractor(
             billingDetailsEntry?.isComplete(billingDetailsCollectionConfiguration) != false
 
         return if ((hasChanges || requiresModification.not()) && isComplete) {
-            toUpdateParams(cardDetailsEntry, billingDetailsEntry)
+            toUpdateParams(
+                cardDetailsEntry = cardDetailsEntry,
+                billingDetailsEntry = billingDetailsEntry,
+                // Only send the brand when it's editable; otherwise it's the card's existing network
+                // and some update endpoints (e.g. checkout sessions) don't support card network updates.
+                includeCardBrand = cardEditConfiguration?.isCbcModifiable == true,
+            )
         } else {
             null
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEntryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEntryTest.kt
@@ -174,7 +174,24 @@ internal class CardDetailsEntryTest {
             expYear = 2030
         )
 
-        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry())
+        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry(), includeCardBrand = true)
+
+        assertThat(params.cardBrand).isNull()
+        assertThat(params.expiryMonth).isEqualTo(12)
+        assertThat(params.expiryYear).isEqualTo(2030)
+        assertThat(params.billingDetails).isEqualTo(BILLING_DETAILS_FORM_DETAILS)
+    }
+
+    @Test
+    fun `toUpdateParams() should omit card brand when includeCardBrand is false`() {
+        val cardBrandChoice = CardBrandChoice(CardBrand.Visa, true)
+        val cardDetailsEntry = createEntry(
+            cardBrandChoice = cardBrandChoice,
+            expMonth = 12,
+            expYear = 2030
+        )
+
+        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry(), includeCardBrand = false)
 
         assertThat(params.cardBrand).isNull()
         assertThat(params.expiryMonth).isEqualTo(12)
@@ -191,7 +208,7 @@ internal class CardDetailsEntryTest {
             expYear = 2030
         )
 
-        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry())
+        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry(), includeCardBrand = true)
 
         assertThat(params.cardBrand).isEqualTo(CardBrand.Visa)
         assertThat(params.expiryMonth).isEqualTo(12)
@@ -208,7 +225,7 @@ internal class CardDetailsEntryTest {
             expYear = null
         )
 
-        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry())
+        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry(), includeCardBrand = true)
 
         assertThat(params.cardBrand).isEqualTo(CardBrand.Visa)
         assertThat(params.expiryMonth).isNull()
@@ -226,7 +243,7 @@ internal class CardDetailsEntryTest {
             expYear = 2030,
         )
 
-        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry())
+        val params = toUpdateParams(cardDetailsEntry, billingDetailsEntry(), includeCardBrand = true)
 
         assertThat(params.cardBrand).isEqualTo(CardBrand.Visa)
         assertThat(params.expiryMonth).isEqualTo(12)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -257,6 +257,39 @@ internal class DefaultEditCardDetailsInteractorTest {
     }
 
     @Test
+    fun cardBrandIsOmittedFromUpdateParamsWhenCbcIsNotModifiable() {
+        var capturedCardUpdateParams: CardUpdateParams? = null
+        val handler = handler(
+            // CARD_WITH_NETWORKS has a resolvable brand, but the brand isn't editable here.
+            isCbcModifiable = false,
+            onCardUpdateParamsChanged = {
+                capturedCardUpdateParams = it
+            }
+        )
+
+        handler.handleViewAction(EditCardDetailsInteractor.ViewAction.DateChanged("1230"))
+
+        assertThat(capturedCardUpdateParams?.expiryYear).isEqualTo(2030)
+        assertThat(capturedCardUpdateParams?.cardBrand).isNull()
+    }
+
+    @Test
+    fun cardBrandIsIncludedInUpdateParamsWhenCbcIsModifiable() {
+        var capturedCardUpdateParams: CardUpdateParams? = null
+        val handler = handler(
+            isCbcModifiable = true,
+            onCardUpdateParamsChanged = {
+                capturedCardUpdateParams = it
+            }
+        )
+
+        handler.handleViewAction(EditCardDetailsInteractor.ViewAction.DateChanged("1230"))
+
+        assertThat(capturedCardUpdateParams?.expiryYear).isEqualTo(2030)
+        assertThat(capturedCardUpdateParams?.cardBrand).isEqualTo(CardBrand.CartesBancaires)
+    }
+
+    @Test
     fun cardUpdateParamsIsUpdatedForValidAddressUpdate() {
         var capturedCardUpdateParams: CardUpdateParams? = null
         val handler = handler(


### PR DESCRIPTION
## Summary
Only include the card brand (`card[networks][preferred]`) in a saved-card update request when the brand is actually editable (CBC is modifiable). Previously the edit flow attached the card's current brand on every card edit even when the brand was never user-changeable (single-network cards) or the brand dropdown was never shown, so an unchanged brand was re-sent on every expiry/billing edit.

- `toUpdateParams` now takes an explicit `includeCardBrand` flag; `EditCardDetailsInteractor` passes `cardEditConfiguration.isCbcModifiable`.
- For genuine CBC cards (`isCbcModifiable == true`) behavior is unchanged: the selected brand is still sent, so a customer's card brand preference is never inadvertently cleared.
- For non-CBC cards the brand is omitted. This is a no-op for CustomerSession/legacy `/v1/payment_methods` updates (the network accepts but ignores an unchanged preferred brand) and is required for checkout session updates, whose endpoint rejects any card network field.

## Motivation
Pre-work for CheckoutSession saved-card expiry/billing updates (#13341). The checkout session update endpoint (`POST /v1/payment_pages/{id}`) defines `payment_method_to_update` with `additionalProperties: false` and only accepts `payment_method_id`, `billing_details`, and `expiry_details` — no card brand. Sending an unchanged brand there breaks the update entirely. Fixing this at the source keeps the brand out of every update where it isn't editable, rather than special-casing it per endpoint.

## Verification
- `./gradlew :paymentsheet:apiCheck :paymentsheet:detekt`
- `./gradlew :paymentsheet:testDebugUnitTest` for the edit/update flows: `CardDetailsEntryTest`, `DefaultUpdatePaymentMethodInteractorTest`, `SavedPaymentMethodMutatorTest`, `UpdateCardScreenViewModelTest` (Link), and the `customersheet.*` suites all pass. (`CustomerSheetScreenshotTest` fails identically on clean `master` due to an unrelated Paparazzi/`Dispatchers.Main` harness issue.)
