### PR TITLE
Improve NFC scanning time

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
@@ -4,10 +4,16 @@ import javax.inject.Inject
 import kotlin.collections.joinToString
 
 internal interface NfcCardDataParser {
+    fun canParse(records: Map<String, ByteArray>): Boolean
+
     fun parse(records: Map<String, ByteArray>): ScannedCardData?
 }
 
 internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParser {
+    override fun canParse(records: Map<String, ByteArray>): Boolean {
+        return TAG_TRACK2 in records || (TAG_PAN in records && TAG_EXPIRY in records)
+    }
+
     override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
         // Tag 0x57 — Track 2 Equivalent Data. Preferred when present because it encodes PAN and
         // expiry together in the same format used on magnetic-stripe Track 2.

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
 import com.stripe.android.core.injection.IOContext
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.collections.plusAssign
 import kotlin.coroutines.CoroutineContext
 
 internal interface NfcCardReader {
@@ -25,14 +26,18 @@ internal class ApduCardReader @Inject constructor(
 
             val records = mutableMapOf<String, ByteArray>()
 
-            for (sfi in PROBE_SFIS) {
+            probeFiles@ for (sfi in PROBE_SFIS) {
                 for (record in 1..MAX_RECORDS_PER_SFI) {
                     val result = ReadRecordCommand(record, sfi)
                         .transceiveWith(transceiver)
 
-                    if (result.isFailure) continue
+                    result.onSuccess { result ->
+                        records += result
 
-                    records += result.getOrThrow()
+                        if (cardDataParser.canParse(records)) {
+                            break@probeFiles
+                        }
+                    }
                 }
             }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -78,8 +78,31 @@ internal class ApduCardReaderTest {
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
 
-        assertReadRecordProbes(startingAtIndex = 1)
         assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
+    }
+
+    @Test
+    fun `readCard stops probing when parser can parse records`() = runScenario(
+        parseResult = SCANNED_CARD_DATA,
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result.getOrNull()).isEqualTo(SCANNED_CARD_DATA)
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
+
+        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("57")
+        assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
+
+        cardDataParser.canParseCalls.ensureAllEventsConsumed()
     }
 
     @Test
@@ -87,8 +110,8 @@ internal class ApduCardReaderTest {
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(byteArrayOf()),
-            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
             apduSuccessResponse(tlv(tag = 0x5A, value = PAN_DATA)),
+            apduSuccessResponse(tlv(tag = 0x5F, tagContinuation = 0x24, value = EXPIRY_DATA)),
         ),
         transceiveResult = RECORD_NOT_FOUND_RESPONSE,
     ) {
@@ -101,13 +124,14 @@ internal class ApduCardReaderTest {
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS[1])
 
-        assertReadRecordProbes(startingAtIndex = 2)
+        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("5A")
+        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("5F24")
 
         val parsedRecords = cardDataParser.parseCalls.awaitItem()
-        assertThat(parsedRecords).containsKey("57")
-        assertThat(parsedRecords.getValue("57").contentEquals(TRACK_2_DATA)).isTrue()
         assertThat(parsedRecords).containsKey("5A")
         assertThat(parsedRecords.getValue("5A").contentEquals(PAN_DATA)).isTrue()
+        assertThat(parsedRecords).containsKey("5F24")
+        assertThat(parsedRecords.getValue("5F24").contentEquals(EXPIRY_DATA)).isTrue()
     }
 
     private fun runScenario(
@@ -184,6 +208,12 @@ internal class ApduCardReaderTest {
             0x11,
             0x11,
             0x11,
+        )
+
+        val EXPIRY_DATA = byteArrayOf(
+            0x25,
+            0x12,
+            0x01,
         )
 
         val READ_RECORD_REQUESTS = buildList {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
@@ -135,6 +135,56 @@ internal class DefaultNfcCardDataParserTest {
         assertThat(result).isNull()
     }
 
+    @Test
+    fun `canParse returns true when Track 2 tag is present`() {
+        assertThat(
+            parser.canParse(
+                mapOf(
+                    TAG_TRACK2 to hexToBytes("4111111111111111D2512101"),
+                ),
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `canParse returns true when both PAN and expiry tags are present`() {
+        assertThat(
+            parser.canParse(
+                mapOf(
+                    TAG_PAN to hexToBytes("4111111111111111"),
+                    TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
+                ),
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `canParse returns false when only PAN tag is present`() {
+        assertThat(
+            parser.canParse(
+                mapOf(
+                    TAG_PAN to hexToBytes("4111111111111111"),
+                ),
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `canParse returns false when only expiry tag is present`() {
+        assertThat(
+            parser.canParse(
+                mapOf(
+                    TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
+                ),
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `canParse returns false when no recognized tags are present`() {
+        assertThat(parser.canParse(emptyMap())).isFalse()
+    }
+
     private fun hexToBytes(hex: String): ByteArray {
         return hex.chunked(2)
             .map { it.toInt(16).toByte() }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
@@ -4,8 +4,17 @@ import app.cash.turbine.Turbine
 
 internal class FakeNfcCardDataParser(
     private val parseResult: ScannedCardData? = null,
+    private val canParseResult: Boolean? = null,
 ) : NfcCardDataParser {
     val parseCalls = Turbine<Map<String, ByteArray>>()
+    val canParseCalls = Turbine<Map<String, ByteArray>>()
+
+    private val defaultParser = DefaultNfcCardDataParser()
+
+    override fun canParse(records: Map<String, ByteArray>): Boolean {
+        canParseCalls.add(records)
+        return canParseResult ?: defaultParser.canParse(records)
+    }
 
     override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
         parseCalls.add(records)


### PR DESCRIPTION
# Summary
Improve NFC scanning time reducing the number of record reads if we find the necessary data from the NFC tags.

# Motivation
Faster NFC scanning times.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified