### PR TITLE
Serialize mutations and show loading state in CheckoutController.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -9,13 +9,23 @@ import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 
 @Singleton
 @CheckoutSessionPreview
@@ -32,14 +42,24 @@ class CheckoutController @Inject internal constructor(
     val checkoutSession: StateFlow<CheckoutSession?>
         get() = stateHolder.checkoutSession
 
+    private val mutex = Mutex()
+    private val pendingMutations = AtomicInteger(0)
+
+    private val _isLoading = MutableStateFlow(false)
+
+    /**
+     * Whether a mutation is currently in progress.
+     */
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
     suspend fun configure(
         checkoutSessionClientSecret: String,
         configuration: Configuration = Configuration(),
-    ): kotlin.Result<Unit> {
+    ): kotlin.Result<Unit> = runSerialized {
         val configurationState = configuration.build()
         val sessionId = checkoutSessionClientSecret.substringBefore("_secret_")
 
-        return checkoutSessionRepository.init(
+        checkoutSessionRepository.init(
             sessionId = sessionId,
             adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
         ).mapCatching { response ->
@@ -52,44 +72,201 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
-    suspend fun applyPromotionCode(promotionCode: String): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    /**
+     * Applies a promotion code to the checkout session.
+     *
+     * @param promotionCode The promotion code to apply. Leading/trailing whitespace is trimmed.
+     */
+    suspend fun applyPromotionCode(
+        promotionCode: String,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.applyPromotionCode(sessionId, promotionCode.trim())
     }
 
-    suspend fun removePromotionCode(): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    /**
+     * Removes the currently applied promotion code from the checkout session.
+     */
+    suspend fun removePromotionCode(): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.applyPromotionCode(sessionId, "")
     }
 
-    suspend fun updateLineItemQuantity(lineItemId: String, quantity: Int): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    /**
+     * Updates the quantity of a line item.
+     *
+     * @param lineItemId The ID of the line item to update.
+     * @param quantity The new quantity.
+     */
+    suspend fun updateLineItemQuantity(
+        lineItemId: String,
+        quantity: Int,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.updateLineItemQuantity(sessionId, lineItemId, quantity)
     }
 
-    suspend fun selectShippingOption(id: String): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    /**
+     * Selects a shipping option.
+     *
+     * @param id The ID of the shipping option to select.
+     */
+    suspend fun selectShippingOption(
+        id: String,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.selectShippingRate(sessionId, id)
     }
 
+    /**
+     * Sets the shipping address for this checkout.
+     *
+     * The address is stored locally and used when presenting payment UI. If automatic tax is
+     * enabled and the tax address source is shipping, the address is also sent to the server
+     * to compute updated tax amounts.
+     *
+     * @param name The recipient's name.
+     * @param phoneNumber The recipient's phone number.
+     * @param address The shipping address.
+     */
     suspend fun updateShippingAddress(
         name: String?,
         phoneNumber: String?,
         address: Address,
-    ): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    ): kotlin.Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.SHIPPING, address) {
+        copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
     }
 
-    suspend fun updateTaxId(type: String, value: String): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    /**
+     * Updates the customer's tax ID.
+     *
+     * @param type The type of tax ID (e.g. "eu_vat"). Leading/trailing whitespace is trimmed.
+     * @param value The tax ID value. Leading/trailing whitespace is trimmed.
+     */
+    suspend fun updateTaxId(
+        type: String,
+        value: String,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.updateTaxId(sessionId, type.trim(), value.trim())
     }
 
+    /**
+     * Sets the billing address for this checkout.
+     *
+     * The address is stored locally and used when presenting payment UI. If automatic tax is
+     * enabled and the tax address source is billing, the address is also sent to the server
+     * to compute updated tax amounts.
+     *
+     * @param name The billing name.
+     * @param phoneNumber The billing phone number.
+     * @param address The billing address.
+     */
     suspend fun updateBillingAddress(
         name: String?,
         phoneNumber: String?,
         address: Address,
-    ): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    ): kotlin.Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.BILLING, address) {
+        copy(billingName = name, billingPhoneNumber = phoneNumber, billingAddress = it)
     }
 
