### PR TITLE
Link controller private preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ NEXT_VERSION_BUMP: MINOR
 ### CryptoOnramp
 * [ADDED] A new `AppAttestationUnavailableException` was added when configuring onramp for additional information when an error occurs.
 
+### PaymentSheet
+* [ADDED] A standalone Link wallet APIs in private preview via `@LinkControllerPreview`.
+
 ## 23.11.1 - 2026-06-30
 
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ NEXT_VERSION_BUMP: MINOR
 * [ADDED] A new `AppAttestationUnavailableException` was added when configuring onramp for additional information when an error occurs.
 
 ### PaymentSheet
-* [ADDED] A standalone Link wallet APIs in private preview via `@LinkControllerPreview`.
+* [ADDED] Standalone Link wallet APIs in private preview via `LinkController`.
 
 ## 23.11.1 - 2026-06-30
 

--- a/crypto-onramp/build.gradle
+++ b/crypto-onramp/build.gradle
@@ -51,6 +51,7 @@ android {
         compilerOptions {
             freeCompilerArgs.addAll([
                     "-opt-in=com.stripe.android.crypto.onramp.ExperimentalCryptoOnramp",
+                    "-opt-in=com.stripe.android.link.LinkControllerPreview",
             ])
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundActivity.kt
@@ -1,3 +1,5 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground
 
 import android.content.Context
@@ -16,6 +18,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 
 @Suppress("LongMethod")

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundState.kt
@@ -1,6 +1,9 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground
 
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 
 data class LinkControllerPlaygroundState(
     val controllerState: LinkController.State? = null,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundViewModel.kt
@@ -1,3 +1,5 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground
 
 import android.app.Application
@@ -7,6 +9,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
@@ -1,4 +1,5 @@
 @file:Suppress("LongMethod", "MagicNumber")
+@file:OptIn(LinkControllerPreview::class)
 
 package com.stripe.android.paymentsheet.example.playground
 
@@ -55,6 +56,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.ui.core.R
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -1,3 +1,5 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground
 
 import android.content.Context
@@ -6,6 +8,7 @@ import androidx.compose.runtime.Stable
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AllowedBillingCountriesSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AllowedBillingCountriesSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AttachBillingDetailsToPaymentMethodSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AttachBillingDetailsToPaymentMethodSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CardBrandAcceptanceSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CardBrandAcceptanceSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectAddressSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectEmailSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectEmailSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectNameSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectNameSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectPhoneSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CollectPhoneSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
@@ -1,7 +1,10 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkControllerAllowUserEmailEditsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkControllerAllowUserEmailEditsSettingsDefinition.kt
@@ -1,6 +1,9 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
 internal object LinkControllerAllowUserEmailEditsSettingsDefinition : BooleanSettingsDefinition(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
@@ -1,10 +1,11 @@
-@file:OptIn(CheckoutSessionPreview::class)
+@file:OptIn(CheckoutSessionPreview::class, LinkControllerPreview::class)
 
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -1,4 +1,4 @@
-@file:OptIn(CheckoutSessionPreview::class)
+@file:OptIn(CheckoutSessionPreview::class, LinkControllerPreview::class)
 
 package com.stripe.android.paymentsheet.example.playground.settings
 
@@ -13,6 +13,7 @@ import com.stripe.android.checkout.Checkout
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -230,6 +230,81 @@ public abstract interface class com/stripe/android/customersheet/SetupIntentClie
 	public abstract fun provideSetupIntentClientSecret (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkController {
+	public static final field $stable I
+	public final fun configure-gIAlu-s (Lcom/stripe/android/link/LinkController$Configuration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createPresenter (Landroidx/activity/ComponentActivity;Lcom/stripe/android/link/LinkController$PresentCallback;)Lcom/stripe/android/link/LinkController$Presenter;
+	public final fun getPaymentMethodPreview ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class com/stripe/android/link/LinkController$Builder {
+	public static final field $stable I
+	public fun <init> (Landroid/app/Application;Landroidx/lifecycle/SavedStateHandle;)V
+	public final fun build ()Lcom/stripe/android/link/LinkController;
+}
+
+public final class com/stripe/android/link/LinkController$Configuration {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun allowLogout (Z)Lcom/stripe/android/link/LinkController$Configuration;
+	public final fun email (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
+	public final fun phoneNumber (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
+	public final fun supportedPaymentMethodTypes (Ljava/util/List;)Lcom/stripe/android/link/LinkController$Configuration;
+}
+
+public final class com/stripe/android/link/LinkController$PaymentMethodPreview {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getIconPainter (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getSublabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/LinkController$PaymentMethodType : java/lang/Enum {
+	public static final field BankAccount Lcom/stripe/android/link/LinkController$PaymentMethodType;
+	public static final field Card Lcom/stripe/android/link/LinkController$PaymentMethodType;
+	public static final field Generic Lcom/stripe/android/link/LinkController$PaymentMethodType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$PaymentMethodType;
+	public static fun values ()[Lcom/stripe/android/link/LinkController$PaymentMethodType;
+}
+
+public abstract interface class com/stripe/android/link/LinkController$PresentCallback {
+	public abstract fun onPresentResult (Lcom/stripe/android/link/LinkController$PresentResult;)V
+}
+
+public abstract interface class com/stripe/android/link/LinkController$PresentResult {
+}
+
+public final class com/stripe/android/link/LinkController$PresentResult$Canceled : com/stripe/android/link/LinkController$PresentResult {
+	public static final field $stable I
+}
+
+public final class com/stripe/android/link/LinkController$PresentResult$Completed : com/stripe/android/link/LinkController$PresentResult {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/LinkController$PresentResult$Failed : com/stripe/android/link/LinkController$PresentResult {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/LinkController$Presenter {
+	public static final field $stable I
+	public final fun present ()V
+}
+
 public final class com/stripe/android/link/onramp/ui/ComposableSingletons$OnrampKYCRefreshScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/link/onramp/ui/ComposableSingletons$OnrampKYCRefreshScreenKt;
 	public fun <init> ()V

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -305,6 +305,9 @@ public final class com/stripe/android/link/LinkController$Presenter {
 	public final fun present ()V
 }
 
+public abstract interface annotation class com/stripe/android/link/LinkControllerPreview : java/lang/annotation/Annotation {
+}
+
 public final class com/stripe/android/link/onramp/ui/ComposableSingletons$OnrampKYCRefreshScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/link/onramp/ui/ComposableSingletons$OnrampKYCRefreshScreenKt;
 	public fun <init> ()V

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -157,6 +157,7 @@ android {
             freeCompilerArgs.addAll([
                     "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                     "-opt-in=kotlinx.coroutines.FlowPreview",
+                    "-opt-in=com.stripe.android.link.LinkControllerPreview",
                     "-Xcontext-parameters",
                     "-Xannotation-default-target=param-property",
                     "-Xconsistent-data-class-copy-visibility"

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -30,7 +30,7 @@ import javax.inject.Singleton
  * A controller to perform various Link operations.
  */
 @Singleton
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@LinkControllerPreview
 @Suppress("TooManyFunctions")
 class LinkController @Inject internal constructor(
     private val interactor: LinkControllerInteractor,
@@ -60,7 +60,7 @@ class LinkController @Inject internal constructor(
      * @param configuration The [Configuration] to use for Link operations.
      * @return The result of the configuration.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     suspend fun configure(configuration: Configuration): Result<Unit> {
         return interactor.configure(configuration)
     }
@@ -206,7 +206,7 @@ class LinkController @Inject internal constructor(
     /**
      * Configuration for [LinkController].
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     class Configuration {
         private var merchantDisplayName: String
         private var publishableKey: String?
@@ -354,7 +354,7 @@ class LinkController @Inject internal constructor(
      * The Presenter is tied to an Activity lifecycle and should be created and destroyed appropriately
      * to avoid memory leaks.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     class Presenter @Inject internal constructor(
         private val coordinator: LinkControllerCoordinator,
         private val interactor: LinkControllerInteractor,
@@ -557,7 +557,7 @@ class LinkController @Inject internal constructor(
     /**
      * Result of [Presenter.present].
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     sealed interface PresentResult {
 
         /**
@@ -565,14 +565,14 @@ class LinkController @Inject internal constructor(
          *
          * @param paymentMethod The [PaymentMethod] created from the selected Link payment method.
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         @Poko
         class Completed internal constructor(val paymentMethod: PaymentMethod) : PresentResult
 
         /**
          * The user canceled the Link flow.
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         class Canceled internal constructor() : PresentResult
 
         /**
@@ -580,7 +580,7 @@ class LinkController @Inject internal constructor(
          *
          * @param error The error that occurred.
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         @Poko
         class Failed internal constructor(val error: Throwable) : PresentResult
     }
@@ -745,7 +745,7 @@ class LinkController @Inject internal constructor(
     /**
      * Callback for receiving results from [Presenter.present].
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     fun interface PresentCallback {
         fun onPresentResult(result: PresentResult)
     }
@@ -803,7 +803,7 @@ class LinkController @Inject internal constructor(
     /**
      * The type of payment method to present for selection.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     enum class PaymentMethodType {
         Card,
         BankAccount,
@@ -817,7 +817,7 @@ class LinkController @Inject internal constructor(
      * @param label The main label text (e.g., "Link").
      * @param sublabel Additional descriptive text (e.g., "Visa •••• 4242").
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     @Poko
     class PaymentMethodPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -871,7 +871,7 @@ class LinkController @Inject internal constructor(
      * @param application The application context.
      * @param savedStateHandle The [SavedStateHandle] for persisting state across process death.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     class Builder(
         private val application: Application,
         private val savedStateHandle: SavedStateHandle,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerPreview.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.link
+
+/**
+ * Marks the LinkController API as being in private preview. The API may change without notice
+ * and is not yet covered by semantic-versioning guarantees.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "LinkController is in private preview and may change without notice."
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class LinkControllerPreview


### PR DESCRIPTION
# Summary
Following up on https://github.com/stripe/stripe-android/pull/13145 and exposing LinkController to private preview using @LinkControllerPreview

# Motivation
https://docs.google.com/document/d/1b5gHtHsxE2Rl_YXvcJswcfPz2P0AtRSciAvpaqa_WKk/edit?tab=t.0#bookmark=id.v6evombxv9i3

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
### PaymentSheet
* [ADDED] Standalone Link wallet APIs in private preview via `LinkController`.
