### PR TITLE
Implement billing_address_collection <> BDCC reconciliation (MOBILESDK-4636)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMerger.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
@@ -35,7 +36,10 @@ internal sealed class CheckoutConfigurationMerger<T> {
                 defaultBillingDetails(merged.billingDetails)
                 shippingDetails(merged.shippingDetails)
                 billingDetailsCollectionConfiguration(
-                    config.billingDetailsCollectionConfiguration.copy(attachDefaultsToPaymentMethod = true)
+                    reconcileBillingCollection(
+                        config.billingDetailsCollectionConfiguration,
+                        state.checkoutSessionResponse,
+                    )
                 )
             }.build()
         }
@@ -54,11 +58,31 @@ internal sealed class CheckoutConfigurationMerger<T> {
                 defaultBillingDetails(merged.billingDetails)
                 shippingDetails(merged.shippingDetails)
                 billingDetailsCollectionConfiguration(
-                    config.billingDetailsCollectionConfiguration.copy(attachDefaultsToPaymentMethod = true)
+                    reconcileBillingCollection(
+                        config.billingDetailsCollectionConfiguration,
+                        state.checkoutSessionResponse,
+                    )
                 )
             }.build()
         }
     }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun reconcileBillingCollection(
+    bdcc: PaymentSheet.BillingDetailsCollectionConfiguration,
+    response: CheckoutSessionResponse,
+): PaymentSheet.BillingDetailsCollectionConfiguration {
+    require(bdcc.address != AddressCollectionMode.Never) {
+        "BillingDetailsCollectionConfiguration.address must not be CollectionMode.Never when using " +
+            "CheckoutSession, because billing address collection is required."
+    }
+    val reconciledAddress = if (response.requiresBillingAddress && bdcc.address == AddressCollectionMode.Automatic) {
+        AddressCollectionMode.Full
+    } else {
+        bdcc.address
+    }
+    return bdcc.copy(address = reconciledAddress, attachDefaultsToPaymentMethod = true)
 }
 
 private data class MergedDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -103,9 +103,14 @@ class EmbeddedPaymentElement @Inject internal constructor(
         configuration: Configuration,
     ): ConfigureResult {
         CheckoutInstances.ensureNoMutationInFlight(checkout.internalState.key)
+        val mergedConfiguration = try {
+            CheckoutConfigurationMerger.EmbeddedConfiguration(configuration)
+                .forCheckoutSession(checkout.internalState)
+        } catch (e: IllegalArgumentException) {
+            return ConfigureResult.Failed(e)
+        }
         return configurationCoordinator.configure(
-            configuration = CheckoutConfigurationMerger.EmbeddedConfiguration(configuration)
-                .forCheckoutSession(checkout.internalState),
+            configuration = mergedConfiguration,
             initializationMode = checkout.internalState.initializationMode,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3325,6 +3325,7 @@ class PaymentSheet internal constructor(
 
         internal fun copy(
             name: CollectionMode = this.name,
+            address: AddressCollectionMode = this.address,
             attachDefaultsToPaymentMethod: Boolean = this.attachDefaultsToPaymentMethod,
         ): BillingDetailsCollectionConfiguration {
             return BillingDetailsCollectionConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -245,10 +245,16 @@ internal class DefaultFlowController @Inject internal constructor(
         callback: PaymentSheet.FlowController.ConfigCallback
     ) {
         CheckoutInstances.ensureNoMutationInFlight(checkout.internalState.key)
+        val mergedConfiguration = try {
+            CheckoutConfigurationMerger.PaymentSheetConfiguration(configuration)
+                .forCheckoutSession(checkout.internalState)
+        } catch (e: IllegalArgumentException) {
+            callback.onConfigured(success = false, error = e)
+            return
+        }
         configure(
             mode = checkout.internalState.initializationMode,
-            configuration = CheckoutConfigurationMerger.PaymentSheetConfiguration(configuration)
-                .forCheckoutSession(checkout.internalState),
+            configuration = mergedConfiguration,
             callback = callback,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -29,6 +29,7 @@ internal data class CheckoutSessionResponse(
     val automaticTaxEnabled: Boolean,
     val taxAddressSource: TaxAddressSource?,
     val allowedShippingCountries: List<String>?,
+    val requiresBillingAddress: Boolean,
 ) : StripeModel {
 
     val shouldDisableWalletsForAutomaticTaxBilling: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -43,6 +43,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val taxContext = json.optJSONObject(FIELD_TAX_CONTEXT)
         val automaticTaxEnabled = taxContext?.optBoolean(FIELD_AUTOMATIC_TAX_ENABLED, false) ?: false
         val taxAddressSource = parseTaxAddressSource(taxContext)
+        val requiresBillingAddress = json.optString(FIELD_BILLING_ADDRESS_COLLECTION) == "required"
         val taxStatus = parseTaxStatusFromMeta(
             taxMeta = json.optJSONObject(FIELD_TAX_META),
             taxAddressSource = taxAddressSource,
@@ -105,6 +106,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             automaticTaxEnabled = automaticTaxEnabled,
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
+            requiresBillingAddress = requiresBillingAddress,
         )
     }
 
@@ -573,6 +575,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_PRICE = "price"
     private const val FIELD_UNIT_AMOUNT = "unit_amount"
     private const val FIELD_UNIT_AMOUNT_OVERRIDE = "unit_amount_override"
+    private const val FIELD_BILLING_ADDRESS_COLLECTION = "billing_address_collection"
     private const val FIELD_ADAPTIVE_PRICING_INFO = "adaptive_pricing_info"
     private const val FIELD_ACTIVE_PRESENTMENT_CURRENCY = "active_presentment_currency"
     private const val FIELD_INTEGRATION_AMOUNT = "integration_amount"

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutBillingReconciliationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutBillingReconciliationTest.kt
@@ -1,0 +1,207 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Reconciliation of the CheckoutSession's billing_address_collection with the SDK's
+ * BillingDetailsCollectionConfiguration.address. Mirrors iOS CheckoutAddressMergingTests.
+ */
+@OptIn(CheckoutSessionPreview::class)
+class CheckoutBillingReconciliationTest {
+
+    @Test
+    fun `paymentSheet - required + Automatic upgrades address to Full`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(address = Automatic))
+        val state = state(requiresBillingAddress = true)
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Full)
+    }
+
+    @Test
+    fun `paymentSheet - required + Full stays Full`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(address = Full))
+        val state = state(requiresBillingAddress = true)
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Full)
+    }
+
+    @Test
+    fun `paymentSheet - auto + Automatic stays Automatic`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(address = Automatic))
+        val state = state(requiresBillingAddress = false)
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Automatic)
+    }
+
+    @Test
+    fun `paymentSheet - auto + Full stays Full`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(address = Full))
+        val state = state(requiresBillingAddress = false)
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Full)
+    }
+
+    @Test
+    fun `paymentSheet - Never with required throws IllegalArgumentException`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(address = Never))
+        val state = state(requiresBillingAddress = true)
+
+        val ex = assertFailsWith<IllegalArgumentException> {
+            CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+        }
+        assertThat(ex.message).contains(
+            "BillingDetailsCollectionConfiguration.address must not be CollectionMode.Never"
+        )
+    }
+
+    @Test
+    fun `paymentSheet - Never with auto throws IllegalArgumentException`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(address = Never))
+        val state = state(requiresBillingAddress = false)
+
+        assertFailsWith<IllegalArgumentException> {
+            CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+        }
+    }
+
+    @Test
+    fun `paymentSheet - attachDefaultsToPaymentMethod is true after reconciliation`() {
+        val config = paymentSheetConfiguration(bdcc = bdcc(attachDefaultsToPaymentMethod = false))
+        val state = state(requiresBillingAddress = false)
+
+        val result = CheckoutConfigurationMerger.PaymentSheetConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `embedded - required + Automatic upgrades address to Full`() {
+        val config = embeddedConfiguration(bdcc = bdcc(address = Automatic))
+        val state = state(requiresBillingAddress = true)
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Full)
+    }
+
+    @Test
+    fun `embedded - required + Full stays Full`() {
+        val config = embeddedConfiguration(bdcc = bdcc(address = Full))
+        val state = state(requiresBillingAddress = true)
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Full)
+    }
+
+    @Test
+    fun `embedded - auto + Automatic stays Automatic`() {
+        val config = embeddedConfiguration(bdcc = bdcc(address = Automatic))
+        val state = state(requiresBillingAddress = false)
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Automatic)
+    }
+
+    @Test
+    fun `embedded - auto + Full stays Full`() {
+        val config = embeddedConfiguration(bdcc = bdcc(address = Full))
+        val state = state(requiresBillingAddress = false)
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(Full)
+    }
+
+    @Test
+    fun `embedded - Never with required throws IllegalArgumentException`() {
+        val config = embeddedConfiguration(bdcc = bdcc(address = Never))
+        val state = state(requiresBillingAddress = true)
+
+        val ex = assertFailsWith<IllegalArgumentException> {
+            CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+        }
+        assertThat(ex.message).contains(
+            "BillingDetailsCollectionConfiguration.address must not be CollectionMode.Never"
+        )
+    }
+
+    @Test
+    fun `embedded - Never with auto throws IllegalArgumentException`() {
+        val config = embeddedConfiguration(bdcc = bdcc(address = Never))
+        val state = state(requiresBillingAddress = false)
+
+        assertFailsWith<IllegalArgumentException> {
+            CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+        }
+    }
+
+    @Test
+    fun `embedded - attachDefaultsToPaymentMethod is true after reconciliation`() {
+        val config = embeddedConfiguration(bdcc = bdcc(attachDefaultsToPaymentMethod = false))
+        val state = state(requiresBillingAddress = false)
+
+        val result = CheckoutConfigurationMerger.EmbeddedConfiguration(config).forCheckoutSession(state)
+
+        assertThat(result.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod).isTrue()
+    }
+
+    private fun bdcc(
+        address: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
+        attachDefaultsToPaymentMethod: Boolean = false,
+    ) = PaymentSheet.BillingDetailsCollectionConfiguration(
+        address = address,
+        attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod,
+    )
+
+    private fun embeddedConfiguration(
+        bdcc: PaymentSheet.BillingDetailsCollectionConfiguration,
+    ): EmbeddedPaymentElement.Configuration {
+        return EmbeddedPaymentElement.Configuration.Builder("Test Merchant")
+            .billingDetailsCollectionConfiguration(bdcc)
+            .build()
+    }
+
+    private fun paymentSheetConfiguration(
+        bdcc: PaymentSheet.BillingDetailsCollectionConfiguration,
+    ): PaymentSheet.Configuration {
+        return PaymentSheet.Configuration.Builder("Test Merchant")
+            .billingDetailsCollectionConfiguration(bdcc)
+            .build()
+    }
+
+    private fun state(requiresBillingAddress: Boolean): InternalState {
+        return InternalState(
+            key = "CheckoutBillingReconciliationTest",
+            configuration = Checkout.Configuration().build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                requiresBillingAddress = requiresBillingAddress,
+            ),
+            shippingName = null,
+            billingName = null,
+            shippingPhoneNumber = null,
+            billingPhoneNumber = null,
+            shippingAddress = null,
+            billingAddress = null,
+            flagImages = null,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfigurationMergerTest.kt
@@ -609,20 +609,26 @@ class CheckoutConfigurationMergerTest {
     private fun embeddedConfiguration(
         defaultBillingDetails: PaymentSheet.BillingDetails? = null,
         shippingDetails: AddressDetails? = null,
+        bdcc: PaymentSheet.BillingDetailsCollectionConfiguration =
+            PaymentSheet.BillingDetailsCollectionConfiguration(),
     ): EmbeddedPaymentElement.Configuration {
         return EmbeddedPaymentElement.Configuration.Builder("Test Merchant")
             .defaultBillingDetails(defaultBillingDetails)
             .shippingDetails(shippingDetails)
+            .billingDetailsCollectionConfiguration(bdcc)
             .build()
     }
 
     private fun paymentSheetConfiguration(
         defaultBillingDetails: PaymentSheet.BillingDetails? = null,
         shippingDetails: AddressDetails? = null,
+        bdcc: PaymentSheet.BillingDetailsCollectionConfiguration =
+            PaymentSheet.BillingDetailsCollectionConfiguration(),
     ): PaymentSheet.Configuration {
         return PaymentSheet.Configuration.Builder("Test Merchant")
             .defaultBillingDetails(defaultBillingDetails)
             .shippingDetails(shippingDetails)
+            .billingDetailsCollectionConfiguration(bdcc)
             .build()
     }
 
@@ -634,12 +640,14 @@ class CheckoutConfigurationMergerTest {
         billingPhoneNumber: String? = null,
         shippingAddress: Address.State? = null,
         billingAddress: Address.State? = null,
+        requiresBillingAddress: Boolean = false,
     ): InternalState {
         return InternalState(
             key = "CheckoutConfigurationMergerTest",
             configuration = Checkout.Configuration().build(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                 customerEmail = customerEmail,
+                requiresBillingAddress = requiresBillingAddress,
             ),
             shippingName = shippingName,
             billingName = billingName,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -7,6 +7,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
@@ -37,6 +38,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
@@ -151,6 +153,26 @@ internal class CheckoutControllerTest {
             assertThat(committedState?.embeddedConfiguration?.embeddedViewDisplaysMandateText)
                 .isFalse()
         }
+
+    @Test
+    fun `configure upgrades Automatic to Full when session requires billing address`() = runConfigureScenario(
+        configuration = CheckoutController.Configuration().paymentElement(
+            PaymentElement.Configuration().billingDetailsCollectionConfiguration(
+                BillingDetailsCollectionConfiguration().address(Automatic)
+            )
+        ),
+        networkSetup = {
+            networkRule.checkoutInit(
+                responseFactory = successResponseFactory { json ->
+                    json.put("billing_address_collection", "required")
+                },
+            )
+        },
+    ) {
+        assertThat(result.isSuccess).isTrue()
+        assertThat(committedState?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+            .isEqualTo(PSFull)
+    }
 
     @Test
     fun `configure returns failure when network request fails`() = runConfigureScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
 @OptIn(CheckoutSessionPreview::class)
@@ -97,6 +98,37 @@ internal class CheckoutStateLoaderTest {
             assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
                 .isEqualTo(PSFull)
         }
+
+    @Test
+    fun `loadInitial upgrades Automatic to Full when the session requires a billing address`() = runScenario {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Automatic))
+            )
+            .build()
+
+        loader.loadInitial(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(requiresBillingAddress = true),
+        )
+
+        assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+            .isEqualTo(PSFull)
+    }
+
+    @Test
+    fun `loadInitial leaves Automatic unchanged when the session does not require a billing address`() = runScenario {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Automatic))
+            )
+            .build()
+
+        loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+
+        assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+            .isEqualTo(PSAutomatic)
+    }
 
     @Test
     fun `reload routes the selection through the chooser`() = runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationHe
 import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedStateHelper
 import com.stripe.android.paymentelement.embedded.content.PaymentOptionDisplayDataHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.async
