### PR TITLE
[🪿] Use RuleChain in ExpressCheckoutElementContentTest

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementContentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementContentTest.kt
@@ -8,19 +8,19 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 internal class ExpressCheckoutElementContentTest {
-    @get:Rule
-    val composeRule = createComposeRule()
+    private val composeRule = createComposeRule()
 
     @get:Rule
-    val composeCleanupRule = createComposeCleanupRule()
-
-    @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(createComposeCleanupRule())
+        .around(composeRule)
+        .around(CoroutineTestRule())
 
     @Test
     fun `renders wallet button text`() {


### PR DESCRIPTION
Committed-By-Agent: goose

# Summary
<!-- Simple summary of what was changed. -->
 Use RuleChain in ExpressCheckoutElementContentTest

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/13435#discussion_r3581239768