### PR TITLE
Treat CustomerSheet OS-teardown as a no-op instead of a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ NEXT_VERSION_BUMP: MINOR
 ### PaymentSheet
 * [ADDED] Standalone Link wallet APIs in private preview via `LinkController`.
 
+### CustomerSheet
+* [FIXED][13383](https://github.com/stripe/stripe-android/issues/13383) `CustomerSheet` no longer reports a failure when the sheet is torn down by the OS without returning a result (e.g. when a `singleTask` host activity is relaunched). The result callback is now a no-op in that case, leaving the merchant's state unchanged.
+
 ## 23.11.1 - 2026-06-30
 
 ### PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -167,10 +167,14 @@ class CustomerSheet internal constructor(
         }
     }
 
-    private fun onCustomerSheetResult(result: InternalCustomerSheetResult) {
-        callback.onCustomerSheetResult(
-            result.toPublicResult(paymentOptionFactory)
-        )
+    private fun onCustomerSheetResult(result: InternalCustomerSheetResult?) {
+        // A null result means the sheet was torn down by the OS without returning a result (e.g.
+        // when a `singleTask` host is relaunched). Leave the caller's state untouched in that case.
+        result?.let {
+            callback.onCustomerSheetResult(
+                it.toPublicResult(paymentOptionFactory)
+            )
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetContract.kt
@@ -9,16 +9,17 @@ import kotlinx.parcelize.Parcelize
 private const val ArgsKey = "args"
 
 internal class CustomerSheetContract :
-    ActivityResultContract<CustomerSheetContract.Args, InternalCustomerSheetResult>() {
+    ActivityResultContract<CustomerSheetContract.Args, InternalCustomerSheetResult?>() {
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(context, CustomerSheetActivity::class.java)
             .putExtra(ArgsKey, input)
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): InternalCustomerSheetResult {
-        return InternalCustomerSheetResult.fromIntent(intent) ?: InternalCustomerSheetResult.Error(
-            IllegalArgumentException("Failed to retrieve a CustomerSheetResult")
-        )
+    override fun parseResult(resultCode: Int, intent: Intent?): InternalCustomerSheetResult? {
+        // A null result means the activity was torn down without returning a result (e.g. the OS
+        // cleared it when a `singleTask` host was relaunched). The happy path always writes a
+        // valid result, so callers should treat null as a no-op rather than a failure.
+        return InternalCustomerSheetResult.fromIntent(intent)
     }
 
     @Parcelize

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper.createViewModel
-import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -75,7 +74,7 @@ internal class CustomerSheetActivityTest {
     }
 
     @Test
-    fun `Finish without result emits null result and contract parses error`() {
+    fun `Finish without result emits null result and contract parses null`() {
         runActivityScenario {
             activity.finish()
             assertThat(
@@ -87,7 +86,7 @@ internal class CustomerSheetActivityTest {
                 scenario.getResult().resultCode,
                 scenario.getResult().resultData,
             )
-            assertThat(result).isInstanceOf<InternalCustomerSheetResult.Error>()
+            assertThat(result).isNull()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetContractTest.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.customersheet
+
+import android.app.Activity
+import android.content.Intent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CustomerSheetContractTest {
+
+    @Test
+    fun `parseResult returns null when canceled without a result`() {
+        val contract = CustomerSheetContract()
+
+        val result = contract.parseResult(Activity.RESULT_CANCELED, null)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parseResult returns null when the intent has no result extra`() {
+        val contract = CustomerSheetContract()
+
+        val result = contract.parseResult(Activity.RESULT_OK, Intent())
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `parseResult parses a canceled result from the intent`() {
+        val contract = CustomerSheetContract()
+        val expected = InternalCustomerSheetResult.Canceled(paymentSelection = null)
+        val intent = Intent().putExtras(expected.toBundle())
+
+        val result = contract.parseResult(Activity.RESULT_OK, intent)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `parseResult parses a selected result from the intent`() {
+        val contract = CustomerSheetContract()
+        val expected = InternalCustomerSheetResult.Selected(paymentSelection = null)
+        val intent = Intent().putExtras(expected.toBundle())
+
+        val result = contract.parseResult(Activity.RESULT_OK, intent)
+
+        assertThat(result).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #13383.

When a host activity uses `launchMode="singleTask"`, backgrounding the app while `CustomerSheet` is open and relaunching via the app icon causes Android to clear `CustomerSheetActivity` off the task stack without it returning a result. The system then delivers `RESULT_CANCELED` with a `null` intent to `CustomerSheetContract.parseResult`, which previously mapped to a hard `Error` ("Failed to retrieve a CustomerSheetResult"). Integrators surface that as a scary retry / soft-block UI, even though the user simply had the sheet torn down by the OS.

### Why a no-op (not an Error, and not a synthetic `Canceled`)

- The sheet UI genuinely cannot resume — the activity is removed from the task stack and CustomerSheet saves no UI/nav state (`CustomerSheetActivity` has no `onSaveInstanceState`).
- But no *committed* data is lost: CustomerSheet writes every change to the backend as it happens (attach / detach / update / set-default are immediate network calls). Re-opening the sheet reloads that state.
- So the desired behavior is "continue as it was before": don't tell the merchant anything, leave their displayed selection untouched, and let a future `present()` reload fresh from the backend.

A synthetic `Canceled(selection = null)` was considered but rejected: it would clear the merchant's displayed selection for integrators that read `result.selection` on cancel. A true no-op avoids that footgun.

## Changes

- `CustomerSheetContract` output type is now nullable; `parseResult` returns `null` when the intent carries no result (the OS-teardown case — the happy path always writes a valid result).
- `CustomerSheet.onCustomerSheetResult` accepts a nullable result and skips the callback on `null`.
- Added `CustomerSheetContractTest` and updated the existing activity-level test that encoded the old Error-on-null behavior.

### Behavior-change note

This changes an implicit guarantee: previously every `present()` eventually produced a `CustomerSheetResultCallback` invocation. After this change, an OS-teardown produces none. This is safe because `present()` is fire-and-forget (the sheet is a separate activity) and the sheet closing itself requires no merchant action.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CustomerSheetContractTest*" --tests "*CustomerSheetActivityTest*"` ✅
- `./gradlew :paymentsheet:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)