### PR TITLE
Integrate Stripe-hosted autocomplete proxy into inline address routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ example/gen
 
 # Git worktrees
 .worktrees/
-.gradle-local/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ example/gen
 
 # Git worktrees
 .worktrees/
+.gradle-local/

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -112,6 +112,7 @@ class AddressLauncher internal constructor(
         internal val googlePlacesApiKey: String? = null,
         internal val autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES,
         internal val billingAddress: PaymentSheet.BillingDetails?,
+        internal val useStripeHostedAutocomplete: Boolean = false,
     ) : Parcelable {
         @JvmOverloads
         constructor(
@@ -152,6 +153,12 @@ class AddressLauncher internal constructor(
              * countries that Stripe has audited to ensure a good autocomplete experience.
              */
             autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+            /**
+             * When true, routes inline autocomplete through Stripe-hosted endpoints instead of the
+             * Google Places SDK. The current hosted path is intended to fail gracefully until the
+             * backend implementation is available.
+             */
+            useStripeHostedAutocomplete: Boolean = false,
         ) : this(
             appearance = appearance,
             address = address,
@@ -162,6 +169,7 @@ class AddressLauncher internal constructor(
             googlePlacesApiKey = googlePlacesApiKey,
             autocompleteCountries = autocompleteCountries,
             billingAddress = null,
+            useStripeHostedAutocomplete = useStripeHostedAutocomplete,
         )
 
         /**
@@ -177,6 +185,7 @@ class AddressLauncher internal constructor(
             private var googlePlacesApiKey: String? = null
             private var autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES
             private var billingAddress: PaymentSheet.BillingDetails? = null
+            private var useStripeHostedAutocomplete: Boolean = false
 
             fun appearance(appearance: PaymentSheet.Appearance) =
                 apply { this.appearance = appearance }
@@ -206,6 +215,9 @@ class AddressLauncher internal constructor(
             fun billingAddress(billingAddress: PaymentSheet.BillingDetails?) =
                 apply { this.billingAddress = billingAddress }
 
+            fun useStripeHostedAutocomplete(useStripeHostedAutocomplete: Boolean) =
+                apply { this.useStripeHostedAutocomplete = useStripeHostedAutocomplete }
+
             fun build() = Configuration(
                 appearance = appearance,
                 address = address,
@@ -216,6 +228,7 @@ class AddressLauncher internal constructor(
                 googlePlacesApiKey = googlePlacesApiKey,
                 autocompleteCountries = autocompleteCountries,
                 billingAddress = billingAddress,
+                useStripeHostedAutocomplete = useStripeHostedAutocomplete,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -153,12 +153,6 @@ class AddressLauncher internal constructor(
              * countries that Stripe has audited to ensure a good autocomplete experience.
              */
             autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-            /**
-             * When true, routes inline autocomplete through Stripe-hosted endpoints instead of the
-             * Google Places SDK. The current hosted path is intended to fail gracefully until the
-             * backend implementation is available.
-             */
-            useStripeHostedAutocomplete: Boolean = false,
         ) : this(
             appearance = appearance,
             address = address,
@@ -169,7 +163,6 @@ class AddressLauncher internal constructor(
             googlePlacesApiKey = googlePlacesApiKey,
             autocompleteCountries = autocompleteCountries,
             billingAddress = null,
-            useStripeHostedAutocomplete = useStripeHostedAutocomplete,
         )
 
         /**
@@ -185,7 +178,6 @@ class AddressLauncher internal constructor(
             private var googlePlacesApiKey: String? = null
             private var autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES
             private var billingAddress: PaymentSheet.BillingDetails? = null
-            private var useStripeHostedAutocomplete: Boolean = false
 
             fun appearance(appearance: PaymentSheet.Appearance) =
                 apply { this.appearance = appearance }
@@ -215,9 +207,6 @@ class AddressLauncher internal constructor(
             fun billingAddress(billingAddress: PaymentSheet.BillingDetails?) =
                 apply { this.billingAddress = billingAddress }
 
-            fun useStripeHostedAutocomplete(useStripeHostedAutocomplete: Boolean) =
-                apply { this.useStripeHostedAutocomplete = useStripeHostedAutocomplete }
-
             fun build() = Configuration(
                 appearance = appearance,
                 address = address,
@@ -228,7 +217,6 @@ class AddressLauncher internal constructor(
                 googlePlacesApiKey = googlePlacesApiKey,
                 autocompleteCountries = autocompleteCountries,
                 billingAddress = billingAddress,
-                useStripeHostedAutocomplete = useStripeHostedAutocomplete,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -6,23 +6,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 internal class BillingInlineAutocompleteAddressInteractor(
-    placesClient: PlacesClientProxy?,
+    placesClient: PlacesClientProxy,
     override val autocompleteConfig: AutocompleteAddressInteractor.Config,
     coroutineScope: CoroutineScope,
-    shouldUseAutocompleteProxyEndpoints: Boolean,
-    googleApiKey: String?,
 ) : AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
 
-    private val stripeHostedProxy: PlacesClientProxy? = if (shouldUseAutocompleteProxyEndpoints) {
-        StripeHostedPlacesClientProxy(googleApiKey = googleApiKey)
-    } else {
-        null
-    }
-
     private val inlineController = InlineAutocompleteController(
         placesClient = placesClient,
-        stripeHostedProxy = stripeHostedProxy,
         config = autocompleteConfig,
         coroutineScope = coroutineScope,
         eventListenerProvider = { eventListener },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -6,19 +6,26 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 internal class BillingInlineAutocompleteAddressInteractor(
-    placesClient: PlacesClientProxy,
+    placesClient: PlacesClientProxy?,
     override val autocompleteConfig: AutocompleteAddressInteractor.Config,
     coroutineScope: CoroutineScope,
     shouldUseAutocompleteProxyEndpoints: Boolean,
+    googleApiKey: String?,
 ) : AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
 
+    private val stripeHostedProxy: PlacesClientProxy? = if (shouldUseAutocompleteProxyEndpoints) {
+        StripeHostedPlacesClientProxy(googleApiKey = googleApiKey)
+    } else {
+        null
+    }
+
     private val inlineController = InlineAutocompleteController(
         placesClient = placesClient,
+        stripeHostedProxy = stripeHostedProxy,
         config = autocompleteConfig,
         coroutineScope = coroutineScope,
         eventListenerProvider = { eventListener },
-        shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
     )
 
     override val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet.addresselement
 
 import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -19,17 +21,16 @@ import java.util.Locale
 
 internal class InlineAutocompleteController(
     private val placesClient: PlacesClientProxy?,
+    private val stripeHostedProxy: PlacesClientProxy?,
     private val config: AutocompleteAddressInteractor.Config,
     private val coroutineScope: CoroutineScope,
     private val eventListenerProvider: () -> ((AutocompleteAddressInteractor.Event) -> Unit)?,
-    private val shouldUseAutocompleteProxyEndpoints: Boolean,
 ) {
     private var lastPredictionLine1: String? = null
+    private var latestQuery: String? = null
+    private var latestCountry: String? = null
     private var observeJob: Job? = null
     private var selectionJob: Job? = null
-
-    // Keep the server flag plumbed through, but do not switch traffic until the proxy path exists.
-    private val isAutocompleteProxyImplementationAvailable = false
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
         AutocompleteAddressInteractor.InlinePredictionsState.Idle
@@ -37,12 +38,12 @@ internal class InlineAutocompleteController(
     val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =
         _inlinePredictionsState.asStateFlow()
 
-    private val canUseAutocompleteProxyEndpoints: Boolean
-        get() = shouldUseAutocompleteProxyEndpoints && isAutocompleteProxyImplementationAvailable
+    private val shouldUseGooglePlaces: Boolean
+        get() = stripeHostedProxy == null && placesClient != null
 
     @OptIn(FlowPreview::class)
     fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
-        if (placesClient == null && !canUseAutocompleteProxyEndpoints) return
+        if (placesClient == null && stripeHostedProxy == null) return
         observeJob?.cancel()
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
@@ -58,6 +59,8 @@ internal class InlineAutocompleteController(
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                         return@collectLatest
                     }
+                    latestQuery = q
+                    latestCountry = c
                     fetchPredictions(q, c)
                 }
         }
@@ -66,49 +69,59 @@ internal class InlineAutocompleteController(
     fun onPredictionSelected(predictionId: String) {
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
-            if (canUseAutocompleteProxyEndpoints) {
-                fetchPlaceFromStripeProxy(predictionId)
-            } else {
+            if (shouldUseGooglePlaces) {
                 fetchPlaceFromGooglePlaces(predictionId)
+            } else {
+                fetchPlaceFromStripeProxy(predictionId)
             }
         }
     }
 
-    @Suppress("UnusedParameter", "UnusedPrivateMember")
     private suspend fun fetchPlaceFromStripeProxy(predictionId: String) {
-        // Stripe proxy endpoint will be implemented in a follow-up PR.
+        val proxy = stripeHostedProxy ?: return
+        proxy.fetchPlace(predictionId).fold(
+            onSuccess = ::handleFetchPlaceSuccess,
+            onFailure = {
+                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                expandFormForHostedFailure()
+            }
+        )
     }
 
     private suspend fun fetchPlaceFromGooglePlaces(predictionId: String) {
         val client = placesClient ?: return
         client.fetchPlace(predictionId).fold(
-            onSuccess = { response ->
-                val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-                val address = response.place.transformGoogleToStripeAddress(locale)
-                lastPredictionLine1 = address.line1
-                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                eventListenerProvider()?.invoke(
-                    AutocompleteAddressInteractor.Event.OnValues(
-                        mapOf(
-                            IdentifierSpec.Line1 to address.line1,
-                            IdentifierSpec.Line2 to address.line2,
-                            IdentifierSpec.City to address.city,
-                            IdentifierSpec.State to address.state,
-                            IdentifierSpec.PostalCode to address.postalCode,
-                            IdentifierSpec.Country to address.country,
-                        )
-                    )
-                )
-            },
+            onSuccess = ::handleFetchPlaceSuccess,
             onFailure = {
                 _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
             }
         )
     }
 
+    private fun handleFetchPlaceSuccess(response: FetchPlaceResponse) {
+        val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+        val address = response.place.transformGoogleToStripeAddress(locale)
+        lastPredictionLine1 = address.line1
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+        eventListenerProvider()?.invoke(
+            AutocompleteAddressInteractor.Event.OnValues(
+                mapOf(
+                    IdentifierSpec.Line1 to address.line1,
+                    IdentifierSpec.Line2 to address.line2,
+                    IdentifierSpec.City to address.city,
+                    IdentifierSpec.State to address.state,
+                    IdentifierSpec.PostalCode to address.postalCode,
+                    IdentifierSpec.Country to address.country,
+                )
+            )
+        )
+    }
+
     fun onDismissed() {
         selectionJob?.cancel()
         lastPredictionLine1 = null
+        latestQuery = null
+        latestCountry = null
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
     }
 
@@ -124,16 +137,28 @@ internal class InlineAutocompleteController(
     }
 
     private suspend fun fetchPredictions(query: String, country: String) {
-        if (canUseAutocompleteProxyEndpoints) {
-            fetchPredictionsFromStripeProxy(query, country)
-        } else {
+        if (shouldUseGooglePlaces) {
             fetchPredictionsFromGooglePlaces(query, country)
+        } else {
+            fetchPredictionsFromStripeProxy(query, country)
         }
     }
 
-    @Suppress("UnusedParameter", "UnusedPrivateMember")
     private suspend fun fetchPredictionsFromStripeProxy(query: String, country: String) {
-        // Stripe proxy endpoint will be implemented in a follow-up PR.
+        val proxy = stripeHostedProxy ?: return
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Loading
+        val result = proxy.findAutocompletePredictions(
+            query = query,
+            country = country,
+            limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,
+        )
+        result.fold(
+            onSuccess = { handleFindPredictionsSuccess(query, it) },
+            onFailure = {
+                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                expandFormForHostedFailure()
+            }
+        )
     }
 
     private suspend fun fetchPredictionsFromGooglePlaces(query: String, country: String) {
@@ -145,21 +170,37 @@ internal class InlineAutocompleteController(
             limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,
         )
         result.fold(
-            onSuccess = { response ->
-                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Results(
-                    query = query,
-                    predictions = response.autocompletePredictions.map { prediction ->
-                        AutocompleteAddressInteractor.InlineAddressPrediction(
-                            id = prediction.placeId,
-                            primaryText = prediction.primaryText.toString(),
-                            secondaryText = prediction.secondaryText.toString(),
-                        )
-                    }
-                )
-            },
+            onSuccess = { handleFindPredictionsSuccess(query, it) },
             onFailure = {
                 _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
             }
+        )
+    }
+
+    private fun handleFindPredictionsSuccess(
+        query: String,
+        response: FindAutocompletePredictionsResponse,
+    ) {
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Results(
+            query = query,
+            predictions = response.autocompletePredictions.map { prediction ->
+                AutocompleteAddressInteractor.InlineAddressPrediction(
+                    id = prediction.placeId,
+                    primaryText = prediction.primaryText.toString(),
+                    secondaryText = prediction.secondaryText.toString(),
+                )
+            }
+        )
+    }
+
+    private fun expandFormForHostedFailure() {
+        val values = buildMap<IdentifierSpec, String?> {
+            latestQuery?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Line1, it) }
+            latestCountry?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Country, it) }
+        }.takeIf { it.isNotEmpty() }
+
+        eventListenerProvider()?.invoke(
+            AutocompleteAddressInteractor.Event.OnExpandForm(values)
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -20,8 +20,7 @@ import kotlinx.coroutines.launch
 import java.util.Locale
 
 internal class InlineAutocompleteController(
-    private val placesClient: PlacesClientProxy?,
-    private val stripeHostedProxy: PlacesClientProxy?,
+    private val placesClient: PlacesClientProxy,
     private val config: AutocompleteAddressInteractor.Config,
     private val coroutineScope: CoroutineScope,
     private val eventListenerProvider: () -> ((AutocompleteAddressInteractor.Event) -> Unit)?,
@@ -38,12 +37,8 @@ internal class InlineAutocompleteController(
     val inlinePredictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =
         _inlinePredictionsState.asStateFlow()
 
-    private val shouldUseGooglePlaces: Boolean
-        get() = stripeHostedProxy == null && placesClient != null
-
     @OptIn(FlowPreview::class)
     fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
-        if (placesClient == null && stripeHostedProxy == null) return
         observeJob?.cancel()
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
@@ -69,33 +64,11 @@ internal class InlineAutocompleteController(
     fun onPredictionSelected(predictionId: String) {
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
-            if (shouldUseGooglePlaces) {
-                fetchPlaceFromGooglePlaces(predictionId)
-            } else {
-                fetchPlaceFromStripeProxy(predictionId)
-            }
+            placesClient.fetchPlace(predictionId).fold(
+                onSuccess = ::handleFetchPlaceSuccess,
+                onFailure = { handleFailure() }
+            )
         }
-    }
-
-    private suspend fun fetchPlaceFromStripeProxy(predictionId: String) {
-        val proxy = stripeHostedProxy ?: return
-        proxy.fetchPlace(predictionId).fold(
-            onSuccess = ::handleFetchPlaceSuccess,
-            onFailure = {
-                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                expandFormForHostedFailure()
-            }
-        )
-    }
-
-    private suspend fun fetchPlaceFromGooglePlaces(predictionId: String) {
-        val client = placesClient ?: return
-        client.fetchPlace(predictionId).fold(
-            onSuccess = ::handleFetchPlaceSuccess,
-            onFailure = {
-                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-            }
-        )
     }
 
     private fun handleFetchPlaceSuccess(response: FetchPlaceResponse) {
@@ -137,43 +110,15 @@ internal class InlineAutocompleteController(
     }
 
     private suspend fun fetchPredictions(query: String, country: String) {
-        if (shouldUseGooglePlaces) {
-            fetchPredictionsFromGooglePlaces(query, country)
-        } else {
-            fetchPredictionsFromStripeProxy(query, country)
-        }
-    }
-
-    private suspend fun fetchPredictionsFromStripeProxy(query: String, country: String) {
-        val proxy = stripeHostedProxy ?: return
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Loading
-        val result = proxy.findAutocompletePredictions(
+        val result = placesClient.findAutocompletePredictions(
             query = query,
             country = country,
             limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,
         )
         result.fold(
             onSuccess = { handleFindPredictionsSuccess(query, it) },
-            onFailure = {
-                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                expandFormForHostedFailure()
-            }
-        )
-    }
-
-    private suspend fun fetchPredictionsFromGooglePlaces(query: String, country: String) {
-        val client = placesClient ?: return
-        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Loading
-        val result = client.findAutocompletePredictions(
-            query = query,
-            country = country,
-            limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,
-        )
-        result.fold(
-            onSuccess = { handleFindPredictionsSuccess(query, it) },
-            onFailure = {
-                _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-            }
+            onFailure = { handleFailure() }
         )
     }
 
@@ -191,6 +136,13 @@ internal class InlineAutocompleteController(
                 )
             }
         )
+    }
+
+    private fun handleFailure() {
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+        if (config.shouldUseStripeHostedAutocomplete) {
+            expandFormForHostedFailure()
+        }
     }
 
     private fun expandFormForHostedFailure() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -78,16 +78,9 @@ internal class InputAddressViewModel @Inject constructor(
         shouldUseStripeHostedAutocomplete = shouldUseStripeHostedAutocomplete,
     )
 
-    private val stripeHostedProxy: PlacesClientProxy? = if (shouldUseStripeHostedAutocomplete) {
-        StripeHostedPlacesClientProxy(googleApiKey = args.config?.googlePlacesApiKey)
-    } else {
-        null
-    }
-
-    private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {
+    private val inlineAutocompleteController = if (isInlineAutocompleteEnabled && placesClient != null) {
         InlineAutocompleteController(
             placesClient = placesClient,
-            stripeHostedProxy = stripeHostedProxy,
             config = autocompleteConfig,
             coroutineScope = viewModelScope,
             eventListenerProvider = { eventListener },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -69,13 +69,11 @@ internal class InputAddressViewModel @Inject constructor(
 
     private val isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled
 
-    private val shouldUseStripeHostedAutocomplete = args.config?.useStripeHostedAutocomplete == true
-
     override val autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
-        shouldUseStripeHostedAutocomplete = shouldUseStripeHostedAutocomplete,
+        shouldUseStripeHostedAutocomplete = args.config?.useStripeHostedAutocomplete == true,
     )
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled && placesClient != null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -69,21 +69,28 @@ internal class InputAddressViewModel @Inject constructor(
 
     private val isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled
 
+    private val shouldUseStripeHostedAutocomplete = args.config?.useStripeHostedAutocomplete == true
+
     override val autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
         autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
+        shouldUseStripeHostedAutocomplete = shouldUseStripeHostedAutocomplete,
     )
+
+    private val stripeHostedProxy: PlacesClientProxy? = if (shouldUseStripeHostedAutocomplete) {
+        StripeHostedPlacesClientProxy(googleApiKey = args.config?.googlePlacesApiKey)
+    } else {
+        null
+    }
 
     private val inlineAutocompleteController = if (isInlineAutocompleteEnabled) {
         InlineAutocompleteController(
             placesClient = placesClient,
+            stripeHostedProxy = stripeHostedProxy,
             config = autocompleteConfig,
             coroutineScope = viewModelScope,
             eventListenerProvider = { eventListener },
-            // The standalone Address Element does not have access to ElementsSession flags.
-            // When the proxy endpoint ships, thread this value through Args.
-            shouldUseAutocompleteProxyEndpoints = false,
         )
     } else {
         null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -51,18 +51,35 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
         override fun create(): AutocompleteAddressInteractor {
-            if (placesClient != null && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+            val shouldUseProxy = shouldUseAutocompleteProxyEndpointsProvider()
+            val hasClient = placesClient != null || shouldUseProxy
+            if (hasClient && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 activeInlineInteractor?.dispose()
                 return BillingInlineAutocompleteAddressInteractor(
                     placesClient = placesClient,
-                    autocompleteConfig = autocompleteConfig,
+                    autocompleteConfig = createInlineAutocompleteConfig(shouldUseProxy),
                     coroutineScope = coroutineScope,
-                    shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpointsProvider(),
+                    shouldUseAutocompleteProxyEndpoints = shouldUseProxy,
+                    googleApiKey = autocompleteConfig.googlePlacesApiKey,
                 ).also { activeInlineInteractor = it }
             }
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,
                 autocompleteConfig = autocompleteConfig,
+            )
+        }
+
+        private fun createInlineAutocompleteConfig(shouldUseProxy: Boolean): AutocompleteAddressInteractor.Config {
+            if (!shouldUseProxy || autocompleteConfig.shouldUseStripeHostedAutocomplete) {
+                return autocompleteConfig
+            }
+
+            return AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = autocompleteConfig.googlePlacesApiKey,
+                autocompleteCountries = autocompleteConfig.autocompleteCountries,
+                isPlacesAvailable = autocompleteConfig.isPlacesAvailable,
+                isInlineAutocompleteEnabled = autocompleteConfig.isInlineAutocompleteEnabled,
+                shouldUseStripeHostedAutocomplete = true,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -61,27 +61,20 @@ internal class PaymentElementAutocompleteAddressInteractor(
                 activeInlineInteractor?.dispose()
                 return BillingInlineAutocompleteAddressInteractor(
                     placesClient = resolvedClient,
-                    autocompleteConfig = createInlineAutocompleteConfig(shouldUseProxy),
+                    autocompleteConfig = AutocompleteAddressInteractor.Config(
+                        googlePlacesApiKey = autocompleteConfig.googlePlacesApiKey,
+                        autocompleteCountries = autocompleteConfig.autocompleteCountries,
+                        isPlacesAvailable = autocompleteConfig.isPlacesAvailable,
+                        isInlineAutocompleteEnabled = autocompleteConfig.isInlineAutocompleteEnabled,
+                        shouldUseStripeHostedAutocomplete = shouldUseProxy ||
+                            autocompleteConfig.shouldUseStripeHostedAutocomplete,
+                    ),
                     coroutineScope = coroutineScope,
                 ).also { activeInlineInteractor = it }
             }
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,
                 autocompleteConfig = autocompleteConfig,
-            )
-        }
-
-        private fun createInlineAutocompleteConfig(shouldUseProxy: Boolean): AutocompleteAddressInteractor.Config {
-            if (!shouldUseProxy || autocompleteConfig.shouldUseStripeHostedAutocomplete) {
-                return autocompleteConfig
-            }
-
-            return AutocompleteAddressInteractor.Config(
-                googlePlacesApiKey = autocompleteConfig.googlePlacesApiKey,
-                autocompleteCountries = autocompleteConfig.autocompleteCountries,
-                isPlacesAvailable = autocompleteConfig.isPlacesAvailable,
-                isInlineAutocompleteEnabled = autocompleteConfig.isInlineAutocompleteEnabled,
-                shouldUseStripeHostedAutocomplete = true,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -51,9 +51,9 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
         override fun create(): AutocompleteAddressInteractor {
-            val shouldUseProxy = shouldUseAutocompleteProxyEndpointsProvider()
-            val resolvedClient = if (shouldUseProxy) {
-                StripeHostedPlacesClientProxy(googleApiKey = autocompleteConfig.googlePlacesApiKey)
+            val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
+            val resolvedClient = if (useStripeHosted) {
+                StripeHostedPlacesClientProxy()
             } else {
                 placesClient
             }
@@ -66,7 +66,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
                         autocompleteCountries = autocompleteConfig.autocompleteCountries,
                         isPlacesAvailable = autocompleteConfig.isPlacesAvailable,
                         isInlineAutocompleteEnabled = autocompleteConfig.isInlineAutocompleteEnabled,
-                        shouldUseStripeHostedAutocomplete = shouldUseProxy ||
+                        shouldUseStripeHostedAutocomplete = useStripeHosted ||
                             autocompleteConfig.shouldUseStripeHostedAutocomplete,
                     ),
                     coroutineScope = coroutineScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -52,15 +52,17 @@ internal class PaymentElementAutocompleteAddressInteractor(
 
         override fun create(): AutocompleteAddressInteractor {
             val shouldUseProxy = shouldUseAutocompleteProxyEndpointsProvider()
-            val hasClient = placesClient != null || shouldUseProxy
-            if (hasClient && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+            val resolvedClient = if (shouldUseProxy) {
+                StripeHostedPlacesClientProxy(googleApiKey = autocompleteConfig.googlePlacesApiKey)
+            } else {
+                placesClient
+            }
+            if (resolvedClient != null && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 activeInlineInteractor?.dispose()
                 return BillingInlineAutocompleteAddressInteractor(
-                    placesClient = placesClient,
+                    placesClient = resolvedClient,
                     autocompleteConfig = createInlineAutocompleteConfig(shouldUseProxy),
                     coroutineScope = coroutineScope,
-                    shouldUseAutocompleteProxyEndpoints = shouldUseProxy,
-                    googleApiKey = autocompleteConfig.googlePlacesApiKey,
                 ).also { activeInlineInteractor = it }
             }
             return PaymentElementAutocompleteAddressInteractor(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+
+internal class StripeHostedPlacesClientProxy(
+    private val googleApiKey: String?
+) : PlacesClientProxy {
+    override suspend fun findAutocompletePredictions(
+        query: String?,
+        country: String,
+        limit: Int
+    ): Result<FindAutocompletePredictionsResponse> {
+        return Result.failure(
+            NotImplementedError("Stripe-hosted autocomplete not yet implemented")
+        )
+    }
+
+    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
+        return Result.failure(
+            NotImplementedError("Stripe-hosted place details not yet implemented")
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -4,9 +4,7 @@ import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 
-internal class StripeHostedPlacesClientProxy(
-    private val googleApiKey: String?
-) : PlacesClientProxy {
+internal class StripeHostedPlacesClientProxy : PlacesClientProxy {
     override suspend fun findAutocompletePredictions(
         query: String?,
         country: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -49,10 +49,11 @@ internal class AddressElementViewModelModule {
         context: Context,
         args: AddressElementActivityContract.Args
     ): PlacesClientProxy? {
-        if (args.config?.useStripeHostedAutocomplete == true) {
-            return StripeHostedPlacesClientProxy(googleApiKey = args.config?.googlePlacesApiKey)
+        val config = args.config ?: return null
+        if (config.useStripeHostedAutocomplete) {
+            return StripeHostedPlacesClientProxy()
         }
-        return args.config?.googlePlacesApiKey?.let {
+        return config.googlePlacesApiKey?.let {
             PlacesClientProxy.create(
                 context,
                 it,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -7,6 +7,7 @@ import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressElementNavigator
 import com.stripe.android.paymentsheet.addresselement.NavHostAddressElementNavigator
+import com.stripe.android.paymentsheet.addresselement.StripeHostedPlacesClientProxy
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.addresselement.analytics.DefaultAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -47,12 +48,17 @@ internal class AddressElementViewModelModule {
     internal fun provideGooglePlacesClient(
         context: Context,
         args: AddressElementActivityContract.Args
-    ): PlacesClientProxy? = args.config?.googlePlacesApiKey?.let {
-        PlacesClientProxy.create(
-            context,
-            it,
-            errorReporter = ErrorReporter.createFallbackInstance(context),
-        )
+    ): PlacesClientProxy? {
+        if (args.config?.useStripeHostedAutocomplete == true) {
+            return StripeHostedPlacesClientProxy(googleApiKey = args.config?.googlePlacesApiKey)
+        }
+        return args.config?.googlePlacesApiKey?.let {
+            PlacesClientProxy.create(
+                context,
+                it,
+                errorReporter = ErrorReporter.createFallbackInstance(context),
+            )
+        }
     }
 
     @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -61,8 +61,6 @@ class BillingInlineAutocompleteAddressInteractorTest {
             placesClient = fakePlaces,
             autocompleteConfig = config,
             coroutineScope = backgroundScope,
-            shouldUseAutocompleteProxyEndpoints = false,
-            googleApiKey = "test_key",
         )
         interactor.register { event -> eventCalls.add(event) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -62,6 +62,7 @@ class BillingInlineAutocompleteAddressInteractorTest {
             autocompleteConfig = config,
             coroutineScope = backgroundScope,
             shouldUseAutocompleteProxyEndpoints = false,
+            googleApiKey = "test_key",
         )
         interactor.register { event -> eventCalls.add(event) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -741,6 +741,70 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
+    fun `proxy fetchPlace failure after prior query includes query and country in expand form`() = runScenario(
+        usePlacesClient = false,
+        useStripeHostedProxy = true,
+    ) {
+        fakeStripeHostedProxy.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(
+                listOf(
+                    AutocompletePrediction(
+                        SpannableString("123 Main St"),
+                        SpannableString("City, ST"),
+                        "place-id-abc",
+                    )
+                )
+            )
+        )
+        fakeStripeHostedProxy.fetchPlaceResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        delegate.onPredictionSelected("place-id-abc")
+
+        fakeStripeHostedProxy.fetchPlaceCalls.awaitItem()
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `proxy prediction failure with null country only includes Line1 in expand form`() = runScenario(
+        usePlacesClient = false,
+        useStripeHostedProxy = true,
+    ) {
+        fakeStripeHostedProxy.findPredictionsResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        countryFlow.value = null
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main",
+                )
+            )
+        )
+    }
+
+    @Test
     fun `null placesClient and no proxy stays Idle`() = runScenario(
         usePlacesClient = false,
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -528,28 +528,6 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `null placesClient results in no fetches and stays Idle`() = runScenario(
-        usePlacesClient = false
-    ) {
-        delegate.observeQueryChanges(queryFlow, countryFlow)
-
-        queryFlow.value = "123 Main"
-        advanceTimeBy(500)
-
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
-    }
-
-    @Test
-    fun `null placesClient on prediction selected does not crash`() = runScenario(
-        usePlacesClient = false
-    ) {
-        delegate.onPredictionSelected("place_1")
-        advanceTimeBy(100)
-
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
-    }
-
-    @Test
     fun `country change triggers re-evaluation`() = runScenario(
         autocompleteCountries = setOf("US")
     ) {
@@ -621,10 +599,10 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `with stripeHostedProxy and placesClient prefers proxy for predictions`() = runScenario(
-        useStripeHostedProxy = true,
+    fun `stripe-hosted config expands form on prediction failure`() = runScenario(
+        shouldUseStripeHostedAutocomplete = true,
     ) {
-        fakeStripeHostedProxy.findPredictionsResult = Result.failure(
+        fakePlacesClient.findPredictionsResult = Result.failure(
             RuntimeException("Hosted proxy unavailable")
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
@@ -632,7 +610,7 @@ class InlineAutocompleteControllerTest {
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
 
-        val call = fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
         assertThat(call.query).isEqualTo("123 Main")
         assertThat(call.country).isEqualTo("US")
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
@@ -647,15 +625,15 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `with stripeHostedProxy and placesClient prefers proxy for place selection`() = runScenario(
-        useStripeHostedProxy = true,
+    fun `stripe-hosted config expands form on place selection failure`() = runScenario(
+        shouldUseStripeHostedAutocomplete = true,
     ) {
-        fakeStripeHostedProxy.fetchPlaceResult = Result.failure(
+        fakePlacesClient.fetchPlaceResult = Result.failure(
             RuntimeException("Hosted proxy unavailable")
         )
         delegate.onPredictionSelected("place-id-123")
 
-        val call = fakeStripeHostedProxy.fetchPlaceCalls.awaitItem()
+        val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
         assertThat(call).isEqualTo("place-id-123")
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem())
@@ -663,55 +641,10 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `with stripeHostedProxy uses proxy for predictions`() = runScenario(
-        usePlacesClient = false,
-        useStripeHostedProxy = true,
+    fun `stripe-hosted fetchPlace failure after prior query includes query and country`() = runScenario(
+        shouldUseStripeHostedAutocomplete = true,
     ) {
-        fakeStripeHostedProxy.findPredictionsResult = Result.failure(
-            RuntimeException("Hosted proxy unavailable")
-        )
-        delegate.observeQueryChanges(queryFlow, countryFlow)
-
-        queryFlow.value = "123 Main"
-        advanceTimeBy(500)
-
-        val call = fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
-        assertThat(call.query).isEqualTo("123 Main")
-        assertThat(call.country).isEqualTo("US")
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
-        assertThat(eventCalls.awaitItem()).isEqualTo(
-            AutocompleteAddressInteractor.Event.OnExpandForm(
-                values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main",
-                    IdentifierSpec.Country to "US",
-                )
-            )
-        )
-    }
-
-    @Test
-    fun `with stripeHostedProxy uses proxy for place selection`() = runScenario(
-        usePlacesClient = false,
-        useStripeHostedProxy = true,
-    ) {
-        fakeStripeHostedProxy.fetchPlaceResult = Result.failure(
-            RuntimeException("Hosted proxy unavailable")
-        )
-        delegate.onPredictionSelected("place-id-123")
-
-        val call = fakeStripeHostedProxy.fetchPlaceCalls.awaitItem()
-        assertThat(call).isEqualTo("place-id-123")
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
-        assertThat(eventCalls.awaitItem())
-            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
-    }
-
-    @Test
-    fun `proxy fetchPlace failure after prior query includes query and country in expand form`() = runScenario(
-        usePlacesClient = false,
-        useStripeHostedProxy = true,
-    ) {
-        fakeStripeHostedProxy.findPredictionsResult = Result.success(
+        fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(
                 listOf(
                     AutocompletePrediction(
@@ -722,7 +655,7 @@ class InlineAutocompleteControllerTest {
                 )
             )
         )
-        fakeStripeHostedProxy.fetchPlaceResult = Result.failure(
+        fakePlacesClient.fetchPlaceResult = Result.failure(
             RuntimeException("Hosted proxy unavailable")
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
@@ -730,10 +663,10 @@ class InlineAutocompleteControllerTest {
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
 
-        fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        fakePlacesClient.findPredictionsCalls.awaitItem()
         delegate.onPredictionSelected("place-id-abc")
 
-        fakeStripeHostedProxy.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.fetchPlaceCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem()).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
@@ -746,11 +679,10 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `proxy prediction failure with null country only includes Line1 in expand form`() = runScenario(
-        usePlacesClient = false,
-        useStripeHostedProxy = true,
+    fun `stripe-hosted prediction failure with null country only includes Line1`() = runScenario(
+        shouldUseStripeHostedAutocomplete = true,
     ) {
-        fakeStripeHostedProxy.findPredictionsResult = Result.failure(
+        fakePlacesClient.findPredictionsResult = Result.failure(
             RuntimeException("Hosted proxy unavailable")
         )
         countryFlow.value = null
@@ -759,7 +691,7 @@ class InlineAutocompleteControllerTest {
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
 
-        fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        fakePlacesClient.findPredictionsCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem()).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
@@ -808,26 +740,20 @@ class InlineAutocompleteControllerTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),
-        usePlacesClient: Boolean = true,
-        useStripeHostedProxy: Boolean = false,
+        shouldUseStripeHostedAutocomplete: Boolean = false,
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
-        val fakePlaces = if (usePlacesClient) FakePlacesClientProxy() else null
-        val stripeHostedProxy = if (useStripeHostedProxy) {
-            FakePlacesClientProxy()
-        } else {
-            null
-        }
+        val fakePlaces = FakePlacesClientProxy()
         val eventCalls = Turbine<AutocompleteAddressInteractor.Event>()
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test_key",
             autocompleteCountries = autocompleteCountries,
             isPlacesAvailable = true,
             isInlineAutocompleteEnabled = true,
+            shouldUseStripeHostedAutocomplete = shouldUseStripeHostedAutocomplete,
         )
         val delegate = InlineAutocompleteController(
             placesClient = fakePlaces,
-            stripeHostedProxy = stripeHostedProxy,
             config = config,
             coroutineScope = backgroundScope,
             eventListenerProvider = { { event -> eventCalls.add(event) } },
@@ -835,34 +761,25 @@ class InlineAutocompleteControllerTest {
 
         Scenario(
             delegate = delegate,
-            fakePlacesClientOrNull = fakePlaces,
-            fakeStripeHostedProxyOrNull = stripeHostedProxy,
+            fakePlacesClient = fakePlaces,
             eventCalls = eventCalls,
             queryFlow = MutableStateFlow(""),
             countryFlow = MutableStateFlow("US"),
             testScope = this,
         ).apply { block() }
 
-        fakePlaces?.ensureAllEventsConsumed()
-        stripeHostedProxy?.ensureAllEventsConsumed()
+        fakePlaces.ensureAllEventsConsumed()
         eventCalls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val delegate: InlineAutocompleteController,
-        private val fakePlacesClientOrNull: FakePlacesClientProxy?,
-        private val fakeStripeHostedProxyOrNull: FakePlacesClientProxy?,
+        val fakePlacesClient: FakePlacesClientProxy,
         val eventCalls: Turbine<AutocompleteAddressInteractor.Event>,
         val queryFlow: MutableStateFlow<String>,
         val countryFlow: MutableStateFlow<String?>,
         val testScope: TestScope,
     ) {
-        val fakePlacesClient: FakePlacesClientProxy
-            get() = requireNotNull(fakePlacesClientOrNull)
-
-        val fakeStripeHostedProxy: FakePlacesClientProxy
-            get() = requireNotNull(fakeStripeHostedProxyOrNull)
-
         fun advanceTimeBy(millis: Long) = testScope.advanceTimeBy(millis)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -621,40 +621,6 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `without stripeHostedProxy falls back to Google Places for predictions`() = runScenario {
-        fakePlacesClient.findPredictionsResult = Result.success(
-            FindAutocompletePredictionsResponse(emptyList())
-        )
-        delegate.observeQueryChanges(queryFlow, countryFlow)
-
-        queryFlow.value = "123 Main"
-        advanceTimeBy(500)
-
-        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
-        assertThat(call.query).isEqualTo("123 Main")
-    }
-
-    @Test
-    fun `without stripeHostedProxy falls back to Google Places for place selection`() = runScenario {
-        fakePlacesClient.fetchPlaceResult = Result.success(
-            FetchPlaceResponse(
-                Place(
-                    listOf(
-                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                    )
-                )
-            )
-        )
-        delegate.onPredictionSelected("place-id-123")
-
-        val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
-        assertThat(call).isEqualTo("place-id-123")
-        eventCalls.awaitItem()
-    }
-
-    @Test
     fun `with stripeHostedProxy and placesClient prefers proxy for predictions`() = runScenario(
         useStripeHostedProxy = true,
     ) {
@@ -802,18 +768,6 @@ class InlineAutocompleteControllerTest {
                 )
             )
         )
-    }
-
-    @Test
-    fun `null placesClient and no proxy stays Idle`() = runScenario(
-        usePlacesClient = false,
-    ) {
-        delegate.observeQueryChanges(queryFlow, countryFlow)
-
-        queryFlow.value = "123 Main"
-        advanceTimeBy(500)
-
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class InlineAutocompleteControllerTest {
 
@@ -620,9 +621,7 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `proxy flag true keeps Google Places enabled for predictions until proxy is implemented`() = runScenario(
-        shouldUseAutocompleteProxyEndpoints = true
-    ) {
+    fun `without stripeHostedProxy falls back to Google Places for predictions`() = runScenario {
         fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(emptyList())
         )
@@ -636,9 +635,7 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `proxy flag true keeps Google Places enabled for place selection until proxy is implemented`() = runScenario(
-        shouldUseAutocompleteProxyEndpoints = true
-    ) {
+    fun `without stripeHostedProxy falls back to Google Places for place selection`() = runScenario {
         fakePlacesClient.fetchPlaceResult = Result.success(
             FetchPlaceResponse(
                 Place(
@@ -658,9 +655,94 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `proxy flag true with null placesClient stays Idle until proxy is implemented`() = runScenario(
+    fun `with stripeHostedProxy and placesClient prefers proxy for predictions`() = runScenario(
+        useStripeHostedProxy = true,
+    ) {
+        fakeStripeHostedProxy.findPredictionsResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        val call = fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        assertThat(call.query).isEqualTo("123 Main")
+        assertThat(call.country).isEqualTo("US")
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `with stripeHostedProxy and placesClient prefers proxy for place selection`() = runScenario(
+        useStripeHostedProxy = true,
+    ) {
+        fakeStripeHostedProxy.fetchPlaceResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        delegate.onPredictionSelected("place-id-123")
+
+        val call = fakeStripeHostedProxy.fetchPlaceCalls.awaitItem()
+        assertThat(call).isEqualTo("place-id-123")
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        assertThat(eventCalls.awaitItem())
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `with stripeHostedProxy uses proxy for predictions`() = runScenario(
         usePlacesClient = false,
-        shouldUseAutocompleteProxyEndpoints = true
+        useStripeHostedProxy = true,
+    ) {
+        fakeStripeHostedProxy.findPredictionsResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        val call = fakeStripeHostedProxy.findPredictionsCalls.awaitItem()
+        assertThat(call.query).isEqualTo("123 Main")
+        assertThat(call.country).isEqualTo("US")
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `with stripeHostedProxy uses proxy for place selection`() = runScenario(
+        usePlacesClient = false,
+        useStripeHostedProxy = true,
+    ) {
+        fakeStripeHostedProxy.fetchPlaceResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        delegate.onPredictionSelected("place-id-123")
+
+        val call = fakeStripeHostedProxy.fetchPlaceCalls.awaitItem()
+        assertThat(call).isEqualTo("place-id-123")
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        assertThat(eventCalls.awaitItem())
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `null placesClient and no proxy stays Idle`() = runScenario(
+        usePlacesClient = false,
     ) {
         delegate.observeQueryChanges(queryFlow, countryFlow)
 
@@ -671,9 +753,7 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `proxy flag false calls Google Places for predictions`() = runScenario(
-        shouldUseAutocompleteProxyEndpoints = false
-    ) {
+    fun `no proxy calls Google Places for predictions`() = runScenario {
         fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(emptyList())
         )
@@ -687,9 +767,7 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `proxy flag false calls Google Places for place selection`() = runScenario(
-        shouldUseAutocompleteProxyEndpoints = false
-    ) {
+    fun `no proxy calls Google Places for place selection`() = runScenario {
         fakePlacesClient.fetchPlaceResult = Result.success(
             FetchPlaceResponse(
                 Place(
@@ -713,10 +791,15 @@ class InlineAutocompleteControllerTest {
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),
         usePlacesClient: Boolean = true,
-        shouldUseAutocompleteProxyEndpoints: Boolean = false,
+        useStripeHostedProxy: Boolean = false,
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
         val fakePlaces = if (usePlacesClient) FakePlacesClientProxy() else null
+        val stripeHostedProxy = if (useStripeHostedProxy) {
+            FakePlacesClientProxy()
+        } else {
+            null
+        }
         val eventCalls = Turbine<AutocompleteAddressInteractor.Event>()
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test_key",
@@ -726,15 +809,16 @@ class InlineAutocompleteControllerTest {
         )
         val delegate = InlineAutocompleteController(
             placesClient = fakePlaces,
+            stripeHostedProxy = stripeHostedProxy,
             config = config,
             coroutineScope = backgroundScope,
             eventListenerProvider = { { event -> eventCalls.add(event) } },
-            shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
         )
 
         Scenario(
             delegate = delegate,
             fakePlacesClientOrNull = fakePlaces,
+            fakeStripeHostedProxyOrNull = stripeHostedProxy,
             eventCalls = eventCalls,
             queryFlow = MutableStateFlow(""),
             countryFlow = MutableStateFlow("US"),
@@ -742,12 +826,14 @@ class InlineAutocompleteControllerTest {
         ).apply { block() }
 
         fakePlaces?.ensureAllEventsConsumed()
+        stripeHostedProxy?.ensureAllEventsConsumed()
         eventCalls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val delegate: InlineAutocompleteController,
         private val fakePlacesClientOrNull: FakePlacesClientProxy?,
+        private val fakeStripeHostedProxyOrNull: FakePlacesClientProxy?,
         val eventCalls: Turbine<AutocompleteAddressInteractor.Event>,
         val queryFlow: MutableStateFlow<String>,
         val countryFlow: MutableStateFlow<String?>,
@@ -755,6 +841,9 @@ class InlineAutocompleteControllerTest {
     ) {
         val fakePlacesClient: FakePlacesClientProxy
             get() = requireNotNull(fakePlacesClientOrNull)
+
+        val fakeStripeHostedProxy: FakePlacesClientProxy
+            get() = requireNotNull(fakeStripeHostedProxyOrNull)
 
         fun advanceTimeBy(millis: Long) = testScope.advanceTimeBy(millis)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -130,20 +130,10 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `builder config can enable stripe-hosted autocomplete`() = runTest(UnconfinedTestDispatcher()) {
-        val viewModel = createViewModel(
-            config = AddressLauncher.Configuration.Builder()
-                .useStripeHostedAutocomplete(true)
-                .build()
-        )
-
-        assertThat(viewModel.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
-    }
-
-    @Test
-    fun `public constructor can enable stripe-hosted autocomplete`() = runTest(UnconfinedTestDispatcher()) {
+    fun `internal config can enable stripe-hosted autocomplete`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel(
             config = AddressLauncher.Configuration(
+                billingAddress = null,
                 useStripeHostedAutocomplete = true,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -130,6 +130,28 @@ class InputAddressViewModelTest {
     }
 
     @Test
+    fun `builder config can enable stripe-hosted autocomplete`() = runTest(UnconfinedTestDispatcher()) {
+        val viewModel = createViewModel(
+            config = AddressLauncher.Configuration.Builder()
+                .useStripeHostedAutocomplete(true)
+                .build()
+        )
+
+        assertThat(viewModel.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
+    }
+
+    @Test
+    fun `public constructor can enable stripe-hosted autocomplete`() = runTest(UnconfinedTestDispatcher()) {
+        val viewModel = createViewModel(
+            config = AddressLauncher.Configuration(
+                useStripeHostedAutocomplete = true,
+            )
+        )
+
+        assertThat(viewModel.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
+    }
+
+    @Test
     fun `viewModel emits onComplete event`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel(
             AddressDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -275,6 +275,30 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
+    fun `Factory creates inline interactor when proxy flag is on and placesClient is null`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = null,
+            autocompleteCountries = setOf("US"),
+            isPlacesAvailable = false,
+            isInlineAutocompleteEnabled = true,
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            placesClient = null,
+            coroutineScope = this,
+            shouldUseAutocompleteProxyEndpointsProvider = { true },
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(BillingInlineAutocompleteAddressInteractor::class.java)
+        assertThat(interactor.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
+        assertThat(interactor.autocompleteConfig.isPlacesAvailable).isFalse()
+    }
+
+    @Test
     fun `multiple onAutocomplete calls with different countries`() = test { scenario ->
         val interactor = createInteractor(launcher = scenario.launcher)
 
@@ -314,7 +338,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
         ),
     ) = PaymentElementAutocompleteAddressInteractor(
         launcher = launcher,
-        autocompleteConfig = autocompleteConfig
+        autocompleteConfig = autocompleteConfig,
     )
 
     private fun createTestAddress() = PaymentSheet.Address(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -217,7 +217,10 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val interactor = factory.create()
 
         assertThat(interactor).isInstanceOf(BillingInlineAutocompleteAddressInteractor::class.java)
-        assertThat(interactor.autocompleteConfig).isEqualTo(config)
+        assertThat(interactor.autocompleteConfig.googlePlacesApiKey).isEqualTo("test-key")
+        assertThat(interactor.autocompleteConfig.autocompleteCountries).isEqualTo(setOf("US"))
+        assertThat(interactor.autocompleteConfig.isInlineAutocompleteEnabled).isTrue()
+        assertThat(interactor.autocompleteConfig.shouldUseStripeHostedAutocomplete).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class StripeHostedPlacesClientProxyTest {
+    @Test
+    fun `findAutocompletePredictions returns failure`() = runTest {
+        val proxy = StripeHostedPlacesClientProxy(googleApiKey = "test-key")
+
+        val result = proxy.findAutocompletePredictions(
+            query = "123 Main",
+            country = "US",
+            limit = 4,
+        )
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
+    }
+
+    @Test
+    fun `findAutocompletePredictions returns failure when googleApiKey is null`() = runTest {
+        val proxy = StripeHostedPlacesClientProxy(googleApiKey = null)
+
+        val result = proxy.findAutocompletePredictions(
+            query = "123 Main",
+            country = "US",
+            limit = 4,
+        )
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
+    }
+
+    @Test
+    fun `fetchPlace returns failure`() = runTest {
+        val proxy = StripeHostedPlacesClientProxy(googleApiKey = "test-key")
+
+        val result = proxy.fetchPlace(placeId = "ChIJ123")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
+    }
+
+    @Test
+    fun `fetchPlace returns failure when googleApiKey is null`() = runTest {
+        val proxy = StripeHostedPlacesClientProxy(googleApiKey = null)
+
+        val result = proxy.fetchPlace(placeId = "ChIJ123")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -7,21 +7,7 @@ import org.junit.Test
 class StripeHostedPlacesClientProxyTest {
     @Test
     fun `findAutocompletePredictions returns failure`() = runTest {
-        val proxy = StripeHostedPlacesClientProxy(googleApiKey = "test-key")
-
-        val result = proxy.findAutocompletePredictions(
-            query = "123 Main",
-            country = "US",
-            limit = 4,
-        )
-
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
-    }
-
-    @Test
-    fun `findAutocompletePredictions returns failure when googleApiKey is null`() = runTest {
-        val proxy = StripeHostedPlacesClientProxy(googleApiKey = null)
+        val proxy = StripeHostedPlacesClientProxy()
 
         val result = proxy.findAutocompletePredictions(
             query = "123 Main",
@@ -35,17 +21,7 @@ class StripeHostedPlacesClientProxyTest {
 
     @Test
     fun `fetchPlace returns failure`() = runTest {
-        val proxy = StripeHostedPlacesClientProxy(googleApiKey = "test-key")
-
-        val result = proxy.fetchPlace(placeId = "ChIJ123")
-
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
-    }
-
-    @Test
-    fun `fetchPlace returns failure when googleApiKey is null`() = runTest {
-        val proxy = StripeHostedPlacesClientProxy(googleApiKey = null)
+        val proxy = StripeHostedPlacesClientProxy()
 
         val result = proxy.fetchPlace(placeId = "ChIJ123")
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -32,16 +32,11 @@ class AutocompleteAddressController(
 
     private val config = interactor.autocompleteConfig
 
-    private val inlineAutocompleteConfigured = config.shouldUseStripeHostedAutocomplete ||
-        !config.googlePlacesApiKey.isNullOrBlank()
-
-    private val inlineAutocompletePlatformAvailable = config.shouldUseStripeHostedAutocomplete ||
-        config.isPlacesAvailable
-
     private val inlineAutocompleteActive =
-        config.isInlineAutocompleteEnabled &&
-            inlineAutocompleteConfigured &&
-            inlineAutocompletePlatformAvailable
+        config.isInlineAutocompleteEnabled && (
+            config.shouldUseStripeHostedAutocomplete ||
+                (!config.googlePlacesApiKey.isNullOrBlank() && config.isPlacesAvailable)
+            )
 
     private val inlineAutocompleteHandler: InlineAutocompleteHandler? =
         if (inlineAutocompleteActive) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -32,8 +32,16 @@ class AutocompleteAddressController(
 
     private val config = interactor.autocompleteConfig
 
+    private val inlineAutocompleteConfigured = config.shouldUseStripeHostedAutocomplete ||
+        !config.googlePlacesApiKey.isNullOrBlank()
+
+    private val inlineAutocompletePlatformAvailable = config.shouldUseStripeHostedAutocomplete ||
+        config.isPlacesAvailable
+
     private val inlineAutocompleteActive =
-        config.isInlineAutocompleteEnabled && config.isPlacesAvailable
+        config.isInlineAutocompleteEnabled &&
+            inlineAutocompleteConfigured &&
+            inlineAutocompletePlatformAvailable
 
     private val inlineAutocompleteHandler: InlineAutocompleteHandler? =
         if (inlineAutocompleteActive) {
@@ -129,7 +137,7 @@ class AutocompleteAddressController(
                 }
 
                 _addressElementFlow.value =
-                    createAddressElement(newValues, toAddressInputMode(expandForm, newValues))
+                    createAddressElement(newValues, newAddressInputMode)
             }
         }
     }
@@ -161,13 +169,7 @@ class AutocompleteAddressController(
     ): AddressInputMode {
         val googlePlacesApiKey = config.googlePlacesApiKey
 
-        return if (googlePlacesApiKey == null) {
-            AddressInputMode.NoAutocomplete(
-                phoneNumberConfig = phoneNumberConfig,
-                nameConfig = nameConfig,
-                emailConfig = emailConfig,
-            )
-        } else if (inlineAutocompleteActive && !expandForm && values[IdentifierSpec.Line1] == null) {
+        return if (inlineAutocompleteActive && !expandForm && values[IdentifierSpec.Line1] == null) {
             AddressInputMode.AutocompleteInline(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,
@@ -176,6 +178,12 @@ class AutocompleteAddressController(
                 emailConfig = emailConfig,
             )
         } else if (config.isInlineAutocompleteEnabled) {
+            AddressInputMode.NoAutocomplete(
+                phoneNumberConfig = phoneNumberConfig,
+                nameConfig = nameConfig,
+                emailConfig = emailConfig,
+            )
+        } else if (googlePlacesApiKey == null) {
             AddressInputMode.NoAutocomplete(
                 phoneNumberConfig = phoneNumberConfig,
                 nameConfig = nameConfig,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -172,13 +172,7 @@ class AutocompleteAddressController(
                 nameConfig = nameConfig,
                 emailConfig = emailConfig,
             )
-        } else if (config.isInlineAutocompleteEnabled) {
-            AddressInputMode.NoAutocomplete(
-                phoneNumberConfig = phoneNumberConfig,
-                nameConfig = nameConfig,
-                emailConfig = emailConfig,
-            )
-        } else if (googlePlacesApiKey == null) {
+        } else if (config.isInlineAutocompleteEnabled || googlePlacesApiKey == null) {
             AddressInputMode.NoAutocomplete(
                 phoneNumberConfig = phoneNumberConfig,
                 nameConfig = nameConfig,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
@@ -32,6 +32,7 @@ interface AutocompleteAddressInteractor {
         val autocompleteCountries: Set<String>,
         val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
         val isInlineAutocompleteEnabled: Boolean = false,
+        val shouldUseStripeHostedAutocomplete: Boolean = false,
     )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -182,6 +182,32 @@ class AutocompleteAddressControllerTest {
     )
 
     @Test
+    fun `Element uses inline autocomplete when stripe-hosted is enabled without Google key or Places`() =
+        elementsTest(
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = null,
+                autocompleteCountries = setOf("US"),
+                isPlacesAvailable = false,
+                isInlineAutocompleteEnabled = true,
+                shouldUseStripeHostedAutocomplete = true,
+            ),
+        ) { elements ->
+            assertThat(elements.filterIsInstance<AddressTextFieldElement>()).hasSize(1)
+            assertThat(elements.any { it.identifier == IdentifierSpec.Line1 }).isFalse()
+        }
+
+    @Test
+    fun `Element does not use full-screen autocomplete when stripe-hosted is enabled without inline autocomplete`() =
+        noAutocompleteTest(
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = null,
+                autocompleteCountries = setOf("US"),
+                isPlacesAvailable = false,
+                shouldUseStripeHostedAutocomplete = true,
+            ),
+        )
+
+    @Test
     fun `Element does not use autocomplete if autocomplete country not supported`() = noAutocompleteTest(
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "123",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Integrate Stripe-hosted autocomplete proxy into inline address routing. When the feature gate is on, the SDK prefers the Stripe-hosted path for address autocomplete; Google Places is only used when the gate is off and a merchant API key is available. The proxy stub (`StripeHostedPlacesClientProxy`) currently returns `Result.failure`, so the full integration is exercised end-to-end but fails gracefully into manual address entry.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This lays the groundwork for routing inline address autocomplete through Stripe's own endpoint instead of requiring merchants to provide a Google Places API key. By wiring the routing, attribution, and fallback logic now (with a stub proxy), the next milestone only needs to implement the actual endpoint integration, all control flow, feature gating, and test coverage are already in place.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A, behind feature flag