### PR TITLE
Add internal appearance theme mode API

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
@@ -36,6 +36,7 @@ internal object AppearanceStore {
         val sectionSpacing: SectionSpacing = SectionSpacing.Default,
         val textFieldInsets: Insets = Insets.Default,
         val verticalModeRowPadding: Float = StripeThemeDefaults.verticalModeRowPadding,
+        val themeMode: PaymentSheet.ThemeMode = PaymentSheet.ThemeMode.default,
         val iconStyle: IconStyle = IconStyle.Filled,
     ) {
         @OptIn(AppearanceAPIAdditionsPreview::class)
@@ -43,6 +44,7 @@ internal object AppearanceStore {
             return PaymentSheet.Appearance.Builder()
                 .colorsLight(colorsLight.build())
                 .colorsDark(colorsDark.build())
+                .themeMode(themeMode)
                 .shapes(shapes.build())
                 .typography(typography.build())
                 .primaryButton(primaryButton.build())

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -9,6 +9,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.FontRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -1220,6 +1221,35 @@ class PaymentSheet internal constructor(
         Automatic
     }
 
+    /**
+     * Determines which color set Payment Element should use.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class ThemeMode {
+        /**
+         * Use the system light or dark mode setting. This will use value from [AppCompatDelegate.getDefaultNightMode].
+         */
+        Automatic,
+
+        /**
+         * Always use the light color set. This will override value from [AppCompatDelegate.getDefaultNightMode]
+         * for Payment Element only.
+         */
+        AlwaysLight,
+
+        /**
+         * Always use the dark color set. This will override value from [AppCompatDelegate.getDefaultNightMode] for
+         * Payment Element only.
+         */
+        AlwaysDark;
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            val default = Automatic
+        }
+    }
+
     @Parcelize
     @Poko
     class Appearance
@@ -1234,6 +1264,10 @@ class PaymentSheet internal constructor(
          * Describes the colors used while the system is in dark mode.
          */
         internal val colorsDark: Colors = Colors.defaultDark,
+        /**
+         * Determines which color set Payment Element should use.
+         */
+        internal val themeMode: ThemeMode = ThemeMode.default,
         /**
          * Describes the appearance of shapes.
          */
@@ -2003,6 +2037,7 @@ class PaymentSheet internal constructor(
         class Builder {
             private var colorsLight = Colors.defaultLight
             private var colorsDark = Colors.defaultDark
+            private var themeMode = ThemeMode.default
             private var shapes = Shapes.default
             private var typography = Typography.default
             private var primaryButton: PrimaryButton = PrimaryButton()
@@ -2027,6 +2062,15 @@ class PaymentSheet internal constructor(
 
             fun colorsDark(colors: Colors) = apply {
                 this.colorsDark = colors
+            }
+
+            /**
+             * Determines which color set Payment Element should use.
+             * Defaults to [ThemeMode.Automatic], which follows the system light/dark mode setting.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun themeMode(themeMode: ThemeMode) = apply {
+                this.themeMode = themeMode
             }
 
             fun shapes(shapes: Shapes) = apply {
@@ -2074,6 +2118,7 @@ class PaymentSheet internal constructor(
                 return Appearance(
                     colorsLight = colorsLight,
                     colorsDark = colorsDark,
+                    themeMode = themeMode,
                     shapes = shapes,
                     typography = typography,
                     primaryButton = primaryButton,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationTest.kt
@@ -68,6 +68,35 @@ class PaymentSheetConfigurationTest {
     }
 
     @Test
+    fun `Appearance uses automatic theme mode by default`() {
+        assertThat(PaymentSheet.Appearance().themeMode)
+            .isEqualTo(PaymentSheet.ThemeMode.Automatic)
+    }
+
+    @Test
+    fun `Appearance Builder stores theme mode`() {
+        val appearance = PaymentSheet.Appearance.Builder()
+            .themeMode(PaymentSheet.ThemeMode.AlwaysDark)
+            .build()
+
+        assertThat(appearance.themeMode)
+            .isEqualTo(PaymentSheet.ThemeMode.AlwaysDark)
+    }
+
+    @Test
+    fun `Appearance equality includes theme mode`() {
+        val automaticAppearance = PaymentSheet.Appearance.Builder()
+            .themeMode(PaymentSheet.ThemeMode.Automatic)
+            .build()
+        val darkAppearance = PaymentSheet.Appearance.Builder()
+            .themeMode(PaymentSheet.ThemeMode.AlwaysDark)
+            .build()
+
+        assertThat(automaticAppearance)
+            .isNotEqualTo(darkAppearance)
+    }
+
+    @Test
     fun `Configuration property count matches expected - update newBuilder when this fails`() {
         val propertyCount = PaymentSheet.Configuration::class.java.declaredFields
             .filterNot { it.isSynthetic }


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
Adds a restricted `PaymentSheet.ThemeMode` enum and `PaymentSheet.Appearance.Builder.themeMode(...)` API so SDK/internal example code can store the approved light/dark theme preference shape.

This is API storage only; no dark-mode rendering behavior changes in this PR.

# Motivation
Android Payment Element needs the approved API shape available internally before wiring behavior, including usage from `paymentsheet-example`.

Keeping the setter `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` lets the example module call it without exposing it as merchant-facing public API.

https://docs.google.com/document/d/1-mjWQoaNe4v-NlpaX-MjZMXvLRKLslwKFNOq7Hc2oU4/edit?usp=sharing

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

Commands run:
- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.paymentsheet.PaymentSheetConfigurationTest`
- `./gradlew :paymentsheet:apiCheck`
- `./gradlew :paymentsheet-example:compileBaseDebugKotlin`
- `git diff --check`

No tests were ignored.

# Screenshots
N/A. API-only change with no UI behavior changes.

# Changelog
N/A. Restricted internal API only; no user-facing behavior change.
