### PR TITLE
Close AddPaymentMethodInteractor built in tests to cancel its scope

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -437,6 +437,7 @@ class DefaultAddPaymentMethodInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
+            interactor.close()
         }
     }
 


### PR DESCRIPTION
## Summary
`DefaultAddPaymentMethodInteractor` launches five perpetual collectors (`selection`, `selectedPaymentMethodCode`, `processing`, `validationRequested`, …) on its `coroutineScope`. `DefaultAddPaymentMethodInteractorTest` built it with a bare `CoroutineScope(dispatcher)` that was never cancelled or closed, leaking the scope and collectors across tests. Calls `interactor.close()` at the end of `runScenario`.

(The other test sites use `FakeAddPaymentMethodInteractor`, which owns no scope.)

Test-only change; no production behavior is affected.

## Testing
`:paymentsheet:testDebugUnitTest --tests "*DefaultAddPaymentMethodInteractorTest"` + `:paymentsheet:detekt` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)