### PR TITLE
Close VerticalModeFormInteractor built in tests to cancel its scope

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -390,6 +390,7 @@ internal class DefaultVerticalModeFormInteractorTest {
         verifyNoMoreInteractions(formArguments, usBankAccountArguments)
         onFormFieldValuesChangedTurbine.ensureAllEventsConsumed()
         reportFieldInteractionTurbine.ensureAllEventsConsumed()
+        interactor.close()
     }
 
     private class TestParams(


### PR DESCRIPTION
## Summary
`DefaultVerticalModeFormInteractor` launches a perpetual `validationRequested` collector on its `coroutineScope`; the test built it with a bare `CoroutineScope(UnconfinedTestDispatcher())` that was never cancelled or closed, leaking the scope and collector across tests. Calls `interactor.close()` at the end of `runScenario` (the scope is constructed outside the `runTest` block, so `backgroundScope` isn't available).

Test-only change; no production behavior is affected.

## Testing
`:paymentsheet:testDebugUnitTest --tests "*DefaultVerticalModeFormInteractorTest"` + `:paymentsheet:detekt` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)