### PR TITLE
Extract FlagImageResolver for adaptive-pricing flag images

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -2,7 +2,6 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.content.Context
-import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
@@ -21,7 +20,6 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorToggle
-import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
@@ -78,7 +76,7 @@ class Checkout private constructor(
                 sessionId = checkoutSessionClientSecret.substringBefore("_secret_"),
                 adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
             ).map { response ->
-                val flagImages = prefetchFlagImages(context, response, component)
+                val flagImages = component.flagImageResolver.resolve(response, cached = null)
                 val key = UUID.randomUUID().toString()
                 CheckoutInstances.getOrCreate(key) {
                     Checkout(
@@ -92,36 +90,6 @@ class Checkout private constructor(
                     )
                 }
             }
-        }
-
-        private suspend fun prefetchFlagImages(
-            context: Context,
-            response: CheckoutSessionResponse,
-            component: CheckoutComponent,
-        ): Map<String, Bitmap>? {
-            val adaptivePricingInfo = response.adaptivePricingInfo ?: return null
-            val localOption = adaptivePricingInfo.localCurrencyOptions.firstOrNull() ?: return null
-            val flagImageRepository = FlagImageRepository(
-                imageLoader = DefaultStripeImageLoader(context),
-                displayDensity = context.resources.displayMetrics.density,
-            )
-            val result = flagImageRepository.fetch(
-                integrationCurrencyCode = adaptivePricingInfo.integrationCurrency,
-                localCurrencyCode = localOption.currency,
-            )
-            for (failure in result.failures) {
-                val event = PaymentSheetEvent.AdaptivePricingFlagImageLoadFailed(
-                    countryCode = failure.countryCode,
-                    url = failure.url,
-                )
-                component.analyticsRequestExecutor.executeAsync(
-                    component.paymentAnalyticsRequestFactory.createRequest(
-                        event = event,
-                        additionalParams = event.params,
-                    )
-                )
-            }
-            return result.images
         }
 
         /**
@@ -606,8 +574,13 @@ class Checkout private constructor(
                 val result = runCatching {
                     internalState.block(internalState.checkoutSessionResponse.id).getOrThrow()
                 }.map { response ->
-                    internalState =
-                        internalState.copy(checkoutSessionResponse = response).additionalStateMutations()
+                    val flagImages = component.flagImageResolver.resolve(
+                        response = response,
+                        cached = internalState.flagImages,
+                    )
+                    internalState = internalState
+                        .copy(checkoutSessionResponse = response, flagImages = flagImages)
+                        .additionalStateMutations()
                     _checkoutSession.value = internalState.asCheckoutSession()
                 }
                 result

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageRepository.kt
@@ -1,14 +1,16 @@
 package com.stripe.android.checkout
 
 import android.graphics.Bitmap
+import com.stripe.android.common.di.DisplayDensity
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import javax.inject.Inject
 import kotlin.math.roundToInt
 
-internal class FlagImageRepository(
+internal class FlagImageRepository @Inject constructor(
     private val imageLoader: StripeImageLoader,
-    private val displayDensity: Float,
+    @DisplayDensity private val displayDensity: Float,
 ) {
     suspend fun fetch(
         integrationCurrencyCode: String,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/FlagImageResolver.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.checkout
+
+import android.graphics.Bitmap
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import javax.inject.Inject
+
+/**
+ * Resolves the adaptive-pricing flag images for a [CheckoutSessionResponse].
+ *
+ * Flags are keyed by uppercase currency code, so when the response's integration and local
+ * currencies are both already present in the [cached] map (i.e. the currencies haven't changed
+ * across a mutation such as applying a promotion code), the cached images are reused instead of
+ * being re-downloaded. A failed fetch reports [PaymentSheetEvent.AdaptivePricingFlagImageLoadFailed]
+ * for each missing flag and leaves the images null so a later mutation can retry.
+ */
+internal class FlagImageResolver @Inject constructor(
+    private val flagImageRepository: FlagImageRepository,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
+) {
+    suspend fun resolve(
+        response: CheckoutSessionResponse,
+        cached: Map<String, Bitmap>?,
+    ): Map<String, Bitmap>? {
+        val adaptivePricingInfo = response.adaptivePricingInfo ?: return null
+        val localOption = adaptivePricingInfo.localCurrencyOptions.firstOrNull() ?: return null
+        val integrationCurrency = adaptivePricingInfo.integrationCurrency
+        val localCurrency = localOption.currency
+
+        if (cached != null &&
+            cached.containsKey(integrationCurrency.uppercase()) &&
+            cached.containsKey(localCurrency.uppercase())
+        ) {
+            return cached
+        }
+
+        val result = flagImageRepository.fetch(
+            integrationCurrencyCode = integrationCurrency,
+            localCurrencyCode = localCurrency,
+        )
+        for (failure in result.failures) {
+            val event = PaymentSheetEvent.AdaptivePricingFlagImageLoadFailed(
+                countryCode = failure.countryCode,
+                url = failure.url,
+            )
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(
+                    event = event,
+                    additionalParams = event.params,
+                )
+            )
+        }
+        return result.images
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
@@ -14,7 +14,7 @@ internal data class InternalState(
     val key: String,
     val configuration: Checkout.Configuration.State,
     val checkoutSessionResponse: CheckoutSessionResponse,
-    private val flagImages: Map<String, Bitmap>?,
+    val flagImages: Map<String, Bitmap>?,
     val shippingName: String? = null,
     val billingName: String? = null,
     val shippingPhoneNumber: String? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutComponent.kt
@@ -3,6 +3,8 @@ package com.stripe.android.checkout.injection
 import android.app.Application
 import android.content.Context
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.checkout.FlagImageResolver
+import com.stripe.android.common.di.DisplayDensity
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
@@ -17,6 +19,8 @@ import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.uicore.image.DefaultStripeImageLoader
+import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
@@ -38,6 +42,7 @@ internal interface CheckoutComponent {
     val checkoutSessionRepository: CheckoutSessionRepository
     val analyticsRequestExecutor: AnalyticsRequestExecutor
     val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    val flagImageResolver: FlagImageResolver
 
     @Component.Factory
     interface Factory {
@@ -67,4 +72,11 @@ internal object CheckoutModule {
         apiKey = paymentConfiguration.get().publishableKey,
         stripeAccount = paymentConfiguration.get().stripeAccountId,
     )
+
+    @Provides
+    fun provideStripeImageLoader(context: Context): StripeImageLoader = DefaultStripeImageLoader(context)
+
+    @Provides
+    @DisplayDensity
+    fun provideDisplayDensity(context: Context): Float = context.resources.displayMetrics.density
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/di/DisplayDensity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/di/DisplayDensity.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.common.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+internal annotation class DisplayDensity

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageRepositoryTest.kt
@@ -2,93 +2,85 @@ package com.stripe.android.checkout
 
 import android.graphics.Bitmap
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.uicore.image.StripeImageLoader
+import com.stripe.android.testing.FakeStripeImageLoader
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
-class FlagImageRepositoryTest {
+internal class FlagImageRepositoryTest {
 
     @Test
-    fun `both downloads succeed - returns images for both currencies`() = runTest {
-        val fakeLoader = FakeStripeImageLoader()
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
+    fun `fetch returns images for both currencies when both downloads succeed`() = runScenario {
         val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNotNull()
         assertThat(result.images!!.keys).containsExactly("USD", "EUR")
         assertThat(result.failures).isEmpty()
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("US", dpr = 3),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 3),
+        )
     }
 
     @Test
-    fun `integration download fails - returns null images and failure`() = runTest {
-        val fakeLoader = FakeStripeImageLoader(
-            failingUrls = setOf(FlagImageRepository.buildFlagUrl("US", dpr = 3)),
-        )
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
+    fun `fetch returns null images and a failure when the integration download fails`() = runScenario(
+        failingUrls = setOf(FlagImageRepository.buildFlagUrl("US", dpr = 3)),
+    ) {
         val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).hasSize(1)
         assertThat(result.failures[0].countryCode).isEqualTo("US")
         assertThat(result.failures[0].url).isEqualTo(FlagImageRepository.buildFlagUrl("US", dpr = 3))
+        loader.awaitLoadedUrls(2)
     }
 
     @Test
-    fun `local download fails - returns null images and failure`() = runTest {
-        val fakeLoader = FakeStripeImageLoader(
-            failingUrls = setOf(FlagImageRepository.buildFlagUrl("EU", dpr = 3)),
-        )
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
+    fun `fetch returns null images and a failure when the local download fails`() = runScenario(
+        failingUrls = setOf(FlagImageRepository.buildFlagUrl("EU", dpr = 3)),
+    ) {
         val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).hasSize(1)
         assertThat(result.failures[0].countryCode).isEqualTo("EU")
+        loader.awaitLoadedUrls(2)
     }
 
     @Test
-    fun `both downloads fail - returns null images and two failures`() = runTest {
-        val fakeLoader = FakeStripeImageLoader(
-            failingUrls = setOf(
-                FlagImageRepository.buildFlagUrl("US", dpr = 3),
-                FlagImageRepository.buildFlagUrl("EU", dpr = 3),
-            ),
-        )
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
-
+    fun `fetch returns null images and two failures when both downloads fail`() = runScenario(
+        failingUrls = setOf(
+            FlagImageRepository.buildFlagUrl("US", dpr = 3),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 3),
+        ),
+    ) {
         val result = repository.fetch("usd", "eur")
 
         assertThat(result.images).isNull()
         assertThat(result.failures).hasSize(2)
+        loader.awaitLoadedUrls(2)
     }
 
     @Test
-    fun `X-currency integration code - skips fetch and returns empty failures`() = runTest {
-        val fakeLoader = FakeStripeImageLoader()
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+    fun `fetch skips download and returns empty failures when the integration currency has no country`() =
+        runScenario {
+            val result = repository.fetch("xaf", "usd")
 
-        val result = repository.fetch("xaf", "usd")
-
-        assertThat(result.images).isNull()
-        assertThat(result.failures).isEmpty()
-    }
+            assertThat(result.images).isNull()
+            assertThat(result.failures).isEmpty()
+            // No load calls; the scenario's ensureAllEventsConsumed verifies the skip.
+        }
 
     @Test
-    fun `X-currency local code - skips fetch and returns empty failures`() = runTest {
-        val fakeLoader = FakeStripeImageLoader()
-        val repository = FlagImageRepository(fakeLoader, displayDensity = 3f)
+    fun `fetch skips download and returns empty failures when the local currency has no country`() =
+        runScenario {
+            val result = repository.fetch("usd", "xpf")
 
-        val result = repository.fetch("usd", "xpf")
-
-        assertThat(result.images).isNull()
-        assertThat(result.failures).isEmpty()
-    }
+            assertThat(result.images).isNull()
+            assertThat(result.failures).isEmpty()
+        }
 
     @Test
     fun `EUR maps to EU country code`() {
@@ -113,24 +105,62 @@ class FlagImageRepositoryTest {
                 "https://b.stripecdn.com/ocs-mobile/assets/flags/US.png"
         )
     }
-}
 
-private class FakeStripeImageLoader(
-    private val failingUrls: Set<String> = emptySet(),
-) : StripeImageLoader {
-    override suspend fun load(url: String, width: Int, height: Int): Result<Bitmap?> {
-        return load(url)
+    @Test
+    fun `fetch rounds the display density to the nearest dpr`() = runScenario(displayDensity = 2.6f) {
+        repository.fetch("usd", "eur")
+
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("US", dpr = 3),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 3),
+        )
     }
 
-    override suspend fun load(url: String): Result<Bitmap?> {
-        return if (url in failingUrls) {
-            Result.failure(RuntimeException("Download failed"))
-        } else {
-            Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888))
-        }
+    @Test
+    fun `fetch clamps a sub-1 display density up to a dpr of 1`() = runScenario(displayDensity = 0.4f) {
+        repository.fetch("usd", "eur")
+
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("US", dpr = 1),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 1),
+        )
     }
 
-    override suspend fun get(url: String): Result<Bitmap?> {
-        return Result.success(null)
+    @Test
+    fun `fetch clamps a large display density down to a dpr of 4`() = runScenario(displayDensity = 10f) {
+        repository.fetch("usd", "eur")
+
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("US", dpr = 4),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 4),
+        )
     }
