### PR TITLE
Support merchant-provided setup intent in LinkControllerPreview API

### DIFF
--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinatorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinatorTest.kt
@@ -120,7 +120,8 @@ class OnrampPresenterCoordinatorTest {
                 presentPaymentMethodsCallback = any(),
                 authenticationCallback = any(),
                 authorizeCallback = any(),
-                presentCallback = any()
+                presentCallback = any(),
+                confirmSetupIntentCallback = any(),
             )
         ).thenReturn(linkPresenter)
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -250,7 +250,39 @@ public final class com/stripe/android/link/LinkController$Configuration {
 	public final fun allowLogout (Z)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun email (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun phoneNumber (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
+	public final fun setupIntentClientSecret (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun supportedPaymentMethodTypes (Ljava/util/List;)Lcom/stripe/android/link/LinkController$Configuration;
+}
+
+public abstract interface class com/stripe/android/link/LinkController$ConfirmSetupIntentCallback {
+	public abstract fun onConfirmSetupIntentResult (Lcom/stripe/android/link/LinkController$ConfirmSetupIntentResult;)V
+}
+
+public abstract interface class com/stripe/android/link/LinkController$ConfirmSetupIntentResult {
+}
+
+public final class com/stripe/android/link/LinkController$ConfirmSetupIntentResult$Canceled : com/stripe/android/link/LinkController$ConfirmSetupIntentResult {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/link/LinkController$ConfirmSetupIntentResult$Canceled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/LinkController$ConfirmSetupIntentResult$Failed : com/stripe/android/link/LinkController$ConfirmSetupIntentResult {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/LinkController$ConfirmSetupIntentResult$Success : com/stripe/android/link/LinkController$ConfirmSetupIntentResult {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/link/LinkController$PaymentMethodPreview {
@@ -302,6 +334,7 @@ public final class com/stripe/android/link/LinkController$PresentResult$Failed :
 
 public final class com/stripe/android/link/LinkController$Presenter {
 	public static final field $stable I
+	public final fun createPaymentMethodAndConfirmSetupIntent ()V
 	public final fun present ()V
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -21,8 +21,13 @@ internal class DefaultLinkConfigurationLoader @Inject constructor(
     private val tag = "LinkConfigurationLoader"
 
     override suspend fun load(configuration: LinkController.Configuration.State): Result<LinkMetadata> {
+        val initializationMode = if (configuration.setupIntentClientSecret != null) {
+            PaymentElementLoader.InitializationMode.SetupIntent(configuration.setupIntentClientSecret)
+        } else {
+            PaymentElementLoader.InitializationMode.CryptoOnramp
+        }
         return paymentElementLoader.load(
-            initializationMode = PaymentElementLoader.InitializationMode.CryptoOnramp,
+            initializationMode = initializationMode,
             integrationConfiguration = PaymentElementLoader.Configuration.CryptoOnramp(configuration),
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = savedStateHandle.contains(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -140,6 +140,7 @@ class LinkController @Inject internal constructor(
         authenticationCallback = {},
         authorizeCallback = {},
         presentCallback = presentCallback,
+        confirmSetupIntentCallback = ConfirmSetupIntentCallback { },
     )
 
     /**
@@ -156,6 +157,7 @@ class LinkController @Inject internal constructor(
         authenticationCallback: AuthenticationCallback,
         authorizeCallback: AuthorizeCallback,
         presentCallback: PresentCallback = PresentCallback {},
+        confirmSetupIntentCallback: ConfirmSetupIntentCallback = ConfirmSetupIntentCallback { },
     ): Presenter {
         return presenterComponentFactory
             .build(
@@ -166,6 +168,7 @@ class LinkController @Inject internal constructor(
                 authenticationCallback = authenticationCallback,
                 authorizeCallback = authorizeCallback,
                 presentCallback = presentCallback,
+                confirmSetupIntentCallback = confirmSetupIntentCallback,
             )
             .presenter
     }
@@ -223,6 +226,7 @@ class LinkController @Inject internal constructor(
             ConfigurationDefaults.billingDetailsCollectionConfiguration
         private var allowUserEmailEdits: Boolean = true
         private var allowLogout: Boolean = true
+        private var setupIntentClientSecret: String? = null
 
         constructor(
             publishableKey: String,
@@ -279,6 +283,11 @@ class LinkController @Inject internal constructor(
 
         fun allowLogout(allowLogout: Boolean) = apply { this.allowLogout = allowLogout }
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun setupIntentClientSecret(setupIntentClientSecret: String?) = apply {
+            this.setupIntentClientSecret = setupIntentClientSecret
+        }
+
         @Parcelize
         @Poko
         internal class State(
@@ -294,6 +303,7 @@ class LinkController @Inject internal constructor(
             internal val email: String?,
             internal val phoneNumber: String?,
             internal val supportedPaymentMethodTypes: List<PaymentMethodType>?,
+            internal val setupIntentClientSecret: String? = null,
         ) : Parcelable
 
         internal fun build(): State = State(
@@ -309,6 +319,7 @@ class LinkController @Inject internal constructor(
             allowUserEmailEdits = allowUserEmailEdits,
             allowLogout = allowLogout,
             linkAppearance = appearance?.build(),
+            setupIntentClientSecret = setupIntentClientSecret,
         )
 
         internal companion object {
@@ -397,6 +408,22 @@ class LinkController @Inject internal constructor(
                 email = email,
                 paymentMethodTypes = null,
             )
+        }
+
+        /**
+         * Creates a payment method from the currently selected Link payment method and confirms
+         * the SetupIntent configured via [Configuration.setupIntentClientSecret].
+         *
+         * This combines payment method creation with SetupIntent confirmation in a single operation.
+         * Requires that [Configuration.setupIntentClientSecret] was provided during configuration
+         * and a payment method was selected via [presentPaymentMethods].
+         *
+         * The result will be communicated through the [ConfirmSetupIntentCallback] provided
+         * during presenter creation. If [Configuration.setupIntentClientSecret] was not provided,
+         * the callback will receive [ConfirmSetupIntentResult.Failed].
+         */
+        fun createPaymentMethodAndConfirmSetupIntent() {
+            coordinator.createPaymentMethodAndConfirmSetupIntent()
         }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -732,6 +759,45 @@ class LinkController @Inject internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Poko
         class Failed internal constructor(val error: Throwable) : AuthenticateWithTokenResult
+    }
+
+    /**
+     * Result of confirming a SetupIntent after payment method creation.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    sealed interface ConfirmSetupIntentResult {
+
+        /**
+         * The SetupIntent was confirmed and the payment method is now attached to the customer.
+         *
+         * @param paymentMethod The payment method that was attached.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
+        class Success internal constructor(val paymentMethod: PaymentMethod) : ConfirmSetupIntentResult
+
+        /**
+         * The user canceled the SetupIntent confirmation (e.g., dismissed 3DS authentication).
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data object Canceled : ConfirmSetupIntentResult
+
+        /**
+         * An error occurred while confirming the SetupIntent.
+         *
+         * @param error The error that occurred.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
+        class Failed internal constructor(val error: Throwable) : ConfirmSetupIntentResult
+    }
+
+    /**
+     * Callback for receiving results from [Presenter.createPaymentMethodAndConfirmSetupIntent].
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun interface ConfirmSetupIntentCallback {
+        fun onConfirmSetupIntentResult(result: ConfirmSetupIntentResult)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -283,7 +283,7 @@ class LinkController @Inject internal constructor(
 
         fun allowLogout(allowLogout: Boolean) = apply { this.allowLogout = allowLogout }
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         fun setupIntentClientSecret(setupIntentClientSecret: String?) = apply {
             this.setupIntentClientSecret = setupIntentClientSecret
         }
@@ -764,7 +764,7 @@ class LinkController @Inject internal constructor(
     /**
      * Result of confirming a SetupIntent after payment method creation.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     sealed interface ConfirmSetupIntentResult {
 
         /**
@@ -772,14 +772,14 @@ class LinkController @Inject internal constructor(
          *
          * @param paymentMethod The payment method that was attached.
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         @Poko
         class Success internal constructor(val paymentMethod: PaymentMethod) : ConfirmSetupIntentResult
 
         /**
          * The user canceled the SetupIntent confirmation (e.g., dismissed 3DS authentication).
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         data object Canceled : ConfirmSetupIntentResult
 
         /**
@@ -787,7 +787,7 @@ class LinkController @Inject internal constructor(
          *
          * @param error The error that occurred.
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         @Poko
         class Failed internal constructor(val error: Throwable) : ConfirmSetupIntentResult
     }
@@ -795,7 +795,7 @@ class LinkController @Inject internal constructor(
     /**
      * Callback for receiving results from [Presenter.createPaymentMethodAndConfirmSetupIntent].
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     fun interface ConfirmSetupIntentCallback {
         fun onConfirmSetupIntentResult(result: ConfirmSetupIntentResult)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link
 
+import android.app.Application
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -8,11 +9,15 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.stripe.android.link.injection.LinkControllerPresenterScope
+import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherFactory
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @LinkControllerPresenterScope
 internal class LinkControllerCoordinator @Inject constructor(
+    private val application: Application,
     private val interactor: LinkControllerInteractor,
     private val lifecycleOwner: LifecycleOwner,
     activityResultRegistryOwner: ActivityResultRegistryOwner,
@@ -21,8 +26,10 @@ internal class LinkControllerCoordinator @Inject constructor(
     private val authenticationCallback: LinkController.AuthenticationCallback,
     private val authorizeCallback: LinkController.AuthorizeCallback,
     private val presentCallback: LinkController.PresentCallback,
+    private val confirmSetupIntentCallback: LinkController.ConfirmSetupIntentCallback,
 ) {
     val linkActivityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>
+    private val paymentLauncher: PaymentLauncher
 
     init {
         check(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED))
@@ -33,6 +40,15 @@ internal class LinkControllerCoordinator @Inject constructor(
         ) { result ->
             interactor.onLinkActivityResult(result)
         }
+
+        paymentLauncher = PaymentLauncherFactory(
+            activityResultRegistryOwner = activityResultRegistryOwner,
+            lifecycleOwner = lifecycleOwner,
+            statusBarColor = null,
+            callback = PaymentLauncher.InternalPaymentResultCallback { result ->
+                interactor.onSetupIntentConfirmationResult(result)
+            }
+        ).create(application)
 
         lifecycleOwner.lifecycleScope.launch {
             lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -52,6 +68,10 @@ internal class LinkControllerCoordinator @Inject constructor(
                     interactor.presentResultFlow
                         .collect(presentCallback::onPresentResult)
                 }
+                launch {
+                    interactor.confirmSetupIntentResultFlow
+                        .collect(confirmSetupIntentCallback::onConfirmSetupIntentResult)
+                }
             }
         }
 
@@ -62,5 +82,36 @@ internal class LinkControllerCoordinator @Inject constructor(
                 }
             }
         )
+    }
+
+    fun createPaymentMethodAndConfirmSetupIntent() {
+        lifecycleOwner.lifecycleScope.launch {
+            val setupIntentClientSecret = interactor.setupIntentClientSecret
+            if (setupIntentClientSecret == null) {
+                interactor.emitConfirmSetupIntentResult(
+                    LinkController.ConfirmSetupIntentResult.Failed(
+                        IllegalStateException("No setupIntentClientSecret in Configuration")
+                    )
+                )
+                return@launch
+            }
+
+            val pmResult = interactor.performCreatePaymentMethodForConfirmation()
+            pmResult.fold(
+                onSuccess = { paymentMethod ->
+                    paymentLauncher.confirm(
+                        ConfirmSetupIntentParams.create(
+                            paymentMethodId = paymentMethod.id,
+                            clientSecret = setupIntentClientSecret,
+                        )
+                    )
+                },
+                onFailure = { error ->
+                    interactor.emitConfirmSetupIntentResult(
+                        LinkController.ConfirmSetupIntentResult.Failed(error)
+                    )
+                }
+            )
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -16,7 +16,6 @@ import com.stripe.android.core.utils.flatMapCatching
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAuthResult
 import com.stripe.android.link.account.toLinkAuthResult
-import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.confirmation.computeExpectedPaymentMethodType
 import com.stripe.android.link.exceptions.AppAttestationException
@@ -34,6 +33,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.utils.flatMapCatching
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAuthResult
 import com.stripe.android.link.account.toLinkAuthResult
+import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.confirmation.computeExpectedPaymentMethodType
 import com.stripe.android.link.exceptions.AppAttestationException
@@ -132,6 +133,13 @@ internal class LinkControllerInteractor @Inject constructor(
         PaymentSelection.IconLoader(application.resources, DefaultStripeImageLoader(application))
     }
 
+    private val _confirmSetupIntentResultFlow =
+        MutableSharedFlow<LinkController.ConfirmSetupIntentResult>(extraBufferCapacity = 1)
+    val confirmSetupIntentResultFlow = _confirmSetupIntentResultFlow.asSharedFlow()
+
+    internal val setupIntentClientSecret: String?
+        get() = _state.value.setupIntentClientSecret
+
     val paymentMethodMetadata: PaymentMethodMetadata?
         get() = _state.value.paymentMethodMetadata
 
@@ -174,7 +182,13 @@ internal class LinkControllerInteractor @Inject constructor(
             }
             .fold(
                 onSuccess = { (component, paymentMethodMetadata) ->
-                    updateState { it.copy(linkComponent = component, paymentMethodMetadata = paymentMethodMetadata) }
+                    updateState {
+                        it.copy(
+                            linkComponent = component,
+                            paymentMethodMetadata = paymentMethodMetadata,
+                            setupIntentClientSecret = config.setupIntentClientSecret,
+                        )
+                    }
                     savedStateHandle[LINK_CONFIGURED_KEY] = true
                     Result.success(Unit)
                 },
@@ -568,6 +582,36 @@ internal class LinkControllerInteractor @Inject constructor(
         )
     }
 
+    internal suspend fun performCreatePaymentMethodForConfirmation(): Result<PaymentMethod> {
+        val result = performCreatePaymentMethod(apiKey = null)
+        updateState { it.copy(createdPaymentMethod = result.getOrNull()) }
+        return result
+    }
+
+    internal fun onSetupIntentConfirmationResult(result: InternalPaymentResult) {
+        val confirmResult = when (result) {
+            is InternalPaymentResult.Completed -> {
+                val paymentMethod = _state.value.createdPaymentMethod
+                if (paymentMethod != null) {
+                    LinkController.ConfirmSetupIntentResult.Success(paymentMethod)
+                } else {
+                    LinkController.ConfirmSetupIntentResult.Failed(
+                        IllegalStateException("Payment method not found after SetupIntent confirmation")
+                    )
+                }
+            }
+            is InternalPaymentResult.Failed ->
+                LinkController.ConfirmSetupIntentResult.Failed(result.throwable)
+            is InternalPaymentResult.Canceled ->
+                LinkController.ConfirmSetupIntentResult.Canceled
+        }
+        _confirmSetupIntentResultFlow.tryEmit(confirmResult)
+    }
+
+    internal fun emitConfirmSetupIntentResult(result: LinkController.ConfirmSetupIntentResult) {
+        _confirmSetupIntentResultFlow.tryEmit(result)
+    }
+
     suspend fun registerConsumer(
         email: String,
         phone: String,
@@ -742,6 +786,7 @@ internal class LinkControllerInteractor @Inject constructor(
     internal data class State(
         val linkComponent: LinkComponent? = null,
         val paymentMethodMetadata: PaymentMethodMetadata? = null,
+        val setupIntentClientSecret: String? = null,
         val emailInput: String? = null,
         val selectedPaymentMethod: LinkPaymentMethod? = null,
         val createdPaymentMethod: PaymentMethod? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerPresenterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerPresenterComponent.kt
@@ -22,6 +22,7 @@ internal interface LinkControllerPresenterComponent {
             @BindsInstance authenticationCallback: LinkController.AuthenticationCallback,
             @BindsInstance authorizeCallback: LinkController.AuthorizeCallback,
             @BindsInstance presentCallback: LinkController.PresentCallback,
+            @BindsInstance confirmSetupIntentCallback: LinkController.ConfirmSetupIntentCallback,
         ): LinkControllerPresenterComponent
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.link
 
+import android.app.Application
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
@@ -35,18 +37,21 @@ internal class LinkControllerCoordinatorTest {
     private val authenticationResultFlow = MutableSharedFlow<LinkController.AuthenticationResult>()
     private val authorizeResultFlow = MutableSharedFlow<LinkController.AuthorizeResult>()
     private val presentResultFlow = MutableSharedFlow<LinkController.PresentResult>()
+    private val confirmSetupIntentResultFlow = MutableSharedFlow<LinkController.ConfirmSetupIntentResult>()
 
     private val viewModel: LinkControllerInteractor = mock {
         on { presentPaymentMethodsResultFlow } doReturn presentPaymentMethodsResultFlow
         on { authenticationResultFlow } doReturn authenticationResultFlow
         on { authorizeResultFlow } doReturn authorizeResultFlow
         on { presentResultFlow } doReturn presentResultFlow
+        on { confirmSetupIntentResultFlow } doReturn confirmSetupIntentResultFlow
     }
 
     private val presentPaymentMethodsResults = mutableListOf<LinkController.PresentPaymentMethodsResult>()
     private val authenticationResults = mutableListOf<LinkController.AuthenticationResult>()
     private val authorizeResults = mutableListOf<LinkController.AuthorizeResult>()
     private val presentResults = mutableListOf<LinkController.PresentResult>()
+    private val confirmSetupIntentResults = mutableListOf<LinkController.ConfirmSetupIntentResult>()
 
     private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED)
 
@@ -59,6 +64,7 @@ internal class LinkControllerCoordinatorTest {
         }
 
         return LinkControllerCoordinator(
+            application = ApplicationProvider.getApplicationContext(),
             interactor = viewModel,
             lifecycleOwner = lifecycleOwner,
             activityResultRegistryOwner = activityResultRegistryOwner,
@@ -67,6 +73,7 @@ internal class LinkControllerCoordinatorTest {
             authenticationCallback = { authenticationResults.add(it) },
             authorizeCallback = { authorizeResults.add(it) },
             presentCallback = { presentResults.add(it) },
+            confirmSetupIntentCallback = { confirmSetupIntentResults.add(it) },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.link
 
-import android.app.Application
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner


### PR DESCRIPTION
# Summary

Updates the LinkController to accept a merchant-provided setup intent client secret. If it isn't provided, we fallback to the existing behavior of managing the full lifecycle of the elements session internally.

# Motivation

Preparing for the possibility that a merchant's integration requires them to provide intents created on their backend.

# Testing

Will be testing this in a bug bash tomorrow

# Changelog

N/a
