### PR TITLE
Make PaymentMethodVerticalLayoutInteractor closeable and cancel coroutines.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -288,7 +288,7 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    class VerticalMode(private val interactor: PaymentMethodVerticalLayoutInteractor) : PaymentSheetScreen {
+    class VerticalMode(private val interactor: PaymentMethodVerticalLayoutInteractor) : PaymentSheetScreen, Closeable {
 
         override val buyButtonState = stateFlowOf(
             BuyButtonState(visible = true)
@@ -330,6 +330,10 @@ internal sealed interface PaymentSheetScreen {
                 interactor,
                 modifier.padding(StripeTheme.getOuterFormInsets())
             )
+        }
+
+        override fun close() {
+            interactor.close()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -35,6 +35,7 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
@@ -51,6 +52,8 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     val showsWalletsHeader: StateFlow<Boolean>
 
     fun handleViewAction(viewAction: ViewAction)
+
+    fun close()
 
     data class State(
         val displayablePaymentMethods: List<DisplayablePaymentMethod>,
@@ -667,5 +670,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private fun shouldExpandOnClick(paymentMethodCode: PaymentMethodCode): Boolean {
         return PromotionSupportedPaymentMethods.supportedPaymentMethods.contains(paymentMethodCode) &&
             !shouldTransitionToFormScreen(paymentMethodCode)
+    }
+
+    override fun close() {
+        coroutineScope.cancel()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeTest.kt
@@ -31,4 +31,11 @@ internal class PaymentSheetScreenVerticalModeTest {
             assertThat(awaitItem()).isEqualTo(R.string.stripe_paymentsheet_choose_payment_method.resolvableString)
         }
     }
+
+    @Test
+    fun `screen close delegates to interactor close`() = runTest {
+        PaymentSheetScreen.VerticalMode(interactor).close()
+        interactor.closeCalls.awaitItem()
+        interactor.validate()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1105,6 +1105,26 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun close_cancelsCollectors_soLaterSelectionUpdatesAreIgnored() {
+        runScenario(
+            initialSelection = PaymentSelection.Link(brand = LinkBrand.Link),
+            formTypeForCode = { FormHelper.FormType.Empty },
+        ) {
+            // The selection collector is live, so a selection change is reflected in state.
+            selectionSource.value = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION
+            assertThat(interactor.state.value.selection)
+                .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("cashapp"))
+
+            interactor.close()
+
+            // After close the collector is cancelled, so later selection changes are ignored.
+            selectionSource.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+            assertThat(interactor.state.value.selection)
+                .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("cashapp"))
+        }
+    }
+
+    @Test
     fun verticalModeScreenSelection_isUpdatedToNullWhenCurrentScreen() {
         runScenario(
             initialSelection = PaymentSelection.Link(brand = LinkBrand.Link),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -52,7 +53,17 @@ internal class FakePaymentMethodVerticalLayoutInteractor(
     override val state: StateFlow<PaymentMethodVerticalLayoutInteractor.State> = stateFlowOf(initialState)
     override val showsWalletsHeader: StateFlow<Boolean> = stateFlowOf(initialShowsWalletsHeader)
 
+    val closeCalls = Turbine<Unit>()
+
     override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
         viewActionRecorder.record(viewAction)
+    }
+
+    override fun close() {
+        closeCalls.add(Unit)
+    }
+
+    fun validate() {
+        closeCalls.ensureAllEventsConsumed()
     }
 }


### PR DESCRIPTION
# Summary
Make PaymentMethodVerticalLayoutInteractor implement a close() method. This ensures that active coroutines are cancelled when the interactor or related screen is closed.

# Motivation
Currently, coroutines within PaymentMethodVerticalLayoutInteractor are not explicitly cancelled when the UI is destroyed, which can lead to leaks or unexpected updates. This adds a close() method to handle proper lifecycle management.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
- [Changed] PaymentMethodVerticalLayoutInteractor now implements close() for resource cleanup.