+
+    // Awaits [count] load calls and returns the requested URLs. The repository fetches the two
+    // flags concurrently, so callers compare against a set rather than an ordered list.
+    private suspend fun FakeStripeImageLoader.awaitLoadedUrls(count: Int): Set<String> =
+        buildSet { repeat(count) { add(awaitLoadCall().url) } }
+
+    private fun runScenario(
+        failingUrls: Set<String> = emptySet(),
+        displayDensity: Float = 3f,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val loader = FakeStripeImageLoader(
+            loadResult = Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)),
+            loadResultByUrl = failingUrls.associateWith {
+                Result.failure<Bitmap?>(RuntimeException("Download failed"))
+            },
+        )
+        val repository = FlagImageRepository(imageLoader = loader, displayDensity = displayDensity)
+
+        Scenario(repository = repository, loader = loader).block()
+
+        loader.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val repository: FlagImageRepository,
+        val loader: FakeStripeImageLoader,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageResolverTest.kt
@@ -1,0 +1,196 @@
+package com.stripe.android.checkout
+
+import android.app.Application
+import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import com.stripe.android.testing.FakeStripeImageLoader
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+internal class FlagImageResolverTest {
+
+    @Test
+    fun `resolve returns null and skips fetch when there is no adaptive pricing info`() = runScenario {
+        val response = CheckoutSessionResponseFactory.create(adaptivePricingInfo = null)
+
+        val result = resolver.resolve(response, cached = null)
+
+        assertThat(result).isNull()
+        // No load calls are recorded; the scenario's ensureAllEventsConsumed verifies the skip.
+    }
+
+    @Test
+    fun `resolve returns null and skips fetch when there are no local currency options`() = runScenario {
+        val response = responseWith(integrationCurrency = "usd", localCurrencies = emptyList())
+
+        val result = resolver.resolve(response, cached = null)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `resolve fetches flag images for both currencies on the first resolve`() = runScenario {
+        val response = responseWith(integrationCurrency = "usd", localCurrencies = listOf("eur"))
+
+        val result = resolver.resolve(response, cached = null)
+
+        assertThat(result?.keys).containsExactly("USD", "EUR")
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("US", dpr = 3),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 3),
+        )
+    }
+
+    @Test
+    fun `resolve reuses cached images when both currencies are unchanged`() = runScenario {
+        val response = responseWith(integrationCurrency = "usd", localCurrencies = listOf("eur"))
+        val cached = resolver.resolve(response, cached = null)
+        loader.awaitLoadedUrls(2)
+
+        val result = resolver.resolve(response, cached = cached)
+
+        assertThat(result).isSameInstanceAs(cached)
+        // No further load calls; the scenario's ensureAllEventsConsumed verifies the cache hit.
+    }
+
+    @Test
+    fun `resolve refetches when the integration currency changes`() = runScenario {
+        val cached = mapOf("USD" to bitmap(), "EUR" to bitmap())
+        val response = responseWith(integrationCurrency = "gbp", localCurrencies = listOf("eur"))
+
+        val result = resolver.resolve(response, cached = cached)
+
+        assertThat(result?.keys).containsExactly("GBP", "EUR")
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("GB", dpr = 3),
+            FlagImageRepository.buildFlagUrl("EU", dpr = 3),
+        )
+    }
+
+    @Test
+    fun `resolve refetches when the local currency changes`() = runScenario {
+        val cached = mapOf("USD" to bitmap(), "EUR" to bitmap())
+        val response = responseWith(integrationCurrency = "usd", localCurrencies = listOf("gbp"))
+
+        val result = resolver.resolve(response, cached = cached)
+
+        assertThat(result?.keys).containsExactly("USD", "GBP")
+        assertThat(loader.awaitLoadedUrls(2)).containsExactly(
+            FlagImageRepository.buildFlagUrl("US", dpr = 3),
+            FlagImageRepository.buildFlagUrl("GB", dpr = 3),
+        )
+    }
+
+    @Test
+    fun `resolve refetches when the cache only covers one of the currencies`() = runScenario {
+        val cached = mapOf("USD" to bitmap())
+        val response = responseWith(integrationCurrency = "usd", localCurrencies = listOf("eur"))
+
+        val result = resolver.resolve(response, cached = cached)
+
+        assertThat(result?.keys).containsExactly("USD", "EUR")
+        assertThat(loader.awaitLoadedUrls(2)).hasSize(2)
+    }
+
+    @Test
+    fun `resolve returns null without reporting analytics when a currency has no country code`() = runScenario {
+        // xaf maps to no country, so the repository skips the download and reports no failures.
+        // Unlike a download failure, this path must not emit analytics.
+        val response = responseWith(integrationCurrency = "xaf", localCurrencies = listOf("eur"))
+
+        val result = resolver.resolve(response, cached = null)
+
+        assertThat(result).isNull()
+        assertThat(analyticsRequestExecutor.getExecutedRequests()).isEmpty()
+        // No load calls; the scenario's ensureAllEventsConsumed verifies the skip.
+    }
+
+    @Test
+    fun `resolve reports analytics and returns null when a flag download fails`() = runScenario(
+        failingUrls = setOf(FlagImageRepository.buildFlagUrl("US", dpr = 3)),
+    ) {
+        val response = responseWith(integrationCurrency = "usd", localCurrencies = listOf("eur"))
+
+        val result = resolver.resolve(response, cached = null)
+
+        assertThat(result).isNull()
+        val requests = analyticsRequestExecutor.getExecutedRequests()
+        assertThat(requests).hasSize(1)
+        assertThat(requests.first().params["event"])
+            .isEqualTo("elements.adaptive_pricing.flag_image_load.failed")
+        // Both currencies are fetched (US fails, EU succeeds); consume them for the scenario's check.
+        loader.awaitLoadedUrls(2)
+    }
+
+    private fun responseWith(
+        integrationCurrency: String,
+        localCurrencies: List<String>,
+    ): CheckoutSessionResponse {
+        return CheckoutSessionResponseFactory.create(
+            adaptivePricingInfo = CheckoutSessionResponse.AdaptivePricingInfo(
+                activePresentmentCurrency = localCurrencies.firstOrNull() ?: integrationCurrency,
+                integrationAmount = 5099,
+                integrationCurrency = integrationCurrency,
+                localCurrencyOptions = localCurrencies.map { currency ->
+                    CheckoutSessionResponse.LocalCurrencyOption(
+                        amount = 4594,
+                        conversionMarkupBps = 400,
+                        currency = currency,
+                        presentmentExchangeRate = "0.900961",
+                    )
+                },
+            ),
+        )
+    }
+
+    private fun bitmap(): Bitmap = Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)
+
+    // Awaits [count] load calls and returns the requested URLs. The repository fetches the two
+    // flags concurrently, so callers compare against a set rather than an ordered list.
+    private suspend fun FakeStripeImageLoader.awaitLoadedUrls(count: Int): Set<String> =
+        buildSet { repeat(count) { add(awaitLoadCall().url) } }
+
+    private fun runScenario(
+        failingUrls: Set<String> = emptySet(),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val loader = FakeStripeImageLoader(
+            loadResult = Result.success(bitmap()),
+            loadResultByUrl = failingUrls.associateWith {
+                Result.failure<Bitmap?>(RuntimeException("Download failed"))
+            },
+        )
+        val analyticsRequestExecutor = FakeAnalyticsRequestExecutor()
+        val resolver = FlagImageResolver(
+            flagImageRepository = FlagImageRepository(imageLoader = loader, displayDensity = 3f),
+            analyticsRequestExecutor = analyticsRequestExecutor,
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = application,
+                publishableKey = "pk_test_123",
+            ),
+        )
+
+        Scenario(
+            resolver = resolver,
+            loader = loader,
+            analyticsRequestExecutor = analyticsRequestExecutor,
+        ).block()
+
+        loader.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val resolver: FlagImageResolver,
+        val loader: FakeStripeImageLoader,
+        val analyticsRequestExecutor: FakeAnalyticsRequestExecutor,
+    )
+}


### PR DESCRIPTION
Extract the adaptive-pricing flag-image resolution out of a standalone resolver so it can be reused and injected, and make FlagImageRepository DI-constructable via an @Inject constructor and a @DisplayDensity qualifier. FlagImageResolver caches images across mutations, reusing them when the integration and local currencies are unchanged and reporting AdaptivePricingFlagImageLoadFailed analytics on download failures.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