@@ -62,6 +63,29 @@ internal class EmbeddedPaymentElementTest {
             .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
 
         deferred.cancel()
+    }
+
+    @Test
+    fun `configure with checkout returns Failed when BDCC address is Never`() = runTest {
+        val checkout = CheckoutStateFactory.createCheckout(applicationContext)
+        val embeddedPaymentElement = createEmbeddedPaymentElement()
+
+        val result = embeddedPaymentElement.configure(
+            checkout,
+            EmbeddedPaymentElement.Configuration.Builder("Test")
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                    ),
+                )
+                .build(),
+        )
+
+        assertThat(result).isInstanceOf(EmbeddedPaymentElement.ConfigureResult.Failed::class.java)
+        val error = (result as EmbeddedPaymentElement.ConfigureResult.Failed).error
+        assertThat(error).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(error).hasMessageThat()
+            .contains("BillingDetailsCollectionConfiguration.address must not be CollectionMode.Never")
     }
 
     private fun createEmbeddedPaymentElement(): EmbeddedPaymentElement {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2384,6 +2384,34 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
+    fun `configureWithCheckout reports failure when BDCC address is Never`() = runTest {
+        val checkout = CheckoutStateFactory.createCheckout(context)
+        val flowController = createFlowController()
+
+        var success: Boolean? = null
+        var error: Throwable? = null
+        flowController.configureWithCheckout(
+            checkout,
+            PaymentSheet.Configuration.Builder("Test")
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                    ),
+                )
+                .build(),
+        ) { configuredSuccess, configuredError ->
+            success = configuredSuccess
+            error = configuredError
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(success).isFalse()
+        assertThat(error).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(error).hasMessageThat()
+            .contains("BillingDetailsCollectionConfiguration.address must not be CollectionMode.Never")
+    }
+
+    @Test
     fun `presentPaymentOptions throws when checkout mutation is in flight`() = runTest {
         val checkout = CheckoutStateFactory.createCheckout(context)
         val flowController = createFlowController(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -28,6 +28,7 @@ internal object CheckoutSessionResponseFactory {
         automaticTaxEnabled: Boolean = false,
         taxAddressSource: CheckoutSessionResponse.TaxAddressSource? = null,
         allowedShippingCountries: List<String>? = null,
+        requiresBillingAddress: Boolean = false,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -50,6 +51,7 @@ internal object CheckoutSessionResponseFactory {
             automaticTaxEnabled = automaticTaxEnabled,
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
+            requiresBillingAddress = requiresBillingAddress,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1349,4 +1349,79 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result).isNotNull()
         assertThat(result?.allowedShippingCountries).isEqualTo(emptyList<String>())
     }
+
+    @Test
+    fun `requiresBillingAddress is true when billing_address_collection is required`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "billing_address_collection": "required"
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isTrue()
+    }
+
+    @Test
+    fun `requiresBillingAddress is false when billing_address_collection is auto`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "billing_address_collection": "auto"
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isFalse()
+    }
+
+    @Test
+    fun `requiresBillingAddress is false when billing_address_collection is absent`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isFalse()
+    }
+
+    @Test
+    fun `requiresBillingAddress is false when billing_address_collection is JSON null`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "billing_address_collection": null
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isFalse()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -259,27 +260,10 @@ internal class CreateCustomerMetadataTest {
         ): PaymentElementLoader.InitializationMode.CheckoutSession {
             return PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "instances_test",
-                checkoutSessionResponse = CheckoutSessionResponse(
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                     id = "cs_test_123",
-                    amount = 1000,
-                    currency = "usd",
-                    mode = CheckoutSessionResponse.Mode.PAYMENT,
-                    status = CheckoutSessionResponse.Status.OPEN,
-                    liveMode = false,
-                    taxStatus = CheckoutSessionResponse.TaxStatus.READY,
-                    customerEmail = null,
-                    elementsSession = null,
-                    paymentIntent = null,
-                    setupIntent = null,
                     customer = customer,
                     savedPaymentMethodsOfferSave = savedPaymentMethodsOfferSave,
-                    totalSummary = null,
-                    lineItems = emptyList(),
-                    shippingOptions = emptyList(),
-                    adaptivePricingInfo = null,
-                    automaticTaxEnabled = false,
-                    taxAddressSource = null,
-                    allowedShippingCountries = null,
                 ),
             )
         }


