### PR TITLE
Localize declined 3DS2 card error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### Payments
+* [FIXED][7581](https://github.com/stripe/stripe-android/issues/7581) Declined card error messages from 3DS2 payment flows are now localized instead of always displaying the raw English message from the server.
+
 ## 23.12.0 - 2026-07-13
 
 ### Connect

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
@@ -20,7 +20,10 @@ internal class PaymentFlowFailureMessageFactory(
         outcome == StripeIntentResult.Outcome.TIMEDOUT -> {
             context.resources.getString(R.string.stripe_failure_reason_timed_out)
         }
-        intent.is3DS2() -> {
+        intent.is3DS2() && !intent.hasLastError() -> {
+            // A 3DS2 intent that succeeded or is still mid-authentication (e.g. the
+            // customer canceled) has no decline to surface. Declined 3DS2 intents
+            // carry a lastPaymentError and fall through to the localized message path.
             null
         }
         (intent.status == StripeIntent.Status.RequiresPaymentMethod) ||
@@ -81,5 +84,10 @@ internal class PaymentFlowFailureMessageFactory(
     private fun StripeIntent.is3DS2(): Boolean {
         return paymentMethod?.type == PaymentMethod.Type.Card &&
             nextActionData is StripeIntent.NextActionData.SdkData.Use3DS2
+    }
+
+    private fun StripeIntent.hasLastError(): Boolean = when (this) {
+        is PaymentIntent -> lastPaymentError != null
+        is SetupIntent -> lastSetupError != null
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentFlowFailureMessageFactoryTest.kt
@@ -1,23 +1,28 @@
 package com.stripe.android.payments
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
+import com.stripe.android.testing.LocaleTestRule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.Locale
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentFlowFailureMessageFactoryTest {
 
-    private val factory = PaymentFlowFailureMessageFactory(
-        ApplicationProvider.getApplicationContext()
-    )
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val localeTestRule = LocaleTestRule()
+
+    private val factory = PaymentFlowFailureMessageFactory(context)
 
     @Test
     fun `create() with PaymentIntent with requiresAction on a card`() {
@@ -85,6 +90,80 @@ class PaymentFlowFailureMessageFactoryTest {
     }
 
     @Test
+    fun `create() with declined 3DS2 PaymentIntent returns localized decline message (en)`() {
+        assertThat(
+            factory.create(
+                intent = declined3ds2PaymentIntent(),
+                requestId = null,
+                outcome = StripeIntentResult.Outcome.FAILED
+            )
+        ).isEqualTo(
+            "Your card has insufficient funds."
+        )
+    }
+
+    @Test
+    fun `create() with declined 3DS2 PaymentIntent returns localized decline message (fr)`() {
+        localeTestRule.setTemporarily(Locale.FRANCE)
+
+        val localizedFactory = PaymentFlowFailureMessageFactory(
+            localeTestRule.contextForLocale(context)
+        )
+
+        assertThat(
+            localizedFactory.create(
+                intent = declined3ds2PaymentIntent(),
+                requestId = null,
+                outcome = StripeIntentResult.Outcome.FAILED
+            )
+        ).isEqualTo(
+            "Votre carte ne dispose pas de fonds suffisants."
+        )
+    }
+
+    @Test
+    fun `create() with succeeded 3DS2 PaymentIntent returns null`() {
+        assertThat(
+            factory.create(
+                intent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
+                    status = StripeIntent.Status.Succeeded
+                ),
+                requestId = null,
+                outcome = StripeIntentResult.Outcome.FAILED
+            )
+        ).isNull()
+    }
+
+    @Test
+    fun `create() with 3DS2 PaymentIntent still mid-authentication returns null`() {
+        // PI_VISA_3DS2 is a genuine 3DS2 intent still in RequiresAction with no error
+        // (e.g. the customer canceled). Without the 3DS2 guard this would surface the
+        // generic authentication-failure message instead of null.
+        assertThat(
+            factory.create(
+                intent = PaymentIntentFixtures.PI_VISA_3DS2.copy(
+                    status = StripeIntent.Status.RequiresAction
+                ),
+                requestId = null,
+                outcome = StripeIntentResult.Outcome.FAILED
+            )
+        ).isNull()
+    }
+
+    @Test
+    fun `create() with declined 3DS2 SetupIntent returns localized decline message`() {
+        assertThat(
+            factory.create(
+                intent = declined3ds2SetupIntent(),
+                requestId = null,
+                outcome = StripeIntentResult.Outcome.FAILED
+            )
+        ).isEqualTo(
+            "Your card has insufficient funds."
+        )
+    }
+
+    @Test
     fun `create() uses requestId with default messaging in live mode`() {
         assertThat(
             factory.create(
@@ -106,6 +185,46 @@ class PaymentFlowFailureMessageFactoryTest {
             )
         ).isEqualTo(
             "Something went wrong. Request ID: req_abc123"
+        )
+    }
+
+    private fun declined3ds2PaymentIntent(): PaymentIntent {
+        // PI_VISA_3DS2 is a genuine 3DS2 intent (card payment method + Use3DS2 next
+        // action). A RequiresPaymentMethod status with a card_declined error models a
+        // card that was declined during the 3DS2 flow, which must still surface the
+        // localized decline message rather than being suppressed as "mid-authentication".
+        return PaymentIntentFixtures.PI_VISA_3DS2.copy(
+            status = StripeIntent.Status.RequiresPaymentMethod,
+            lastPaymentError = PaymentIntent.Error(
+                code = "card_declined",
+                declineCode = "insufficient_funds",
+                type = PaymentIntent.Error.Type.CardError,
+                charge = null,
+                docUrl = null,
+                message = "Your card has insufficient funds.",
+                param = null,
+                paymentMethod = null,
+            ),
+            isLiveMode = false,
+        )
+    }
+
+    private fun declined3ds2SetupIntent(): SetupIntent {
+        // SI_3DS2_PROCESSING is a genuine 3DS2 SetupIntent (card payment method +
+        // Use3DS2 next action). A RequiresPaymentMethod status with a card_declined
+        // error models a card declined during the 3DS2 flow.
+        return SetupIntentFixtures.SI_3DS2_PROCESSING.copy(
+            status = StripeIntent.Status.RequiresPaymentMethod,
+            lastSetupError = SetupIntent.Error(
+                code = "card_declined",
+                declineCode = "insufficient_funds",
+                docUrl = null,
+                message = "Your card has insufficient funds.",
+                param = null,
+                paymentMethod = null,
+                type = SetupIntent.Error.Type.CardError,
+            ),
+            isLiveMode = false,
         )
     }
 }


### PR DESCRIPTION
Declined card payments that go through the 3DS2 flow previously short-circuited before the localized error-message mapping ran, so the raw English server message was shown even when the rest of the UI was localized.

Remove the unconditional 3DS2 null return so declined 3DS2 intents flow through the same localized decline-message path as other flows, while still not surfacing a message for a 3DS2 intent that succeeded or is mid-authentication.

Fixes #7581

Committed-By-Agent: goose

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
