### PR TITLE
Destroy CheckoutControllers built in tests to prevent viewModelScope leaks

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -51,9 +51,13 @@ internal class CheckoutControllerTest {
             .loadLabel(applicationContext.packageManager)
             .toString()
 
+    // Destroys built controllers when the test finishes, releasing each one's viewModelScope.
+    private val controllerRule = CheckoutControllerTestRule()
+
     @get:Rule
     val ruleChain: RuleChain = RuleChain
-        .outerRule(networkRule)
+        .outerRule(controllerRule)
+        .around(networkRule)
         .around(PaymentConfigurationTestRule(applicationContext))
 
     @Test
@@ -773,10 +777,12 @@ internal class CheckoutControllerTest {
     private fun createController(
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
     ): CheckoutController {
-        return CheckoutController.Builder(
-            application = applicationContext,
-            savedStateHandle = savedStateHandle,
-        ).build()
+        return controllerRule.track(
+            CheckoutController.Builder(
+                application = applicationContext,
+                savedStateHandle = savedStateHandle,
+            ).build()
+        )
     }
 
     private fun runConfigureScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTestRule.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTestRule.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Tracks the [CheckoutController]s built during a test and calls [CheckoutController.destroy] on each
+ * when the test finishes.
+ *
+ * Every `CheckoutController.Builder.build()` creates a controller that owns a `viewModelScope` with a
+ * perpetual collector (started in [CheckoutConfirmationStateHolder]). Only [CheckoutController.destroy]
+ * cancels that scope, so an untracked controller leaks its scope and DI graph across tests.
+ *
+ * Register controllers via [track].
+ */
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutControllerTestRule : TestWatcher() {
+    private val controllers = mutableListOf<CheckoutController>()
+
+    fun track(controller: CheckoutController): CheckoutController =
+        controller.also { controllers.add(it) }
+
+    override fun finished(description: Description) {
+        controllers.forEach { it.destroy() }
+        super.finished(description)
+    }
+}


### PR DESCRIPTION
## Summary
Every `CheckoutController.Builder.build()` creates a controller that owns a `viewModelScope` with a perpetual collector (started in `CheckoutConfirmationStateHolder`). Only `CheckoutController.destroy()` cancels that scope, so controllers built in tests leaked their scope and DI graph across tests.

Adds `CheckoutControllerTestRule`, which tracks controllers built during a test and calls `destroy()` on each when the test finishes, and wires it into `CheckoutControllerTest`.

Test-only change; no production behavior is affected.

## Context
First of a set of independent PRs addressing "a class subscribes to a flow forever on a scope that tests never cancel" across `paymentsheet`.

## Testing
`./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutControllerTest"` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)