### PR TITLE
Cancel PaymentMethodVerticalLayoutInteractor scope when its screen cl…

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -288,7 +288,8 @@ internal sealed interface PaymentSheetScreen {
         }
     }
 
-    class VerticalMode(private val interactor: PaymentMethodVerticalLayoutInteractor) : PaymentSheetScreen {
+    class VerticalMode(private val interactor: PaymentMethodVerticalLayoutInteractor) :
+        PaymentSheetScreen, Closeable {
 
         override val buyButtonState = stateFlowOf(
             BuyButtonState(visible = true)
@@ -330,6 +331,10 @@ internal sealed interface PaymentSheetScreen {
                 interactor,
                 modifier.padding(StripeTheme.getOuterFormInsets())
             )
+        }
+
+        override fun close() {
+            interactor.close()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -35,6 +35,7 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
@@ -51,6 +52,9 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     val showsWalletsHeader: StateFlow<Boolean>
 
     fun handleViewAction(viewAction: ViewAction)
+
+    /** Cancels the interactor's coroutine scope and its perpetual collectors. */
+    fun close()
 
     data class State(
         val displayablePaymentMethods: List<DisplayablePaymentMethod>,
@@ -590,6 +594,10 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 cancelPaymentMethodVisibilityTracking()
             }
         }
+    }
+
+    override fun close() {
+        coroutineScope.cancel()
     }
 
     private val visibilityTracker = PaymentMethodInitialVisibilityTracker(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1918,6 +1918,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
+            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
@@ -55,4 +55,6 @@ internal class FakePaymentMethodVerticalLayoutInteractor(
     override fun handleViewAction(viewAction: PaymentMethodVerticalLayoutInteractor.ViewAction) {
         viewActionRecorder.record(viewAction)
     }
+
+    override fun close() = Unit
 }


### PR DESCRIPTION
…oses

DefaultPaymentMethodVerticalLayoutInteractor owns a CoroutineScope with four perpetual collectors started in init, but had no teardown: the scope was never cancelled in production or in tests, so it (and its DI graph) outlived every test that built the interactor.

Give the interactor a close() that cancels its scope, and make PaymentSheetScreen.VerticalMode implement Closeable and delegate to it — the same wiring the SelectSavedPaymentMethods / ManageSavedPaymentMethods / VerticalModeForm screens already use. NavigationHandler only closes a screen when it is popped or removed, so the scope is cancelled exactly when the screen leaves the back stack, matching the sibling screens. The test runScenario now calls interactor.close(); FakePaymentMethodVerticalLayoutInteractor implements the new method as a no-op.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
