### PR TITLE
Add CardScanGoogleActivity to launch Google Pay card scanning flow.

### DIFF
--- a/payments-ui-core/res/layout/stripe_activity_card_scan.xml
+++ b/payments-ui-core/res/layout/stripe_activity_card_scan.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+    <ProgressBar
+        android:id="@+id/stripe_progress_bar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:contentDescription="@string/stripe_loading" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -67,6 +67,8 @@
   <string name="stripe_klarna_mandate">By continuing to Klarna, you allow %1$s to charge your Klarna account for future payments in accordance with their terms and Klarna\'s terms. You can change this at any time in your Klarna app or by reaching out to %2$s.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Pay later with Klarna</string>
+  <!-- Accessibility label for a loading indicator. -->
+  <string name="stripe_loading">Loading</string>
   <!-- Caption for Phone field on address form -->
   <string name="stripe_konbini_confirmation_number_label">Phone</string>
   <!-- Label for name on card field -->

--- a/payments-ui-core/res/values/styles.xml
+++ b/payments-ui-core/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="StripeCardScanGoogleTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+    </style>
+</resources>

--- a/payments-ui-core/src/main/AndroidManifest.xml
+++ b/payments-ui-core/src/main/AndroidManifest.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="com.google.android.libraries.places,com.google.android.gms.common" />
+
+    <application>
+        <activity
+            android:name="com.stripe.android.ui.core.cardscan.CardScanGoogleActivity"
+            android:exported="false"
+            android:theme="@style/StripeCardScanGoogleTheme" />
+    </application>
 </manifest>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanGoogleActivity.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanGoogleActivity.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.ui.core.cardscan
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatActivity
+import com.stripe.android.ui.core.R
+
+internal class CardScanGoogleActivity : AppCompatActivity() {
+    private val paymentCardRecognitionClient: PaymentCardRecognitionClient by lazy {
+        paymentCardRecognitionClientFactory()
+    }
+    private var hasLaunchedGoogleCardScanner = false
+
+    private val cardScanLauncher = registerForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult()
+    ) { result ->
+        setResult(result.resultCode, result.data)
+        finish()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        hasLaunchedGoogleCardScanner =
+            savedInstanceState?.getBoolean(HAS_LAUNCHED_GOOGLE_CARD_SCANNER) == true
+        setContentView(R.layout.stripe_activity_card_scan)
+
+        if (!hasLaunchedGoogleCardScanner) {
+            fetchAndLaunchGoogleCardScanner()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(HAS_LAUNCHED_GOOGLE_CARD_SCANNER, hasLaunchedGoogleCardScanner)
+        super.onSaveInstanceState(outState)
+    }
+
+    private fun fetchAndLaunchGoogleCardScanner() {
+        paymentCardRecognitionClient.fetchIntent(
+            context = this,
+            onFailure = ::finishWithFailure,
+            onSuccess = ::launchGoogleCardScanner,
+        )
+    }
+
+    private fun launchGoogleCardScanner(intentSenderRequest: IntentSenderRequest) {
+        if (isFinishing || isDestroyed) {
+            return
+        }
+
+        hasLaunchedGoogleCardScanner = true
+        runCatching {
+            cardScanLauncher.launch(intentSenderRequest)
+        }.onFailure(::finishWithFailure)
+    }
+
+    private fun finishWithFailure(error: Throwable) {
+        if (isFinishing || isDestroyed) {
+            return
+        }
+
+        setResult(
+            RESULT_CARD_SCAN_FAILED,
+            createFailureIntent(error.message)
+        )
+        finish()
+    }
+
+    companion object {
+        internal const val RESULT_CARD_SCAN_FAILED = Activity.RESULT_FIRST_USER
+
+        private const val HAS_LAUNCHED_GOOGLE_CARD_SCANNER = "has_launched_google_card_scanner"
+        private const val EXTRA_ERROR_MESSAGE = "extra_error_message"
+
+        @VisibleForTesting
+        internal var paymentCardRecognitionClientFactory: () -> PaymentCardRecognitionClient = {
+            DefaultPaymentCardRecognitionClient()
+        }
+
+        internal fun createIntent(context: Context): Intent {
+            return Intent(context, CardScanGoogleActivity::class.java)
+        }
+
+        internal fun createFailureIntent(errorMessage: String?): Intent {
+            return Intent().putExtra(EXTRA_ERROR_MESSAGE, errorMessage)
+        }
+
+        internal fun getErrorMessage(intent: Intent?): String? {
+            return intent?.getStringExtra(EXTRA_ERROR_MESSAGE)
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncher.kt
@@ -2,13 +2,14 @@ package com.stripe.android.ui.core.cardscan
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.core.app.ActivityOptionsCompat
@@ -29,7 +30,7 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
     override val isAvailable: StateFlow<Boolean> = _isAvailable.asStateFlow()
 
     @VisibleForTesting
-    lateinit var activityLauncher: ActivityResultLauncher<IntentSenderRequest>
+    var activityLauncher: ActivityResultLauncher<Unit>? = null
 
     init {
         paymentCardRecognitionClient.fetchIntent(
@@ -51,21 +52,27 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
             return
         }
 
+        val launcher = activityLauncher ?: return
         _isLaunching = true
-        paymentCardRecognitionClient.fetchIntent(
-            context = context,
-            onFailure = { e ->
-                eventsReporter.onCardScanFailed(implementation, e)
-            },
-            onSuccess = { intentSenderRequest ->
-                eventsReporter.onCardScanStarted("google_pay")
-                activityLauncher.launch(intentSenderRequest, options)
-            }
-        )
+        eventsReporter.onCardScanStarted(implementation)
+        runCatching {
+            launcher.launch(Unit, options)
+        }.onFailure { e ->
+            _isLaunching = false
+            eventsReporter.onCardScanFailed(implementation, e)
+        }
     }
 
     internal fun parseActivityResult(result: ActivityResult): CardScanResult {
         val scanResult = when {
+            result.resultCode == CardScanGoogleActivity.RESULT_CARD_SCAN_FAILED -> {
+                CardScanResult.Failed(
+                    CardScanActivityResultException(
+                        CardScanGoogleActivity.getErrorMessage(result.data)
+                            ?: "Failed to start Google Pay card recognition"
+                    )
+                )
+            }
             result.resultCode == Activity.RESULT_OK && result.data != null -> {
                 val data = result.data ?: return CardScanResult.Canceled
                 val paymentCardRecognitionResult = PaymentCardRecognitionResult.getFromIntent(data)
@@ -102,6 +109,16 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
     }
 
     companion object {
+        private val activityResultContract = object : ActivityResultContract<Unit, ActivityResult>() {
+            override fun createIntent(context: Context, input: Unit): Intent {
+                return CardScanGoogleActivity.createIntent(context)
+            }
+
+            override fun parseResult(resultCode: Int, intent: Intent?): ActivityResult {
+                return ActivityResult(resultCode, intent)
+            }
+        }
+
         @Composable
         internal fun rememberCardScanGoogleLauncher(
             context: Context,
@@ -119,14 +136,23 @@ internal class CardScanGoogleLauncher @VisibleForTesting constructor(
                 )
             }
             val activityLauncher = rememberLauncherForActivityResult(
-                ActivityResultContracts.StartIntentSenderForResult(),
+                activityResultContract,
             ) { result ->
                 launcher._isLaunching = false
                 onResult(launcher.parseActivityResult(result))
             }
-            return remember(activityLauncher) {
+            val registeredLauncher = remember(launcher, activityLauncher) {
                 launcher.apply { this.activityLauncher = activityLauncher }
             }
+            DisposableEffect(launcher, activityLauncher) {
+                launcher.activityLauncher = activityLauncher
+                onDispose {
+                    if (launcher.activityLauncher === activityLauncher) {
+                        launcher.activityLauncher = null
+                    }
+                }
+            }
+            return registeredLauncher
         }
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanGoogleActivityTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanGoogleActivityTest.kt
@@ -1,0 +1,102 @@
+package com.stripe.android.ui.core.cardscan
+
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Looper
+import androidx.activity.result.IntentSenderRequest
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+internal class CardScanGoogleActivityTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun tearDown() {
+        CardScanGoogleActivity.paymentCardRecognitionClientFactory = {
+            DefaultPaymentCardRecognitionClient()
+        }
+    }
+
+    @Test
+    fun `activity returns failed result when fetching Google intent fails`() {
+        CardScanGoogleActivity.paymentCardRecognitionClientFactory = {
+            FakePaymentCardRecognitionClient(shouldSucceed = false)
+        }
+
+        ActivityScenario.launchActivityForResult<CardScanGoogleActivity>(
+            CardScanGoogleActivity.createIntent(context)
+        ).use { scenario ->
+            waitForIdle()
+
+            assertThat(scenario.result.resultCode).isEqualTo(CardScanGoogleActivity.RESULT_CARD_SCAN_FAILED)
+            assertThat(CardScanGoogleActivity.getErrorMessage(scenario.result.resultData))
+                .isEqualTo("Failed to fetch intent")
+        }
+    }
+
+    @Test
+    fun `activity ignores Google intent result after it has finished`() {
+        val paymentCardRecognitionClient = ControllablePaymentCardRecognitionClient()
+        CardScanGoogleActivity.paymentCardRecognitionClientFactory = {
+            paymentCardRecognitionClient
+        }
+
+        ActivityScenario.launchActivityForResult<CardScanGoogleActivity>(
+            CardScanGoogleActivity.createIntent(context)
+        ).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.finish()
+            }
+            waitForIdle()
+
+            assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_CANCELED)
+
+            paymentCardRecognitionClient.completeFetch(context)
+            waitForIdle()
+
+            assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_CANCELED)
+        }
+    }
+
+    private fun waitForIdle() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private class ControllablePaymentCardRecognitionClient : PaymentCardRecognitionClient {
+        private var pendingSuccess: ((IntentSenderRequest) -> Unit)? = null
+
+        override fun fetchIntent(
+            context: Context,
+            onFailure: (Throwable) -> Unit,
+            onSuccess: (IntentSenderRequest) -> Unit
+        ) {
+            pendingSuccess = onSuccess
+        }
+
+        fun completeFetch(context: Context) {
+            val onSuccess = checkNotNull(pendingSuccess)
+            pendingSuccess = null
+            onSuccess(createIntentSenderRequest(context))
+        }
+    }
+}
+
+private fun createIntentSenderRequest(context: Context): IntentSenderRequest {
+    val pendingIntent = PendingIntent.getActivity(
+        context,
+        0,
+        Intent(),
+        PendingIntent.FLAG_IMMUTABLE
+    )
+
+    return IntentSenderRequest.Builder(pendingIntent.intentSender).build()
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncherTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanGoogleLauncherTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.ui.core.cardscan
 import android.app.Activity
 import android.content.Intent
 import androidx.activity.result.ActivityResult
-import androidx.activity.result.IntentSenderRequest
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.wallet.CreditCardExpirationDate
 import com.google.android.gms.wallet.PaymentCardRecognitionResult
@@ -122,7 +121,26 @@ class CardScanGoogleLauncherTest {
     }
 
     @Test
-    fun `card scan launcher should be able to launch card scan activity`() = runScenario {
+    fun `parseActivityResult with card scan failed result code returns Failed`() = runScenario {
+        val result = ActivityResult(
+            CardScanGoogleActivity.RESULT_CARD_SCAN_FAILED,
+            CardScanGoogleActivity.createFailureIntent("Failed to fetch intent")
+        )
+
+        val scanResult = launcher.parseActivityResult(result)
+
+        assertThat(scanResult).isInstanceOf(CardScanResult.Failed::class.java)
+        val failedResult = scanResult as CardScanResult.Failed
+        assertThat(failedResult.error).hasMessageThat().isEqualTo("Failed to fetch intent")
+
+        assertThat(fakeEventsReporter.apiCheckSucceededCalls.awaitItem()).isNotNull()
+        val scanFailedCall = fakeEventsReporter.scanFailedCalls.awaitItem()
+        assertThat(scanFailedCall.implementation).isEqualTo("google_pay")
+        assertThat(scanFailedCall.error).isInstanceOf(CardScanActivityResultException::class.java)
+    }
+
+    @Test
+    fun `card scan launcher should immediately launch card scan activity`() = runScenario {
         assertThat(launcher.isAvailable.value).isTrue()
 
         launcher.launch(ApplicationProvider.getApplicationContext())
@@ -133,37 +151,34 @@ class CardScanGoogleLauncherTest {
     }
 
     @Test
-    fun `card scan launcher should not be available when fetchIntent fails`() = runScenario(
+    fun `card scan launcher should not be available when availability fetch fails`() = runScenario(
         isFetchClientSucceed = false
     ) {
         assertThat(launcher.isAvailable.value).isFalse()
-        launcher.launch(ApplicationProvider.getApplicationContext())
 
         val apiCheckFailedCall = fakeEventsReporter.apiCheckFailedCalls.awaitItem()
         assertThat(apiCheckFailedCall.error?.message).isEqualTo("Failed to fetch intent")
-
-        val scanFailedCall = fakeEventsReporter.scanFailedCalls.awaitItem()
-        assertThat(scanFailedCall.implementation).isEqualTo("google_pay")
-        assertThat(scanFailedCall.error).isInstanceOf(Exception::class.java)
     }
 
     private class Scenario(
         val launcher: CardScanGoogleLauncher,
         val fakeEventsReporter: FakeCardScanEventsReporter,
-        val activityLauncher: FakeActivityLauncher<IntentSenderRequest>,
+        val activityLauncher: FakeActivityLauncher<Unit>,
     )
 
     private fun runScenario(
         isFetchClientSucceed: Boolean = true,
+        paymentCardRecognitionClient: PaymentCardRecognitionClient =
+            FakePaymentCardRecognitionClient(isFetchClientSucceed),
         block: suspend Scenario.() -> Unit
     ) = runTest {
-        val activityLauncher = FakeActivityLauncher<IntentSenderRequest>()
+        val activityLauncher = FakeActivityLauncher<Unit>()
         val fakeEventsReporter = FakeCardScanEventsReporter()
         val launcher = CardScanGoogleLauncher(
             context = ApplicationProvider.getApplicationContext(),
             eventsReporter = fakeEventsReporter,
             options = null,
-            paymentCardRecognitionClient = FakePaymentCardRecognitionClient(isFetchClientSucceed)
+            paymentCardRecognitionClient = paymentCardRecognitionClient
         ).apply {
             this.activityLauncher = activityLauncher
         }


### PR DESCRIPTION
# Summary
Introduce `CardScanGoogleActivity` to launch the Google Pay card scanning flow. Refactor and update how the card scan launcher triggers and handles results, and provide theme and accessibility improvements. Add new tests for activity and error handling.

# Motivation
Improve modularity of the Google Pay card scan integration by delegating its launch process to a dedicated activity. Simplifies the card scanning launch and result flow, and ensures proper error handling. Enhances accessibility and maintainability.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
- [Added] CardScanGoogleActivity for launching Google Pay card scan flow.
- [Changed] CardScanGoogleLauncher updated to use dedicated Activity and improved result handling.
- [Added] Accessibility label for loading indicator.