### PR TITLE
Add autocomplete proxy endpoint feature flag with gated branching for future Stripe proxy endpoint + tests

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -213,6 +213,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                 ),
                                 placesClient = null,
                                 coroutineScope = null,
+                                shouldUseAutocompleteProxyEndpointsProvider = { false },
                             ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -95,6 +95,7 @@ internal data class PaymentMethodMetadata(
     val elementsSessionId: String? = null,
     val disableSsdOcrCardScan: Boolean,
     val cardArts: List<PaymentMethod.Card.CardArt>,
+    val shouldUseAutocompleteProxyEndpoints: Boolean,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
 ) : Parcelable {
 
@@ -428,6 +429,7 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = cardArts,
+                shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = paymentMethodLayout,
             )
         }
@@ -499,6 +501,7 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
+                shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -108,6 +108,9 @@ internal data class ElementsSession(
     val forceVerticalPaymentMethodLayout: Boolean
         get() = flags[Flag.ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT] == true
 
+    val shouldUseAutocompleteProxyEndpoints: Boolean
+        get() = flags[Flag.OCS_MOBILE_SHOULD_USE_AUTOCOMPLETE_PROXY_ENDPOINTS] == true
+
     @Parcelize
     data class LinkSettings(
         val linkFundingSources: List<String>,
@@ -250,6 +253,9 @@ internal data class ElementsSession(
         ELEMENTS_MOBILE_CARDSCAN_DISABLE_SSDOCR("elements_mobile_cardscan_disable_ssdocr"),
         ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT(
             "elements_mobile_force_vertical_payment_method_layout"
+        ),
+        OCS_MOBILE_SHOULD_USE_AUTOCOMPLETE_PROXY_ENDPOINTS(
+            "ocs_mobile_should_use_autocomplete_proxy_endpoints"
         ),
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -9,6 +9,7 @@ internal class BillingInlineAutocompleteAddressInteractor(
     placesClient: PlacesClientProxy,
     override val autocompleteConfig: AutocompleteAddressInteractor.Config,
     coroutineScope: CoroutineScope,
+    shouldUseAutocompleteProxyEndpoints: Boolean,
 ) : AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
 
@@ -17,6 +18,7 @@ internal class BillingInlineAutocompleteAddressInteractor(
         config = autocompleteConfig,
         coroutineScope = coroutineScope,
         eventListenerProvider = { eventListener },
+        shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
     )
 
     override val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -22,10 +22,14 @@ internal class InlineAutocompleteController(
     private val config: AutocompleteAddressInteractor.Config,
     private val coroutineScope: CoroutineScope,
     private val eventListenerProvider: () -> ((AutocompleteAddressInteractor.Event) -> Unit)?,
+    private val shouldUseAutocompleteProxyEndpoints: Boolean,
 ) {
     private var lastPredictionLine1: String? = null
     private var observeJob: Job? = null
     private var selectionJob: Job? = null
+
+    // Keep the server flag plumbed through, but do not switch traffic until the proxy path exists.
+    private val isAutocompleteProxyImplementationAvailable = false
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
         AutocompleteAddressInteractor.InlinePredictionsState.Idle
@@ -33,9 +37,12 @@ internal class InlineAutocompleteController(
     val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =
         _inlinePredictionsState.asStateFlow()
 
+    private val canUseAutocompleteProxyEndpoints: Boolean
+        get() = shouldUseAutocompleteProxyEndpoints && isAutocompleteProxyImplementationAvailable
+
     @OptIn(FlowPreview::class)
     fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
-        if (placesClient == null) return
+        if (placesClient == null && !canUseAutocompleteProxyEndpoints) return
         observeJob?.cancel()
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
@@ -57,33 +64,46 @@ internal class InlineAutocompleteController(
     }
 
     fun onPredictionSelected(predictionId: String) {
-        if (placesClient == null) return
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
-            placesClient.fetchPlace(predictionId).fold(
-                onSuccess = { response ->
-                    val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-                    val address = response.place.transformGoogleToStripeAddress(locale)
-                    lastPredictionLine1 = address.line1
-                    _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                    eventListenerProvider()?.invoke(
-                        AutocompleteAddressInteractor.Event.OnValues(
-                            mapOf(
-                                IdentifierSpec.Line1 to address.line1,
-                                IdentifierSpec.Line2 to address.line2,
-                                IdentifierSpec.City to address.city,
-                                IdentifierSpec.State to address.state,
-                                IdentifierSpec.PostalCode to address.postalCode,
-                                IdentifierSpec.Country to address.country,
-                            )
+            if (canUseAutocompleteProxyEndpoints) {
+                fetchPlaceFromStripeProxy(predictionId)
+            } else {
+                fetchPlaceFromGooglePlaces(predictionId)
+            }
+        }
+    }
+
+    @Suppress("UnusedParameter", "UnusedPrivateMember")
+    private suspend fun fetchPlaceFromStripeProxy(predictionId: String) {
+        // Stripe proxy endpoint will be implemented in a follow-up PR.
+    }
+
+    private suspend fun fetchPlaceFromGooglePlaces(predictionId: String) {
+        val client = placesClient ?: return
+        client.fetchPlace(predictionId).fold(
+            onSuccess = { response ->
+                val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+                val address = response.place.transformGoogleToStripeAddress(locale)
+                lastPredictionLine1 = address.line1
+                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                eventListenerProvider()?.invoke(
+                    AutocompleteAddressInteractor.Event.OnValues(
+                        mapOf(
+                            IdentifierSpec.Line1 to address.line1,
+                            IdentifierSpec.Line2 to address.line2,
+                            IdentifierSpec.City to address.city,
+                            IdentifierSpec.State to address.state,
+                            IdentifierSpec.PostalCode to address.postalCode,
+                            IdentifierSpec.Country to address.country,
                         )
                     )
-                },
-                onFailure = {
-                    _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                }
-            )
-        }
+                )
+            },
+            onFailure = {
+                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+            }
+        )
     }
 
     fun onDismissed() {
@@ -104,6 +124,19 @@ internal class InlineAutocompleteController(
     }
 
     private suspend fun fetchPredictions(query: String, country: String) {
+        if (canUseAutocompleteProxyEndpoints) {
+            fetchPredictionsFromStripeProxy(query, country)
+        } else {
+            fetchPredictionsFromGooglePlaces(query, country)
+        }
+    }
+
+    @Suppress("UnusedParameter", "UnusedPrivateMember")
+    private suspend fun fetchPredictionsFromStripeProxy(query: String, country: String) {
+        // Stripe proxy endpoint will be implemented in a follow-up PR.
+    }
+
+    private suspend fun fetchPredictionsFromGooglePlaces(query: String, country: String) {
         val client = placesClient ?: return
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Loading
         val result = client.findAutocompletePredictions(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -81,6 +81,8 @@ internal class InputAddressViewModel @Inject constructor(
             config = autocompleteConfig,
             coroutineScope = viewModelScope,
             eventListenerProvider = { eventListener },
+            // The standalone Address Element does not have access to ElementsSession flags.
+            // When the proxy endpoint ships, thread this value through Args.
             shouldUseAutocompleteProxyEndpoints = false,
         )
     } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -81,6 +81,7 @@ internal class InputAddressViewModel @Inject constructor(
             config = autocompleteConfig,
             coroutineScope = viewModelScope,
             eventListenerProvider = { eventListener },
+            shouldUseAutocompleteProxyEndpoints = false,
         )
     } else {
         null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -46,6 +46,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
         private val placesClient: PlacesClientProxy?,
         private val coroutineScope: CoroutineScope?,
+        private val shouldUseAutocompleteProxyEndpointsProvider: () -> Boolean,
     ) : AutocompleteAddressInteractor.Factory {
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
@@ -56,6 +57,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
                     placesClient = placesClient,
                     autocompleteConfig = autocompleteConfig,
                     coroutineScope = coroutineScope,
+                    shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpointsProvider(),
                 ).also { activeInlineInteractor = it }
             }
             return PaymentElementAutocompleteAddressInteractor(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -92,6 +92,9 @@ internal abstract class BaseSheetViewModel(
             ),
             placesClient = placesClient,
             coroutineScope = viewModelScope,
+            shouldUseAutocompleteProxyEndpointsProvider = {
+                _paymentMethodMetadata.value?.shouldUseAutocompleteProxyEndpoints ?: false
+            },
         )
 
     internal val validationRequested = MutableSharedFlow<Unit>()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -80,6 +80,7 @@ internal object PaymentMethodMetadataFactory {
         elementsSessionId: String? = null,
         disableSsdOcrCardScan: Boolean = false,
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
+        shouldUseAutocompleteProxyEndpoints: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
@@ -152,6 +153,7 @@ internal object PaymentMethodMetadataFactory {
             elementsSessionId = elementsSessionId,
             disableSsdOcrCardScan = disableSsdOcrCardScan,
             cardArts = cardArts,
+            shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
             paymentMethodLayout = paymentMethodLayout,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1218,6 +1218,7 @@ internal class PaymentMethodMetadataTest {
             elementsSessionId = "session_1234",
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
+            shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
 
@@ -1379,6 +1380,7 @@ internal class PaymentMethodMetadataTest {
             elementsSessionId = "session_1234",
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
+            shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)

--- a/paymentsheet/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -328,6 +328,44 @@ class ElementsSessionTest {
         assertThat(session.disableSsdOcrCardScan).isFalse()
     }
 
+    @Test
+    fun `OCS_MOBILE_SHOULD_USE_AUTOCOMPLETE_PROXY_ENDPOINTS flag has correct value`() {
+        assertThat(
+            ElementsSession.Flag.OCS_MOBILE_SHOULD_USE_AUTOCOMPLETE_PROXY_ENDPOINTS.flagValue
+        ).isEqualTo("ocs_mobile_should_use_autocomplete_proxy_endpoints")
+    }
+
+    @Test
+    fun `shouldUseAutocompleteProxyEndpoints returns true when flag is enabled`() {
+        val session = createElementsSession(
+            flags = mapOf(
+                ElementsSession.Flag.OCS_MOBILE_SHOULD_USE_AUTOCOMPLETE_PROXY_ENDPOINTS to true
+            )
+        )
+
+        assertThat(session.shouldUseAutocompleteProxyEndpoints).isTrue()
+    }
+
+    @Test
+    fun `shouldUseAutocompleteProxyEndpoints returns false when flag is disabled`() {
+        val session = createElementsSession(
+            flags = mapOf(
+                ElementsSession.Flag.OCS_MOBILE_SHOULD_USE_AUTOCOMPLETE_PROXY_ENDPOINTS to false
+            )
+        )
+
+        assertThat(session.shouldUseAutocompleteProxyEndpoints).isFalse()
+    }
+
+    @Test
+    fun `shouldUseAutocompleteProxyEndpoints returns false when flag is missing`() {
+        val session = createElementsSession(
+            flags = emptyMap()
+        )
+
+        assertThat(session.shouldUseAutocompleteProxyEndpoints).isFalse()
+    }
+
     private fun createElementsSession(
         passiveCaptcha: PassiveCaptchaParams? = null,
         flags: Map<ElementsSession.Flag, Boolean> = emptyMap(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -61,6 +61,7 @@ class BillingInlineAutocompleteAddressInteractorTest {
             placesClient = fakePlaces,
             autocompleteConfig = config,
             coroutineScope = backgroundScope,
+            shouldUseAutocompleteProxyEndpoints = false,
         )
         interactor.register { event -> eventCalls.add(event) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -619,10 +619,101 @@ class InlineAutocompleteControllerTest {
         assertThat(call.country).isEqualTo("")
     }
 
+    @Test
+    fun `proxy flag true keeps Google Places enabled for predictions until proxy is implemented`() = runScenario(
+        shouldUseAutocompleteProxyEndpoints = true
+    ) {
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(emptyList())
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+        assertThat(call.query).isEqualTo("123 Main")
+    }
+
+    @Test
+    fun `proxy flag true keeps Google Places enabled for place selection until proxy is implemented`() = runScenario(
+        shouldUseAutocompleteProxyEndpoints = true
+    ) {
+        fakePlacesClient.fetchPlaceResult = Result.success(
+            FetchPlaceResponse(
+                Place(
+                    listOf(
+                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
+                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
+                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
+                    )
+                )
+            )
+        )
+        delegate.onPredictionSelected("place-id-123")
+
+        val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
+        assertThat(call).isEqualTo("place-id-123")
+        eventCalls.awaitItem()
+    }
+
+    @Test
+    fun `proxy flag true with null placesClient stays Idle until proxy is implemented`() = runScenario(
+        usePlacesClient = false,
+        shouldUseAutocompleteProxyEndpoints = true
+    ) {
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+    }
+
+    @Test
+    fun `proxy flag false calls Google Places for predictions`() = runScenario(
+        shouldUseAutocompleteProxyEndpoints = false
+    ) {
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(emptyList())
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+        assertThat(call.query).isEqualTo("123 Main")
+    }
+
+    @Test
+    fun `proxy flag false calls Google Places for place selection`() = runScenario(
+        shouldUseAutocompleteProxyEndpoints = false
+    ) {
+        fakePlacesClient.fetchPlaceResult = Result.success(
+            FetchPlaceResponse(
+                Place(
+                    listOf(
+                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
+                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
+                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
+                    )
+                )
+            )
+        )
+
+        delegate.onPredictionSelected("place-id-123")
+
+        val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
+        assertThat(call).isEqualTo("place-id-123")
+        eventCalls.awaitItem()
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),
         usePlacesClient: Boolean = true,
+        shouldUseAutocompleteProxyEndpoints: Boolean = false,
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
         val fakePlaces = if (usePlacesClient) FakePlacesClientProxy() else null
@@ -638,6 +729,7 @@ class InlineAutocompleteControllerTest {
             config = config,
             coroutineScope = backgroundScope,
             eventListenerProvider = { { event -> eventCalls.add(event) } },
+            shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -188,6 +188,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteConfig = config,
             placesClient = null,
             coroutineScope = this,
+            shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
 
         val interactor = factory.create()
@@ -210,6 +211,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteConfig = config,
             placesClient = FakePlacesClientProxy(),
             coroutineScope = this,
+            shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
 
         val interactor = factory.create()
@@ -232,6 +234,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteConfig = config,
             placesClient = fakePlaces,
             coroutineScope = backgroundScope,
+            shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
         val queryFlow = MutableStateFlow("")
         val countryFlow = MutableStateFlow<String?>("US")
@@ -263,6 +266,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             autocompleteConfig = config,
             placesClient = null,
             coroutineScope = this,
+            shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
 
         val interactor = factory.create()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add the `ocs_mobile_should_use_autocomplete_proxy_endpoints` feature flag from ElementsSession into  InlineAutocompleteController. Add if-else branching in predictions and place selection that will route to Stripe's proxy endpoint once it's implemented. Traffic stays on Google Places for now, the proxy path is gated by a hardcoded`false` flag until the next PR adds the actual endpoint.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
First step toward replacing Google Places API calls with Stripe proxy endpoints for address autocomplete. This PR sets up the flag and branching so the follow-up PR only needs to fill in the proxy implementation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A, behind feature flag.