### PR TITLE
Add scanned card data validation

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -104,6 +104,10 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_network_error_message">An error occurred. Check your connection and try again.</string>
   <!-- Instruction shown below the NFC coil animation while waiting for a card tap -->
   <string name="stripe_nfc_scan_hold_card_behind_phone">Hold card behind phone</string>
+  <!-- Error with action to take shown in the NFC scanning flow if the scanned card is expired -->
+  <string name="stripe_nfc_scan_error_expired_card">Card expired. Try another card.</string>
+  <!-- Error with action to take shown in the NFC scanning flow if the scanned card is not supported by Stripe or by the merchant -->
+  <string name="stripe_nfc_scan_unsupported_card">Card not supported. Try another card.</string>
   <!-- Text for separator within a separator that separates a button to tap to add a card and the card form -->
   <string name="stripe_or_enter_manually">or enter manually</string>
   <!-- Text for the 'Pay with Link' button. 'Link' is a Stripe brand, please do not translate the word 'Link'. -->

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
@@ -34,6 +34,7 @@ internal interface NfcCardScanner {
 internal class DefaultNfcCardScanner @Inject constructor(
     private val hardwareDelegate: NfcHardwareDelegate,
     private val cardReader: NfcCardReader,
+    private val cardValidator: NfcCardValidator,
     private val transceiverFactory: NfcTagTransceiver.Factory,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val workContext: CoroutineContext,
@@ -64,7 +65,14 @@ internal class DefaultNfcCardScanner @Inject constructor(
                     }
                 }.fold(
                     onSuccess = { cardData ->
-                        _state.emit(NfcCardScanner.State.Complete(cardData))
+                        val state = when (val result = cardValidator.validate(cardData)) {
+                            is NfcCardValidator.Result.Validated -> NfcCardScanner.State.Complete(cardData)
+                            is NfcCardValidator.Result.Invalid -> NfcCardScanner.State.Failed(
+                                error = NfcCardScanner.Error(result.userMessage)
+                            )
+                        }
+
+                        _state.emit(state)
                     },
                     onFailure = {
                         _state.emit(NfcCardScanner.State.Failed(GENERIC_ERROR))

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScannerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScannerModule.kt
@@ -18,4 +18,7 @@ internal interface NfcCardScannerModule {
 
     @Binds
     fun bindsNfcCardDataParser(parser: DefaultNfcCardDataParser): NfcCardDataParser
+
+    @Binds
+    fun bindsNfcCardValidator(validator: DefaultNfcCardValidator): NfcCardValidator
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardValidator.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.DateUtils
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.R
+import javax.inject.Inject
+
+internal interface NfcCardValidator {
+    fun validate(cardData: ScannedCardData): Result
+
+    sealed interface Result {
+        data object Validated : Result
+        data class Invalid(val userMessage: ResolvableString) : Result
+    }
+}
+
+internal class DefaultNfcCardValidator @Inject constructor(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+) : NfcCardValidator {
+    override fun validate(cardData: ScannedCardData): NfcCardValidator.Result {
+        if (!paymentMethodMetadata.cardBrandFilter.isAccepted(CardBrand.fromCardNumber(cardData.cardNumber))) {
+            return NfcCardValidator.Result.Invalid(
+                userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+            )
+        }
+
+        if (
+            !DateUtils.isExpiryDataValid(
+                expiryYear = cardData.expirationYear,
+                expiryMonth = cardData.expirationMonth,
+            )
+        ) {
+            return NfcCardValidator.Result.Invalid(
+                userMessage = R.string.stripe_nfc_scan_error_expired_card.resolvableString,
+            )
+        }
+
+        return NfcCardValidator.Result.Validated
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
@@ -23,7 +23,7 @@ internal class DefaultNfcCardScannerTest {
     val coroutineTestRule = CoroutineTestRule(dispatcher)
 
     @Test
-    fun `start emits Scanning then Complete when card read succeeds`() = runScenario(
+    fun `scanner emits Scanning then Complete when card read & validator succeeds`() = runScenario(
         cardData = ScannedCardData(
             cardNumber = "4242424242424242",
             expirationMonth = 12,
@@ -55,6 +55,13 @@ internal class DefaultNfcCardScannerTest {
         assertThat(transceiver.openCalls.awaitItem()).isNotNull()
         assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
         assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
+        assertThat(fakeCardValidator.validateCalls.awaitItem()).isEqualTo(
+            ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 12,
+                expirationYear = 2030,
+            ),
+        )
     }
 
     @Test
@@ -159,6 +166,49 @@ internal class DefaultNfcCardScannerTest {
         assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
     }
 
+    @Test
+    fun `scanner emits Failed when card validation fails`() = runScenario(
+        cardData = ScannedCardData(
+            cardNumber = "4242424242424242",
+            expirationMonth = 12,
+            expirationYear = 2030,
+        ),
+        validationResult = NfcCardValidator.Result.Invalid(
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        ),
+    ) {
+        scanner.state.test {
+            scanner.start(activity)
+
+            val startCall = fakeHardwareDelegate.startCalls.awaitItem()
+            startCall.onTagDiscovered.invoke(tag)
+
+            assertThat(awaitItem()).isEqualTo(NfcCardScanner.State.Scanning)
+            assertThat(awaitItem()).isEqualTo(
+                NfcCardScanner.State.Failed(
+                    error = NfcCardScanner.Error(
+                        userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+                    ),
+                ),
+            )
+        }
+
+        assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
+
+        val transceiver = requireNotNull(fakeTransceiver)
+
+        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
+        assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
+        assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
+        assertThat(fakeCardValidator.validateCalls.awaitItem()).isEqualTo(
+            ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 12,
+                expirationYear = 2030,
+            ),
+        )
+    }
+
     private fun runScenario(
         isHardwareAvailable: Boolean = true,
         cardData: ScannedCardData? = null,
@@ -169,6 +219,7 @@ internal class DefaultNfcCardScannerTest {
             openException = openException,
             closeException = closeException,
         ),
+        validationResult: NfcCardValidator.Result = NfcCardValidator.Result.Validated,
         block: suspend Scenario.() -> Unit,
     ) = runTest(dispatcher) {
         val fakeHardwareDelegate = FakeNfcHardwareDelegate(result = isHardwareAvailable)
@@ -181,12 +232,14 @@ internal class DefaultNfcCardScannerTest {
                 else -> Result.failure(NotImplementedError())
             },
         )
+        val fakeCardValidator = FakeNfcCardValidator(result = validationResult)
         val activity = mock<AppCompatActivity>()
         val tag = mock<Tag>()
 
         val scanner = DefaultNfcCardScanner(
             hardwareDelegate = fakeHardwareDelegate,
             cardReader = fakeCardReader,
+            cardValidator = fakeCardValidator,
             transceiverFactory = fakeTransceiverFactory,
             viewModelScope = CoroutineScope(dispatcher),
             workContext = dispatcher,
@@ -199,12 +252,14 @@ internal class DefaultNfcCardScannerTest {
             fakeHardwareDelegate = fakeHardwareDelegate,
             fakeTransceiverFactory = fakeTransceiverFactory,
             fakeCardReader = fakeCardReader,
+            fakeCardValidator = fakeCardValidator,
             fakeTransceiver = fakeTransceiver,
         ).block()
 
         fakeHardwareDelegate.ensureAllEventsConsumed()
         fakeTransceiverFactory.ensureAllEventsConsumed()
         fakeCardReader.ensureAllEventsConsumed()
+        fakeCardValidator.ensureAllEventsConsumed()
         fakeTransceiver?.ensureAllEventsConsumed()
     }
 
@@ -215,6 +270,7 @@ internal class DefaultNfcCardScannerTest {
         val fakeHardwareDelegate: FakeNfcHardwareDelegate,
         val fakeTransceiverFactory: FakeNfcTagTransceiverFactory,
         val fakeCardReader: FakeNfcCardReader,
+        val fakeCardValidator: FakeNfcCardValidator,
         val fakeTransceiver: FakeNfcTagTransceiver?,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardValidatorTest.kt
@@ -1,0 +1,79 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.CardBrandFilter
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.ui.wallet.RejectCardBrands
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.CardBrand
+import com.stripe.android.paymentsheet.R
+import org.junit.Test
+
+internal class DefaultNfcCardValidatorTest {
+    @Test
+    fun `validate returns Validated when card brand is accepted and expiry is valid`() = runScenario {
+        val result = validator.validate(
+            ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 12,
+                expirationYear = 2030,
+            ),
+        )
+
+        assertThat(result).isEqualTo(NfcCardValidator.Result.Validated)
+    }
+
+    @Test
+    fun `validate returns Invalid when card brand is not accepted`() = runScenario(
+        cardBrandFilter = RejectCardBrands(CardBrand.Visa),
+    ) {
+        val result = validator.validate(
+            ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 12,
+                expirationYear = 2030,
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            NfcCardValidator.Result.Invalid(
+                userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+            ),
+        )
+    }
+
+    @Test
+    fun `validate returns Invalid when card is expired`() = runScenario {
+        val result = validator.validate(
+            ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 1,
+                expirationYear = 2020,
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            NfcCardValidator.Result.Invalid(
+                userMessage = R.string.stripe_nfc_scan_error_expired_card.resolvableString,
+            ),
+        )
+    }
+
+    private fun runScenario(
+        cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
+        block: Scenario.() -> Unit = {},
+    ) {
+        val validator = DefaultNfcCardValidator(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                cardBrandFilter = cardBrandFilter,
+            ),
+        )
+
+        Scenario(validator = validator).block()
+    }
+
+    private class Scenario(
+        val validator: DefaultNfcCardValidator,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardValidator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardValidator.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import app.cash.turbine.Turbine
+
+internal class FakeNfcCardValidator(
+    private val result: NfcCardValidator.Result = NfcCardValidator.Result.Validated,
+) : NfcCardValidator {
+    val validateCalls = Turbine<ScannedCardData>()
+
+    override fun validate(cardData: ScannedCardData): NfcCardValidator.Result {
+        validateCalls.add(cardData)
+        return result
+    }
+
+    fun ensureAllEventsConsumed() {
+        validateCalls.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary
Add scanned card data validation in NFC Scanning flow through `NfcCardValidator` that validates if the received scanned card data are not expired and supported by the merchant's PE configuration.

# Motivation
Better card validation by NFC scanning flow

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified