### PR TITLE
Add expressCheckoutElement to checkout package 🪿✨

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -91,6 +91,8 @@ class CheckoutController(
             CurrencySelectorElement.Configuration()
         private var shippingAddressElementConfiguration: ShippingAddressElement.Configuration =
             ShippingAddressElement.Configuration()
+        private var expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration =
+            ExpressCheckoutElement.Configuration()
 
         fun adaptivePricingAllowed(
             adaptivePricingAllowed: Boolean
@@ -116,12 +118,19 @@ class CheckoutController(
             this.shippingAddressElementConfiguration = configuration
         }
 
+        fun expressCheckoutElement(
+            configuration: ExpressCheckoutElement.Configuration
+        ): Configuration = apply {
+            this.expressCheckoutElementConfiguration = configuration
+        }
+
         @Parcelize
         internal data class State(
             val adaptivePricingAllowed: Boolean,
             val paymentElementConfiguration: PaymentElement.Configuration.State,
             val currencySelectorElementConfiguration: CurrencySelectorElement.Configuration.State,
             val shippingAddressElementConfiguration: ShippingAddressElement.Configuration.State,
+            val expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State,
         ) : Parcelable
 
         internal fun build(): State = State(
@@ -129,6 +138,7 @@ class CheckoutController(
             paymentElementConfiguration = paymentElementConfiguration.build(),
             currencySelectorElementConfiguration = currencySelectorElementConfiguration.build(),
             shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),
+            expressCheckoutElementConfiguration = expressCheckoutElementConfiguration.build(),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
@@ -19,6 +19,10 @@ class CheckoutPresenter internal constructor() {
         TODO("Not yet implemented")
     }
 
+    fun expressCheckoutElement(): ExpressCheckoutElement {
+        TODO("Not yet implemented")
+    }
+
     fun confirm() {
         TODO("Not yet implemented")
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
@@ -10,7 +11,8 @@ import kotlinx.parcelize.Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ExpressCheckoutElement internal constructor() {
 
-    fun present() {
+    @Composable
+    fun Content() {
         TODO("Not yet implemented")
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.checkout
+
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.parcelize.Parcelize
+
+@CheckoutSessionPreview
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class ExpressCheckoutElement internal constructor() {
+
+    fun present() {
+        TODO("Not yet implemented")
+    }
+
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class Configuration {
+        private var visibility: PaymentSheet.WalletButtonsConfiguration.Visibility =
+            PaymentSheet.WalletButtonsConfiguration.Visibility()
+
+        fun visibility(
+            visibility: PaymentSheet.WalletButtonsConfiguration.Visibility
+        ): Configuration = apply {
+            this.visibility = visibility
+        }
+
+        @Parcelize
+        internal data class State(
+            val visibility: PaymentSheet.WalletButtonsConfiguration.Visibility,
+        ) : Parcelable
+
+        internal fun build(): State = State(
+            visibility = visibility,
+        )
+    }
+}


### PR DESCRIPTION
[Minion run](https://agents.corp.stripe.com/sessions/b88a2f67-9ef3-403f-a80c-07bf17ac2237)

# Summary
Added `ExpressCheckoutElement` to the checkout package, matching the existing `ShippingAddressElement` API shape while storing wallet button visibility configuration. `CheckoutController.Configuration` and `CheckoutPresenter` now expose `expressCheckoutElement` alongside `shippingAddressElement`.

# Motivation
Set up scaffolding for ECE

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A | N/A |

# Changelog
No changelog entry added.