### PR TITLE
Preserve payment selection across reloads via loader resolver strategy.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -60,8 +60,8 @@ internal class CheckoutStateLoader @Inject constructor(
             ),
         ).getOrThrow()
 
-        // Preserve the customer's existing selection across reloads when it's still valid, rather
-        // than blindly adopting the loader's recomputed selection (reuses the embedded logic).
+        // Keep the chooser outside PaymentElementLoader.load. The loader runs on IO, while the
+        // embedded chooser stores comparison state in SavedStateHandle.
         val selection = selectionChooser.choose(
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
             paymentMethods = loaderState.customer?.paymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -64,6 +64,7 @@ import com.stripe.android.paymentsheet.state.DefaultPaymentMethodFilter
 import com.stripe.android.paymentsheet.state.DefaultRetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.DefaultTapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
+import com.stripe.android.paymentsheet.state.LoadedPaymentSelectionResolver
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
@@ -71,6 +72,7 @@ import com.stripe.android.paymentsheet.state.TapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.TapToAddConnectionStarterModule
 import dagger.Binds
 import dagger.BindsInstance
+import dagger.BindsOptionalOf
 import dagger.Component
 import dagger.Module
 import dagger.Provides
@@ -120,6 +122,9 @@ internal interface CheckoutControllerComponent {
 internal interface CheckoutControllerModule {
     @Binds
     fun bindPaymentElementLoader(loader: DefaultPaymentElementLoader): PaymentElementLoader
+
+    @BindsOptionalOf
+    fun optionalLoadedPaymentSelectionResolver(): LoadedPaymentSelectionResolver
 
     @Binds
     fun bindsElementsSessionRepository(impl: RealElementsSessionRepository): ElementsSessionRepository

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import android.os.Bundle
-import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.ConfigureResult
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -23,8 +21,6 @@ internal interface EmbeddedConfigurationCoordinator {
 internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     private val configurationHandler: EmbeddedConfigurationHandler,
-    private val selectionHolder: EmbeddedSelectionHolder,
-    private val selectionChooser: EmbeddedSelectionChooser,
     private val stateHelper: EmbeddedStateHelper,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : EmbeddedConfigurationCoordinator {
@@ -56,18 +52,13 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
         state: PaymentElementLoader.State,
         configuration: EmbeddedPaymentElement.Configuration,
     ) {
-        val newPaymentSelection = selectionChooser.choose(
-            paymentMethodMetadata = state.paymentMethodMetadata,
-            paymentMethods = state.customer?.paymentMethods,
-            previousSelection = selectionHolder.selection.value,
-            newSelection = state.paymentSelection,
-            newConfiguration = configuration.asCommonConfiguration(),
-            formSheetAction = configuration.formSheetAction,
-        )
+        // Selection resolution (preserving the customer's previous selection when still valid) is
+        // applied by [EmbeddedConfigurationHandler] outside its cache, so [state.paymentSelection]
+        // is already the resolved selection.
         stateHelper.state = EmbeddedPaymentElement.State(
             confirmationState = EmbeddedConfirmationStateHolder.State(
                 paymentMethodMetadata = state.paymentMethodMetadata,
-                selection = newPaymentSelection,
+                selection = state.paymentSelection,
                 configuration = configuration,
             ),
             customer = state.customer,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
@@ -27,6 +28,8 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val sheetStateHolder: SheetStateHolder,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
+    private val selectionResolver: EmbeddedSelectionChooserResolver,
+    private val selectionHolder: EmbeddedSelectionHolder,
 ) : EmbeddedConfigurationHandler {
 
     private var cache: ConfigurationCache?
@@ -41,6 +44,30 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
     private var inFlightRequest: InFlightRequest? = null
 
     override suspend fun configure(
+        configuration: EmbeddedPaymentElement.Configuration,
+        initializationMode: PaymentElementLoader.InitializationMode,
+    ): Result<PaymentElementLoader.State> {
+        // The cached state is selection-independent (the loader returns its raw computed
+        // selection); selection resolution runs here on every configure — cache hit or fresh load
+        // — against the current selection, so a reconfigure that only changes the selection still
+        // resolves correctly.
+        return loadRawState(configuration, initializationMode).map { rawState ->
+            rawState.copy(
+                paymentSelection = selectionResolver.resolve(
+                    state = rawState,
+                    integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                        isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
+                        configuration = configuration,
+                    ),
+                    reconfigureContext = PaymentElementLoader.ReconfigureContext(
+                        previousSelection = selectionHolder.selection.value,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private suspend fun loadRawState(
         configuration: EmbeddedPaymentElement.Configuration,
         initializationMode: PaymentElementLoader.InitializationMode,
     ): Result<PaymentElementLoader.State> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.state.DefaultPaymentMethodFilter
 import com.stripe.android.paymentsheet.state.DefaultRetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.DefaultTapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
+import com.stripe.android.paymentsheet.state.LoadedPaymentSelectionResolver
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
@@ -50,6 +51,7 @@ import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import dagger.Binds
 import dagger.BindsInstance
+import dagger.BindsOptionalOf
 import dagger.Component
 import dagger.Module
 import dagger.Provides
@@ -134,6 +136,12 @@ internal interface EmbeddedPaymentElementViewModelModule {
 
     @Binds
     fun bindPaymentElementLoader(loader: DefaultPaymentElementLoader): PaymentElementLoader
+
+    // No real resolver bound here: the config handler caches the loader's raw state and applies
+    // selection resolution outside the cache (see DefaultEmbeddedConfigurationHandler), so the
+    // loader itself must return the raw selection (identity).
+    @BindsOptionalOf
+    fun optionalLoadedPaymentSelectionResolver(): LoadedPaymentSelectionResolver
 
     @Binds
     fun bindsTapToAddAvailabilityFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooserResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooserResolver.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.LoadedPaymentSelectionResolver
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import javax.inject.Inject
+
+/**
+ * Adapts [EmbeddedSelectionChooser] to the loader's [LoadedPaymentSelectionResolver] contract so
+ * embedded selection-preservation logic can run in [DefaultEmbeddedConfigurationHandler] on both
+ * fresh loads and cache hits.
+ */
+internal class EmbeddedSelectionChooserResolver @Inject constructor(
+    private val chooser: EmbeddedSelectionChooser,
+) : LoadedPaymentSelectionResolver {
+    override fun resolve(
+        state: PaymentElementLoader.State,
+        integrationConfiguration: PaymentElementLoader.Configuration,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
+    ): PaymentSelection? {
+        val embedded = integrationConfiguration as? PaymentElementLoader.Configuration.Embedded
+            ?: return state.paymentSelection
+
+        return chooser.choose(
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            paymentMethods = state.customer?.paymentMethods,
+            previousSelection = reconfigureContext?.previousSelection,
+            newSelection = state.paymentSelection,
+            newConfiguration = embedded.configuration.asCommonConfiguration(),
+            formSheetAction = embedded.configuration.formSheetAction,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -19,7 +19,6 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     private val paymentElementLoader: PaymentElementLoader,
     @UIContext private val uiContext: CoroutineContext,
     private val viewModel: FlowControllerViewModel,
-    private val paymentSelectionUpdater: PaymentSelectionUpdater,
     private val confirmationHandler: FlowControllerConfirmationHandler,
 ) {
 
@@ -85,7 +84,14 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = false,
                 initializedViaCompose = initializedViaCompose,
-            )
+            ),
+            // Preserve the customer's existing selection across reconfigures when it's still valid
+            // (the loader applies the payment selection updater via its injected resolver).
+            reconfigureContext = PaymentElementLoader.ReconfigureContext(
+                previousSelection = viewModel.paymentSelection,
+                previousPaymentSheetConfig = viewModel.state?.config,
+                walletButtonsAlreadyShown = viewModel.walletButtonsRendered,
+            ),
         ).fold(
             onSuccess = { state ->
                 if (state.validationError != null) {
@@ -106,13 +112,9 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
         state: PaymentSheetState.Full,
         configuration: PaymentSheet.Configuration,
     ) {
-        viewModel.paymentSelection = paymentSelectionUpdater(
-            selection = viewModel.paymentSelection,
-            previousConfig = viewModel.state?.config,
-            newState = state,
-            newConfig = configuration,
-            walletButtonsAlreadyShown = viewModel.walletButtonsRendered,
-        )
+        // The loader already resolved the selection (preserving the prior one when still valid)
+        // via its injected PaymentSelectionUpdaterResolver.
+        viewModel.paymentSelection = state.paymentSelection
 
         withContext(uiContext) {
             viewModel.state = DefaultFlowController.State(paymentSheetState = state, config = configuration)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -16,6 +16,7 @@ import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Companion.FLOW_CONTROLLER_LINK_LAUNCHER
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Companion.WALLETS_BUTTON_LINK_LAUNCHER
+import com.stripe.android.paymentsheet.state.LoadedPaymentSelectionResolver
 import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
@@ -133,5 +134,10 @@ internal object FlowControllerModule {
         fun bindsFlowControllerConfirmationHandler(
             handler: DefaultFlowControllerConfirmationHandler
         ): FlowControllerConfirmationHandler
+
+        @Binds
+        fun bindsSelectionResolver(
+            impl: PaymentSelectionUpdaterResolver
+        ): LoadedPaymentSelectionResolver
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterResolver.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.LoadedPaymentSelectionResolver
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.state.PaymentSheetState
+import javax.inject.Inject
+
+/**
+ * Adapts [PaymentSelectionUpdater] to the loader's [LoadedPaymentSelectionResolver] contract so
+ * FlowController's selection-preservation logic runs inside [PaymentElementLoader.load].
+ */
+internal class PaymentSelectionUpdaterResolver @Inject constructor(
+    private val updater: PaymentSelectionUpdater,
+) : LoadedPaymentSelectionResolver {
+    override fun resolve(
+        state: PaymentElementLoader.State,
+        integrationConfiguration: PaymentElementLoader.Configuration,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
+    ): PaymentSelection? {
+        val configuration = (integrationConfiguration as? PaymentElementLoader.Configuration.PaymentSheet)
+            ?.configuration ?: return state.paymentSelection
+
+        return updater(
+            selection = reconfigureContext?.previousSelection,
+            previousConfig = reconfigureContext?.previousPaymentSheetConfig,
+            newState = PaymentSheetState.Full(state),
+            newConfig = configuration,
+            walletButtonsAlreadyShown = reconfigureContext?.walletButtonsAlreadyShown ?: false,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -63,11 +63,13 @@ import com.stripe.android.paymentsheet.state.DefaultPaymentMethodFilter
 import com.stripe.android.paymentsheet.state.DefaultRetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.DefaultTapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
+import com.stripe.android.paymentsheet.state.LoadedPaymentSelectionResolver
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.TapToAddAvailabilityFactory
 import dagger.Binds
+import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
@@ -117,6 +119,9 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsPaymentSheetLoader(impl: DefaultPaymentElementLoader): PaymentElementLoader
+
+    @BindsOptionalOf
+    abstract fun optionalLoadedPaymentSelectionResolver(): LoadedPaymentSelectionResolver
 
     @Binds
     abstract fun bindsTapToAddAvailabilityFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadedPaymentSelectionResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadedPaymentSelectionResolver.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet.state
+
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+/**
+ * Resolves the final [PaymentSelection] for a freshly loaded [PaymentElementLoader.State].
+ *
+ * The loader computes an initial selection ([PaymentElementLoader.State.paymentSelection]); this
+ * strategy gets the final say, letting an integration preserve the customer's previous selection
+ * across reloads/reconfigures when it's still valid. Bound per Dagger graph — see
+ * [IdentityLoadedPaymentSelectionResolver] for the default when no integration-specific resolver is
+ * provided.
+ */
+internal fun interface LoadedPaymentSelectionResolver {
+    fun resolve(
+        state: PaymentElementLoader.State,
+        integrationConfiguration: PaymentElementLoader.Configuration,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
+    ): PaymentSelection?
+}
+
+/**
+ * Default resolver: keeps the loader's freshly computed selection. Used by integrations that don't
+ * preserve a previous selection (e.g. the PaymentSheet launcher and Link/crypto onramp).
+ */
+internal object IdentityLoadedPaymentSelectionResolver : LoadedPaymentSelectionResolver {
+    override fun resolve(
+        state: PaymentElementLoader.State,
+        integrationConfiguration: PaymentElementLoader.Configuration,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
+    ): PaymentSelection? = state.paymentSelection
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.util.Optional
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -74,11 +75,23 @@ internal interface PaymentElementLoader {
         initializationMode: InitializationMode,
         integrationConfiguration: Configuration,
         metadata: Metadata,
+        reconfigureContext: ReconfigureContext? = null,
     ): Result<State>
 
     data class Metadata(
         val isReloadingAfterProcessDeath: Boolean = false,
         val initializedViaCompose: Boolean,
+    )
+
+    /**
+     * Caller-owned mutable state describing a prior configuration, used by a
+     * [LoadedPaymentSelectionResolver] to preserve the customer's previous selection across
+     * reloads/reconfigures. `null` (the default) means a fresh load with nothing to preserve.
+     */
+    data class ReconfigureContext(
+        val previousSelection: PaymentSelection?,
+        val previousPaymentSheetConfig: PaymentSheet.Configuration? = null,
+        val walletButtonsAlreadyShown: Boolean = false,
     )
 
     sealed interface Configuration {
@@ -269,6 +282,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val durationProvider: DurationProvider,
     private val paymentMethodMessagePromotionsExperimentHandler: PaymentMethodMessagePromotionsExperimentHandler,
     private val isNfcScanningAvailable: IsNfcScanningAvailable,
+    private val selectionResolver: Optional<LoadedPaymentSelectionResolver>,
 ) : PaymentElementLoader {
 
     fun interface AnalyticsMetadataFactory {
@@ -289,6 +303,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
     ): Result<PaymentElementLoader.State> = workContext.runCatching(::reportFailedLoad) {
         val configuration = integrationConfiguration.commonConfiguration
         // Validate configuration before loading
@@ -457,7 +472,13 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             paymentMethodMetadata = state.paymentMethodMetadata,
         )
 
-        return@runCatching state
+        // Analytics above report the loader's freshly computed selection; the resolver gets the
+        // final say (e.g. preserving the customer's previous selection across a reconfigure) and
+        // only the returned selection reflects it.
+        val resolver = selectionResolver.orElse(IdentityLoadedPaymentSelectionResolver)
+        return@runCatching state.copy(
+            paymentSelection = resolver.resolve(state, integrationConfiguration, reconfigureContext),
+        )
     }
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -6,26 +6,17 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
-import com.stripe.android.common.model.CommonConfiguration
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
-import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
-import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -75,58 +66,56 @@ internal class CheckoutStateLoaderTest {
 
             assertThat(confirmationStateHolder.state?.configuration?.embeddedViewDisplaysMandateText)
                 .isFalse()
-        }
+    }
 
     @Test
-    fun `load routes the selection through the chooser`() = runScenario(
+    fun `load resolves selection locally with chooser and commits it`() = runScenario(
         loaderSelection = PaymentSelection.GooglePay,
-        chosenSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+        selectionChooser = EmbeddedSelectionChooser { _, _, previousSelection, _, _, _ ->
+            previousSelection
+        },
     ) {
-        // The customer's prior selection is what the chooser must be offered as the previous value.
         selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
         loader.load(checkoutControllerState())
 
-        // The committed state adopts whatever the chooser returned, not the loader's recomputed
-        // selection, and the selection holder is updated to match.
         assertThat(confirmationStateHolder.state?.selection)
             .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         assertThat(selectionHolder.selection.value)
             .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-        val call = chooser.lastCall
-        assertThat(call?.previousSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-        assertThat(call?.newSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(paymentElementLoader.lastReconfigureContext).isNull()
     }
 
     @Test
-    fun `load preserves a non-default selection across a mutation`() = runScenario(
-        // The loader would recompute a card selection, but the customer's Google Pay pick must win.
-        loaderSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
-        isGooglePayAvailable = true,
-        selectionChooser = { savedStateHandle ->
-            DefaultEmbeddedSelectionChooser(
-                savedStateHandle = savedStateHandle,
-                formHelperFactory = EmbeddedFormHelperFactory(
-                    linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-                    embeddedSelectionHolder = EmbeddedSelectionHolder(savedStateHandle),
-                    cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
-                    savedStateHandle = savedStateHandle,
-                ),
-                eventReporter = FakeEventReporter(),
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
-                internalRowSelectionCallback = { null },
-            )
-        },
+    fun `load re-resolves against the current selection on a reload`() {
+        val previousSelections = mutableListOf<PaymentSelection?>()
+        runScenario(
+            loaderSelection = PaymentSelection.GooglePay,
+            selectionChooser = EmbeddedSelectionChooser { _, _, previousSelection, newSelection, _, _ ->
+                previousSelections += previousSelection
+                previousSelection ?: newSelection
+            },
+        ) {
+            loader.load(checkoutControllerState())
+
+            selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+            loader.load(requireNotNull(stateHolder.state))
+
+            assertThat(previousSelections)
+                .containsExactly(null, PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+                .inOrder()
+            assertThat(confirmationStateHolder.state?.selection)
+                .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            assertThat(paymentElementLoader.lastReconfigureContext).isNull()
+        }
+    }
+
+    @Test
+    fun `load commits the loader selection when the chooser returns it`() = runScenario(
+        loaderSelection = PaymentSelection.GooglePay,
     ) {
-        // Initial load seeds the chooser's stored previous configuration.
         loader.load(checkoutControllerState())
-
-        // The customer picks Google Pay after the initial load.
-        selectionHolder.set(PaymentSelection.GooglePay)
-
-        // A mutation reloads with the same configuration, so the chooser keeps the customer's
-        // selection rather than adopting the loader's recomputed one.
-        loader.load(requireNotNull(stateHolder.state))
 
         assertThat(confirmationStateHolder.state?.selection).isEqualTo(PaymentSelection.GooglePay)
         assertThat(selectionHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
@@ -198,12 +187,11 @@ internal class CheckoutStateLoaderTest {
     private fun runScenario(
         merchantDisplayName: String = "Example, Inc.",
         loaderSelection: PaymentSelection? = null,
-        chosenSelection: PaymentSelection? = null,
         shouldFail: Boolean = false,
         isGooglePayAvailable: Boolean = false,
-        // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
-        // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
-        selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
+        selectionChooser: EmbeddedSelectionChooser = EmbeddedSelectionChooser { _, _, _, newSelection, _, _ ->
+            newSelection
+        },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val application = ApplicationProvider.getApplicationContext<Application>()
@@ -227,17 +215,16 @@ internal class CheckoutStateLoaderTest {
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
         val stateHolder = CheckoutControllerStateHolder(savedStateHandle)
-        val recordingChooser = RecordingSelectionChooser(chosenSelection)
-        val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
+        val paymentElementLoader = FakePaymentElementLoader(
+            paymentSelection = loaderSelection,
+            shouldFail = shouldFail,
+            isGooglePayAvailable = isGooglePayAvailable,
+        )
         val loader = CheckoutStateLoader(
             merchantDisplayName = merchantDisplayName,
             flagImageResolver = flagImageResolver,
-            paymentElementLoader = FakePaymentElementLoader(
-                paymentSelection = loaderSelection,
-                shouldFail = shouldFail,
-                isGooglePayAvailable = isGooglePayAvailable,
-            ),
-            selectionChooser = chooser,
+            paymentElementLoader = paymentElementLoader,
+            selectionChooser = selectionChooser,
             selectionHolder = selectionHolder,
             confirmationStateHolder = confirmationStateHolder,
             stateHolder = stateHolder,
@@ -248,7 +235,7 @@ internal class CheckoutStateLoaderTest {
             stateHolder = stateHolder,
             confirmationStateHolder = confirmationStateHolder,
             selectionHolder = selectionHolder,
-            chooser = recordingChooser,
+            paymentElementLoader = paymentElementLoader,
             imageLoader = imageLoader,
         ).block()
 
@@ -260,33 +247,7 @@ internal class CheckoutStateLoaderTest {
         val stateHolder: CheckoutControllerStateHolder,
         val confirmationStateHolder: CheckoutConfirmationStateHolder,
         val selectionHolder: EmbeddedSelectionHolder,
-        val chooser: RecordingSelectionChooser,
+        val paymentElementLoader: FakePaymentElementLoader,
         val imageLoader: FakeStripeImageLoader,
     )
-
-    // Records the arguments of the most recent choose() call and returns a preconfigured selection,
-    // so tests can verify the loader threads the holder's previous selection and the loader's new
-    // selection into the chooser.
-    private class RecordingSelectionChooser(
-        private val result: PaymentSelection?,
-    ) : EmbeddedSelectionChooser {
-        var lastCall: Call? = null
-
-        override fun choose(
-            paymentMethodMetadata: PaymentMethodMetadata,
-            paymentMethods: List<PaymentMethod>?,
-            previousSelection: PaymentSelection?,
-            newSelection: PaymentSelection?,
-            newConfiguration: CommonConfiguration,
-            formSheetAction: EmbeddedPaymentElement.FormSheetAction,
-        ): PaymentSelection? {
-            lastCall = Call(previousSelection = previousSelection, newSelection = newSelection)
-            return result
-        }
-
-        data class Call(
-            val previousSelection: PaymentSelection?,
-            val newSelection: PaymentSelection?,
-        )
-    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.utils.FakePaymentElementLoader
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -122,6 +123,7 @@ internal class DefaultLinkConfigurationLoaderTest {
             initializationMode = any(),
             integrationConfiguration = configCaptor.capture(),
             metadata = any(),
+            reconfigureContext = anyOrNull(),
         )
         val commonConfig = configCaptor.firstValue.commonConfiguration
         assertThat(commonConfig.merchantDisplayName).isEqualTo(TestFactory.MERCHANT_NAME)
@@ -148,6 +150,7 @@ internal class DefaultLinkConfigurationLoaderTest {
             initializationMode = any(),
             integrationConfiguration = any(),
             metadata = metadataCaptor.capture(),
+            reconfigureContext = anyOrNull(),
         )
         assertThat(metadataCaptor.firstValue.isReloadingAfterProcessDeath).isTrue()
     }
@@ -168,6 +171,7 @@ internal class DefaultLinkConfigurationLoaderTest {
             initializationMode = any(),
             integrationConfiguration = any(),
             metadata = metadataCaptor.capture(),
+            reconfigureContext = anyOrNull(),
         )
         assertThat(metadataCaptor.firstValue.isReloadingAfterProcessDeath).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
@@ -76,20 +76,16 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
     }
 
     @Test
-    fun `configure sets state to previousSelection`() = testScenario(
-        selectionChooser = {
-            PaymentSelection.GooglePay
-        },
-    ) {
+    fun `configure passes the loaded selection through to the confirmation state`() = testScenario {
+        // Selection resolution (preserving the previous selection when still valid) is applied by
+        // the configuration handler; the coordinator uses whatever selection the handler returns.
+        val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         configurationHandler.emit(
             Result.success(
-                createPaymentElementLoaderState(
-                    paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-                )
+                createPaymentElementLoaderState(paymentSelection = selection)
             )
         )
 
-        selectionHolder.set(PaymentSelection.GooglePay)
         assertThat(confirmationStateHolder.state).isNull()
 
         assertThat(
@@ -101,7 +97,7 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         stateHelper.stateTurbine.awaitItem().let { state ->
             assertThat(state).isNotNull()
             assertThat(state?.confirmationState?.paymentMethodMetadata).isNotNull()
-            assertThat(state?.confirmationState?.selection).isEqualTo(PaymentSelection.GooglePay)
+            assertThat(state?.confirmationState?.selection).isEqualTo(selection)
         }
     }
 
@@ -190,7 +186,6 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
     }
 
     private fun testScenario(
-        selectionChooser: (PaymentSelection?) -> PaymentSelection? = { it },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
@@ -207,10 +202,6 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         val configurationCoordinator = DefaultEmbeddedConfigurationCoordinator(
             confirmationStateHolder = confirmationStateHolder,
             configurationHandler = configurationHandler,
-            selectionHolder = selectionHolder,
-            selectionChooser = { _, _, _, newSelection, _, _ ->
-                selectionChooser(newSelection)
-            },
             stateHelper = stateHelper,
             viewModelScope = CoroutineScope(UnconfinedTestDispatcher()),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -11,8 +11,10 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedConfigurationHandler.ConfigurationCache
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.Dispatchers
@@ -104,6 +106,33 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
             initializationMode = initializationMode,
         ).getOrThrow()
         assertThat(state1).isEqualTo(state2)
+    }
+
+    @Test
+    fun `configure re-resolves selection against current holder on a cache hit`() = runScenario(
+        // Preserve the previous selection when present, else use the loader's selection.
+        chooser = { _, _, previousSelection, newSelection, _, _ -> previousSelection ?: newSelection },
+    ) {
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+        loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
+        )
+
+        // First load: no previous selection, so the loader's (null) selection is used.
+        val first = handler.configure(configuration, initializationMode).getOrThrow()
+        assertThat(first.paymentSelection).isNull()
+
+        // The customer picks Google Pay after the initial load.
+        selectionHolder.set(PaymentSelection.GooglePay)
+
+        // The second configure hits the cache (only one loader emit was provided, so a second load
+        // would hang) yet re-resolves against the current selection.
+        val second = handler.configure(configuration, initializationMode).getOrThrow()
+        assertThat(second.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(loader.loadCalledTurbine.awaitItem()).isEqualTo(initializationMode)
     }
 
     @Test
@@ -316,17 +345,24 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
     }
 
     private fun runScenario(
+        chooser: EmbeddedSelectionChooser = EmbeddedSelectionChooser {
+                _, _, _, newSelection, _, _ ->
+            newSelection
+        },
         block: suspend Scenario.() -> Unit
     ) {
         runTest {
             val loader = FakePaymentElementLoader()
             val savedStateHandle = SavedStateHandle()
             val sheetStateHolder = SheetStateHolder(savedStateHandle)
+            val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
             val handler = DefaultEmbeddedConfigurationHandler(
                 loader,
                 savedStateHandle,
                 sheetStateHolder,
                 internalRowSelectionCallback = { null },
+                selectionResolver = EmbeddedSelectionChooserResolver(chooser),
+                selectionHolder = selectionHolder,
             )
             Scenario(
                 loader = loader,
@@ -334,6 +370,7 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
                 handler = handler,
                 testScope = this,
                 sheetStateHolder = sheetStateHolder,
+                selectionHolder = selectionHolder,
             ).apply {
                 block()
             }
@@ -347,6 +384,7 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val handler: DefaultEmbeddedConfigurationHandler,
         val testScope: TestScope,
         val sheetStateHolder: SheetStateHolder,
+        val selectionHolder: EmbeddedSelectionHolder,
     )
 
     private class FakePaymentElementLoader : PaymentElementLoader {
@@ -389,6 +427,7 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
             initializationMode: PaymentElementLoader.InitializationMode,
             integrationConfiguration: PaymentElementLoader.Configuration,
             metadata: PaymentElementLoader.Metadata,
+            reconfigureContext: PaymentElementLoader.ReconfigureContext?,
         ): Result<PaymentElementLoader.State> {
             loadCalledTurbine.add(initializationMode)
             return resultTurbine.awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooserResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooserResolverTest.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import org.junit.Test
+
+internal class EmbeddedSelectionChooserResolverTest {
+
+    @Test
+    fun `delegates to chooser and threads previous and new selection for Embedded configuration`() {
+        var capturedPrevious: PaymentSelection? = null
+        var capturedNew: PaymentSelection? = null
+        val chooserResult = PaymentSelection.GooglePay
+
+        val resolver = EmbeddedSelectionChooserResolver(
+            chooser = { _, _, previousSelection, newSelection, _, _ ->
+                capturedPrevious = previousSelection
+                capturedNew = newSelection
+                chooserResult
+            },
+        )
+
+        val loaderSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        val result = resolver.resolve(
+            state = state(paymentSelection = loaderSelection),
+            integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                isRowSelectionImmediateAction = false,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example").build(),
+            ),
+            reconfigureContext = PaymentElementLoader.ReconfigureContext(
+                previousSelection = PaymentSelection.GooglePay,
+            ),
+        )
+
+        assertThat(result).isEqualTo(chooserResult)
+        assertThat(capturedPrevious).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(capturedNew).isEqualTo(loaderSelection)
+    }
+
+    @Test
+    fun `returns loader selection without invoking chooser for non-Embedded configuration`() {
+        var chooserInvoked = false
+        val resolver = EmbeddedSelectionChooserResolver(
+            chooser = { _, _, _, _, _, _ ->
+                chooserInvoked = true
+                PaymentSelection.GooglePay
+            },
+        )
+
+        val result = resolver.resolve(
+            state = state(paymentSelection = PaymentSelection.GooglePay),
+            integrationConfiguration = PaymentElementLoader.Configuration.PaymentSheet(
+                PaymentSheet.Configuration("Example"),
+            ),
+            reconfigureContext = null,
+        )
+
+        assertThat(result).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(chooserInvoked).isFalse()
+    }
+
+    private fun state(paymentSelection: PaymentSelection?) = PaymentElementLoader.State(
+        config = PaymentSheet.Configuration("Example").asCommonConfiguration(),
+        customer = null,
+        paymentSelection = paymentSelection,
+        validationError = null,
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -457,54 +457,10 @@ internal class DefaultFlowControllerTest {
         assertThat(flowController.getPaymentOption()).isNull()
     }
 
-    @Test
-    fun `getPaymentOption() returns null when setupFutureUsage is added via reconfiguration`() = runTest {
-        val intentWithoutSFU = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-
-        val cardSelection = PaymentSelection.New.Card(
-            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-            brand = CardBrand.Visa,
-            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-        )
-
-        val paymentSheetLoader = FakePaymentElementLoader(
-            stripeIntent = intentWithoutSFU,
-            paymentSelection = cardSelection,
-        )
-
-        val flowController = createFlowController(
-            paymentElementLoader = paymentSheetLoader,
-            paymentSelectionUpdater = DefaultPaymentSelectionUpdater(),
-        )
-
-        val intentConfig = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                amount = 5000,
-                currency = "usd",
-            ),
-        )
-
-        // First configure: no setupFutureUsage — card selection is preserved
-        flowController.configureWithIntentConfigurationExpectingSuccess(intentConfig)
-        assertThat(flowController.getPaymentOption()).isNotNull()
-
-        // Merchant reconfigures with setupFutureUsage = OffSession
-        paymentSheetLoader.updateStripeIntent(
-            intentWithoutSFU.copy(setupFutureUsage = StripeIntent.Usage.OffSession)
-        )
-
-        val intentConfigWithSFU = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                amount = 5000,
-                currency = "usd",
-                setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
-            ),
-        )
-        flowController.configureWithIntentConfigurationExpectingSuccess(intentConfigWithSFU)
-
-        // Card selection should be invalidated — user must re-open payment sheet to see mandate
-        assertThat(flowController.getPaymentOption()).isNull()
-    }
+    // Selection preservation/invalidation on reconfiguration (e.g. a new-card selection being
+    // invalidated when setupFutureUsage is added) is now resolved inside PaymentElementLoader via
+    // PaymentSelectionUpdaterResolver. That logic is covered by PaymentSelectionUpdaterTest and
+    // PaymentSelectionUpdaterResolverTest; it can't be exercised through the fake loader here.
 
     @Test
     fun `init with failure should return expected value`() = runTest {
@@ -2525,9 +2481,6 @@ internal class DefaultFlowControllerTest {
         eventReporter: EventReporter = this.eventReporter,
         confirmationHandler: FlowControllerConfirmationHandler? = null,
         linkHandler: LinkHandler? = null,
-        paymentSelectionUpdater: PaymentSelectionUpdater = PaymentSelectionUpdater { _, _, newState, _, _ ->
-            newState.paymentSelection
-        },
     ): DefaultFlowController {
         return DefaultFlowController(
             viewModelScope = testScope,
@@ -2552,7 +2505,6 @@ internal class DefaultFlowControllerTest {
                 paymentElementLoader = paymentElementLoader,
                 uiContext = testDispatcher,
                 viewModel = viewModel,
-                paymentSelectionUpdater = paymentSelectionUpdater,
                 confirmationHandler = confirmationHandler ?: FakeFlowControllerConfirmationHandler(),
             ),
             errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -7,9 +7,15 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -20,8 +26,10 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.FLOW_CONTROLLER_CALL
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.SessionTestRule
+import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.PaymentElementCallbackTestRule
@@ -210,6 +218,53 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
         assertThat(configurationHandler.isConfigured).isTrue()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link(brand = LinkBrand.Link))
+    }
+
+    @Test
+    fun `configure resolves selection with loader reconfigure context`() = runTest {
+        val previousConfig = PaymentSheet.Configuration("Some name")
+        val newConfig = PaymentSheet.Configuration("Some name")
+        val previousSelection = PaymentSelection.New.Card(
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(setupFutureUsage = null),
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            brand = CardBrand.Visa,
+        )
+        val loadedState = paymentElementLoaderStateWithSetupFutureUsage(
+            configuration = newConfig,
+            paymentSelection = PaymentSelection.GooglePay,
+        )
+        val loader = ResolvingPaymentElementLoader(loadedState)
+        val configureErrors = Turbine<Throwable?>()
+
+        viewModel.paymentSelection = previousSelection
+        viewModel.walletButtonsRendered = true
+        viewModel.state = DefaultFlowController.State(
+            paymentSheetState = PaymentSheetState.Full(
+                paymentElementLoaderStateWithSetupFutureUsage(
+                    configuration = previousConfig,
+                    paymentSelection = previousSelection,
+                )
+            ),
+            config = previousConfig,
+        )
+
+        createConfigurationHandler(paymentElementLoader = loader).configure(
+            scope = this,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+            ),
+            configuration = newConfig,
+            initializedViaCompose = false,
+        ) { _, exception ->
+            configureErrors.add(exception)
+        }
+
+        assertThat(configureErrors.awaitItem()).isNull()
+        assertThat(viewModel.paymentSelection).isNull()
+        assertThat(loader.lastReconfigureContext?.previousSelection).isEqualTo(previousSelection)
+        assertThat(loader.lastReconfigureContext?.previousPaymentSheetConfig).isEqualTo(previousConfig)
+        assertThat(loader.lastReconfigureContext?.walletButtonsAlreadyShown).isTrue()
     }
 
     @Test
@@ -426,7 +481,6 @@ class FlowControllerConfigurationHandlerTest {
                 paymentElementLoader = defaultPaymentSheetLoader(),
                 uiContext = testDispatcher,
                 viewModel = viewModel,
-                paymentSelectionUpdater = { _, _, newState, _, _ -> newState.paymentSelection },
                 confirmationHandler = handler,
             )
 
@@ -472,8 +526,56 @@ class FlowControllerConfigurationHandlerTest {
             paymentElementLoader = paymentElementLoader,
             uiContext = testDispatcher,
             viewModel = viewModel,
-            paymentSelectionUpdater = { _, _, newState, _, _ -> newState.paymentSelection },
             confirmationHandler = FakeFlowControllerConfirmationHandler(),
         )
+    }
+
+    private fun paymentElementLoaderStateWithSetupFutureUsage(
+        configuration: PaymentSheet.Configuration,
+        paymentSelection: PaymentSelection?,
+    ): PaymentElementLoader.State {
+        return PaymentElementLoader.State(
+            config = configuration.asCommonConfiguration(),
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            paymentSelection = paymentSelection,
+            validationError = null,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    setupFutureUsage = StripeIntent.Usage.OffSession,
+                ),
+                sharedDataSpecs = listOf(
+                    SharedDataSpec("card"),
+                ),
+                isGooglePayReady = true,
+            ),
+        )
+    }
+
+    private class ResolvingPaymentElementLoader(
+        private val rawState: PaymentElementLoader.State,
+        private val resolver: PaymentSelectionUpdaterResolver = PaymentSelectionUpdaterResolver(
+            DefaultPaymentSelectionUpdater()
+        ),
+    ) : PaymentElementLoader {
+        var lastReconfigureContext: PaymentElementLoader.ReconfigureContext? = null
+            private set
+
+        override suspend fun load(
+            initializationMode: PaymentElementLoader.InitializationMode,
+            integrationConfiguration: PaymentElementLoader.Configuration,
+            metadata: PaymentElementLoader.Metadata,
+            reconfigureContext: PaymentElementLoader.ReconfigureContext?,
+        ): Result<PaymentElementLoader.State> {
+            lastReconfigureContext = reconfigureContext
+            return Result.success(
+                rawState.copy(
+                    paymentSelection = resolver.resolve(
+                        state = rawState,
+                        integrationConfiguration = integrationConfiguration,
+                        reconfigureContext = reconfigureContext,
+                    )
+                )
+            )
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterResolverTest.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import org.junit.Test
+
+internal class PaymentSelectionUpdaterResolverTest {
+
+    @Test
+    fun `delegates to updater and threads reconfigure context for PaymentSheet configuration`() {
+        var capturedSelection: PaymentSelection? = null
+        var capturedPreviousConfig: PaymentSheet.Configuration? = null
+        var capturedWalletButtonsAlreadyShown: Boolean? = null
+        val updaterResult = PaymentSelection.Link(brand = LinkBrand.Link)
+
+        val previousConfig = PaymentSheet.Configuration("Previous")
+        val resolver = PaymentSelectionUpdaterResolver(
+            updater = { selection, previousConfigArg, _, _, walletButtonsAlreadyShown ->
+                capturedSelection = selection
+                capturedPreviousConfig = previousConfigArg
+                capturedWalletButtonsAlreadyShown = walletButtonsAlreadyShown
+                updaterResult
+            },
+        )
+
+        val result = resolver.resolve(
+            state = state(paymentSelection = PaymentSelection.GooglePay),
+            integrationConfiguration = PaymentElementLoader.Configuration.PaymentSheet(
+                PaymentSheet.Configuration("Example"),
+            ),
+            reconfigureContext = PaymentElementLoader.ReconfigureContext(
+                previousSelection = PaymentSelection.GooglePay,
+                previousPaymentSheetConfig = previousConfig,
+                walletButtonsAlreadyShown = true,
+            ),
+        )
+
+        assertThat(result).isEqualTo(updaterResult)
+        assertThat(capturedSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(capturedPreviousConfig).isEqualTo(previousConfig)
+        assertThat(capturedWalletButtonsAlreadyShown).isTrue()
+    }
+
+    @Test
+    fun `returns loader selection without invoking updater for non-PaymentSheet configuration`() {
+        var updaterInvoked = false
+        val resolver = PaymentSelectionUpdaterResolver(
+            updater = { _, _, _, _, _ ->
+                updaterInvoked = true
+                PaymentSelection.Link(brand = LinkBrand.Link)
+            },
+        )
+
+        val result = resolver.resolve(
+            state = state(paymentSelection = PaymentSelection.GooglePay),
+            integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                isRowSelectionImmediateAction = false,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example").build(),
+            ),
+            reconfigureContext = null,
+        )
+
+        assertThat(result).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(updaterInvoked).isFalse()
+    }
+
+    private fun state(paymentSelection: PaymentSelection?) = PaymentElementLoader.State(
+        config = PaymentSheet.Configuration("Example").asCommonConfiguration(),
+        customer = null,
+        paymentSelection = paymentSelection,
+        validationError = null,
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -105,6 +105,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import java.util.Optional
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -329,6 +330,30 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         ).getOrThrow()
         assertThat(result.paymentMethodMetadata.customerMetadata).isNull()
+
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `load applies the injected selection resolver to the returned selection`() = runScenario {
+        val loader = createPaymentElementLoader(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+            // Resolver overrides whatever the loader computed.
+            selectionResolver = { _, _, _ -> PaymentSelection.GooglePay },
+        )
+
+        val result = loader.load(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            PaymentSheetFixtures.CONFIG_MINIMUM,
+            metadata = PaymentElementLoader.Metadata(
+                initializedViaCompose = false,
+            ),
+        ).getOrThrow()
+
+        assertThat(result.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -4923,6 +4948,7 @@ internal class DefaultPaymentElementLoaderTest {
             FakePaymentMethodMessagePromotionsExperimentHandler(),
         isNfcScanningAvailable: IsNfcScanningAvailable =
             FakeIsNfcScanningAvailable(result = false),
+        selectionResolver: LoadedPaymentSelectionResolver? = null,
     ): PaymentElementLoader {
         val retrieveCustomerEmailImpl = DefaultRetrieveCustomerEmail(
             customerRepo,
@@ -4977,6 +5003,7 @@ internal class DefaultPaymentElementLoaderTest {
             durationProvider = durationProvider,
             paymentMethodMessagePromotionsExperimentHandler = paymentMethodMessageExperimentHandler,
             isNfcScanningAvailable = isNfcScanningAvailable,
+            selectionResolver = Optional.ofNullable(selectionResolver),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -39,6 +39,10 @@ internal class FakePaymentElementLoader(
     private val integrationMetadata: IntegrationMetadata? = null,
 ) : PaymentElementLoader {
 
+    /** The [PaymentElementLoader.ReconfigureContext] passed to the most recent [load] call. */
+    var lastReconfigureContext: PaymentElementLoader.ReconfigureContext? = null
+        private set
+
     fun updateStripeIntent(intent: StripeIntent) {
         this.stripeIntent = intent
     }
@@ -87,7 +91,9 @@ internal class FakePaymentElementLoader(
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
     ): Result<PaymentElementLoader.State> {
+        lastReconfigureContext = reconfigureContext
         delay(delay)
         return if (shouldFail) {
             Result.failure(IllegalStateException("oh no"))

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentElementLoader.kt
@@ -43,6 +43,7 @@ internal class RelayingPaymentElementLoader : PaymentElementLoader {
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
+        reconfigureContext: PaymentElementLoader.ReconfigureContext?,
     ): Result<PaymentElementLoader.State> {
         return results.receive()
     }


### PR DESCRIPTION
# Summary
Introduces a resolver strategy for PaymentElementLoader to preserve the user's payment selection across reloads or reconfigurations. Integrations can inject a resolver to customize how previous selections are retained, updated, or invalidated.

# Motivation
Previously, preserving the user's selection across reloads was handled externally and inconsistently. With this change, selection preservation logic is unified inside PaymentElementLoader via an injectable resolver interface. This enables integrations like FlowController and Embedded Payment Element to ensure the appropriate selection is retained (when still valid) after mutations or process death, and correctly invalidate selections when intent/config changes.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Changed] PaymentElementLoader supports resolving the final payment selection via an injectable resolver, enabling consistent selection preservation across reloads/reconfigurations.