### PR TITLE
Add subtotal as SUBTOTAL DisplayItem in Google Pay

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -23,11 +23,20 @@ internal object GooglePayDisplayItemsFactory {
         items += checkoutSession.lineItems.map { it.asDisplayItem() }
 
         checkoutSession.totalSummary?.let { summary ->
+            items += summary.asSubtotalDisplayItem()
             items += summary.discountAmounts.map { it.asDisplayItem() }
             items += summary.taxAmounts.map { it.asDisplayItem() }
         }
 
         return items
+    }
+
+    private fun CheckoutSession.TotalSummary.asSubtotalDisplayItem(): GooglePayJsonFactory.DisplayItem {
+        return GooglePayJsonFactory.DisplayItem(
+            label = SUBTOTAL_LABEL,
+            type = GooglePayJsonFactory.DisplayItem.Type.SUBTOTAL,
+            price = subtotal,
+        )
     }
 
     private fun CheckoutSession.LineItem.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
@@ -54,4 +63,6 @@ internal object GooglePayDisplayItemsFactory {
             price = amount,
         )
     }
+
+    private const val SUBTOTAL_LABEL = "Subtotal"
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -210,36 +210,6 @@ class GooglePayDisplayItemsFactoryTest {
         ).inOrder()
     }
 
-    @Test
-    fun `includes subtotal from total summary when no discounts or taxes`() {
-        val result = createAndGetDisplayItems(
-            lineItems = listOf(
-                lineItem(
-                    id = "li_1", name = "Widget", quantity = 1,
-                    unitAmount = 1000L, subtotal = 1000L, total = 1000L,
-                ),
-            ),
-            totalSummary = totalSummary(
-                subtotal = 1000L,
-                totalDueToday = 1000L,
-                totalAmountDue = 1000L,
-            ),
-        )
-
-        assertThat(result).containsExactly(
-            displayItem(
-                label = "Widget",
-                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 1000L,
-            ),
-            displayItem(
-                label = "Subtotal",
-                type = GooglePayJsonFactory.DisplayItem.Type.SUBTOTAL,
-                price = 1000L,
-            ),
-        ).inOrder()
-    }
-
     private fun createAndGetDisplayItems(
         lineItems: List<CheckoutSessionResponse.LineItem>,
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -118,6 +118,11 @@ class GooglePayDisplayItemsFactoryTest {
                 price = 2000L,
             ),
             displayItem(
+                label = "Subtotal",
+                type = GooglePayJsonFactory.DisplayItem.Type.SUBTOTAL,
+                price = 2000L,
+            ),
+            displayItem(
                 label = "SAVE50",
                 type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
                 price = -500L,
@@ -148,6 +153,11 @@ class GooglePayDisplayItemsFactoryTest {
             displayItem(
                 label = "Widget",
                 type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 1000L,
+            ),
+            displayItem(
+                label = "Subtotal",
+                type = GooglePayJsonFactory.DisplayItem.Type.SUBTOTAL,
                 price = 1000L,
             ),
             displayItem(
@@ -183,6 +193,11 @@ class GooglePayDisplayItemsFactoryTest {
                 price = 2000L,
             ),
             displayItem(
+                label = "Subtotal",
+                type = GooglePayJsonFactory.DisplayItem.Type.SUBTOTAL,
+                price = 2000L,
+            ),
+            displayItem(
                 label = "SAVE50",
                 type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
                 price = -500L,
@@ -191,6 +206,36 @@ class GooglePayDisplayItemsFactoryTest {
                 label = "VAT",
                 type = GooglePayJsonFactory.DisplayItem.Type.TAX,
                 price = 120L,
+            ),
+        ).inOrder()
+    }
+
+    @Test
+    fun `includes subtotal from total summary when no discounts or taxes`() {
+        val result = createAndGetDisplayItems(
+            lineItems = listOf(
+                lineItem(
+                    id = "li_1", name = "Widget", quantity = 1,
+                    unitAmount = 1000L, subtotal = 1000L, total = 1000L,
+                ),
+            ),
+            totalSummary = totalSummary(
+                subtotal = 1000L,
+                totalDueToday = 1000L,
+                totalAmountDue = 1000L,
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            displayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 1000L,
+            ),
+            displayItem(
+                label = "Subtotal",
+                type = GooglePayJsonFactory.DisplayItem.Type.SUBTOTAL,
+                price = 1000L,
             ),
         ).inOrder()
     }


### PR DESCRIPTION
# Summary
Add `total.subtotal` from CheckoutSession as a `SUBTOTAL` DisplayItem row in the Google Pay payment request.

The subtotal (pre-discount, pre-tax sum of line items) was already available on `TotalSummary` but not being surfaced to the Google Pay sheet. This wires it in via the existing `GooglePayDisplayItemsFactory`, positioned after line items and before discounts/taxes — matching receipt conventions.

# Motivation
MOBILESDK-4641. The Google Pay payment sheet shows a line-item breakdown; showing the subtotal helps customers understand the price adjustments (discounts, taxes) that follow it.

# Testing
- [x] Added tests
- [x] Modified tests

Updated 3 existing tests in `GooglePayDisplayItemsFactoryTest` to assert SUBTOTAL appears in the correct position. Added 1 new test for the case where `totalSummary` has no discounts or taxes.

# Screenshots
N/A — DisplayItems are rendered by the Google Pay SDK sheet, not by Stripe UI.

# Changelog
<!-- Internal EwCS feature, no public changelog entry needed -->