### PR TITLE
Use checkout session id as CheckoutControllerState key.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -6,7 +6,6 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
-import java.util.UUID
 
 /**
  * Internal state for [CheckoutController]. Unlike [InternalState] (used by [Checkout]), this holds
@@ -48,7 +47,7 @@ internal data class CheckoutControllerState(
             configuration: CheckoutController.Configuration.State,
             checkoutSessionResponse: CheckoutSessionResponse,
         ): CheckoutControllerState = CheckoutControllerState(
-            key = UUID.randomUUID().toString(),
+            key = checkoutSessionResponse.id,
             configuration = configuration,
             checkoutSessionResponse = checkoutSessionResponse,
             flagImages = null,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -137,6 +137,7 @@ internal class CheckoutStateLoaderTest {
         loader.load(checkoutControllerState())
 
         assertThat(stateHolder.checkoutSession.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        assertThat(stateHolder.state?.key).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
         // No adaptive pricing in the response, so no flag images are resolved.
         assertThat(stateHolder.state?.flagImages).isNull()
     }


### PR DESCRIPTION
# Summary
Replaces the random UUID with the checkout session response id as the key in `CheckoutControllerState`. Updates test to verify the new key behavior.

# Motivation
Ensures consistency and traceability by using the checkout session id instead of a random UUID as the unique key for each CheckoutControllerState. This aids debugging and better aligns with the lifecycle of checkout sessions.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
- [Changed] Use the checkout session id as the key for CheckoutControllerState.