### PR TITLE
Add shipping country validation to checkout.updateShippingAddress (MOBILESDK-4647)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Address.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Address.kt
@@ -42,7 +42,7 @@ class Address {
     @Parcelize
     internal data class State(
         val city: String?,
-        val country: String?,
+        val country: String,
         val line1: String?,
         val line2: String?,
         val postalCode: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -19,6 +19,7 @@ import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.validateShippingCountry
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorToggle
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
@@ -465,8 +466,13 @@ class Checkout private constructor(
         name: String? = null,
         phoneNumber: String? = null,
         address: Address,
-    ): Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.SHIPPING, address) {
-        copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
+    ): Result<Unit> {
+        internalState.checkoutSessionResponse
+            .validateShippingCountry(address.build().country)
+            .onFailure { return Result.failure(it) }
+        return updateAddress(CheckoutSessionResponse.TaxAddressSource.SHIPPING, address) {
+            copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.validateShippingCountry
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -129,8 +130,13 @@ class CheckoutController @Inject internal constructor(
         name: String?,
         phoneNumber: String?,
         address: Address,
-    ): kotlin.Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.SHIPPING, address) {
-        copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
+    ): kotlin.Result<Unit> {
+        stateHolder.state?.checkoutSessionResponse
+            ?.validateShippingCountry(address.build().country)
+            ?.onFailure { return kotlin.Result.failure(it) }
+        return updateAddress(CheckoutSessionResponse.TaxAddressSource.SHIPPING, address) {
+            copy(shippingName = name, shippingPhoneNumber = phoneNumber, shippingAddress = it)
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -28,6 +28,7 @@ internal data class CheckoutSessionResponse(
     val adaptivePricingInfo: AdaptivePricingInfo?,
     val automaticTaxEnabled: Boolean,
     val taxAddressSource: TaxAddressSource?,
+    val allowedShippingCountries: List<String>?,
 ) : StripeModel {
 
     val shouldDisableWalletsForAutomaticTaxBilling: Boolean
@@ -133,5 +134,16 @@ internal data class CheckoutSessionResponse(
         REQUIRES_SHIPPING_ADDRESS,
         REQUIRES_BILLING_ADDRESS,
         UNKNOWN,
+    }
+}
+
+internal fun CheckoutSessionResponse.validateShippingCountry(country: String): Result<Unit> {
+    val allowed = allowedShippingCountries ?: return Result.success(Unit)
+    return if (country in allowed) {
+        Result.success(Unit)
+    } else {
+        Result.failure(
+            IllegalArgumentException("Country code '$country' is not in allowedShippingCountries")
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -82,6 +82,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val adaptivePricingInfo = parseAdaptivePricingInfo(
             json.optJSONObject(FIELD_ADAPTIVE_PRICING_INFO)
         )
+        val allowedShippingCountries = parseAllowedShippingCountries(json)
 
         return CheckoutSessionResponse(
             id = sessionId,
@@ -103,6 +104,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             adaptivePricingInfo = adaptivePricingInfo,
             automaticTaxEnabled = automaticTaxEnabled,
             taxAddressSource = taxAddressSource,
+            allowedShippingCountries = allowedShippingCountries,
         )
     }
 
@@ -515,6 +517,12 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         }
     }
 
+    private fun parseAllowedShippingCountries(json: JSONObject): List<String>? {
+        val shippingCollection = json.optJSONObject(FIELD_SHIPPING_ADDRESS_COLLECTION) ?: return null
+        val countries = shippingCollection.optJSONArray(FIELD_ALLOWED_COUNTRIES) ?: return null
+        return jsonArrayToList(countries)
+    }
+
     private const val FIELD_SESSION_ID = "session_id"
     private const val FIELD_UI_MODE = "ui_mode"
     private const val UI_MODE_CUSTOM = "custom"
@@ -572,4 +580,6 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_LOCAL_CURRENCY_OPTIONS = "local_currency_options"
     private const val FIELD_CONVERSION_MARKUP_BPS = "conversion_markup_bps"
     private const val FIELD_PRESENTMENT_EXCHANGE_RATE = "presentment_exchange_rate"
+    private const val FIELD_SHIPPING_ADDRESS_COLLECTION = "shipping_address_collection"
+    private const val FIELD_ALLOWED_COUNTRIES = "allowed_countries"
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test
@@ -728,6 +729,103 @@ internal class CheckoutControllerTest {
             assertThat(isLoadingTurbine.awaitItem()).isFalse()
         }
 
+    // region allowedShippingCountries validation
+
+    @Test
+    fun `updateShippingAddress succeeds when country is in allowedShippingCountries`() =
+        runMutationScenario(
+            initModifier = combine(allowedShippingCountries(listOf("US", "CA")), automaticTaxFor("shipping")),
+        ) {
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+                responseFactory = successResponseFactory(
+                    combine(allowedShippingCountries(listOf("US", "CA")), automaticTaxFor("shipping")),
+                ),
+            )
+
+            val result = controller.updateShippingAddress(
+                name = null,
+                phoneNumber = null,
+                address = Address().country("US"),
+            )
+
+            assertThat(result.isSuccess).isTrue()
+        }
+
+    @Test
+    fun `updateShippingAddress fails with IllegalArgumentException for disallowed country`() =
+        runMutationScenario(
+            initModifier = allowedShippingCountries(listOf("US", "CA")),
+            assertLoadingConsumed = true,
+        ) {
+            val before = controller.checkoutSession.value
+
+            // Fast-fail returns before runSerialized, so isLoading must never flip to true.
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+            val result = controller.updateShippingAddress(
+                name = null,
+                phoneNumber = null,
+                address = Address().country("DE"),
+            )
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(exception).hasMessageThat().isEqualTo(
+                "Country code 'DE' is not in allowedShippingCountries"
+            )
+            assertThat(controller.checkoutSession.value).isEqualTo(before)
+        }
+
+    @Test
+    fun `updateShippingAddress succeeds when allowedShippingCountries is null`() =
+        runMutationScenario {
+            // No allowlist set, so any country passes.
+            val result = controller.updateShippingAddress(
+                name = null,
+                phoneNumber = null,
+                address = Address().country("DE"),
+            )
+
+            assertThat(result.isSuccess).isTrue()
+        }
+
+    @Test
+    fun `updateShippingAddress fails for all countries when allowedShippingCountries is empty`() =
+        runMutationScenario(initModifier = allowedShippingCountries(emptyList())) {
+            val before = controller.checkoutSession.value
+
+            val result = controller.updateShippingAddress(
+                name = null,
+                phoneNumber = null,
+                address = Address().country("US"),
+            )
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(exception).hasMessageThat().isEqualTo(
+                "Country code 'US' is not in allowedShippingCountries"
+            )
+            assertThat(controller.checkoutSession.value).isEqualTo(before)
+        }
+
+    @Test
+    fun `updateBillingAddress is not gated by allowedShippingCountries`() =
+        runMutationScenario(initModifier = allowedShippingCountries(listOf("US"))) {
+            val result = controller.updateBillingAddress(
+                name = null,
+                phoneNumber = null,
+                address = Address().country("DE"),
+            )
+
+            assertThat(result.isSuccess).isTrue()
+        }
+
+    // endregion
+
     private fun NetworkRule.defaultInit() {
         checkoutInit(responseFactory = ::successResponse)
     }
@@ -759,6 +857,19 @@ internal class CheckoutControllerTest {
         .put("subtotal", due)
         .put("due", due)
         .put("total", due)
+
+    private fun combine(vararg modifiers: (JSONObject) -> Unit): (JSONObject) -> Unit = { json ->
+        modifiers.forEach { it(json) }
+    }
+
+    // Sets shipping_address_collection.allowed_countries in the session JSON.
+    private fun allowedShippingCountries(countries: List<String>): (JSONObject) -> Unit = { json ->
+        val countriesArray = JSONArray().apply { countries.forEach { put(it) } }
+        json.put(
+            "shipping_address_collection",
+            JSONObject().put("allowed_countries", countriesArray),
+        )
+    }
 
     // Enables automatic tax with the given address source ("shipping" or "billing"), so an address
     // update sends tax_region to the server.

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -1240,6 +1240,149 @@ class CheckoutTest {
         assertThat(afterRefresh.id).isEqualTo("cs_test_after_address")
     }
 
+    // region allowedShippingCountries validation
+
+    @Test
+    fun `updateShippingAddress succeeds when country is in allowedShippingCountries`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
+                allowedShippingCountries = listOf("US", "CA"),
+            ),
+        ) {
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "US"),
+            ) { response ->
+                response.testBodyFromFile("checkout-session-update-shipping-address.json")
+            }
+
+            checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .country("US")
+                .postalCode("80202")
+            val result = checkout.updateShippingAddress(address = address)
+
+            checkoutSessionTurbine.awaitItem()
+            result.getOrThrow()
+        }
+
+    @Test
+    fun `updateShippingAddress fails with IllegalArgumentException for disallowed country`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
+                allowedShippingCountries = listOf("US", "CA"),
+            ),
+            shouldValidateEvents = false,
+        ) {
+            val initial = checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .country("DE")
+                .postalCode("10115")
+            val result = checkout.updateShippingAddress(address = address)
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(exception).hasMessageThat().isEqualTo(
+                "Country code 'DE' is not in allowedShippingCountries"
+            )
+            assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+        }
+
+    @Test
+    fun `updateShippingAddress succeeds when allowedShippingCountries is null`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = false,
+                allowedShippingCountries = null,
+            ),
+            shouldValidateEvents = false,
+        ) {
+            checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .country("DE")
+            val result = checkout.updateShippingAddress(address = address)
+
+            result.getOrThrow()
+        }
+
+    @Test
+    fun `updateShippingAddress fails for all countries when allowedShippingCountries is empty`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = false,
+                allowedShippingCountries = emptyList(),
+            ),
+            shouldValidateEvents = false,
+        ) {
+            val initial = checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .country("US")
+            val result = checkout.updateShippingAddress(address = address)
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(exception).hasMessageThat().isEqualTo(
+                "Country code 'US' is not in allowedShippingCountries"
+            )
+            assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+        }
+
+    @Test
+    fun `updateBillingAddress is not gated by allowedShippingCountries`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                allowedShippingCountries = listOf("US"),
+            ),
+        ) {
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "DE"),
+            ) { response ->
+                response.testBodyFromFile("checkout-session-update-shipping-address.json")
+            }
+
+            checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+                .country("DE")
+            val result = checkout.updateBillingAddress(address = address)
+
+            checkoutSessionTurbine.awaitItem()
+            result.getOrThrow()
+        }
+
+    @Test
+    fun `updateShippingAddress with missing country throws IllegalArgumentException before allowlist check`() =
+        runCreateWithStateScenario(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = false,
+                allowedShippingCountries = listOf("US"),
+            ),
+            shouldValidateEvents = false,
+        ) {
+            checkoutSessionTurbine.awaitItem()
+
+            val address = Address()
+            val result = runCatching { checkout.updateShippingAddress(address = address) }
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+            assertThat(exception).hasMessageThat().isEqualTo("Country is required.")
+        }
+
+    // endregion
+
     private fun runCreateWithStateScenario(
         checkoutSessionResponse: CheckoutSessionResponse = taxEnabledForShipping(),
         shouldValidateEvents: Boolean = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -27,6 +27,7 @@ internal object CheckoutSessionResponseFactory {
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
         automaticTaxEnabled: Boolean = false,
         taxAddressSource: CheckoutSessionResponse.TaxAddressSource? = null,
+        allowedShippingCountries: List<String>? = null,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -48,6 +49,7 @@ internal object CheckoutSessionResponseFactory {
             adaptivePricingInfo = adaptivePricingInfo,
             automaticTaxEnabled = automaticTaxEnabled,
             taxAddressSource = taxAddressSource,
+            allowedShippingCountries = allowedShippingCountries,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1270,4 +1270,83 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result?.automaticTaxEnabled).isFalse()
         assertThat(result?.taxAddressSource).isNull()
     }
+
+    @Test
+    fun `parse allowedShippingCountries from shipping_address_collection`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "shipping_address_collection": {
+                    "allowed_countries": ["US", "CA", "GB"]
+                }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.allowedShippingCountries).isEqualTo(listOf("US", "CA", "GB"))
+    }
+
+    @Test
+    fun `parse allowedShippingCountries is null when shipping_address_collection is absent`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.allowedShippingCountries).isNull()
+    }
+
+    @Test
+    fun `parse allowedShippingCountries is null when allowed_countries key is absent`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "shipping_address_collection": {}
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.allowedShippingCountries).isNull()
+    }
+
+    @Test
+    fun `parse allowedShippingCountries is empty list when allowed_countries is empty array`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "shipping_address_collection": {
+                    "allowed_countries": []
+                }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.allowedShippingCountries).isEqualTo(emptyList<String>())
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
@@ -279,6 +279,7 @@ internal class CreateCustomerMetadataTest {
                     adaptivePricingInfo = null,
                     automaticTaxEnabled = false,
                     taxAddressSource = null,
+                    allowedShippingCountries = null,
                 ),
             )
         }


### PR DESCRIPTION
# Summary
Adds shipping-country validation to the checkout `updateShippingAddress()` APIs. When the checkout session restricts shipping countries, an address whose country is not in the allowed set is now rejected locally at update time (before confirm) instead of failing with a server rejection later.

Changes:
- `CheckoutSessionResponse` gains `allowedShippingCountries: List<String>?`, parsed from the top-level `shipping_address_collection.allowed_countries` in the session init response.
- New shared `CheckoutSessionResponse.validateShippingCountry()` extension, used by both `Checkout.updateAddress` and `CheckoutController.updateAddress` so the two paths stay consistent.
- Validation runs shipping-source only (billing is not gated) as a fast-fail `Result.failure` before any state mutation, mutex/lock, or network call. On the reject path no loading flag flips and no local state changes.
- `Address.State.country` tightened to non-null `String` (it is only ever produced by `Address.build()`, which already requires it).

Semantics (verified against iOS + EwCS web + pay-server backend):
- `null`/absent `allowedShippingCountries` → allow all (skip validation).
- Empty list `[]` → reject all (matches the EwCS web client and iOS; the backend never emits `[]` in practice).
- Exact string match, no case normalization (server emits uppercase ISO-3166-1 alpha-2 codes).
- On failure, `Result.failure(IllegalArgumentException("Country code '<code>' is not in allowedShippingCountries"))`, consistent with the checkout package's existing plain-exception pattern.

# Motivation
Web validates the shipping country against the session's `allowed_countries` before confirm (`validateShippingAddress.ts`); Android did not. Since `shippingAddress` is a local field (not sent to the server until confirm), validating at `updateShippingAddress()` time gives faster feedback than a server rejection at confirm. This is especially important for the Address Element UX, where the error can be surfaced inline as the user selects a country rather than failing the entire payment flow. Fixes MOBILESDK-4647.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

`CheckoutTest` and `CheckoutControllerTest` each cover: allowed country succeeds, disallowed country fails (`IllegalArgumentException` with exact message, no state change, no network), `null` list allows all, empty list rejects all, and billing not gated. The `CheckoutController` reject test also asserts `isLoading` never toggles (locking in that validation stays outside the mutex). `CheckoutSessionResponseJsonParserTest` covers the parser cases (present array, absent object, absent key, empty array → `emptyList()`). `:paymentsheet:testDebugUnitTest` and `:paymentsheet:detekt` pass.

# Changelog
N/A. This touches only internal checkout-session code (`@RestrictTo(LIBRARY_GROUP)`, under the `@CheckoutSessionPreview` opt-in surface); no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