-    suspend fun runServerUpdate(serverUpdate: suspend () -> kotlin.Result<Unit>): kotlin.Result<Unit> {
-        TODO("Not yet implemented")
+    /**
+     * Runs an async function that calls your server to update the Checkout Session,
+     * then automatically refreshes [checkoutSession] with the latest session data.
+     *
+     * A 20-second timeout is enforced. If [serverUpdate] doesn't complete within 20 seconds,
+     * this method returns a [kotlin.Result.failure] with a timeout exception.
+     *
+     * @param serverUpdate A suspend function that makes a request to your server to update
+     * the Checkout Session.
+     */
+    suspend fun runServerUpdate(
+        serverUpdate: suspend () -> kotlin.Result<Unit>,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        withTimeout(SERVER_UPDATE_TIMEOUT_MS) { serverUpdate() }.fold(
+            onSuccess = {
+                checkoutSessionRepository.init(
+                    sessionId = sessionId,
+                    adaptivePricingAllowed = configuration.adaptivePricingAllowed,
+                )
+            },
+            onFailure = { kotlin.Result.failure(it) },
+        )
+    }
+
+    private suspend fun updateAddress(
+        addressType: CheckoutSessionResponse.TaxAddressSource,
+        address: Address,
+        mutation: CheckoutControllerState.(Address.State) -> CheckoutControllerState,
+    ): kotlin.Result<Unit> {
+        val built = address.build()
+        return withCheckoutState(
+            additionalStateMutations = { mutation(built) },
+        ) { sessionId ->
+            val shouldSendTaxRegion = checkoutSessionResponse.automaticTaxEnabled &&
+                checkoutSessionResponse.taxAddressSource == addressType
+            if (shouldSendTaxRegion) {
+                checkoutSessionRepository.updateTaxRegion(sessionId, built)
+            } else {
+                kotlin.Result.success(checkoutSessionResponse)
+            }
+        }
+    }
+
+    /**
+     * Runs a mutation against the checkout session, serializing it behind [mutex] so mutations run
+     * in sequence. [block] produces the updated [CheckoutSessionResponse]; the result is folded into
+     * a new [CheckoutControllerState] (with any [additionalStateMutations] applied) and handed to
+     * [checkoutStateLoader] to reload the payment element and atomically commit the new state.
+     *
+     * Returns [kotlin.Result.failure] if the session hasn't been configured yet or a payment flow is
+     * currently presented.
+     */
+    private suspend fun withCheckoutState(
+        additionalStateMutations: CheckoutControllerState.() -> CheckoutControllerState = { this },
+        block: suspend CheckoutControllerState.(sessionId: String) -> kotlin.Result<CheckoutSessionResponse>,
+    ): kotlin.Result<Unit> {
+        val currentState = stateHolder.state
+            ?: return kotlin.Result.failure(
+                IllegalStateException("Cannot mutate checkout session before it is configured.")
+            )
+        if (currentState.integrationLaunched) {
+            return kotlin.Result.failure(
+                IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
+            )
+        }
+        return runSerialized {
+            runCatching {
+                // Re-read the latest committed state inside the lock so serialized mutations
+                // build on each other's results rather than a stale snapshot.
+                val state = requireNotNull(stateHolder.state)
+                val response = state.block(state.checkoutSessionResponse.id).getOrThrow()
+                val newState = state
+                    .copy(checkoutSessionResponse = response)
+                    .additionalStateMutations()
+                // load resolves flag images (reusing newState's carried-over cache) and
+                // atomically commits the reloaded state to the holders.
+                checkoutStateLoader.load(newState)
+            }
+        }
+    }
+
+    /**
+     * Serializes [block] behind [mutex] so configuration and mutations run in sequence, and toggles
+     * [isLoading] while any serialized work is in flight (tracked via [pendingMutations] so
+     * concurrent callers share a single loading window).
+     */
+    private suspend fun <T> runSerialized(
+        block: suspend () -> kotlin.Result<T>,
+    ): kotlin.Result<T> {
+        if (pendingMutations.incrementAndGet() == 1) {
+            _isLoading.value = true
+        }
+        return try {
+            // Run network requests with a mutex to ensure events are processed in order.
+            mutex.withLock {
+                block()
+            }
+        } finally {
+            if (pendingMutations.decrementAndGet() == 0) {
+                _isLoading.value = false
+            }
+        }
     }
 
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -3,25 +3,41 @@ package com.stripe.android.checkout
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
+import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
+import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("LargeClass")
 internal class CheckoutControllerTest {
 
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
@@ -226,6 +242,471 @@ internal class CheckoutControllerTest {
             .isEqualTo("existing_identifier")
     }
 
+    @Test
+    fun `applyPromotionCode sends promotion code and reloads on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.applyPromotionCode("10OFF")
+
+        result.getOrThrow()
+        assertThat(controller.confirmationStateHolder.state).isNotNull()
+    }
+
+    @Test
+    fun `applyPromotionCode trims whitespace from promotion code`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.applyPromotionCode("  10OFF  ")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `applyPromotionCode returns failure and preserves session on error`() = runMutationScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid promotion code"}}""")
+        }
+        val before = controller.checkoutSession.value
+
+        val result = controller.applyPromotionCode("INVALID")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
+    fun `removePromotionCode sends empty promotion code on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", ""),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.removePromotionCode()
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateLineItemQuantity sends line item params and updates session on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("updated_line_item_quantity[line_item_id]", "li_1"),
+            bodyPart("updated_line_item_quantity[quantity]", "3"),
+            bodyPart("updated_line_item_quantity[fail_update_on_discount_error]", "true"),
+            responseFactory = successResponseFactory { json ->
+                json.put("total_summary", totalSummaryJson(due = 7000))
+            },
+        )
+
+        val result = controller.updateLineItemQuantity("li_1", 3)
+
+        result.getOrThrow()
+        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(7000)
+    }
+
+    @Test
+    fun `updateLineItemQuantity returns failure and preserves session on error`() = runMutationScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid quantity"}}""")
+        }
+        val before = controller.checkoutSession.value
+
+        val result = controller.updateLineItemQuantity("li_1", -1)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
+    fun `selectShippingOption sends shipping rate on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("shipping_rate", "shr_express"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.selectShippingOption("shr_express")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `selectShippingOption returns failure on error`() = runMutationScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid shipping rate"}}""")
+        }
+        val before = controller.checkoutSession.value
+
+        val result = controller.selectShippingOption("shr_invalid")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
+    fun `updateTaxId sends type and value on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("tax_id_collection[tax_id][type]", "us_ein"),
+            bodyPart("tax_id_collection[tax_id][value]", "123456789"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.updateTaxId("us_ein", "123456789")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateTaxId trims whitespace from type and value`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("tax_id_collection[tax_id][type]", "us_ein"),
+            bodyPart("tax_id_collection[tax_id][value]", "123456789"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.updateTaxId("  us_ein  ", "  123456789  ")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateShippingAddress sends tax_region and stores address when automatic tax targets shipping`() =
+        runMutationScenario(initModifier = automaticTaxFor("shipping")) {
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("tax_region[city]", "Denver"),
+                bodyPart("tax_region[state]", "CO"),
+                bodyPart("tax_region[postal_code]", "80202"),
+                bodyPart("tax_region[line1]", "123 Main St"),
+                bodyPart("tax_region[line2]", "Apt 4"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+                responseFactory = successResponseFactory(automaticTaxFor("shipping")),
+            )
+
+            val result = controller.updateShippingAddress(
+                name = "John",
+                phoneNumber = "5551234567",
+                address = fullAddress,
+            )
+
+            result.getOrThrow()
+            val state = committedState()
+            assertThat(state.shippingName).isEqualTo("John")
+            assertThat(state.shippingPhoneNumber).isEqualTo("5551234567")
+            assertThat(state.shippingAddress).isEqualTo(fullAddress.build())
+        }
+
+    @Test
+    fun `updateShippingAddress omits empty fields from tax_region request`() =
+        runMutationScenario(initModifier = automaticTaxFor("shipping")) {
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("tax_region[postal_code]", "80202"),
+                not(hasBodyPart("tax_region[city]")),
+                not(hasBodyPart("tax_region[state]")),
+                not(hasBodyPart("tax_region[line1]")),
+                not(hasBodyPart("tax_region[line2]")),
+                responseFactory = successResponseFactory(automaticTaxFor("shipping")),
+            )
+
+            val address = Address().country("US").postalCode("80202")
+            val result = controller.updateShippingAddress(name = null, phoneNumber = null, address = address)
+
+            assertThat(result.isSuccess).isTrue()
+        }
+
+    @Test
+    fun `updateShippingAddress stores address without a network call when automatic tax is disabled`() =
+        runMutationScenario {
+            // No checkoutUpdate is enqueued: with automatic tax off, the address is stored locally
+            // and the payment element is reloaded from the existing response, firing no request.
+            val result = controller.updateShippingAddress(name = "John", phoneNumber = null, address = fullAddress)
+
+            result.getOrThrow()
+            val state = committedState()
+            assertThat(state.shippingName).isEqualTo("John")
+            assertThat(state.shippingAddress).isEqualTo(fullAddress.build())
+        }
+
+    @Test
+    fun `updateShippingAddress does not store address on failure`() =
+        runMutationScenario(initModifier = automaticTaxFor("shipping")) {
+            networkRule.checkoutUpdate { response ->
+                response.setResponseCode(400)
+                response.setBody("""{"error": {"message": "Invalid address"}}""")
+            }
+
+            val result = controller.updateShippingAddress(name = "John", phoneNumber = null, address = fullAddress)
+
+            assertThat(result.isFailure).isTrue()
+            val state = committedState()
+            assertThat(state.shippingName).isNull()
+            assertThat(state.shippingAddress).isNull()
+        }
+
+    @Test
+    fun `updateBillingAddress sends tax_region and stores address when automatic tax targets billing`() =
+        runMutationScenario(initModifier = automaticTaxFor("billing")) {
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("tax_region[city]", "Denver"),
+                bodyPart("tax_region[postal_code]", "80202"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+                responseFactory = successResponseFactory(automaticTaxFor("billing")),
+            )
+
+            val result = controller.updateBillingAddress(
+                name = "Jane",
+                phoneNumber = "5559876543",
+                address = fullAddress,
+            )
+
+            result.getOrThrow()
+            val state = committedState()
+            assertThat(state.billingName).isEqualTo("Jane")
+            assertThat(state.billingPhoneNumber).isEqualTo("5559876543")
+            assertThat(state.billingAddress).isEqualTo(fullAddress.build())
+        }
+
+    @Test
+    fun `updateBillingAddress does not send tax_region when automatic tax targets shipping`() =
+        runMutationScenario(initModifier = automaticTaxFor("shipping")) {
+            // Automatic tax targets shipping, so a billing address update stays local: no request.
+            val result = controller.updateBillingAddress(name = "Jane", phoneNumber = null, address = fullAddress)
+
+            result.getOrThrow()
+            val state = committedState()
+            assertThat(state.billingName).isEqualTo("Jane")
+            assertThat(state.billingAddress).isEqualTo(fullAddress.build())
+        }
+
+    @Test
+    fun `runServerUpdate refreshes the session after serverUpdate completes`() = runMutationScenario {
+        networkRule.checkoutInit(
+            responseFactory = successResponseFactory { json ->
+                json.put("total_summary", totalSummaryJson(due = 8000))
+            },
+        )
+
+        val result = controller.runServerUpdate { Result.success(Unit) }
+
+        result.getOrThrow()
+        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(8000)
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when serverUpdate throws`() = runMutationScenario {
+        val before = controller.checkoutSession.value
+
+        val result = controller.runServerUpdate { throw IllegalStateException("Server error") }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo("Server error")
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when serverUpdate fails`() = runMutationScenario {
+        val result = controller.runServerUpdate {
+            Result.failure(IllegalStateException("Server error"))
+        }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo("Server error")
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when the refresh fails`() = runMutationScenario {
+        networkRule.checkoutInit { response ->
+            response.setResponseCode(500)
+            response.setBody("""{"error": {"message": "Internal server error"}}""")
+        }
+        val before = controller.checkoutSession.value
+
+        val result = controller.runServerUpdate { Result.success(Unit) }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when serverUpdate exceeds the timeout`() = runMutationScenario {
+        val result = controller.runServerUpdate {
+            delay(21_000)
+            Result.success(Unit)
+        }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(TimeoutCancellationException::class.java)
+    }
+
+    @Test
+    fun `mutation returns failure before the session is configured`() = runTest {
+        val controller = createController()
+
+        val result = controller.applyPromotionCode("10OFF")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate checkout session before it is configured.")
+    }
+
+    @Test
+    fun `mutation returns failure when a payment flow is presented`() = runMutationScenario {
+        markIntegrationLaunched()
+
+        val result = controller.applyPromotionCode("10OFF")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
+    }
+
+    @Test
+    fun `runServerUpdate returns failure when a payment flow is presented`() = runMutationScenario {
+        markIntegrationLaunched()
+
+        val result = controller.runServerUpdate { Result.success(Unit) }
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
+    }
+
+    @Test
+    fun `isLoading transitions to true then false on a successful mutation`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+            responseFactory = successResponseFactory(),
+        )
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+        controller.applyPromotionCode("10OFF")
+
+        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        isLoadingTurbine.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `isLoading stays true while queued mutations are pending`() = runMutationScenario {
+        val holdFirstResponse = CountDownLatch(1)
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "10OFF"),
+        ) { response ->
+            holdFirstResponse.await(10, TimeUnit.SECONDS)
+            successResponseFactory().invoke(response)
+        }
+        networkRule.checkoutUpdate(
+            bodyPart("promotion_code", "20OFF"),
+            responseFactory = successResponseFactory(),
+        )
+
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+        val job1 = async { controller.applyPromotionCode("10OFF") }
+        val job2 = async { controller.applyPromotionCode("20OFF") }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+
+        holdFirstResponse.countDown()
+        job1.await()
+        job2.await()
+
+        // isLoading should go directly from true to false with no intermediate flicker.
+        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        isLoadingTurbine.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `concurrent mutations are serialized so the second uses the first result's session id`() =
+        runMutationScenario {
+            // The first mutation is delayed and returns a new session id.
+            networkRule.checkoutUpdate(
+                bodyPart("promotion_code", "10OFF"),
+            ) { response ->
+                response.setBodyDelay(200, TimeUnit.MILLISECONDS)
+                successResponseFactory { json -> json.put("session_id", "cs_test_after_promo") }.invoke(response)
+            }
+            // The second mutation must target the session id produced by the first, proving the
+            // mutex serialized them (an unserialized call would hit the original id and fail).
+            networkRule.checkoutUpdate(
+                bodyPart("updated_line_item_quantity[line_item_id]", "li_1"),
+                sessionId = "cs_test_after_promo",
+                responseFactory = successResponseFactory { json -> json.put("session_id", "cs_test_after_promo") },
+            )
+
+            val results = listOf(
+                async { controller.applyPromotionCode("10OFF") },
+                async { controller.updateLineItemQuantity("li_1", 2) },
+            ).awaitAll()
+
+            assertThat(results[0].isSuccess).isTrue()
+            assertThat(results[1].isSuccess).isTrue()
+            assertThat(controller.checkoutSession.value?.id).isEqualTo("cs_test_after_promo")
+        }
+
+    @Test
+    fun `configure toggles isLoading true then false`() = runTest {
+        networkRule.defaultInit()
+        val controller = createController()
+
+        turbineScope {
+            val isLoadingTurbine = controller.isLoading.testIn(backgroundScope)
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+            controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+
+            assertThat(isLoadingTurbine.awaitItem()).isTrue()
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            isLoadingTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `configure is serialized behind an in-flight mutation and shares its loading window`() =
+        runMutationScenario {
+            val holdMutation = CountDownLatch(1)
+            networkRule.checkoutUpdate(
+                bodyPart("promotion_code", "10OFF"),
+            ) { response ->
+                holdMutation.await(10, TimeUnit.SECONDS)
+                successResponseFactory().invoke(response)
+            }
+            networkRule.checkoutInit(responseFactory = successResponseFactory())
+
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+            val mutation = async { controller.applyPromotionCode("10OFF") }
+            val configure = async { controller.configure(DEFAULT_CLIENT_SECRET) }
+            testScheduler.advanceUntilIdle()
+
+            assertThat(isLoadingTurbine.awaitItem()).isTrue()
+            // configure cannot complete while the mutation holds the mutex, proving it is serialized.
+            assertThat(configure.isCompleted).isFalse()
+
+            holdMutation.countDown()
+            assertThat(mutation.await().isSuccess).isTrue()
+            assertThat(configure.await().isSuccess).isTrue()
+
+            // A single loading window spanned both operations, with no flicker to false in between.
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            isLoadingTurbine.ensureAllEventsConsumed()
+        }
+
     private fun NetworkRule.defaultInit() {
         checkoutInit(responseFactory = ::successResponse)
     }
@@ -235,10 +716,38 @@ internal class CheckoutControllerTest {
     // Link is disabled so the loader doesn't fire a consumer session lookup that's unrelated to
     // what these tests verify.
     private fun successResponse(response: MockResponse) {
+        successResponseFactory().invoke(response)
+    }
+
+    // Builds an init-style success response. Because every mutation reloads the payment element,
+    // mutation responses must also carry a full elements_session, so the same builder is reused for
+    // both `configure` and mutation endpoints. [jsonModifier] tweaks the body per test.
+    private fun successResponseFactory(
+        jsonModifier: (JSONObject) -> Unit = {},
+    ): (MockResponse) -> Unit = { response ->
         response.testBodyFromFile("checkout-session-init.json") { json ->
             json.put("customer_email", "checkout@example.com")
             json.getJSONObject("elements_session").remove("link_settings")
+            jsonModifier(json)
         }
+    }
+
+    // Builds a total_summary object. The parser requires subtotal, due, and total to all be present
+    // to produce a non-null summary, so a test asserting on totalDueToday must set all three.
+    private fun totalSummaryJson(due: Long): JSONObject = JSONObject()
+        .put("subtotal", due)
+        .put("due", due)
+        .put("total", due)
+
+    // Enables automatic tax with the given address source ("shipping" or "billing"), so an address
+    // update sends tax_region to the server.
+    private fun automaticTaxFor(source: String): (JSONObject) -> Unit = { json ->
+        json.put(
+            "tax_context",
+            JSONObject()
+                .put("automatic_tax_enabled", true)
+                .put("automatic_tax_address_source", source),
+        )
     }
 
     private fun createController(
@@ -267,6 +776,61 @@ internal class CheckoutControllerTest {
         val controller: CheckoutController,
         val result: Result<Unit>,
     )
+
+    // Configures a controller from a fresh init, then hands it to [block] alongside the shared
+    // SavedStateHandle (used to read committed state and simulate a presented payment flow) and an
+    // isLoading Turbine.
+    private fun runMutationScenario(
+        initModifier: (JSONObject) -> Unit = {},
+        block: suspend MutationScenario.() -> Unit,
+    ) = runTest {
+        networkRule.checkoutInit(responseFactory = successResponseFactory(initModifier))
+        val savedStateHandle = SavedStateHandle()
+        val controller = createController(savedStateHandle)
+        controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+
+        turbineScope {
+            val isLoadingTurbine = controller.isLoading.testIn(backgroundScope)
+            block(
+                MutationScenario(
+                    controller = controller,
+                    savedStateHandle = savedStateHandle,
+                    testScope = this@runTest,
+                    isLoadingTurbine = isLoadingTurbine,
+                )
+            )
+            isLoadingTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class MutationScenario(
+        val controller: CheckoutController,
+        private val savedStateHandle: SavedStateHandle,
+        private val testScope: TestScope,
+        val isLoadingTurbine: ReceiveTurbine<Boolean>,
+    ) : CoroutineScope by testScope {
+        val testScheduler: TestCoroutineScheduler get() = testScope.testScheduler
+
+        val fullAddress: Address = Address()
+            .city("Denver")
+            .country("US")
+            .line1("123 Main St")
+            .line2("Apt 4")
+            .postalCode("80202")
+            .state("CO")
+
+        // Reads the state the controller committed via its state holder, which shares this
+        // SavedStateHandle in the production graph.
+        fun committedState(): CheckoutControllerState =
+            requireNotNull(CheckoutControllerStateHolder(savedStateHandle).state)
+
+        // Simulates a presented payment flow by flipping the committed state's integrationLaunched
+        // flag, which the mutation guard reads back through the same SavedStateHandle.
+        fun markIntegrationLaunched() {
+            val stateHolder = CheckoutControllerStateHolder(savedStateHandle)
+            stateHolder.state = committedState().copy(integrationLaunched = true)
+        }
+    }
 
     private companion object {
         const val DEFAULT_CLIENT_SECRET = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example"


### PR DESCRIPTION
# Summary

This PR serializes all mutations in `CheckoutController` so they cannot run concurrently and provides an `isLoading` state to track when mutations are in progress. It also adds comprehensive tests for mutation behavior, error handling, and loading state transitions.

# Motivation

Previously, concurrent mutations (such as applying a promotion code and updating a line item) could conflict, leading to race conditions and inconsistent state. The changes ensure all mutations are serialized behind a mutex and transparently communicate loading state to UI consumers.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
- [Added] All CheckoutController mutations are now serialized and expose isLoading state for UI loading indicators.