### PR TITLE
Cancel test-owned coroutine scopes in paymentsheet interactor/holder …

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
@@ -228,6 +228,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         onContinueCalls.ensureAllEventsConsumed()
         onConfirmCalls.ensureAllEventsConsumed()
         fakeEventReporter.validate()
+        scenario.interactor.close()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -568,6 +568,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
 
             eventReporter.validate()
             onCompleteCalls.ensureAllEventsConsumed()
+            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -28,10 +28,12 @@ import com.stripe.android.utils.FakeActivityResultLauncher
 import com.stripe.android.utils.FakeLinkComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -64,6 +66,15 @@ class LinkControllerInteractorTest {
         )
     private val linkComponentFactoryProvider: Provider<LinkComponent.Factory> =
         Provider { FakeLinkComponent.Factory(linkComponent) }
+
+    // Each created interactor owns a scope with a perpetual collector in its init; track and cancel
+    // them so the scopes don't outlive the test.
+    private val trackedScopes = mutableListOf<CoroutineScope>()
+
+    @After
+    fun cancelTrackedScopes() {
+        trackedScopes.forEach { it.cancel() }
+    }
 
     @Test
     fun `Initial state is correct`() = runTest {
@@ -1024,13 +1035,14 @@ class LinkControllerInteractorTest {
     }
 
     private fun createInteractor(): LinkControllerInteractor {
+        val coroutineScope = CoroutineScope(dispatcher).also { trackedScopes.add(it) }
         return LinkControllerInteractor(
             application = application,
             logger = logger,
             linkConfigurationLoader = linkConfigurationLoader,
             linkAccountHolder = linkAccountHolder,
             linkComponentFactoryProvider = linkComponentFactoryProvider,
-            coroutineScope = CoroutineScope(dispatcher),
+            coroutineScope = coroutineScope,
             savedStateHandle = savedStateHandle,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -21,9 +21,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.CoroutineTestRule
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.mockito.Mockito.mock
@@ -145,7 +143,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(
             savedStateHandle = savedStateHandle,
             selectionHolder = selectionHolder,
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = backgroundScope,
         )
         confirmationStateHolder.state = loadedState
         val stateHelper = FakeEmbeddedStateHelper()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -25,7 +25,6 @@ import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -138,7 +137,7 @@ internal class DefaultEmbeddedContentHelperTest {
     private fun testScenario(
         setup: SavedStateHandle.() -> Unit = {},
         block: suspend Scenario.() -> Unit,
-    ) = runTest {
+    ) = runTest(UnconfinedTestDispatcher()) {
         val savedStateHandle = SavedStateHandle().apply { setup() }
         val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
         val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
@@ -151,12 +150,12 @@ internal class DefaultEmbeddedContentHelperTest {
         val eventReporter = FakeEventReporter()
         val errorReporter = FakeErrorReporter()
         val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = backgroundScope,
             internalRowSelectionCallback = { null }
         )
 
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
-            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+            coroutineScope = backgroundScope,
             savedStateHandle = savedStateHandle,
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
@@ -180,7 +179,7 @@ internal class DefaultEmbeddedContentHelperTest {
             confirmationStateHolder = EmbeddedConfirmationStateHolder(
                 savedStateHandle = savedStateHandle,
                 selectionHolder = selectionHolder,
-                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+                coroutineScope = backgroundScope,
             ),
             rowSelectionImmediateActionHandler = immediateActionHandler,
             errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -25,8 +25,6 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -221,7 +219,7 @@ internal class DefaultEmbeddedStateHelperTest {
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(
             savedStateHandle = savedStateHandle,
             selectionHolder = selectionHolder,
-            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+            coroutineScope = backgroundScope,
         )
         val embeddedContentHelper = FakeEmbeddedContentHelper()
         val confirmationHandler = FakeConfirmationHandler()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultPaymentOptionDisplayDataHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultPaymentOptionDisplayDataHolderTest.kt
@@ -7,8 +7,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -49,7 +47,7 @@ internal class DefaultPaymentOptionDisplayDataHolderTest {
         val selectionHolder = EmbeddedSelectionHolder(savedStateHandle = SavedStateHandle())
         Scenario(
             paymentOptionDisplayDataHolder = DefaultPaymentOptionDisplayDataHolder(
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                coroutineScope = backgroundScope,
                 selectionHolder = selectionHolder,
                 confirmationStateSupplier = confirmationStateSupplier,
                 paymentOptionDisplayDataFactory = paymentOptionDisplayDataFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -546,6 +546,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
+            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -377,6 +377,7 @@ class DefaultManageScreenInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
+            interactor.close()
         }
     }
 


### PR DESCRIPTION
…tests

Several tests built classes that own a long-lived CoroutineScope with a perpetual collector in init (never completes) and never cancelled that scope, so the scope + collector + DI graph leaked across tests.

- Embedded holder tests (EmbeddedContentHelper, PaymentOptionDisplayDataHolder, EmbeddedConfirmationStateHolder): pass runTest's auto-cancelled backgroundScope instead of a bare CoroutineScope(Dispatchers.Unconfined) / CoroutineScope(UnconfinedTestDispatcher()). DefaultEmbeddedContentHelperTest runs on an UnconfinedTestDispatcher so backgroundScope keeps the eager init semantics its assertions rely on.
- Interactor tests (SelectSaved, ManageScreen, TapToAddCardAdded, TapToAddConfirmation): call interactor.close() at the end of runScenario; these create their own scope internally, so close() is the only teardown lever.
- LinkControllerInteractorTest: track each created scope and cancel them in @After (createInteractor() has no access to backgroundScope).

Test-only changes; no production behavior is affected.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
