### PR TITLE
Test isLoading reset to false when configure fails with network error.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -677,6 +677,26 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `configure resets isLoading to false when the request fails`() = runTest {
+        networkRule.checkoutInit { response ->
+            response.setResponseCode(500)
+            response.setBody("""{"error": {"message": "Internal server error"}}""")
+        }
+        val controller = createController()
+
+        turbineScope {
+            val isLoadingTurbine = controller.isLoading.testIn(backgroundScope)
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+            assertThat(controller.configure(DEFAULT_CLIENT_SECRET).isFailure).isTrue()
+
+            // The failure path must still release the loading window via the finally block.
+            assertThat(isLoadingTurbine.awaitItem()).isTrue()
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        }
+    }
+
+    @Test
     fun `configure is serialized behind an in-flight mutation and shares its loading window`() =
         runMutationScenario {
             val holdMutation = CountDownLatch(1)


### PR DESCRIPTION
# Summary
Add a test to verify that the isLoading state is reset to false when CheckoutController's configure method fails due to a network error.

# Motivation
Ensures that the loading UI state is managed correctly, even in error scenarios, and does not remain stuck in a loading state after a failed configuration attempt.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog