### PR TITLE
Introduce CheckoutController Builder, DI component, and scoped destroy()

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -5,20 +5,26 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import dev.drewhamilton.poko.Poko
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Suppress("TooManyFunctions", "UnusedParameter")
-class CheckoutController(
-    application: Application,
-    savedStateHandle: SavedStateHandle,
+class CheckoutController @Inject internal constructor(
     resultCallback: ResultCallback,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     private val _checkoutSession = MutableStateFlow<CheckoutSession?>(null)
     val checkoutSession: StateFlow<CheckoutSession?> = _checkoutSession.asStateFlow()
@@ -75,11 +81,29 @@ class CheckoutController(
     }
 
     fun destroy() {
-        TODO("Not yet implemented")
+        viewModelScope.cancel()
     }
 
     fun clearPaymentOption() {
         TODO("Not yet implemented")
+    }
+
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class Builder(
+        private val application: Application,
+        private val savedStateHandle: SavedStateHandle,
+        private val resultCallback: ResultCallback,
+    ) {
+        fun build(): CheckoutController {
+            val component = DaggerCheckoutControllerComponent.factory().create(
+                application = application,
+                savedStateHandle = savedStateHandle,
+                resultCallback = resultCallback,
+            )
+
+            return component.checkoutController
+        }
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -1,0 +1,45 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout.injection
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        CheckoutControllerModule::class,
+    ],
+)
+internal interface CheckoutControllerComponent {
+    val checkoutController: CheckoutController
+
+    @Component.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance application: Application,
+            @BindsInstance savedStateHandle: SavedStateHandle,
+            @BindsInstance resultCallback: CheckoutController.ResultCallback,
+        ): CheckoutControllerComponent
+    }
+}
+
+@Module
+internal object CheckoutControllerModule {
+    @Provides
+    @Singleton
+    @ViewModelScope
+    fun provideViewModelScope(): CoroutineScope {
+        return CoroutineScope(Dispatchers.Main)
+    }
+}


### PR DESCRIPTION
Wire CheckoutController through a Dagger component so it can be constructed via a Builder. Inject a @ViewModelScope CoroutineScope and cancel it in destroy(). No state-holder or loading behavior is included.

This is ultimately how merchants will create their checkout controller.
