### PR TITLE
Disable navigation button during network operations in embedded sheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -107,7 +107,7 @@ internal class EmbeddedNavigator private constructor(
 
         abstract fun title(): StateFlow<ResolvableString?>
 
-        abstract fun isPerformingNetworkOperation(): Boolean
+        abstract fun isPerformingNetworkOperation(): StateFlow<Boolean>
 
         class ManageAll(
             private val interactor: ManageScreenInteractor,
@@ -124,8 +124,8 @@ internal class EmbeddedNavigator private constructor(
                 }
             }
 
-            override fun isPerformingNetworkOperation(): Boolean {
-                return false
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> {
+                return stateFlowOf(false)
             }
 
             @Composable
@@ -148,8 +148,8 @@ internal class EmbeddedNavigator private constructor(
                 return stateFlowOf(interactor.screenTitle)
             }
 
-            override fun isPerformingNetworkOperation(): Boolean {
-                return interactor.state.value.status.isPerformingNetworkOperation
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> {
+                return interactor.state.mapAsStateFlow { it.status.isPerformingNetworkOperation }
             }
 
             @Composable
@@ -180,8 +180,8 @@ internal class EmbeddedNavigator private constructor(
 
             override fun title(): StateFlow<ResolvableString?> = stateFlowOf(null)
 
-            override fun isPerformingNetworkOperation(): Boolean {
-                return sheetActivityStateHolder.state.value.isProcessing
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> {
+                return sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing }
             }
 
             @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -97,7 +97,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         }
 
         onBackPressedDispatcher.addCallback {
-            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation()) {
+            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation().value) {
                 embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
             }
         }
@@ -114,7 +114,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
     private fun SheetContent() {
         val screen by embeddedNavigator.screen.collectAsState()
         val bottomSheetState = rememberStripeBottomSheetState(
-            confirmValueChange = { !screen.isPerformingNetworkOperation() }
+            confirmValueChange = { !screen.isPerformingNetworkOperation().value }
         )
         ElementsBottomSheetLayout(
             state = bottomSheetState,
@@ -154,10 +154,13 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
                 val topBarState by remember(screen) {
                     screen.topBarState()
                 }.collectAsState()
+                val isPerformingNetworkOperation by remember(screen) {
+                    screen.isPerformingNetworkOperation()
+                }.collectAsState()
                 PaymentSheetTopBar(
                     state = topBarState,
                     canNavigateBack = navigator.canGoBack,
-                    isEnabled = true,
+                    isEnabled = !isPerformingNetworkOperation,
                     handleBackPressed = { embeddedNavigator.performAction(EmbeddedNavigator.Action.Back) },
                 )
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -227,7 +227,7 @@ internal class EmbeddedNavigatorTest {
     @Test
     fun `ManageAll isPerformingNetworkOperation returns false`() {
         val screen = EmbeddedNavigator.Screen.ManageAll(FakeManageScreenInteractor())
-        assertThat(screen.isPerformingNetworkOperation()).isFalse()
+        assertThat(screen.isPerformingNetworkOperation().value).isFalse()
     }
 
     @Test
@@ -269,7 +269,7 @@ internal class EmbeddedNavigatorTest {
             )
         )
         val screen = EmbeddedNavigator.Screen.ManageUpdate(interactor)
-        assertThat(screen.isPerformingNetworkOperation()).isFalse()
+        assertThat(screen.isPerformingNetworkOperation().value).isFalse()
     }
 
     @Test
@@ -283,7 +283,7 @@ internal class EmbeddedNavigatorTest {
             )
         )
         val screen = EmbeddedNavigator.Screen.ManageUpdate(interactor)
-        assertThat(screen.isPerformingNetworkOperation()).isTrue()
+        assertThat(screen.isPerformingNetworkOperation().value).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -2,7 +2,12 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import android.app.Application
 import android.os.Bundle
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -28,7 +33,9 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.RetryRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -44,6 +51,7 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
+import com.stripe.android.ui.core.R as StripeUiCoreR
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
@@ -184,6 +192,53 @@ internal class EmbeddedSheetActivityTest {
         managePage.waitUntilVisible()
         managePage.clickDone()
         managePage.assertCardIsVisible(cbcCardId, "visa")
+    }
+
+    @Test
+    fun `top bar navigation button is disabled while updating card brand`() = launch {
+        managePage.waitUntilVisible()
+        managePage.clickEdit()
+        managePage.clickEdit(cbcCardId)
+
+        val countDownLatch = CountDownLatch(1)
+        networkRule.setupPaymentMethodUpdateResponse(
+            paymentMethodDetails = cbcCardDetails,
+            cardBrand = "visa",
+            countDownLatch = countDownLatch,
+        )
+        editPage.waitUntilVisible()
+        editPage.setCardBrandWithSelector("Visa")
+        editPage.update(waitUntilComplete = false)
+
+        // While the update is in flight the top bar navigation button must be disabled,
+        // matching the blocked system back button and swipe-to-dismiss.
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(SHEET_NAVIGATION_BUTTON_TAG).assertIsNotEnabled()
+
+        countDownLatch.countDown()
+        managePage.waitUntilVisible()
+
+        // Once the update completes the navigation button is re-enabled.
+        composeTestRule.onNodeWithTag(SHEET_NAVIGATION_BUTTON_TAG).assertIsEnabled()
+    }
+
+    @Test
+    fun `top bar shows close icon on manage list and back icon on edit screen`() = launch {
+        managePage.waitUntilVisible()
+
+        // The manage list is the root screen, so the navigation button closes the sheet.
+        composeTestRule.onNodeWithContentDescription(
+            applicationContext.getString(R.string.stripe_paymentsheet_close)
+        ).assertIsDisplayed()
+
+        managePage.clickEdit()
+        managePage.clickEdit(cbcCardId)
+        editPage.waitUntilVisible()
+
+        // The edit screen is pushed on top, so the navigation button goes back.
+        composeTestRule.onNodeWithContentDescription(
+            applicationContext.getString(StripeUiCoreR.string.stripe_back)
+        ).assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Disable the top bar navigation button in the embedded payment sheet when a network operation is in progress (such as updating a card). Refactor navigation state handling to use StateFlow for network operations and update tests accordingly.

# Motivation
Ensures the navigation button is consistent with the system back button and swipe-to-dismiss, preventing navigation actions during in-flight network operations. Improves UX and prevents accidental interruptions.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Changed] Top bar navigation button is now disabled during network operations in the embedded payment sheet.