### PR DESCRIPTION
# Summary
Implements the [MOBILESDK-4636](https://jira.corp.stripe.com/browse/MOBILESDK-4636) `billing_address_collection` <> BDCC reconciliation across **all** CheckoutSession paths (FlowController, EmbeddedPaymentElement, and CheckoutController).

**Stacked on #13469** (the checkout-owned config pre-work). Base retargets to `master` when #13469 merges — review/merge #13469 first.

Design principle: "permission lives on the API, presentation lives on the client." Server `billing_address_collection` is the address-requirement contract; BDCC is the client presentation config; reconciliation arbitrates the `address` overlap.

## Behavior (decision table)
Reconciliation runs in `CheckoutConfigurationMerger.reconcileBillingCollection`, invoked from all three paths:

| CS `billing_address_collection` | BDCC `address` | Result |
| --- | --- | --- |
| `required` | `Automatic` | upgraded to `Full` |
| `required` | `Full` | `Full` (unchanged) |
| `auto` | `Automatic` | `Automatic` (unchanged) |
| `auto` | `Full` | `Full` (unchanged) |
| `auto` or `required` | `Never` | rejected: `IllegalArgumentException`, surfaced as a configuration failure (`ConfigureResult.Failed` / `ConfigCallback` error / CheckoutController `configure()` `Result.failure`) — never an uncaught crash |

`Never` is a blanket rejection for any CheckoutSession, matching iOS. `attachDefaultsToPaymentMethod = true` retained. The `auto + automatic` automatic-tax "minimum fields" behavior is out of scope (iOS doesn't implement it either).

## Testing
- [x] Added tests
- [ ] Manually verified

Unit tests only (matches iOS):
- Parser: `requiresBillingAddress` for `required`/`auto`/absent/JSON-null.
- `CheckoutBillingReconciliationTest`: decision table x PaymentSheet + Embedded variants, `.never` rejection, attachDefaults regression.
- FlowController/Embedded: `.never` reported (not crash).
- CheckoutController: `CheckoutStateLoaderTest` (`required -> Full`, `auto` unchanged, `.never` throws + commits nothing) and `CheckoutControllerTest` (`configure()` `Result.failure` on `.never`; `required -> Full` end-to-end).

`:paymentsheet:testDebugUnitTest` + `:paymentsheet:detekt` pass; android-code-reviewer APPROVE.

# Changelog
N/A. `@RestrictTo(LIBRARY_GROUP)` (private preview); no public API change.
