### PR TITLE
Improve errors emitted from `NfcCardReader`

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -108,6 +108,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_nfc_scan_error_expired_card">Card expired. Try another card.</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card is not supported by Stripe or by the merchant -->
   <string name="stripe_nfc_scan_unsupported_card">Card not supported. Try another card.</string>
+  <!-- Error with action to take shown in the NFC scanning flow if the scanned card was declined -->
+  <string name="stripe_nfc_scan_error_declined_card">Card declined. Try another card.</string>
   <!-- Text for separator within a separator that separates a button to tap to add a card and the card form -->
   <string name="stripe_or_enter_manually">or enter manually</string>
   <!-- Text for the 'Pay with Link' button. 'Link' is a Stripe brand, please do not translate the word 'Link'. -->

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -1,28 +1,55 @@
 package com.stripe.android.common.nfcscan.scanner
 
+import com.stripe.android.common.nfcscan.scanner.apdu.ApduResponseError
 import com.stripe.android.common.nfcscan.scanner.apdu.ReadRecordCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectApplicationCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.strings.ResolvableString
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.collections.plusAssign
 import kotlin.coroutines.CoroutineContext
 
 internal interface NfcCardReader {
-    suspend fun readCard(transceiver: NfcTagTransceiver): Result<ScannedCardData>
+    interface ErrorCreator {
+        fun create(error: Throwable): Result.Error
+    }
+
+    suspend fun readCard(transceiver: NfcTagTransceiver): Result
+
+    sealed interface Result {
+        data class Found(val scannedCardData: ScannedCardData) : Result
+        data class Error(
+            val errorCode: String,
+            val userMessage: ResolvableString,
+        ) : Result
+    }
 }
 
 internal class ApduCardReader @Inject constructor(
     @IOContext private val workContext: CoroutineContext,
+    private val errorMapper: NfcCardReader.ErrorCreator,
     private val cardDataParser: NfcCardDataParser,
 ) : NfcCardReader {
-    override suspend fun readCard(
+    override suspend fun readCard(transceiver: NfcTagTransceiver): NfcCardReader.Result {
+        return runCatching {
+            readFromTransceiver(transceiver)
+        }.fold(
+            onSuccess = { cardData ->
+                NfcCardReader.Result.Found(scannedCardData = cardData)
+            },
+            onFailure = errorMapper::create,
+        )
+    }
+
+    private suspend fun readFromTransceiver(
         transceiver: NfcTagTransceiver
-    ): Result<ScannedCardData> = withContext(workContext) {
-        runCatching {
+    ): ScannedCardData = withContext(workContext) {
+        try {
+            transceiver.open()
             val applicationIdentifier = SelectPpseCommand.transceiveWith(transceiver).getOrThrow()
-            SelectApplicationCommand(applicationIdentifier).transceiveWith(transceiver)
+            SelectApplicationCommand(applicationIdentifier).transceiveWith(transceiver).getOrThrow()
 
             val records = mutableMapOf<String, ByteArray>()
 
@@ -37,18 +64,32 @@ internal class ApduCardReader @Inject constructor(
                         if (cardDataParser.canParse(records)) {
                             break@probeFiles
                         }
+                    }.onFailure { error ->
+                        if (!isRecordNotFoundError(error)) {
+                            throw error
+                        }
                     }
                 }
             }
 
             cardDataParser.parse(records)
                 ?: throw IllegalStateException("Could not parse card data from NFC tag")
+        } finally {
+            transceiver.close()
         }
+    }
+
+    private fun isRecordNotFoundError(error: Throwable): Boolean {
+        return error is ApduResponseError.Command &&
+            error.sw1 == RECORD_NOT_FOUND_SW1 && error.sw2 == RECORD_NOT_FOUND_SW2
     }
 
     private companion object {
         // SFIs 1-3 cover virtually all Visa/Mastercard/Amex/Discover payment records.
         val PROBE_SFIS = 1..3
         const val MAX_RECORDS_PER_SFI = 8
+
+        const val RECORD_NOT_FOUND_SW1 = 0x6A.toByte()
+        const val RECORD_NOT_FOUND_SW2 = 0x83.toByte()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
@@ -5,8 +5,6 @@ import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegate
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.paymentsheet.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -55,41 +53,34 @@ internal class DefaultNfcCardScanner @Inject constructor(
             viewModelScope.launch(workContext) {
                 _state.emit(NfcCardScanner.State.Scanning)
 
-                runCatching {
-                    transceiver.open()
-
-                    try {
-                        cardReader.readCard(transceiver)
-                            .getOrThrow()
-                    } finally {
-                        transceiver.close()
-                    }
-                }.fold(
-                    onSuccess = { cardData ->
-                        val state = when (val result = cardValidator.validate(cardData)) {
-                            is NfcCardValidator.Result.Validated -> NfcCardScanner.State.Complete(cardData)
-                            is NfcCardValidator.Result.Invalid -> NfcCardScanner.State.Failed(
+                val cardData = when (val readerResult = cardReader.readCard(transceiver)) {
+                    is NfcCardReader.Result.Found -> readerResult.scannedCardData
+                    is NfcCardReader.Result.Error -> {
+                        _state.emit(
+                            NfcCardScanner.State.Failed(
                                 error = NfcCardScanner.Error(
-                                    code = result.errorCode,
-                                    userMessage = result.userMessage,
+                                    code = readerResult.errorCode,
+                                    userMessage = readerResult.userMessage,
                                 )
                             )
-                        }
+                        )
 
-                        _state.emit(state)
-                    },
-                    onFailure = {
-                        _state.emit(NfcCardScanner.State.Failed(GENERIC_ERROR))
+                        return@launch
                     }
-                )
+                }
+
+                val finalResult = when (val result = cardValidator.validate(cardData)) {
+                    is NfcCardValidator.Result.Validated -> NfcCardScanner.State.Complete(cardData)
+                    is NfcCardValidator.Result.Invalid -> NfcCardScanner.State.Failed(
+                        error = NfcCardScanner.Error(
+                            code = result.errorCode,
+                            userMessage = result.userMessage,
+                        )
+                    )
+                }
+
+                _state.emit(finalResult)
             }
         }
-    }
-
-    private companion object {
-        val GENERIC_ERROR = NfcCardScanner.Error(
-            code = "unknown",
-            userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScannerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScannerModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.nfcscan.scanner
 
+import com.stripe.android.common.nfcscan.scanner.apdu.ApduErrorCreator
 import dagger.Binds
 import dagger.Module
 
@@ -15,6 +16,9 @@ internal interface NfcCardScannerModule {
 
     @Binds
     fun bindsNfcCardReader(reader: ApduCardReader): NfcCardReader
+
+    @Binds
+    fun bindsNfcCardReaderErrorCreator(errorMapper: ApduErrorCreator): NfcCardReader.ErrorCreator
 
     @Binds
     fun bindsNfcCardDataParser(parser: DefaultNfcCardDataParser): NfcCardDataParser

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
@@ -76,7 +76,7 @@ internal abstract class ApduCommand<TResponseData> {
         val sw2 = rawResponse[rawResponse.size - 1]
 
         if (sw1 != 0x90.toByte() || sw2 != 0x00.toByte()) {
-            return Result.failure(ApduResponseError.Command(sw1, sw2))
+            return Result.failure(ApduResponseError.Command(this, sw1, sw2))
         }
 
         val rawData = rawResponse.copyOfRange(0, rawResponse.size - 2)

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
@@ -1,0 +1,100 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+import com.stripe.android.common.nfcscan.scanner.NfcCardReader
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
+import java.io.IOException
+import javax.inject.Inject
+
+internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreator {
+    override fun create(error: Throwable): NfcCardReader.Result.Error {
+        val defaultAction = R.string.stripe_tap_to_add_card_default_error_action.resolvableString
+
+        return when (error) {
+            is SecurityException -> NfcCardReader.Result.Error(
+                errorCode = TRANSCEIVER_SECURITY_ERROR_CODE,
+                userMessage = defaultAction,
+            )
+            is IOException -> NfcCardReader.Result.Error(
+                errorCode = TRANSCEIVER_IO_ERROR_CODE,
+                userMessage = defaultAction,
+            )
+            is ApduResponseError.TooShort -> NfcCardReader.Result.Error(
+                errorCode = APDU_RESPONSE_TOO_SHORT_ERROR_CODE,
+                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+            )
+            is ApduResponseError.Parsing -> NfcCardReader.Result.Error(
+                errorCode = APDU_RESPONSE_PARSING_ERROR_CODE,
+                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+            )
+            is ApduResponseError.Invalid -> unsupportedCard()
+            is ApduResponseError.Command -> mapCommandError(error)
+            is IllegalStateException -> generalFailure()
+            else -> NfcCardReader.Result.Error(
+                errorCode = UNKNOWN_ERROR_CODE,
+                userMessage = defaultAction
+            )
+        }
+    }
+
+    private fun mapCommandError(error: ApduResponseError.Command): NfcCardReader.Result.Error {
+        return when {
+            isDeclined(error) -> declined()
+            isUnsupported(error) -> unsupportedCard()
+            else -> generalFailure()
+        }
+    }
+
+    private fun isDeclined(error: ApduResponseError.Command): Boolean {
+        return error.sw1 == CONDITIONS_OF_USE_NOT_SATISFIED_SW1 &&
+            error.sw2 == CONDITIONS_OF_USE_NOT_SATISFIED_SW2
+    }
+
+    private fun isUnsupported(error: ApduResponseError.Command): Boolean {
+        return when (error.apduCommand) {
+            is SelectPpseCommand,
+            is SelectApplicationCommand -> error.sw1 == FILE_NOT_FOUND_SW1 && error.sw2 == FILE_NOT_FOUND_SW2
+            is ReadRecordCommand -> false
+            else -> false
+        }
+    }
+
+    private fun unsupportedCard(): NfcCardReader.Result.Error {
+        return NfcCardReader.Result.Error(
+            errorCode = UNSUPPORTED_CARD_ERROR_CODE,
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+    }
+
+    private fun declined(): NfcCardReader.Result.Error {
+        return NfcCardReader.Result.Error(
+            errorCode = CARD_DECLINED_ERROR_CODE,
+            userMessage = R.string.stripe_nfc_scan_error_declined_card.resolvableString,
+        )
+    }
+
+    private fun generalFailure(): NfcCardReader.Result.Error {
+        return NfcCardReader.Result.Error(
+            errorCode = GENERAL_READ_ERROR_CODE,
+            userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+        )
+    }
+
+    private companion object {
+        const val TRANSCEIVER_SECURITY_ERROR_CODE = "nfcTransceiverSecurityError"
+        const val TRANSCEIVER_IO_ERROR_CODE = "nfcTransceiverIoError"
+        const val UNKNOWN_ERROR_CODE = "unknownNfcReaderError"
+
+        const val APDU_RESPONSE_TOO_SHORT_ERROR_CODE = "apduResponseTooShort"
+        const val APDU_RESPONSE_PARSING_ERROR_CODE = "apduParsingCode"
+
+        const val UNSUPPORTED_CARD_ERROR_CODE = "cardUnsupportedByNfc"
+        const val CARD_DECLINED_ERROR_CODE = "cardDeclinedByNfc"
+        const val GENERAL_READ_ERROR_CODE = "nfcCardReadFailed"
+
+        const val FILE_NOT_FOUND_SW1 = 0x6A.toByte()
+        const val FILE_NOT_FOUND_SW2 = 0x82.toByte()
+        const val CONDITIONS_OF_USE_NOT_SATISFIED_SW1 = 0x69.toByte()
+        const val CONDITIONS_OF_USE_NOT_SATISFIED_SW2 = 0x85.toByte()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
@@ -7,6 +7,7 @@ internal sealed class ApduResponseError(
     class TooShort : ApduResponseError("APDU response is too short! Needs at least two bytes!")
 
     data class Command(
+        val apduCommand: ApduCommand<*>,
         val sw1: Byte,
         val sw2: Byte,
     ) : ApduResponseError("APDU error: SW1=$sw1, SW2=$sw2")

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -2,12 +2,18 @@ package com.stripe.android.common.nfcscan.scanner
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.scanner.apdu.ApduResponseError
+import com.stripe.android.common.nfcscan.scanner.apdu.ReadRecordCommand
+import com.stripe.android.common.nfcscan.scanner.apdu.SelectApplicationCommand
+import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
 import com.stripe.android.common.nfcscan.scanner.apdu.tlv
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentsheet.R
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import java.io.IOException
 
 internal class ApduCardReaderTest {
     @Test
@@ -17,10 +23,12 @@ internal class ApduCardReaderTest {
             apduSuccessResponse(byteArrayOf()),
         ),
         transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        errorResult = PARSE_FAILURE_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalStateException>()
+        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
+        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -37,10 +45,12 @@ internal class ApduCardReaderTest {
             apduSuccessResponse(byteArrayOf()),
         ),
         transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        errorResult = PARSE_FAILURE_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalStateException>()
+        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
+        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -52,12 +62,70 @@ internal class ApduCardReaderTest {
 
     @Test
     fun `readCard propagates PPSE selection failure`() = runScenario(
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        transceiveResults = emptyList(),
+        transceiveResult = FILE_NOT_FOUND_RESPONSE,
+        errorResult = UNSUPPORTED_CARD_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result.exceptionOrNull()).isInstanceOf<ApduResponseError.Command>()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
+        assertThat(errorCreator.createCalls.awaitItem()).isEqualTo(
+            ApduResponseError.Command(
+                apduCommand = SelectPpseCommand,
+                sw1 = 0x6A.toByte(),
+                sw2 = 0x82.toByte(),
+            ),
+        )
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+    }
+
+    @Test
+    fun `readCard propagates SelectApplication failure`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+        ),
+        transceiveResult = FILE_NOT_FOUND_RESPONSE,
+        errorResult = UNSUPPORTED_CARD_ERROR,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
+
+        val error = errorCreator.createCalls.awaitItem()
+
+        assertThat(error).isInstanceOf<ApduResponseError.Command>()
+        val commandError = error as ApduResponseError.Command
+
+        assertThat(commandError.apduCommand).isInstanceOf<SelectApplicationCommand>()
+        assertThat(commandError.sw1).isEqualTo(0x6A.toByte())
+        assertThat(commandError.sw2).isEqualTo(0x82.toByte())
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+    }
+
+    @Test
+    fun `readCard propagates ReadRecord failure that is not record not found`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+        ),
+        transceiveResult = CARD_DECLINED_RESPONSE,
+        errorResult = CARD_DECLINED_ERROR,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(CARD_DECLINED_ERROR)
+        assertThat(errorCreator.createCalls.awaitItem()).isEqualTo(
+            ApduResponseError.Command(
+                apduCommand = ReadRecordCommand(recordNumber = 1, shortFileIdentifier = 1),
+                sw1 = 0x69.toByte(),
+                sw2 = 0x85.toByte(),
+            ),
+        )
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
     }
 
     @Test
@@ -72,7 +140,7 @@ internal class ApduCardReaderTest {
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result.getOrNull()).isEqualTo(SCANNED_CARD_DATA)
+        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -93,7 +161,7 @@ internal class ApduCardReaderTest {
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result.getOrNull()).isEqualTo(SCANNED_CARD_DATA)
+        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -114,10 +182,13 @@ internal class ApduCardReaderTest {
             apduSuccessResponse(tlv(tag = 0x5F, tagContinuation = 0x24, value = EXPIRY_DATA)),
         ),
         transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        errorResult = PARSE_FAILURE_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalStateException>()
+        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
+        assertThat(errorCreator.createCalls.awaitItem())
+            .isInstanceOf<IllegalStateException>()
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -134,21 +205,43 @@ internal class ApduCardReaderTest {
         assertThat(parsedRecords.getValue("5F24").contentEquals(EXPIRY_DATA)).isTrue()
     }
 
+    @Test
+    fun `readCard returns transceiver io error when open fails`() = runScenario(
+        openException = IOException("open failed"),
+        errorResult = TRANSCEIVER_IO_ERROR,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(TRANSCEIVER_IO_ERROR)
+        val error = errorCreator.createCalls.awaitItem()
+        assertThat(error).isInstanceOf<IOException>()
+        assertThat(error.message).isEqualTo("open failed")
+    }
+
     private fun runScenario(
         transceiveResult: ByteArray = apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-        transceiveResults: List<ByteArray> = emptyList(),
+        transceiveResults: List<ByteArray> = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID))
+        ),
         parseResult: ScannedCardData? = null,
+        openException: Throwable? = null,
+        errorResult: NfcCardReader.Result.Error = PARSE_FAILURE_ERROR,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val fakeTransceiver = FakeNfcTagTransceiver(
             transceiveResult = transceiveResult,
             transceiveResults = transceiveResults,
+            openException = openException,
         )
         val fakeCardDataParser = FakeNfcCardDataParser(
             parseResult = parseResult,
         )
+        val fakeErrorCreator = FakeNfcCardReaderErrorCreator(
+            result = errorResult,
+        )
         val reader = ApduCardReader(
             workContext = UnconfinedTestDispatcher(testScheduler),
+            errorMapper = fakeErrorCreator,
             cardDataParser = fakeCardDataParser,
         )
 
@@ -156,16 +249,21 @@ internal class ApduCardReaderTest {
             cardReader = reader,
             transceiver = fakeTransceiver,
             cardDataParser = fakeCardDataParser,
+            errorCreator = fakeErrorCreator,
         ).apply { block() }
 
+        fakeTransceiver.openCalls.awaitItem()
+        fakeTransceiver.closeCalls.awaitItem()
         fakeTransceiver.ensureAllEventsConsumed()
         fakeCardDataParser.ensureAllEventsConsumed()
+        fakeErrorCreator.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val cardReader: ApduCardReader,
         val transceiver: FakeNfcTagTransceiver,
         val cardDataParser: FakeNfcCardDataParser,
+        val errorCreator: FakeNfcCardReaderErrorCreator,
     ) {
         suspend fun assertReadRecordProbes(startingAtIndex: Int = 0) {
             for (index in startingAtIndex until READ_RECORD_REQUESTS.size) {
@@ -177,6 +275,26 @@ internal class ApduCardReaderTest {
 
     private companion object {
         const val MAX_RECORDS_PER_SFI = 8
+
+        val PARSE_FAILURE_ERROR = NfcCardReader.Result.Error(
+            errorCode = "nfcCardReadFailed",
+            userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+        )
+
+        val UNSUPPORTED_CARD_ERROR = NfcCardReader.Result.Error(
+            errorCode = "cardUnsupportedByNfc",
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+
+        val CARD_DECLINED_ERROR = NfcCardReader.Result.Error(
+            errorCode = "cardDeclinedByNfc",
+            userMessage = R.string.stripe_nfc_scan_error_declined_card.resolvableString,
+        )
+
+        val TRANSCEIVER_IO_ERROR = NfcCardReader.Result.Error(
+            errorCode = "nfcTransceiverIoError",
+            userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+        )
 
         val SCANNED_CARD_DATA = ScannedCardData(
             cardNumber = "4111111111111111",
@@ -243,6 +361,8 @@ internal class ApduCardReaderTest {
             0x10,
         )
         val RECORD_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x83.toByte())
+        val FILE_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x82.toByte())
+        val CARD_DECLINED_RESPONSE = byteArrayOf(0x69.toByte(), 0x85.toByte())
         val SELECT_PPSE_REQUEST = byteArrayOf(
             0x00,
             0xA4.toByte(),

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
-import java.io.IOException
 
 internal class DefaultNfcCardScannerTest {
     private val dispatcher = UnconfinedTestDispatcher()
@@ -24,11 +23,13 @@ internal class DefaultNfcCardScannerTest {
 
     @Test
     fun `scanner emits Scanning then Complete when card read & validator succeeds`() = runScenario(
-        cardData = ScannedCardData(
-            cardNumber = "4242424242424242",
-            expirationMonth = 12,
-            expirationYear = 2030,
-        ),
+        cardReadResult = NfcCardReader.Result.Found(
+            scannedCardData = ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 12,
+                expirationYear = 2030,
+            ),
+        )
     ) {
         scanner.state.test {
             scanner.start(activity)
@@ -49,12 +50,7 @@ internal class DefaultNfcCardScannerTest {
         }
 
         assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
-
-        val transceiver = requireNotNull(fakeTransceiver)
-
-        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
         assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
-        assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
         assertThat(fakeCardValidator.validateCalls.awaitItem()).isEqualTo(
             ScannedCardData(
                 cardNumber = "4242424242424242",
@@ -66,7 +62,10 @@ internal class DefaultNfcCardScannerTest {
 
     @Test
     fun `start emits Failed when card reader fails`() = runScenario(
-        cardReadError = IllegalStateException("read failed"),
+        cardReadResult = NfcCardReader.Result.Error(
+            errorCode = "cardUnsupportedByNfc",
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        ),
     ) {
         scanner.state.test {
             scanner.start(activity)
@@ -78,20 +77,15 @@ internal class DefaultNfcCardScannerTest {
             assertThat(awaitItem()).isEqualTo(
                 NfcCardScanner.State.Failed(
                     error = NfcCardScanner.Error(
-                        code = "unknown",
-                        userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+                        code = "cardUnsupportedByNfc",
+                        userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
                     ),
                 ),
             )
         }
 
         assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
-
-        val transceiver = requireNotNull(fakeTransceiver)
-
-        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
         assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
-        assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -111,73 +105,13 @@ internal class DefaultNfcCardScannerTest {
     }
 
     @Test
-    fun `start emits Failed when transceiver open fails`() = runScenario(
-        openException = IOException("open failed"),
-    ) {
-        scanner.state.test {
-            scanner.start(activity)
-
-            val startCall = fakeHardwareDelegate.startCalls.awaitItem()
-            startCall.onTagDiscovered.invoke(tag)
-
-            assertThat(awaitItem()).isEqualTo(NfcCardScanner.State.Scanning)
-            assertThat(awaitItem()).isEqualTo(
-                NfcCardScanner.State.Failed(
-                    error = NfcCardScanner.Error(
-                        code = "unknown",
-                        userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-                    ),
-                ),
-            )
-        }
-
-        assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
-
-        val transceiver = requireNotNull(fakeTransceiver)
-
-        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
-    }
-
-    @Test
-    fun `start emits Failed when transceiver close fails`() = runScenario(
-        cardData = ScannedCardData(
-            cardNumber = "4242424242424242",
-            expirationMonth = 12,
-            expirationYear = 2030,
-        ),
-        closeException = IOException("close failed"),
-    ) {
-        scanner.state.test {
-            scanner.start(activity)
-
-            val startCall = fakeHardwareDelegate.startCalls.awaitItem()
-            startCall.onTagDiscovered.invoke(tag)
-
-            assertThat(awaitItem()).isEqualTo(NfcCardScanner.State.Scanning)
-            val failedState = awaitItem() as NfcCardScanner.State.Failed
-            assertThat(failedState.error).isEqualTo(
-                NfcCardScanner.Error(
-                    code = "unknown",
-                    userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-                ),
-            )
-        }
-
-        assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
-
-        val transceiver = requireNotNull(fakeTransceiver)
-
-        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
-        assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
-        assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
-    }
-
-    @Test
     fun `scanner emits Failed when card validation fails`() = runScenario(
-        cardData = ScannedCardData(
-            cardNumber = "4242424242424242",
-            expirationMonth = 12,
-            expirationYear = 2030,
+        cardReadResult = NfcCardReader.Result.Found(
+            scannedCardData = ScannedCardData(
+                cardNumber = "4242424242424242",
+                expirationMonth = 12,
+                expirationYear = 2030,
+            ),
         ),
         validationResult = NfcCardValidator.Result.Invalid(
             errorCode = "cardUnsupportedByMerchant",
@@ -202,12 +136,7 @@ internal class DefaultNfcCardScannerTest {
         }
 
         assertThat(fakeTransceiverFactory.createCalls.awaitItem()).isEqualTo(tag)
-
-        val transceiver = requireNotNull(fakeTransceiver)
-
-        assertThat(transceiver.openCalls.awaitItem()).isNotNull()
         assertThat(fakeCardReader.readCardCalls.awaitItem()).isEqualTo(fakeTransceiver)
-        assertThat(transceiver.closeCalls.awaitItem()).isNotNull()
         assertThat(fakeCardValidator.validateCalls.awaitItem()).isEqualTo(
             ScannedCardData(
                 cardNumber = "4242424242424242",
@@ -219,27 +148,17 @@ internal class DefaultNfcCardScannerTest {
 
     private fun runScenario(
         isHardwareAvailable: Boolean = true,
-        cardData: ScannedCardData? = null,
-        cardReadError: Throwable? = null,
-        openException: Throwable? = null,
-        closeException: Throwable? = null,
-        transceiver: NfcTagTransceiver? = FakeNfcTagTransceiver(
-            openException = openException,
-            closeException = closeException,
+        transceiver: FakeNfcTagTransceiver? = FakeNfcTagTransceiver(),
+        cardReadResult: NfcCardReader.Result = NfcCardReader.Result.Error(
+            errorCode = "notImplemented",
+            userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
         ),
         validationResult: NfcCardValidator.Result = NfcCardValidator.Result.Validated,
         block: suspend Scenario.() -> Unit,
     ) = runTest(dispatcher) {
         val fakeHardwareDelegate = FakeNfcHardwareDelegate(result = isHardwareAvailable)
         val fakeTransceiverFactory = FakeNfcTagTransceiverFactory(transceiver = transceiver)
-        val fakeTransceiver = transceiver as? FakeNfcTagTransceiver
-        val fakeCardReader = FakeNfcCardReader(
-            result = when {
-                cardData != null -> Result.success(cardData)
-                cardReadError != null -> Result.failure(cardReadError)
-                else -> Result.failure(NotImplementedError())
-            },
-        )
+        val fakeCardReader = FakeNfcCardReader(result = cardReadResult)
         val fakeCardValidator = FakeNfcCardValidator(result = validationResult)
         val activity = mock<AppCompatActivity>()
         val tag = mock<Tag>()
@@ -261,14 +180,14 @@ internal class DefaultNfcCardScannerTest {
             fakeTransceiverFactory = fakeTransceiverFactory,
             fakeCardReader = fakeCardReader,
             fakeCardValidator = fakeCardValidator,
-            fakeTransceiver = fakeTransceiver,
+            fakeTransceiver = transceiver,
         ).block()
 
         fakeHardwareDelegate.ensureAllEventsConsumed()
         fakeTransceiverFactory.ensureAllEventsConsumed()
         fakeCardReader.ensureAllEventsConsumed()
         fakeCardValidator.ensureAllEventsConsumed()
-        fakeTransceiver?.ensureAllEventsConsumed()
+        transceiver?.ensureAllEventsConsumed()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardReader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardReader.kt
@@ -3,11 +3,14 @@ package com.stripe.android.common.nfcscan.scanner
 import app.cash.turbine.Turbine
 
 internal class FakeNfcCardReader(
-    private val result: Result<ScannedCardData> = Result.failure(NotImplementedError()),
+    private val result: NfcCardReader.Result = NfcCardReader.Result.Error(
+        errorCode = "notImplemented",
+        userMessage = com.stripe.android.core.strings.resolvableString("Not implemented"),
+    ),
 ) : NfcCardReader {
     val readCardCalls = Turbine<NfcTagTransceiver>()
 
-    override suspend fun readCard(transceiver: NfcTagTransceiver): Result<ScannedCardData> {
+    override suspend fun readCard(transceiver: NfcTagTransceiver): NfcCardReader.Result {
         readCardCalls.add(transceiver)
         return result
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardReaderErrorCreator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardReaderErrorCreator.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.common.nfcscan.scanner
+
+import app.cash.turbine.Turbine
+import com.stripe.android.core.strings.resolvableString
+
+internal class FakeNfcCardReaderErrorCreator(
+    private val result: NfcCardReader.Result.Error = NfcCardReader.Result.Error(
+        errorCode = "testError",
+        userMessage = resolvableString("test error"),
+    ),
+) : NfcCardReader.ErrorCreator {
+    val createCalls = Turbine<Throwable>()
+
+    override fun create(error: Throwable): NfcCardReader.Result.Error {
+        createCalls.add(error)
+        return result
+    }
+
+    fun ensureAllEventsConsumed() {
+        createCalls.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
@@ -1,0 +1,165 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.scanner.NfcCardReader
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
+import org.junit.Test
+import java.io.IOException
+
+internal class ApduErrorCreatorTest {
+    private val errorMapper = ApduErrorCreator()
+
+    @Test
+    fun `create returns unsupported card error for SelectPpse file not found`() {
+        val result = errorMapper.create(
+            ApduResponseError.Command(
+                apduCommand = SelectPpseCommand,
+                sw1 = 0x6A.toByte(),
+                sw2 = 0x82.toByte(),
+            ),
+        )
+
+        assertThat(result.errorCode).isEqualTo("cardUnsupportedByNfc")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+    }
+
+    @Test
+    fun `create returns unsupported card error for SelectApplication file not found`() {
+        val result = errorMapper.create(
+            ApduResponseError.Command(
+                apduCommand = SelectApplicationCommand(ApplicationIdentifier("A0000000031010")),
+                sw1 = 0x6A.toByte(),
+                sw2 = 0x82.toByte(),
+            ),
+        )
+
+        assertThat(result.errorCode).isEqualTo("cardUnsupportedByNfc")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+    }
+
+    @Test
+    fun `create returns declined card error for conditions of use not satisfied`() {
+        val result = errorMapper.create(
+            ApduResponseError.Command(
+                apduCommand = SelectApplicationCommand(ApplicationIdentifier("A0000000031010")),
+                sw1 = 0x69.toByte(),
+                sw2 = 0x85.toByte(),
+            ),
+        )
+
+        assertThat(result.errorCode).isEqualTo("cardDeclinedByNfc")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_nfc_scan_error_declined_card.resolvableString,
+        )
+    }
+
+    @Test
+    fun `create returns unsupported card error for invalid PPSE response`() {
+        val result = errorMapper.create(
+            ApduResponseError.Invalid(data = byteArrayOf(0x01)),
+        )
+
+        assertThat(result.errorCode).isEqualTo("cardUnsupportedByNfc")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+    }
+
+    @Test
+    fun `create returns general failure for unknown status word`() {
+        val result = errorMapper.create(
+            ApduResponseError.Command(
+                apduCommand = ReadRecordCommand(recordNumber = 1, shortFileIdentifier = 1),
+                sw1 = 0x64.toByte(),
+                sw2 = 0x00,
+            ),
+        )
+
+        assertThat(result.errorCode).isEqualTo("nfcCardReadFailed")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+        )
+    }
+
+    @Test
+    fun `create returns transceiver security error for SecurityException`() {
+        val result = errorMapper.create(SecurityException("NFC access denied"))
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "nfcTransceiverSecurityError",
+                userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+            ),
+        )
+    }
+
+    @Test
+    fun `create returns transceiver io error for IOException`() {
+        val result = errorMapper.create(IOException("transceive failed"))
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "nfcTransceiverIoError",
+                userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+            ),
+        )
+    }
+
+    @Test
+    fun `create returns too short error for ApduResponseError TooShort`() {
+        val result = errorMapper.create(ApduResponseError.TooShort())
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "apduResponseTooShort",
+                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+            ),
+        )
+    }
+
+    @Test
+    fun `create returns parsing error for ApduResponseError Parsing`() {
+        val result = errorMapper.create(
+            ApduResponseError.Parsing(
+                data = byteArrayOf(0x01, 0x02),
+                cause = IllegalArgumentException("invalid tlv"),
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "apduParsingCode",
+                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+            ),
+        )
+    }
+
+    @Test
+    fun `create returns unknown error for unrecognized throwable`() {
+        val result = errorMapper.create(RuntimeException("unexpected"))
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "unknownNfcReaderError",
+                userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+            ),
+        )
+    }
+
+    @Test
+    fun `create returns general failure for IllegalStateException`() {
+        val result = errorMapper.create(IllegalStateException("Could not parse card data from NFC tag"))
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "nfcCardReadFailed",
+                userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Improve errors emitted from `NfcCardReader` by:
- Opening & closing transceiver in the reader, handling any errors in the reader itself.
- Adding `ApduErrorCreator` for building readable error messages & codes.
- Passing `NfcCardReader` codes through `NfcCardScanner`.

# Motivation
Better error representation in NFC scanning flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified