### PR TITLE
Update ECE to only show available express buttons

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
@@ -22,11 +22,14 @@ class ExpressCheckoutElement internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         enum class LinkVisibility {
             Auto,
             Never,
         }
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         enum class GooglePayVisibility {
             Auto,
             Never,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
@@ -3,10 +3,12 @@ package com.stripe.android.checkout
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
+import com.stripe.android.checkout.ece.ExpressButton
 import com.stripe.android.checkout.ece.ExpressCheckoutElementContent
 import com.stripe.android.checkout.ece.ExpressCheckoutElementInteractor
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.WalletsState
 import kotlinx.parcelize.Parcelize
 
 @CheckoutSessionPreview
@@ -23,22 +25,40 @@ class ExpressCheckoutElement internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
-        private var visibility: PaymentSheet.WalletButtonsConfiguration.Visibility =
-            PaymentSheet.WalletButtonsConfiguration.Visibility()
+        enum class LinkVisibility {
+            Auto,
+            Never,
+        }
 
-        fun visibility(
-            visibility: PaymentSheet.WalletButtonsConfiguration.Visibility
+        enum class GooglePayVisibility {
+            Auto,
+            Never,
+        }
+
+        private var linkVisibility: LinkVisibility = LinkVisibility.Auto
+        private var googlePayVisibility: GooglePayVisibility = GooglePayVisibility.Auto
+
+        fun linkVisibility(
+            linkVisibility: LinkVisibility
         ): Configuration = apply {
-            this.visibility = visibility
+            this.linkVisibility = linkVisibility
+        }
+
+        fun googlePayVisibility(
+            googlePayVisibility: GooglePayVisibility
+        ): Configuration = apply {
+            this.googlePayVisibility = googlePayVisibility
         }
 
         @Parcelize
         internal data class State(
-            val visibility: PaymentSheet.WalletButtonsConfiguration.Visibility,
+            val linkVisibility: LinkVisibility,
+            val googlePayVisibility: GooglePayVisibility,
         ) : Parcelable
 
         internal fun build(): State = State(
-            visibility = visibility,
+            linkVisibility = linkVisibility,
+            googlePayVisibility = googlePayVisibility,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
@@ -3,12 +3,9 @@ package com.stripe.android.checkout
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
-import com.stripe.android.checkout.ece.ExpressButton
 import com.stripe.android.checkout.ece.ExpressCheckoutElementContent
 import com.stripe.android.checkout.ece.ExpressCheckoutElementInteractor
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.WalletsState
 import kotlinx.parcelize.Parcelize
 
 @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
@@ -1,5 +1,10 @@
+@file:OptIn(CheckoutSessionPreview::class)
 package com.stripe.android.checkout.ece
 
+import com.stripe.android.checkout.ExpressCheckoutElement
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 
@@ -12,12 +17,31 @@ internal interface ExpressCheckoutElementInteractor {
 }
 
 internal class DefaultExpressCheckoutElementInteractor(
+    availableExpressButtons: List<ExpressButton>,
+) : ExpressCheckoutElementInteractor {
     override val state: StateFlow<ExpressCheckoutElementInteractor.State> = stateFlowOf(
         ExpressCheckoutElementInteractor.State(
-            expressButtons = listOf(
-                ExpressButton.Link,
-                ExpressButton.GooglePay,
-            )
+            expressButtons = availableExpressButtons,
         )
-    ),
-) : ExpressCheckoutElementInteractor
+    )
+
+    fun create(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        expressCheckoutElementConfig: ExpressCheckoutElement.Configuration.State,
+    ): DefaultExpressCheckoutElementInteractor {
+        return DefaultExpressCheckoutElementInteractor(
+            availableExpressButtons = paymentMethodMetadata.availableWallets.mapNotNull { walletType ->
+                when (walletType) {
+                    WalletType.GooglePay -> ExpressButton.GooglePay.takeIf {
+                        expressCheckoutElementConfig.googlePayVisibility !=
+                            ExpressCheckoutElement.Configuration.GooglePayVisibility.Never
+                    }
+                    WalletType.Link -> ExpressButton.Link.takeIf {
+                        expressCheckoutElementConfig.linkVisibility !=
+                            ExpressCheckoutElement.Configuration.LinkVisibility.Never
+                    }
+                }
+            }
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ExpressCheckoutElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ExpressCheckoutElementTest.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class ExpressCheckoutElementTest {
+    @Test
+    fun `configuration defaults both wallet visibilities to auto`() {
+        val state = ExpressCheckoutElement.Configuration().build()
+
+        assertThat(state.linkVisibility).isEqualTo(
+            ExpressCheckoutElement.Configuration.LinkVisibility.Auto
+        )
+        assertThat(state.googlePayVisibility).isEqualTo(
+            ExpressCheckoutElement.Configuration.GooglePayVisibility.Auto
+        )
+    }
+
+    @Test
+    fun `configuration builds requested wallet visibilities`() {
+        val state = ExpressCheckoutElement.Configuration()
+            .linkVisibility(ExpressCheckoutElement.Configuration.LinkVisibility.Never)
+            .googlePayVisibility(ExpressCheckoutElement.Configuration.GooglePayVisibility.Never)
+            .build()
+
+        assertThat(state.linkVisibility).isEqualTo(
+            ExpressCheckoutElement.Configuration.LinkVisibility.Never
+        )
+        assertThat(state.googlePayVisibility).isEqualTo(
+            ExpressCheckoutElement.Configuration.GooglePayVisibility.Never
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -1,20 +1,64 @@
 package com.stripe.android.checkout.ece
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.ExpressCheckoutElement
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import org.junit.Test
 
+@OptIn(CheckoutSessionPreview::class)
 internal class DefaultExpressCheckoutElementInteractorTest {
     @Test
-    fun `default state contains link and google pay buttons`() {
-        val interactor = DefaultExpressCheckoutElementInteractor()
-
-        assertThat(interactor.state.value).isEqualTo(
-            ExpressCheckoutElementInteractor.State(
-                expressButtons = listOf(
-                    ExpressButton.Link,
-                    ExpressButton.GooglePay,
-                )
+    fun `state contains provided express buttons`() {
+        val interactor = DefaultExpressCheckoutElementInteractor(
+            availableExpressButtons = listOf(
+                ExpressButton.Link,
+                ExpressButton.GooglePay,
             )
+        )
+
+        assertThat(interactor.state.value.expressButtons).containsExactly(
+            ExpressButton.Link,
+            ExpressButton.GooglePay,
+        )
+    }
+
+    @Test
+    fun `create keeps only wallets returned by metadata`() {
+        val interactor = createInteractor(
+            availableWallets = listOf(WalletType.GooglePay),
+        )
+
+        assertThat(interactor.state.value.expressButtons).containsExactly(
+            ExpressButton.GooglePay
+        )
+    }
+
+    @Test
+    fun `create filters out wallets disabled by configuration`() {
+        val interactor = createInteractor(
+            availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+        ) {
+            linkVisibility(ExpressCheckoutElement.Configuration.LinkVisibility.Never)
+        }
+
+        assertThat(interactor.state.value.expressButtons).containsExactly(
+            ExpressButton.GooglePay
+        )
+    }
+
+    private fun createInteractor(
+        availableWallets: List<WalletType>,
+        configure: ExpressCheckoutElement.Configuration.() -> Unit = {},
+    ): DefaultExpressCheckoutElementInteractor {
+        return DefaultExpressCheckoutElementInteractor(emptyList()).create(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                availableWallets = availableWallets,
+            ),
+            expressCheckoutElementConfig = ExpressCheckoutElement.Configuration()
+                .apply(configure)
+                .build(),
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update ECE to only show available express buttons

Which buttons are available depends on:
- PaymentMethodMetadata's availableWallets 
- The ECE config. I updated this type to more closely match the type used on stripe-js ([example](https://docs.stripe.com/js/elements_object/create_express_checkout_element#express_checkout_element_create-options-paymentMethods-googlePay)) and to not re-use the PaymentSheet type

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Add functionality to ECE

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified