### PR TITLE
Report an error code as to why NFC scanning attempt failed.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
@@ -62,14 +62,16 @@ internal class NfcScanningViewModel @Inject constructor(
                         eventReporter.onNfcScanAttemptStarted()
                     }
                     is NfcCardScanner.State.Failed -> {
+                        val error = state.error
+
                         _viewState.emit(
                             NfcScanningViewState(
                                 tapZone = tapZone,
-                                status = NfcScanningStatus.Idle(error = state.error.userMessage),
+                                status = NfcScanningStatus.Idle(error = error.userMessage),
                             )
                         )
 
-                        eventReporter.onNfcScanAttemptFailed()
+                        eventReporter.onNfcScanAttemptFailed(errorCode = error.code)
                     }
                     is NfcCardScanner.State.Complete -> {
                         _viewState.emit(

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
@@ -29,8 +29,10 @@ internal interface NfcScanningEventReporter {
     /**
      * User attempt to scan their card with NFC failed meaning the scanner was NOT able to produce valid card
      * details from the NFC card held against the device.
+     *
+     * @param errorCode code generated from NFC scanning flow indicating the error
      */
-    fun onNfcScanAttemptFailed()
+    fun onNfcScanAttemptFailed(errorCode: String)
 
     /**
      * NFC scan flow completed successfully meaning the user is being returned to the calling payment flow after
@@ -70,9 +72,13 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
         fireEvent(eventName = SCAN_ATTEMPT_SUCCEEDED_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
     }
 
-    override fun onNfcScanAttemptFailed() {
+    override fun onNfcScanAttemptFailed(errorCode: String) {
         val duration = durationProvider.end(DurationProvider.Key.NfcScanAttempt)
-        fireEvent(eventName = SCAN_ATTEMPT_FAILED_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
+        fireEvent(
+            eventName = SCAN_ATTEMPT_FAILED_EVENT_NAME,
+            additionalParams = duration.mapOfDurationInSeconds() +
+                mapOf(FIELD_ERROR_CODE to errorCode)
+        )
     }
 
     override fun onNfcScanCancelled() {
@@ -96,6 +102,8 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
     }
 
     private companion object {
+        const val FIELD_ERROR_CODE = "error_code"
+
         const val SCAN_STARTED_EVENT_NAME = "nfc_scan_started"
         const val SCAN_SUCCESS_EVENT_NAME = "nfc_scan_success"
         const val SCAN_CANCELED_EVENT_NAME = "nfc_scan_canceled"

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
@@ -23,6 +23,7 @@ internal interface NfcCardScanner {
     }
 
     data class Error(
+        val code: String,
         val userMessage: ResolvableString,
     )
 
@@ -68,7 +69,10 @@ internal class DefaultNfcCardScanner @Inject constructor(
                         val state = when (val result = cardValidator.validate(cardData)) {
                             is NfcCardValidator.Result.Validated -> NfcCardScanner.State.Complete(cardData)
                             is NfcCardValidator.Result.Invalid -> NfcCardScanner.State.Failed(
-                                error = NfcCardScanner.Error(result.userMessage)
+                                error = NfcCardScanner.Error(
+                                    code = result.errorCode,
+                                    userMessage = result.userMessage,
+                                )
                             )
                         }
 
@@ -84,6 +88,7 @@ internal class DefaultNfcCardScanner @Inject constructor(
 
     private companion object {
         val GENERIC_ERROR = NfcCardScanner.Error(
+            code = "unknown",
             userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardValidator.kt
@@ -13,7 +13,10 @@ internal interface NfcCardValidator {
 
     sealed interface Result {
         data object Validated : Result
-        data class Invalid(val userMessage: ResolvableString) : Result
+        data class Invalid(
+            val errorCode: String,
+            val userMessage: ResolvableString,
+        ) : Result
     }
 }
 
@@ -23,6 +26,7 @@ internal class DefaultNfcCardValidator @Inject constructor(
     override fun validate(cardData: ScannedCardData): NfcCardValidator.Result {
         if (!paymentMethodMetadata.cardBrandFilter.isAccepted(CardBrand.fromCardNumber(cardData.cardNumber))) {
             return NfcCardValidator.Result.Invalid(
+                errorCode = UNSUPPORTED_CARD_VALIDATION_ERROR_CODE,
                 userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
             )
         }
@@ -34,10 +38,16 @@ internal class DefaultNfcCardValidator @Inject constructor(
             )
         ) {
             return NfcCardValidator.Result.Invalid(
+                errorCode = EXPIRED_CARD_VALIDATION_ERROR_CODE,
                 userMessage = R.string.stripe_nfc_scan_error_expired_card.resolvableString,
             )
         }
 
         return NfcCardValidator.Result.Validated
+    }
+
+    private companion object {
+        const val UNSUPPORTED_CARD_VALIDATION_ERROR_CODE = "cardUnsupportedByMerchant"
+        const val EXPIRED_CARD_VALIDATION_ERROR_CODE = "expiredCard"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -54,15 +54,16 @@ internal class NfcScanningViewModelTest {
     }
 
     @Test
-    fun `card scanner failed reports attempt failed`() = runScenario {
+    fun `card scanner failed reports attempt failed with error code`() = runScenario {
         scannerState.emit(
             NfcCardScanner.State.Failed(
                 error = NfcCardScanner.Error(
+                    code = "expiredCard",
                     userMessage = R.string.stripe_nfc_expired_error.resolvableString,
                 ),
             ),
         )
-        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isNotNull()
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("expiredCard")
     }
 
     @Test
@@ -115,12 +116,15 @@ internal class NfcScanningViewModelTest {
 
             scannerState.emit(
                 NfcCardScanner.State.Failed(
-                    error = NfcCardScanner.Error(userMessage = errorMessage),
+                    error = NfcCardScanner.Error(
+                        code = "unknown",
+                        userMessage = errorMessage,
+                    ),
                 ),
             )
 
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Idle(error = errorMessage))
-            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("unknown")
         }
     }
 
@@ -133,11 +137,14 @@ internal class NfcScanningViewModelTest {
 
             scannerState.emit(
                 NfcCardScanner.State.Failed(
-                    error = NfcCardScanner.Error(userMessage = errorMessage),
+                    error = NfcCardScanner.Error(
+                        code = "unknown",
+                        userMessage = errorMessage,
+                    ),
                 ),
             )
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Idle(error = errorMessage))
-            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("unknown")
 
             scannerState.emit(NfcCardScanner.State.Scanning)
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Scanning)

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
@@ -70,10 +70,10 @@ internal class DefaultNfcScanningEventReporterTest {
     }
 
     @Test
-    fun `onNfcScanAttemptFailed ends duration and fires event with duration`() = runScenario {
+    fun `onNfcScanAttemptFailed ends duration and fires event with duration and error code`() = runScenario {
         durationProvider.start(DurationProvider.Key.NfcScanAttempt)
 
-        reporter.onNfcScanAttemptFailed()
+        reporter.onNfcScanAttemptFailed(errorCode = "expiredCard")
 
         assertThat(durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScanAttempt)))
             .isTrue()
@@ -81,6 +81,7 @@ internal class DefaultNfcScanningEventReporterTest {
         val loggedParams = executor.getExecutedRequests().single().params
         assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_attempt_failed")
         assertThat(loggedParams).containsEntry("duration", 1.0f)
+        assertThat(loggedParams).containsEntry("error_code", "expiredCard")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
@@ -6,7 +6,7 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
     val onNfcScanStartedCalls = Turbine<Unit>()
     val onNfcScanAttemptStartedCalls = Turbine<Unit>()
     val onNfcScanAttemptSucceededCalls = Turbine<Unit>()
-    val onNfcScanAttemptFailedCalls = Turbine<Unit>()
+    val onNfcScanAttemptFailedCalls = Turbine<String>()
     val onNfcScanSucceededCalls = Turbine<Unit>()
     val onNfcScanCancelledCalls = Turbine<Unit>()
 
@@ -22,8 +22,8 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
         onNfcScanAttemptSucceededCalls.add(Unit)
     }
 
-    override fun onNfcScanAttemptFailed() {
-        onNfcScanAttemptFailedCalls.add(Unit)
+    override fun onNfcScanAttemptFailed(errorCode: String) {
+        onNfcScanAttemptFailedCalls.add(errorCode)
     }
 
     override fun onNfcScanSucceeded() {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
@@ -78,6 +78,7 @@ internal class DefaultNfcCardScannerTest {
             assertThat(awaitItem()).isEqualTo(
                 NfcCardScanner.State.Failed(
                     error = NfcCardScanner.Error(
+                        code = "unknown",
                         userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
                     ),
                 ),
@@ -123,6 +124,7 @@ internal class DefaultNfcCardScannerTest {
             assertThat(awaitItem()).isEqualTo(
                 NfcCardScanner.State.Failed(
                     error = NfcCardScanner.Error(
+                        code = "unknown",
                         userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
                     ),
                 ),
@@ -153,8 +155,12 @@ internal class DefaultNfcCardScannerTest {
 
             assertThat(awaitItem()).isEqualTo(NfcCardScanner.State.Scanning)
             val failedState = awaitItem() as NfcCardScanner.State.Failed
-            assertThat(failedState.error.userMessage)
-                .isEqualTo(R.string.stripe_tap_to_add_card_default_error_action.resolvableString)
+            assertThat(failedState.error).isEqualTo(
+                NfcCardScanner.Error(
+                    code = "unknown",
+                    userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+                ),
+            )
         }
 
         assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
@@ -174,6 +180,7 @@ internal class DefaultNfcCardScannerTest {
             expirationYear = 2030,
         ),
         validationResult = NfcCardValidator.Result.Invalid(
+            errorCode = "cardUnsupportedByMerchant",
             userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
         ),
     ) {
@@ -187,6 +194,7 @@ internal class DefaultNfcCardScannerTest {
             assertThat(awaitItem()).isEqualTo(
                 NfcCardScanner.State.Failed(
                     error = NfcCardScanner.Error(
+                        code = "cardUnsupportedByMerchant",
                         userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
                     ),
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardValidatorTest.kt
@@ -38,6 +38,7 @@ internal class DefaultNfcCardValidatorTest {
 
         assertThat(result).isEqualTo(
             NfcCardValidator.Result.Invalid(
+                errorCode = "cardUnsupportedByMerchant",
                 userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
             ),
         )
@@ -55,6 +56,7 @@ internal class DefaultNfcCardValidatorTest {
 
         assertThat(result).isEqualTo(
             NfcCardValidator.Result.Invalid(
+                errorCode = "expiredCard",
                 userMessage = R.string.stripe_nfc_scan_error_expired_card.resolvableString,
             ),
         )


### PR DESCRIPTION
# Summary
Report an error code as to why an NFC scanning attempt failed. 

# Motivation
Allows developers to have better visibility into NFC scanning flow errors for future debugging and improvements

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified