### PR TITLE
Make embedded selection holder an interface.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -342,6 +342,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         PREFETCHED_PMS_NULL_FOR_EPHEMERAL_KEY(
             partialEventName = "payment_methods_prefetch.null_for_ephemeral_key"
+        ),
+        CHECKOUT_SELECTION_SET_BEFORE_LOAD(
+            partialEventName = "checkout.selection_set_before_load"
         );
 
         override val eventName: String

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import android.graphics.Bitmap
+import android.os.Bundle
 import android.os.Parcelable
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -16,6 +17,10 @@ import kotlinx.parcelize.Parcelize
  * [configuration]. It is only ever built by [CheckoutStateLoader] after a payment element load, so
  * the resolved [paymentMethodMetadata] and [embeddedConfiguration] are always present; everything
  * the controller and its collaborators observe is derived from this one value.
+ *
+ * [CheckoutStateLoader] builds every committed state after a load, but the selection setters on
+ * [CheckoutControllerStateHolder] (which implements [EmbeddedSelectionHolder]) also [copy] it to
+ * update [paymentSelection]/[temporarySelection]/[previousNewSelections] without a reload.
  */
 @OptIn(CheckoutSessionPreview::class)
 @Parcelize
@@ -29,6 +34,8 @@ internal data class CheckoutControllerState(
     val paymentMethodMetadata: PaymentMethodMetadata,
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
     val paymentSelection: PaymentSelection?,
+    val temporarySelection: String?,
+    val previousNewSelections: Bundle,
 ) : Parcelable, CheckoutSessionData {
     override val shippingName: String? get() = collectedDetails.shippingName
     override val billingName: String? get() = collectedDetails.billingName

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -52,8 +52,8 @@ internal class CheckoutControllerStateHolder @Inject constructor(
     override val previousNewSelections: Bundle
         get() = state?.previousNewSelections ?: Bundle()
 
-    override fun set(updatedSelection: PaymentSelection?) {
-        val current = requireState(operation = "set") ?: return
+    override fun setSelection(updatedSelection: PaymentSelection?) {
+        val current = requireState(operation = "setSelection") ?: return
         val previousNewSelections = Bundle(current.previousNewSelections).apply {
             stashNewSelection(updatedSelection)
         }
@@ -63,8 +63,8 @@ internal class CheckoutControllerStateHolder @Inject constructor(
         )
     }
 
-    override fun setTemporary(code: PaymentMethodCode?) {
-        val current = requireState(operation = "setTemporary") ?: return
+    override fun setTemporarySelection(code: PaymentMethodCode?) {
+        val current = requireState(operation = "setTemporarySelection") ?: return
         state = current.copy(temporarySelection = code)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -1,7 +1,14 @@
 package com.stripe.android.checkout
 
+import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.previousNewSelection
+import com.stripe.android.paymentelement.embedded.stashNewSelection
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
@@ -13,12 +20,17 @@ import javax.inject.Singleton
  * projections (e.g. [checkoutSession]) are derived from the one [stateFlow]. Kept separate from the
  * controller so [CheckoutStateLoader] can commit loaded state directly rather than reaching back
  * into the controller.
+ *
+ * Implements [EmbeddedSelectionHolder] so the checkout Dagger graph resolves that interface to this
+ * holder: the payment element's selection state reads from and writes to [CheckoutControllerState]
+ * rather than a separate holder, keeping a single source of truth.
  */
 @OptIn(CheckoutSessionPreview::class)
 @Singleton
 internal class CheckoutControllerStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
-) {
+    private val errorReporter: ErrorReporter,
+) : EmbeddedSelectionHolder {
     var state: CheckoutControllerState?
         get() = savedStateHandle[STATE_KEY]
         set(value) {
@@ -30,6 +42,58 @@ internal class CheckoutControllerStateHolder @Inject constructor(
 
     val checkoutSession: StateFlow<CheckoutSession?> =
         stateFlow.mapAsStateFlow { it?.asCheckoutSession() }
+
+    override val selection: StateFlow<PaymentSelection?> =
+        stateFlow.mapAsStateFlow { it?.paymentSelection }
+
+    override val temporarySelection: StateFlow<String?> =
+        stateFlow.mapAsStateFlow { it?.temporarySelection }
+
+    override val previousNewSelections: Bundle
+        get() = state?.previousNewSelections ?: Bundle()
+
+    override fun set(updatedSelection: PaymentSelection?) {
+        val current = requireState(operation = "set") ?: return
+        val previousNewSelections = Bundle(current.previousNewSelections).apply {
+            stashNewSelection(updatedSelection)
+        }
+        state = current.copy(
+            paymentSelection = updatedSelection,
+            previousNewSelections = previousNewSelections,
+        )
+    }
+
+    override fun setTemporary(code: PaymentMethodCode?) {
+        val current = requireState(operation = "setTemporary") ?: return
+        state = current.copy(temporarySelection = code)
+    }
+
+    override fun setPreviousNewSelections(bundle: Bundle) {
+        val current = requireState(operation = "setPreviousNewSelections") ?: return
+        val previousNewSelections = Bundle(current.previousNewSelections).apply {
+            putAll(bundle)
+        }
+        state = current.copy(previousNewSelections = previousNewSelections)
+    }
+
+    override fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
+        return previousNewSelections.previousNewSelection(code)
+    }
+
+    /**
+     * The selection lives on [CheckoutControllerState], so the mutators can only act once
+     * [CheckoutStateLoader] has committed a state. A call before then is a programming error (a
+     * mis-ordered selection write); report it and no-op rather than silently dropping the value.
+     */
+    private fun requireState(operation: String): CheckoutControllerState? {
+        return state ?: run {
+            errorReporter.report(
+                errorEvent = ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SELECTION_SET_BEFORE_LOAD,
+                additionalNonPiiParams = mapOf("operation" to operation),
+            )
+            null
+        }
+    }
 
     companion object {
         const val STATE_KEY = "CheckoutController_InternalState"

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -20,10 +20,6 @@ import javax.inject.Singleton
  * projections (e.g. [checkoutSession]) are derived from the one [stateFlow]. Kept separate from the
  * controller so [CheckoutStateLoader] can commit loaded state directly rather than reaching back
  * into the controller.
- *
- * Implements [EmbeddedSelectionHolder] so the checkout Dagger graph resolves that interface to this
- * holder: the payment element's selection state reads from and writes to [CheckoutControllerState]
- * rather than a separate holder, keeping a single source of truth.
  */
 @OptIn(CheckoutSessionPreview::class)
 @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -12,18 +12,6 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 
-/**
- * Loads the payment element for a checkout session and, on success, commits the fully resolved
- * [CheckoutControllerState] — the single source of truth — to the [stateHolder]. Because the
- * resolved [CheckoutControllerState.paymentMethodMetadata] and
- * [CheckoutControllerState.embeddedConfiguration] are only known after a load, this loader is the
- * sole builder of load-resolved states: [loadInitial] builds the first one for a freshly configured
- * session, and [reload] rebuilds it after a mutation, carrying the previously collected data
- * forward. (The selection setters on [CheckoutControllerStateHolder] also commit states, by copying
- * an already-loaded one to update the selection fields, without going through this loader.) Extracted
- * from [CheckoutController] so the load-and-commit flow can be unit tested in isolation from the
- * controller.
- */
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
     @MerchantDisplayName private val merchantDisplayName: String,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import android.graphics.Bitmap
+import android.os.Bundle
 import com.stripe.android.checkout.injection.MerchantDisplayName
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -16,10 +17,12 @@ import javax.inject.Inject
  * [CheckoutControllerState] — the single source of truth — to the [stateHolder]. Because the
  * resolved [CheckoutControllerState.paymentMethodMetadata] and
  * [CheckoutControllerState.embeddedConfiguration] are only known after a load, this loader is the
- * sole builder of committed states: [loadInitial] builds the first one for a freshly configured
+ * sole builder of load-resolved states: [loadInitial] builds the first one for a freshly configured
  * session, and [reload] rebuilds it after a mutation, carrying the previously collected data
- * forward. Extracted from [CheckoutController] so the load-and-commit flow can be unit tested in
- * isolation from the controller.
+ * forward. (The selection setters on [CheckoutControllerStateHolder] also commit states, by copying
+ * an already-loaded one to update the selection fields, without going through this loader.) Extracted
+ * from [CheckoutController] so the load-and-commit flow can be unit tested in isolation from the
+ * controller.
  */
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
@@ -36,9 +39,7 @@ internal class CheckoutStateLoader @Inject constructor(
         commit(
             configuration = configuration,
             sessionData = InitialSessionData(checkoutSessionResponse),
-            cachedFlagImages = null,
-            previousSelection = null,
-            integrationLaunched = false,
+            carryForward = CarryForward.initial(),
         )
     }
 
@@ -46,24 +47,20 @@ internal class CheckoutStateLoader @Inject constructor(
         commit(
             configuration = state.configuration,
             sessionData = state,
-            cachedFlagImages = state.flagImages,
-            previousSelection = state.paymentSelection,
-            integrationLaunched = state.integrationLaunched,
+            carryForward = CarryForward.from(state),
         )
     }
 
     private suspend fun commit(
         configuration: CheckoutController.Configuration.State,
         sessionData: CheckoutSessionData,
-        cachedFlagImages: Map<String, Bitmap>?,
-        previousSelection: PaymentSelection?,
-        integrationLaunched: Boolean,
+        carryForward: CarryForward,
     ) {
         val response = sessionData.checkoutSessionResponse
 
-        // [cachedFlagImages] carries the previously resolved images forward, so they're reused when
-        // the currencies haven't changed.
-        val flagImages = flagImageResolver.resolve(response, cached = cachedFlagImages)
+        // [CarryForward.cachedFlagImages] carries the previously resolved images forward, so they're
+        // reused when the currencies haven't changed.
+        val flagImages = flagImageResolver.resolve(response, cached = carryForward.cachedFlagImages)
 
         val baseConfig = EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
             .embeddedViewDisplaysMandateText(
@@ -95,7 +92,7 @@ internal class CheckoutStateLoader @Inject constructor(
         val selection = selectionChooser.choose(
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
             paymentMethods = loaderState.customer?.paymentMethods,
-            previousSelection = previousSelection,
+            previousSelection = carryForward.previousSelection,
             newSelection = loaderState.paymentSelection,
             newConfiguration = embeddedConfig.asCommonConfiguration(),
             formSheetAction = embeddedConfig.formSheetAction,
@@ -107,11 +104,44 @@ internal class CheckoutStateLoader @Inject constructor(
             checkoutSessionResponse = response,
             flagImages = flagImages,
             collectedDetails = sessionData.toCollectedDetails(),
-            integrationLaunched = integrationLaunched,
+            integrationLaunched = carryForward.integrationLaunched,
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
             paymentSelection = selection,
+            temporarySelection = carryForward.temporarySelection,
+            previousNewSelections = carryForward.previousNewSelections,
         )
+    }
+
+    /**
+     * The fields carried from the prior state (or fresh defaults) into the next committed state, so a
+     * [reload] preserves everything the load itself doesn't recompute. Collapses [commit]'s parameter
+     * list into a single carrier.
+     */
+    private data class CarryForward(
+        val cachedFlagImages: Map<String, Bitmap>?,
+        val previousSelection: PaymentSelection?,
+        val temporarySelection: String?,
+        val previousNewSelections: Bundle,
+        val integrationLaunched: Boolean,
+    ) {
+        companion object {
+            fun initial() = CarryForward(
+                cachedFlagImages = null,
+                previousSelection = null,
+                temporarySelection = null,
+                previousNewSelections = Bundle(),
+                integrationLaunched = false,
+            )
+
+            fun from(state: CheckoutControllerState) = CarryForward(
+                cachedFlagImages = state.flagImages,
+                previousSelection = state.paymentSelection,
+                temporarySelection = state.temporarySelection,
+                previousNewSelections = state.previousNewSelections,
+                integrationLaunched = state.integrationLaunched,
+            )
+        }
     }
 
     /** The [CheckoutSessionData] for a first load: the session response with no collected details. */

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
@@ -181,6 +182,9 @@ internal interface CheckoutControllerModule {
 
     @Binds
     fun bindsEmbeddedSelectionChooser(impl: DefaultEmbeddedSelectionChooser): EmbeddedSelectionChooser
+
+    @Binds
+    fun bindsEmbeddedSelectionHolder(impl: CheckoutControllerStateHolder): EmbeddedSelectionHolder
 
     companion object {
         private const val CALLBACK_IDENTIFIER_KEY = "CheckoutController_CallbackIdentifier"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -150,7 +150,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
      * Sets the current [paymentOption] to `null`.
      */
     fun clearPaymentOption() {
-        selectionHolder.set(null)
+        selectionHolder.setSelection(null)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
@@ -21,13 +21,13 @@ internal class DefaultEmbeddedSelectionHolder @Inject constructor(
             savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = it
         }
 
-    override fun set(updatedSelection: PaymentSelection?) {
+    override fun setSelection(updatedSelection: PaymentSelection?) {
         savedStateHandle[EMBEDDED_SELECTION_KEY] = updatedSelection
         previousNewSelections.stashNewSelection(updatedSelection)
         savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = previousNewSelections
     }
 
-    override fun setTemporary(code: PaymentMethodCode?) {
+    override fun setTemporarySelection(code: PaymentMethodCode?) {
         savedStateHandle[EMBEDDED_TEMPORARY_SELECTION_KEY] = code
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.paymentelement.embedded
+
+import android.os.Bundle
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class DefaultEmbeddedSelectionHolder @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) : EmbeddedSelectionHolder {
+    override val selection: StateFlow<PaymentSelection?> =
+        savedStateHandle.getStateFlow(EMBEDDED_SELECTION_KEY, null)
+    override val temporarySelection: StateFlow<String?> =
+        savedStateHandle.getStateFlow(EMBEDDED_TEMPORARY_SELECTION_KEY, null)
+    override val previousNewSelections: Bundle = savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY]
+        ?: Bundle().also {
+            savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = it
+        }
+
+    override fun set(updatedSelection: PaymentSelection?) {
+        savedStateHandle[EMBEDDED_SELECTION_KEY] = updatedSelection
+        previousNewSelections.stashNewSelection(updatedSelection)
+        savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = previousNewSelections
+    }
+
+    override fun setTemporary(code: PaymentMethodCode?) {
+        savedStateHandle[EMBEDDED_TEMPORARY_SELECTION_KEY] = code
+    }
+
+    override fun setPreviousNewSelections(bundle: Bundle) {
+        this.previousNewSelections.putAll(bundle)
+        savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = previousNewSelections
+    }
+
+    override fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
+        return previousNewSelections.previousNewSelection(code)
+    }
+
+    companion object {
+        const val EMBEDDED_SELECTION_KEY = "EMBEDDED_SELECTION_KEY"
+        const val EMBEDDED_TEMPORARY_SELECTION_KEY = "EMBEDDED_TEMPORARY_SELECTION_KEY"
+        const val EMBEDDED_PREVIOUS_SELECTIONS_KEY = "EMBEDDED_PREVIOUS_SELECTIONS_KEY"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -180,7 +180,7 @@ internal interface EmbeddedActivityModule {
                     EmbeddedPaymentElement.FormSheetAction.Continue -> TapToAddMode.Continue
                     EmbeddedPaymentElement.FormSheetAction.Confirm -> TapToAddMode.Complete
                 },
-                updateSelection = embeddedSelectionHolder::set,
+                updateSelection = embeddedSelectionHolder::setSelection,
                 customerStateHolder = customerStateHolder,
                 linkSignupMode = stateFlowOf(paymentMethodMetadata.linkState?.signupMode),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -61,6 +61,11 @@ import kotlin.coroutines.CoroutineContext
 )
 internal interface EmbeddedCommonModule {
     @Binds
+    fun bindsEmbeddedSelectionHolder(
+        selectionHolder: DefaultEmbeddedSelectionHolder,
+    ): EmbeddedSelectionHolder
+
+    @Binds
     @Singleton
     fun bindsEventReporter(eventReporter: DefaultEventReporter): EventReporter
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
@@ -1,46 +1,36 @@
 package com.stripe.android.paymentelement.embedded
 
 import android.os.Bundle
-import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.paymentMethodType
 import kotlinx.coroutines.flow.StateFlow
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-internal class EmbeddedSelectionHolder @Inject constructor(
-    private val savedStateHandle: SavedStateHandle,
-) {
-    val selection: StateFlow<PaymentSelection?> = savedStateHandle.getStateFlow(EMBEDDED_SELECTION_KEY, null)
-    val temporarySelection: StateFlow<String?> = savedStateHandle.getStateFlow(EMBEDDED_TEMPORARY_SELECTION_KEY, null)
-    val previousNewSelections: Bundle = savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] ?: Bundle()
+/**
+ * Holds the payment element's current [selection] and [temporarySelection], plus the stash of
+ * previously entered new payment methods ([previousNewSelections]).
+ *
+ * Two implementations exist and their contracts differ in ways callers must respect:
+ * - [DefaultEmbeddedSelectionHolder] is standalone, backed directly by `SavedStateHandle`.
+ * - [com.stripe.android.checkout.CheckoutControllerStateHolder] projects the selection off the single
+ *   `CheckoutControllerState`. Its mutators ([set], [setTemporary], [setPreviousNewSelections]) require
+ *   a committed backing state; calls made before the element has loaded are dropped (and reported), so
+ *   do not mutate selection before load.
+ *
+ * Durability of [previousNewSelections] across process death is implementation-defined: the
+ * `CheckoutControllerState`-backed impl persists it, whereas [DefaultEmbeddedSelectionHolder] keeps it
+ * in memory only.
+ */
+// TODO: Rename methods since it's an interface now.
+internal interface EmbeddedSelectionHolder {
+    val selection: StateFlow<PaymentSelection?>
+    val temporarySelection: StateFlow<String?>
+    val previousNewSelections: Bundle
 
-    fun set(updatedSelection: PaymentSelection?) {
-        savedStateHandle[EMBEDDED_SELECTION_KEY] = updatedSelection
+    fun set(updatedSelection: PaymentSelection?)
 
-        if (updatedSelection != null && updatedSelection is PaymentSelection.New) {
-            previousNewSelections.putParcelable(updatedSelection.paymentMethodType, updatedSelection)
-        }
-    }
+    fun setTemporary(code: PaymentMethodCode?)
 
-    fun setTemporary(code: PaymentMethodCode?) {
-        savedStateHandle[EMBEDDED_TEMPORARY_SELECTION_KEY] = code
-    }
+    fun setPreviousNewSelections(bundle: Bundle)
 
-    fun setPreviousNewSelections(bundle: Bundle) {
-        this.previousNewSelections.putAll(bundle)
-    }
-
-    fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
-        @Suppress("DEPRECATION")
-        return previousNewSelections.getParcelable(code) as PaymentSelection.New?
-    }
-
-    companion object {
-        const val EMBEDDED_SELECTION_KEY = "EMBEDDED_SELECTION_KEY"
-        const val EMBEDDED_TEMPORARY_SELECTION_KEY = "EMBEDDED_TEMPORARY_SELECTION_KEY"
-        const val EMBEDDED_PREVIOUS_SELECTIONS_KEY = "EMBEDDED_PREVIOUS_SELECTIONS_KEY"
-    }
+    fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New?
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
@@ -5,21 +5,6 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.flow.StateFlow
 
-/**
- * Holds the payment element's current [selection] and [temporarySelection], plus the stash of
- * previously entered new payment methods ([previousNewSelections]).
- *
- * Two implementations exist and their contracts differ in ways callers must respect:
- * - [DefaultEmbeddedSelectionHolder] is standalone, backed directly by `SavedStateHandle`.
- * - [com.stripe.android.checkout.CheckoutControllerStateHolder] projects the selection off the single
- *   `CheckoutControllerState`. Its mutators ([setSelection], [setTemporarySelection],
- *   [setPreviousNewSelections]) require a committed backing state; calls made before the element has loaded
- *   are dropped (and reported), so do not mutate selection before load.
- *
- * Durability of [previousNewSelections] across process death is implementation-defined: the
- * `CheckoutControllerState`-backed impl persists it, whereas [DefaultEmbeddedSelectionHolder] keeps it
- * in memory only.
- */
 internal interface EmbeddedSelectionHolder {
     val selection: StateFlow<PaymentSelection?>
     val temporarySelection: StateFlow<String?>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
@@ -12,23 +12,22 @@ import kotlinx.coroutines.flow.StateFlow
  * Two implementations exist and their contracts differ in ways callers must respect:
  * - [DefaultEmbeddedSelectionHolder] is standalone, backed directly by `SavedStateHandle`.
  * - [com.stripe.android.checkout.CheckoutControllerStateHolder] projects the selection off the single
- *   `CheckoutControllerState`. Its mutators ([set], [setTemporary], [setPreviousNewSelections]) require
- *   a committed backing state; calls made before the element has loaded are dropped (and reported), so
- *   do not mutate selection before load.
+ *   `CheckoutControllerState`. Its mutators ([setSelection], [setTemporarySelection],
+ *   [setPreviousNewSelections]) require a committed backing state; calls made before the element has loaded
+ *   are dropped (and reported), so do not mutate selection before load.
  *
  * Durability of [previousNewSelections] across process death is implementation-defined: the
  * `CheckoutControllerState`-backed impl persists it, whereas [DefaultEmbeddedSelectionHolder] keeps it
  * in memory only.
  */
-// TODO: Rename methods since it's an interface now.
 internal interface EmbeddedSelectionHolder {
     val selection: StateFlow<PaymentSelection?>
     val temporarySelection: StateFlow<String?>
     val previousNewSelections: Bundle
 
-    fun set(updatedSelection: PaymentSelection?)
+    fun setSelection(updatedSelection: PaymentSelection?)
 
-    fun setTemporary(code: PaymentMethodCode?)
+    fun setTemporarySelection(code: PaymentMethodCode?)
 
     fun setPreviousNewSelections(bundle: Bundle)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/PreviousNewSelections.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/PreviousNewSelections.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentelement.embedded
+
+import android.os.Bundle
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
+
+/**
+ * Stashes [selection] into this bundle, keyed by its payment method type, when it is a
+ * [PaymentSelection.New] — so a previously entered new payment method can be restored later. No-op for
+ * a null or non-[PaymentSelection.New] selection.
+ *
+ * Shared by the [EmbeddedSelectionHolder] implementations so their stash/lookup logic can't drift.
+ */
+internal fun Bundle.stashNewSelection(selection: PaymentSelection?) {
+    if (selection is PaymentSelection.New) {
+        putParcelable(selection.paymentMethodType, selection)
+    }
+}
+
+/** Returns the previously stashed [PaymentSelection.New] for [code], or null if none. */
+internal fun Bundle.previousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
+    @Suppress("DEPRECATION")
+    return getParcelable(code) as PaymentSelection.New?
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/PreviousNewSelections.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/PreviousNewSelections.kt
@@ -5,20 +5,12 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 
-/**
- * Stashes [selection] into this bundle, keyed by its payment method type, when it is a
- * [PaymentSelection.New] — so a previously entered new payment method can be restored later. No-op for
- * a null or non-[PaymentSelection.New] selection.
- *
- * Shared by the [EmbeddedSelectionHolder] implementations so their stash/lookup logic can't drift.
- */
 internal fun Bundle.stashNewSelection(selection: PaymentSelection?) {
     if (selection is PaymentSelection.New) {
         putParcelable(selection.paymentMethodType, selection)
     }
 }
 
-/** Returns the previously stashed [PaymentSelection.New] for [code], or null if none. */
 internal fun Bundle.previousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
     @Suppress("DEPRECATION")
     return getParcelable(code) as PaymentSelection.New?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -73,7 +73,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             sheetStateHolder.sheetIsOpen = false
             when (result.launchMode) {
                 is EmbeddedLaunchMode.Form -> {
-                    selectionHolder.setTemporary(null)
+                    selectionHolder.setTemporarySelection(null)
                     handleFormResult(result)
                 }
                 is EmbeddedLaunchMode.Manage -> handleManageResult(result)
@@ -84,7 +84,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.set(result.selection)
+                selectionHolder.setSelection(result.selection)
                 if (result.hasBeenConfirmed) {
                     embeddedResultCallbackHelper.setResult(
                         EmbeddedPaymentElement.Result.Completed()
@@ -107,7 +107,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.set(result.selection)
+                selectionHolder.setSelection(result.selection)
                 if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
                     rowSelectionImmediateActionHandler.invoke()
                 }
@@ -137,7 +137,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        selectionHolder.setTemporary(code)
+        selectionHolder.setTemporarySelection(code)
         val currentSelection = (selectionHolder.selection.value as? PaymentSelection.New?)
             .takeIf { it?.paymentMethodType == code }
             ?: selectionHolder.getPreviousNewSelection(code)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -323,7 +323,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     }
 
     private fun setSelection(paymentSelection: PaymentSelection?) {
-        selectionHolder.set(paymentSelection)
+        selectionHolder.setSelection(paymentSelection)
     }
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -50,7 +50,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
         confirmationStateHolder.state = state.confirmationState
         customerStateHolder.setCustomerState(state.customer)
         selectionHolder.setPreviousNewSelections(state.previousNewSelections)
-        selectionHolder.set(state.confirmationState.selection)
+        selectionHolder.setSelection(state.confirmationState.selection)
         embeddedContentHelper.dataLoaded(
             paymentMethodMetadata = state.confirmationState.paymentMethodMetadata,
             appearance = state.confirmationState.configuration.appearance.embeddedAppearance,
@@ -80,7 +80,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     private fun clearState() {
         embeddedContentHelper.clearEmbeddedContent()
         confirmationStateHolder.state = null
-        selectionHolder.set(null)
+        selectionHolder.setSelection(null)
         selectionHolder.previousNewSelections.clear()
         customerStateHolder.setCustomerState(null)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -45,7 +45,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
                     selectedPaymentMethodCode = paymentMethodCode,
                     paymentMethodMetadata = paymentMethodMetadata,
                 ),
-            selectionUpdater = { embeddedSelectionHolder.set(it) },
+            selectionUpdater = { embeddedSelectionHolder.setSelection(it) },
             tapToAddHelper = tapToAddHelper,
             // If no saved payment methods, then first saved payment method is automatically set as default
             setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
@@ -60,7 +60,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
         val formType = formHelper.formTypeForCode(paymentMethodCode)
         val formArguments = formHelper.createFormArguments(paymentMethodCode)
         if (formType is FormHelper.FormType.MandateOnly) {
-            embeddedSelectionHolder.set(
+            embeddedSelectionHolder.setSelection(
                 formArguments.noUserInteractionFormFieldValues().transformToPaymentSelection(
                     paymentMethod = requireNotNull(
                         paymentMethodMetadata.supportedPaymentMethodForCode(code = paymentMethodCode)
@@ -100,7 +100,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             paymentMethodMetadata = paymentMethodMetadata,
             selectedPaymentMethodCode = paymentMethodCode,
             hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
-            setSelection = embeddedSelectionHolder::set,
+            setSelection = embeddedSelectionHolder::setSelection,
             hasSavedPaymentMethods = hasSavedPaymentMethods,
             onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
             onMandateTextChanged = { mandateText, _ ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
@@ -34,7 +34,7 @@ internal class DefaultEmbeddedManageScreenInteractorFactory @Inject constructor(
             toggleEdit = savedPaymentMethodMutator::toggleEditing,
             onSelectPaymentMethod = {
                 val savedPmSelection = PaymentSelection.Saved(it.paymentMethod)
-                selectionHolder.set(savedPmSelection)
+                selectionHolder.setSelection(savedPmSelection)
                 eventReporter.onSelectPaymentOption(savedPmSelection)
                 embeddedNavigatorProvider.get().performAction(
                     EmbeddedNavigator.Action.Close(shouldInvokeRowSelectionCallback = true)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -45,7 +45,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 if (result == null) {
                     val currentSelection = selectionHolder.selection.value
                     if (method.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
-                        selectionHolder.set(null)
+                        selectionHolder.setSelection(null)
                     }
                 }
                 result
@@ -57,7 +57,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                     onSuccess = { paymentMethod ->
                         val currentSelection = selectionHolder.selection.value
                         if (paymentMethod.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
-                            selectionHolder.set(PaymentSelection.Saved(paymentMethod))
+                            selectionHolder.setSelection(PaymentSelection.Saved(paymentMethod))
                         }
                     },
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
@@ -42,7 +42,7 @@ internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
             uiContext = uiContext,
             savedPaymentMethodRepository = savedPaymentMethodRepository,
             selection = selectionHolder.selection,
-            setSelection = selectionHolder::set,
+            setSelection = selectionHolder::setSelection,
             customerStateHolder = customerStateHolder,
             prePaymentMethodRemoveActions = {
                 if (customerStateHolder.paymentMethods.value.size > 1) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -209,7 +209,7 @@ internal class EmbeddedNavigator private constructor(
                         )
                     },
                     state = state,
-                    updateSelection = embeddedSelectionHolder::set,
+                    updateSelection = embeddedSelectionHolder::setSelection,
                     savedPaymentMethodConfirmInteractorFactory = savedPaymentMethodConfirmInteractorFactory,
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -37,7 +37,7 @@ internal class EmbeddedSheetViewModel @Inject constructor(
             )
 
             component.customerStateHolder.setCustomerState(args.customerState)
-            component.selectionHolder.set(args.selection)
+            component.selectionHolder.setSelection(args.selection)
 
             return component.viewModel as T
         }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -1,0 +1,166 @@
+package com.stripe.android.checkout
+
+import android.os.Bundle
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.previousNewSelection
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutControllerStateHolderTest {
+    @Test
+    fun `selection projects paymentSelection from the committed state`() = testScenario {
+        stateHolder.state = committedState(paymentSelection = PaymentSelection.GooglePay)
+
+        assertThat(stateHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `set updates paymentSelection on the state and emits`() = testScenario {
+        stateHolder.state = committedState()
+
+        stateHolder.selection.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.set(PaymentSelection.GooglePay)
+            assertThat(awaitItem()).isEqualTo(PaymentSelection.GooglePay)
+        }
+
+        assertThat(stateHolder.state?.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `set with a new selection emits on selection and stashes it into previousNewSelections`() = testScenario {
+        val originalPreviousNewSelections = Bundle()
+        stateHolder.state = committedState(previousNewSelections = originalPreviousNewSelections)
+
+        stateHolder.selection.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            assertThat(awaitItem()).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        }
+
+        assertThat(stateHolder.state?.paymentSelection).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        assertThat(stateHolder.state?.previousNewSelections).isNotSameInstanceAs(originalPreviousNewSelections)
+        assertThat(originalPreviousNewSelections.isEmpty).isTrue()
+        assertThat(stateHolder.getPreviousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `setTemporary updates temporarySelection on the state and emits`() = testScenario {
+        stateHolder.state = committedState()
+
+        stateHolder.temporarySelection.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.setTemporary("card")
+            assertThat(awaitItem()).isEqualTo("card")
+        }
+
+        assertThat(stateHolder.state?.temporarySelection).isEqualTo("card")
+    }
+
+    @Test
+    fun `setPreviousNewSelections merges into the existing previousNewSelections rather than replacing`() =
+        testScenario {
+            val originalPreviousNewSelections = Bundle().apply {
+                putParcelable("card", PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            }
+            stateHolder.state = committedState(
+                previousNewSelections = originalPreviousNewSelections,
+            )
+
+            val bundle = Bundle().apply {
+                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            }
+            stateHolder.setPreviousNewSelections(bundle)
+
+            assertThat(stateHolder.state?.previousNewSelections).isNotSameInstanceAs(originalPreviousNewSelections)
+            assertThat(stateHolder.getPreviousNewSelection("card"))
+                .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            assertThat(stateHolder.getPreviousNewSelection("cashapp"))
+                .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            assertThat(originalPreviousNewSelections.previousNewSelection("cashapp")).isNull()
+        }
+
+    @Test
+    fun `selection setters no-op before the state is committed`() = testScenario {
+        stateHolder.set(PaymentSelection.GooglePay)
+        stateHolder.setTemporary("card")
+        stateHolder.setPreviousNewSelections(
+            Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
+        )
+
+        assertThat(stateHolder.state).isNull()
+        assertThat(stateHolder.selection.value).isNull()
+        assertThat(stateHolder.temporarySelection.value).isNull()
+        assertThat(stateHolder.getPreviousNewSelection("cashapp")).isNull()
+    }
+
+    @Test
+    fun `projects selection, temporarySelection and previousNewSelections from a restored state`() = runTest {
+        // Simulates process-death restore: a committed state is read back from SavedStateHandle by a
+        // freshly constructed holder, and every selection projection must reflect it.
+        val restored = committedState(
+            paymentSelection = PaymentSelection.GooglePay,
+            temporarySelection = "card",
+            previousNewSelections = Bundle().apply {
+                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            },
+        )
+        val stateHolder = CheckoutControllerStateHolder(
+            savedStateHandle = SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restored)),
+            errorReporter = FakeErrorReporter(),
+        )
+
+        assertThat(stateHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(stateHolder.temporarySelection.value).isEqualTo("card")
+        assertThat(stateHolder.getPreviousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    private fun committedState(
+        paymentSelection: PaymentSelection? = null,
+        temporarySelection: String? = null,
+        previousNewSelections: Bundle = Bundle(),
+    ) = CheckoutControllerState(
+        key = DEFAULT_KEY,
+        configuration = CheckoutController.Configuration().build(),
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+        flagImages = null,
+        collectedDetails = CheckoutCollectedDetails(),
+        integrationLaunched = false,
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        paymentSelection = paymentSelection,
+        temporarySelection = temporarySelection,
+        previousNewSelections = previousNewSelections,
+    )
+
+    private fun testScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        Scenario(
+            stateHolder = CheckoutControllerStateHolder(SavedStateHandle(), FakeErrorReporter()),
+        ).block()
+    }
+
+    private class Scenario(
+        val stateHolder: CheckoutControllerStateHolder,
+    )
+
+    private companion object {
+        const val DEFAULT_KEY = "test_key"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.previousNewSelection
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeErrorReporter
@@ -97,10 +98,15 @@ internal class CheckoutControllerStateHolderTest {
     @Test
     fun `selection setters no-op before the state is committed`() = testScenario {
         stateHolder.setSelection(PaymentSelection.GooglePay)
+        assertSetBeforeLoadError(operation = "setSelection")
+
         stateHolder.setTemporarySelection("card")
+        assertSetBeforeLoadError(operation = "setTemporarySelection")
+
         stateHolder.setPreviousNewSelections(
             Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
         )
+        assertSetBeforeLoadError(operation = "setPreviousNewSelections")
 
         assertThat(stateHolder.state).isNull()
         assertThat(stateHolder.selection.value).isNull()
@@ -151,13 +157,24 @@ internal class CheckoutControllerStateHolderTest {
     private fun testScenario(
         block: suspend Scenario.() -> Unit,
     ) = runTest {
+        val errorReporter = FakeErrorReporter()
         Scenario(
-            stateHolder = CheckoutControllerStateHolder(SavedStateHandle(), FakeErrorReporter()),
+            stateHolder = CheckoutControllerStateHolder(SavedStateHandle(), errorReporter),
+            errorReporter = errorReporter,
         ).block()
+        errorReporter.ensureAllEventsConsumed()
+    }
+
+    private suspend fun Scenario.assertSetBeforeLoadError(operation: String) {
+        val call = errorReporter.awaitCall()
+        assertThat(call.errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SELECTION_SET_BEFORE_LOAD)
+        assertThat(call.additionalNonPiiParams).isEqualTo(mapOf("operation" to operation))
     }
 
     private class Scenario(
         val stateHolder: CheckoutControllerStateHolder,
+        val errorReporter: FakeErrorReporter,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -28,12 +28,12 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
-    fun `set updates paymentSelection on the state and emits`() = testScenario {
+    fun `setSelection updates paymentSelection on the state and emits`() = testScenario {
         stateHolder.state = committedState()
 
         stateHolder.selection.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.set(PaymentSelection.GooglePay)
+            stateHolder.setSelection(PaymentSelection.GooglePay)
             assertThat(awaitItem()).isEqualTo(PaymentSelection.GooglePay)
         }
 
@@ -41,13 +41,13 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
-    fun `set with a new selection emits on selection and stashes it into previousNewSelections`() = testScenario {
+    fun `setSelection with a new selection emits and stashes it into previousNewSelections`() = testScenario {
         val originalPreviousNewSelections = Bundle()
         stateHolder.state = committedState(previousNewSelections = originalPreviousNewSelections)
 
         stateHolder.selection.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            stateHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
             assertThat(awaitItem()).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         }
 
@@ -59,12 +59,12 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
-    fun `setTemporary updates temporarySelection on the state and emits`() = testScenario {
+    fun `setTemporarySelection updates temporarySelection on the state and emits`() = testScenario {
         stateHolder.state = committedState()
 
         stateHolder.temporarySelection.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.setTemporary("card")
+            stateHolder.setTemporarySelection("card")
             assertThat(awaitItem()).isEqualTo("card")
         }
 
@@ -96,8 +96,8 @@ internal class CheckoutControllerStateHolderTest {
 
     @Test
     fun `selection setters no-op before the state is committed`() = testScenario {
-        stateHolder.set(PaymentSelection.GooglePay)
-        stateHolder.setTemporary("card")
+        stateHolder.setSelection(PaymentSelection.GooglePay)
+        stateHolder.setTemporarySelection("card")
         stateHolder.setPreviousNewSelections(
             Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.CleanupTestRule
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -199,7 +200,7 @@ internal class CheckoutControllerTest {
         val savedStateHandle = SavedStateHandle()
         val controller = createController(savedStateHandle)
         assertThat(controller.checkoutSession.value).isNull()
-        assertThat(CheckoutControllerStateHolder(savedStateHandle).state).isNull()
+        assertThat(CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state).isNull()
     }
 
     @Test
@@ -224,7 +225,7 @@ internal class CheckoutControllerTest {
 
         // A fresh state holder over the same SavedStateHandle simulates the controller being
         // rebuilt after process death: the committed state is read back from persisted storage.
-        val state = CheckoutControllerStateHolder(savedStateHandle).state
+        val state = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state
         assertThat(state).isNotNull()
         assertThat(state!!.embeddedConfiguration.merchantDisplayName)
             .isEqualTo(expectedMerchantDisplayName)
@@ -920,7 +921,7 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         val committedState: CheckoutControllerState?
-            get() = CheckoutControllerStateHolder(savedStateHandle).state
+            get() = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state
     }
 
     // Configures a controller from a fresh init, then hands it to [block] alongside the shared
@@ -977,12 +978,12 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         fun committedState(): CheckoutControllerState =
-            requireNotNull(CheckoutControllerStateHolder(savedStateHandle).state)
+            requireNotNull(CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state)
 
         // Simulates a presented payment flow by flipping the committed state's integrationLaunched
         // flag, which the mutation guard reads back through the same SavedStateHandle.
         fun markIntegrationLaunched() {
-            val stateHolder = CheckoutControllerStateHolder(savedStateHandle)
+            val stateHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter())
             stateHolder.state = committedState().copy(integrationLaunched = true)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.graphics.Bitmap
+import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -15,7 +16,6 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
@@ -106,7 +107,7 @@ internal class CheckoutStateLoaderTest {
                 savedStateHandle = savedStateHandle,
                 formHelperFactory = EmbeddedFormHelperFactory(
                     linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-                    embeddedSelectionHolder = EmbeddedSelectionHolder(savedStateHandle),
+                    embeddedSelectionHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()),
                     cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                     savedStateHandle = savedStateHandle,
                 ),
@@ -168,6 +169,39 @@ internal class CheckoutStateLoaderTest {
         imageLoader.ensureAllEventsConsumed()
     }
 
+    @Test
+    fun `reload carries the temporary selection and previous new selections forward`() = runScenario {
+        val seeded = committedState(
+            temporarySelection = "card",
+            previousNewSelections = Bundle().apply {
+                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            },
+        )
+
+        loader.reload(seeded)
+
+        assertThat(stateHolder.state?.temporarySelection).isEqualTo("card")
+        assertThat(stateHolder.getPreviousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `loadInitial resets the temporary selection and previous new selections`() = runScenario {
+        // A prior state carries a temporary selection and a stashed new payment method; a fresh
+        // configuration load must start from a clean slate rather than carrying them forward.
+        stateHolder.state = committedState(
+            temporarySelection = "card",
+            previousNewSelections = Bundle().apply {
+                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            },
+        )
+
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        assertThat(stateHolder.state?.temporarySelection).isNull()
+        assertThat(stateHolder.getPreviousNewSelection("cashapp")).isNull()
+    }
+
     private fun defaultConfiguration() = CheckoutController.Configuration().build()
 
     private fun response() = CheckoutSessionResponseFactory.create()
@@ -176,6 +210,8 @@ internal class CheckoutStateLoaderTest {
     // resolved metadata/configuration are placeholders; reload recomputes and overwrites them.
     private fun committedState(
         paymentSelection: PaymentSelection? = null,
+        temporarySelection: String? = null,
+        previousNewSelections: Bundle = Bundle(),
         checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
     ) = CheckoutControllerState(
         key = checkoutSessionResponse.id,
@@ -187,6 +223,8 @@ internal class CheckoutStateLoaderTest {
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection = paymentSelection,
+        temporarySelection = temporarySelection,
+        previousNewSelections = previousNewSelections,
     )
 
     // Adaptive pricing (usd → eur) drives flag image resolution during load.
@@ -228,7 +266,7 @@ internal class CheckoutStateLoaderTest {
             ),
         )
         val savedStateHandle = SavedStateHandle()
-        val stateHolder = CheckoutControllerStateHolder(savedStateHandle)
+        val stateHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter())
         val recordingChooser = RecordingSelectionChooser(chosenSelection)
         val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
         val loader = CheckoutStateLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.checkout.CheckoutStateFactory
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationCoordinator
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationHelper
 import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
@@ -70,7 +70,7 @@ internal class EmbeddedPaymentElementTest {
                 override fun confirm() = error("Not expected")
             },
             contentHelper = FakeEmbeddedContentHelper(),
-            selectionHolder = EmbeddedSelectionHolder(SavedStateHandle()),
+            selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
             paymentOptionDisplayDataHolder = object : PaymentOptionDisplayDataHolder {
                 override val paymentOption = MutableStateFlow<EmbeddedPaymentElement.PaymentOptionDisplayData?>(null)
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
@@ -6,12 +6,15 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder.Companion.EMBEDDED_PREVIOUS_SELECTIONS_KEY
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder.Companion.EMBEDDED_SELECTION_KEY
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder.Companion.EMBEDDED_TEMPORARY_SELECTION_KEY
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-internal class EmbeddedSelectionHolderTest {
+internal class DefaultEmbeddedSelectionHolderTest {
     @Test
     fun `setting selection emits value in selection state flow`() = testScenario {
         selectionHolder.selection.test {
@@ -23,10 +26,10 @@ internal class EmbeddedSelectionHolderTest {
 
     @Test
     fun `setting selection updates savedStateHandle`() = testScenario {
-        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isNull()
         selectionHolder.set(PaymentSelection.GooglePay)
-        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isEqualTo(PaymentSelection.GooglePay)
     }
 
@@ -39,15 +42,36 @@ internal class EmbeddedSelectionHolderTest {
     }
 
     @Test
+    fun `initializing with empty savedStateHandle stores previousNewSelections bundle`() = testScenario {
+        val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
+
+        assertThat(savedBundle).isNotNull()
+        assertThat(savedBundle?.isEmpty).isTrue()
+    }
+
+    @Test
+    fun `setting new selection persists previousNewSelections in savedStateHandle`() = testScenario {
+        selectionHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+
+        val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
+        assertThat(savedBundle?.previousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+
+        val restoredHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+        assertThat(restoredHolder.getPreviousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    @Test
     fun `initializing with selection in savedStateHandle sets initial value`() = testScenario(
         setup = {
-            set(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY, PaymentSelection.GooglePay)
+            set(EMBEDDED_SELECTION_KEY, PaymentSelection.GooglePay)
         },
     ) {
-        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isEqualTo(PaymentSelection.GooglePay)
         selectionHolder.set(null)
-        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isNull()
     }
 
@@ -55,7 +79,7 @@ internal class EmbeddedSelectionHolderTest {
     fun `initializing with previousNewSelections in savedStateHandle sets initial value`() = testScenario(
         setup = {
             set(
-                EmbeddedSelectionHolder.EMBEDDED_PREVIOUS_SELECTIONS_KEY,
+                EMBEDDED_PREVIOUS_SELECTIONS_KEY,
                 Bundle().apply {
                     putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
                 }
@@ -77,23 +101,23 @@ internal class EmbeddedSelectionHolderTest {
 
     @Test
     fun `setting temporarySelection updates savedStateHandle`() = testScenario {
-        assertThat(savedStateHandle.get<PaymentMethodCode?>(EmbeddedSelectionHolder.EMBEDDED_TEMPORARY_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isNull()
         selectionHolder.setTemporary("card")
-        assertThat(savedStateHandle.get<PaymentMethodCode?>(EmbeddedSelectionHolder.EMBEDDED_TEMPORARY_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isEqualTo("card")
     }
 
     @Test
     fun `initializing with temporarySelection in savedStateHandle sets initial value`() = testScenario(
         setup = {
-            set(EmbeddedSelectionHolder.EMBEDDED_TEMPORARY_SELECTION_KEY, "card")
+            set(EMBEDDED_TEMPORARY_SELECTION_KEY, "card")
         },
     ) {
-        assertThat(savedStateHandle.get<PaymentMethodCode?>(EmbeddedSelectionHolder.EMBEDDED_TEMPORARY_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isEqualTo("card")
         selectionHolder.setTemporary(null)
-        assertThat(savedStateHandle.get<PaymentMethodCode?>(EmbeddedSelectionHolder.EMBEDDED_TEMPORARY_SELECTION_KEY))
+        assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isNull()
     }
 
@@ -108,6 +132,19 @@ internal class EmbeddedSelectionHolderTest {
         assertThat(selectionHolder.previousNewSelections.size()).isEqualTo(1)
     }
 
+    @Test
+    fun `setting previousNewSelections persists bundle in savedStateHandle`() = testScenario {
+        val previousNewSelections = Bundle().apply {
+            putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        }
+
+        selectionHolder.setPreviousNewSelections(previousNewSelections)
+
+        val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
+        assertThat(savedBundle?.previousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
     private class Scenario(
         val selectionHolder: EmbeddedSelectionHolder,
         val savedStateHandle: SavedStateHandle,
@@ -120,7 +157,7 @@ internal class EmbeddedSelectionHolderTest {
         val savedStateHandle = SavedStateHandle()
         setup(savedStateHandle)
         Scenario(
-            selectionHolder = EmbeddedSelectionHolder(savedStateHandle),
+            selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle),
             savedStateHandle = savedStateHandle,
         ).block()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
@@ -19,7 +19,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     fun `setting selection emits value in selection state flow`() = testScenario {
         selectionHolder.selection.test {
             assertThat(awaitItem()).isNull()
-            selectionHolder.set(PaymentSelection.GooglePay)
+            selectionHolder.setSelection(PaymentSelection.GooglePay)
             assertThat(awaitItem()?.paymentMethodType).isEqualTo("google_pay")
         }
     }
@@ -28,7 +28,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     fun `setting selection updates savedStateHandle`() = testScenario {
         assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isNull()
-        selectionHolder.set(PaymentSelection.GooglePay)
+        selectionHolder.setSelection(PaymentSelection.GooglePay)
         assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isEqualTo(PaymentSelection.GooglePay)
     }
@@ -36,7 +36,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     @Test
     fun `setting selection updates previousNewSelections`() = testScenario {
         assertThat(selectionHolder.previousNewSelections.isEmpty).isTrue()
-        selectionHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         assertThat(selectionHolder.previousNewSelections.isEmpty).isFalse()
         assertThat(selectionHolder.previousNewSelections.size()).isEqualTo(1)
     }
@@ -51,7 +51,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
 
     @Test
     fun `setting new selection persists previousNewSelections in savedStateHandle`() = testScenario {
-        selectionHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
         val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
         assertThat(savedBundle?.previousNewSelection("cashapp"))
@@ -70,7 +70,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     ) {
         assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isEqualTo(PaymentSelection.GooglePay)
-        selectionHolder.set(null)
+        selectionHolder.setSelection(null)
         assertThat(savedStateHandle.get<PaymentSelection?>(EMBEDDED_SELECTION_KEY))
             .isNull()
     }
@@ -94,7 +94,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     fun `setting temporarySelection emits value in temporarySelection state flow`() = testScenario {
         selectionHolder.temporarySelection.test {
             assertThat(awaitItem()).isNull()
-            selectionHolder.setTemporary("card")
+            selectionHolder.setTemporarySelection("card")
             assertThat(awaitItem()).isEqualTo("card")
         }
     }
@@ -103,7 +103,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     fun `setting temporarySelection updates savedStateHandle`() = testScenario {
         assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isNull()
-        selectionHolder.setTemporary("card")
+        selectionHolder.setTemporarySelection("card")
         assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isEqualTo("card")
     }
@@ -116,7 +116,7 @@ internal class DefaultEmbeddedSelectionHolderTest {
     ) {
         assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isEqualTo("card")
-        selectionHolder.setTemporary(null)
+        selectionHolder.setTemporarySelection(null)
         assertThat(savedStateHandle.get<PaymentMethodCode?>(EMBEDDED_TEMPORARY_SELECTION_KEY))
             .isNull()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactoryTest.kt
@@ -99,7 +99,7 @@ internal class EmbeddedFormHelperFactoryTest {
         openCardScanAutomatically: Boolean,
     ): AutomaticallyLaunchedCardScanFormDataHelper {
         val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
-        selectionHolder.set(selection)
+        selectionHolder.setSelection(selection)
         val factory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             embeddedSelectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactoryTest.kt
@@ -98,7 +98,7 @@ internal class EmbeddedFormHelperFactoryTest {
         selection: PaymentSelection?,
         openCardScanAutomatically: Boolean,
     ): AutomaticallyLaunchedCardScanFormDataHelper {
-        val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         selectionHolder.set(selection)
         val factory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
@@ -119,7 +119,7 @@ internal class EmbeddedFormHelperFactoryTest {
     ): CardDetailsAction? {
         val factory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            embeddedSelectionHolder = EmbeddedSelectionHolder(SavedStateHandle()),
+            embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             savedStateHandle = SavedStateHandle(),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
@@ -90,7 +90,7 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
             )
         )
 
-        selectionHolder.set(PaymentSelection.GooglePay)
+        selectionHolder.setSelection(PaymentSelection.GooglePay)
         assertThat(confirmationStateHolder.state).isNull()
 
         assertThat(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -196,7 +197,7 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         val confirmationHandler = FakeConfirmationHandler()
         val configurationHandler = FakeEmbeddedConfigurationHandler()
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(
             savedStateHandle = savedStateHandle,
             selectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -139,7 +139,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         val confirmationHandler = FakeConfirmationHandler()
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
-        selectionHolder.set(loadedState?.selection)
+        selectionHolder.setSelection(loadedState?.selection)
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(
             savedStateHandle = savedStateHandle,
             selectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -138,7 +138,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         selectionHolder.set(loadedState?.selection)
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(
             savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -10,8 +10,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper.Companion.STATE_KEY_EMBEDDED_CONTENT
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
@@ -139,7 +139,7 @@ internal class DefaultEmbeddedContentHelperTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
         val savedStateHandle = SavedStateHandle().apply { setup() }
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
@@ -10,8 +10,8 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_CONFIGURATION_KEY
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_PAYMENT_METHOD_METADATA_KEY
@@ -479,7 +479,7 @@ internal class DefaultEmbeddedSelectionChooserTest {
         val savedStateHandle = SavedStateHandle()
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            embeddedSelectionHolder = EmbeddedSelectionHolder(savedStateHandle),
+            embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             savedStateHandle = savedStateHandle,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -109,7 +109,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val code = "card"
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val state = EmbeddedConfirmationStateFixtures.defaultState()
-        selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -126,8 +126,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val code = "card"
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val state = EmbeddedConfirmationStateFixtures.defaultState()
-        selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-        selectionHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -144,7 +144,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val code = "card"
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val state = EmbeddedConfirmationStateFixtures.defaultState()
-        selectionHolder.set(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+        selectionHolder.setSelection(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -161,7 +161,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val code = "card"
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val state = EmbeddedConfirmationStateFixtures.defaultState()
-        selectionHolder.set(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -211,7 +211,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
     @Test
     fun `formActivityLauncher clears selection holder and invokes callback on complete result`() = testScenario {
         val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-        selectionHolder.set(selection)
+        selectionHolder.setSelection(selection)
         launchForm("test_code")
 
         val result = EmbeddedActivityResult.Complete(
@@ -235,7 +235,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         shouldRowSelectionBeInvoked = true
     ) {
         val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-        selectionHolder.set(selection)
+        selectionHolder.setSelection(selection)
         launchForm("cashapp")
 
         val result = EmbeddedActivityResult.Complete(
@@ -261,7 +261,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             shouldRowSelectionBeInvoked = true
         ) {
             val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-            selectionHolder.set(selection)
+            selectionHolder.setSelection(selection)
             launchForm("cashapp")
 
             val result = EmbeddedActivityResult.Complete(
@@ -283,7 +283,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             shouldRowSelectionBeInvoked = false
         ) {
             val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-            selectionHolder.set(selection)
+            selectionHolder.setSelection(selection)
             launchForm("cashapp")
 
             val result = EmbeddedActivityResult.Complete(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
@@ -626,7 +627,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         var rowSelectionCallbackInvoked = false
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -207,7 +208,7 @@ internal class DefaultEmbeddedStateHelperTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultPaymentOptionDisplayDataHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultPaymentOptionDisplayDataHolderTest.kt
@@ -21,7 +21,7 @@ internal class DefaultPaymentOptionDisplayDataHolderTest {
     fun `null confirmationState emits null paymentOption`() = testScenario {
         paymentOptionDisplayDataHolder.paymentOption.test {
             assertThat(awaitItem()).isNull()
-            selectionHolder.set(PaymentSelection.GooglePay)
+            selectionHolder.setSelection(PaymentSelection.GooglePay)
         }
     }
 
@@ -31,7 +31,7 @@ internal class DefaultPaymentOptionDisplayDataHolderTest {
     ) {
         paymentOptionDisplayDataHolder.paymentOption.test {
             assertThat(awaitItem()).isNull()
-            selectionHolder.set(PaymentSelection.GooglePay)
+            selectionHolder.setSelection(PaymentSelection.GooglePay)
             assertThat(awaitItem()?.paymentMethodType).isEqualTo("google_pay")
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultPaymentOptionDisplayDataHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultPaymentOptionDisplayDataHolderTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.test.runTest
@@ -44,7 +45,7 @@ internal class DefaultPaymentOptionDisplayDataHolderTest {
             cardArtDrawableLoader = { null },
             context = ApplicationProvider.getApplicationContext(),
         )
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle = SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle = SavedStateHandle())
         Scenario(
             paymentOptionDisplayDataHolder = DefaultPaymentOptionDisplayDataHolder(
                 coroutineScope = backgroundScope,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -12,8 +12,8 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
@@ -134,7 +134,7 @@ internal class EmbeddedContentUiTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -15,9 +15,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
@@ -119,7 +119,7 @@ internal class FormActivityScreenShotTest {
         savedPaymentMethodSelectionToConfirm: PaymentSelection.Saved? = null,
     ) {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         val confirmationHandler = FakeConfirmationHandler()
         confirmationHandler.state.value = confirmationState
         val stateHolder = DefaultSheetActivityStateHolder(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -12,9 +12,9 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.FakeSheetActivityConfirmationHelper
@@ -424,7 +424,7 @@ internal class EmbeddedNavigatorTest {
         savedPaymentMethods: List<PaymentMethod>,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     ): EmbeddedNavigator.Screen.Form.Factory {
-        val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         val interactorFactory = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             embeddedSelectionHolder = selectionHolder,
@@ -458,7 +458,7 @@ internal class EmbeddedNavigatorTest {
             eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
-            embeddedSelectionHolder = EmbeddedSelectionHolder(SavedStateHandle()),
+            embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
             savedPaymentMethodConfirmInteractorFactory = FakeSavedPaymentMethodConfirmInteractor.Factory(),
             customerStateHolder = FakeCustomerStateHolder(),
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -104,7 +105,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
             .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
             .configurationModifier()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -45,7 +45,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
         onClickDelegate.set { }
         onClickDelegate.clear()
 
-        selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         confirmationHelper.confirm()
 
         assertThat(confirmationHandler.startTurbine.awaitItem()).isNotNull()
@@ -55,7 +55,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
 
     @Test
     fun `confirm starts confirmation with correct option when selection is not null`() = testScenario {
-        selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
         confirmationHelper.confirm()
 
@@ -77,7 +77,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
     fun `when formSheetAction=continue confirm returns result`() = testScenario(
         configurationModifier = { formSheetAction(EmbeddedPaymentElement.FormSheetAction.Continue) }
     ) {
-        selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
         confirmationHelper.confirm()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -109,7 +109,7 @@ class DefaultSheetActivityStateHolderTest {
     fun `state updates isEnabled when selection is set`() = testScenario {
         stateHolder.state.test {
             assertThat(awaitItem().isEnabled).isFalse()
-            selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
             assertThat(awaitItem().isEnabled).isTrue()
         }
     }
@@ -120,7 +120,7 @@ class DefaultSheetActivityStateHolderTest {
             awaitAndVerifyInitialState()
 
             val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-            selectionHolder.set(selection)
+            selectionHolder.setSelection(selection)
 
             val enabledState = awaitItem()
             assertThat(enabledState.processingState).isEqualTo(PrimaryButtonProcessingState.Idle(null))
@@ -152,7 +152,7 @@ class DefaultSheetActivityStateHolderTest {
         stateHolder.state.test {
             awaitAndVerifyInitialState()
             val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-            selectionHolder.set(selection)
+            selectionHolder.setSelection(selection)
 
             // State emitted from setting selection
             assertThat(awaitItem().isEnabled).isTrue()
@@ -277,7 +277,7 @@ class DefaultSheetActivityStateHolderTest {
             val updateState = awaitItem()
             assertThat(updateState.isEnabled).isTrue()
 
-            selectionHolder.set(null)
+            selectionHolder.setSelection(null)
 
             expectNoEvents()
         }
@@ -288,10 +288,10 @@ class DefaultSheetActivityStateHolderTest {
         stateHolder.state.test {
             awaitAndVerifyInitialState()
 
-            selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
             assertThat(awaitItem().isEnabled).isTrue()
 
-            selectionHolder.set(null)
+            selectionHolder.setSelection(null)
             assertThat(awaitItem().isEnabled).isFalse()
         }
     }
@@ -307,7 +307,7 @@ class DefaultSheetActivityStateHolderTest {
             assertThat(processingState.isProcessing).isTrue()
             assertThat(processingState.isEnabled).isFalse()
 
-            selectionHolder.set(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
             expectNoEvents()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -437,7 +438,7 @@ class DefaultSheetActivityStateHolderTest {
         block: suspend Scenario.() -> Unit
     ) = runTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent)
-        val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         val onClickOverrideDelegate = OnClickDelegateOverrideImpl()
         val confirmationHandler = FakeConfirmationHandler()
         val stateHolder = DefaultSheetActivityStateHolder(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -306,7 +306,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             openCardScanAutomatically = true,
         )
         val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
-        selectionHolder.set(paymentSelection)
+        selectionHolder.setSelection(paymentSelection)
         val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -12,9 +12,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
@@ -251,7 +251,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             hasCustomerConfiguration = true,
             isPaymentMethodSetAsDefaultEnabled = true,
         )
-        val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
@@ -305,7 +305,7 @@ internal class DefaultVerticalModeFormInteractorTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             openCardScanAutomatically = true,
         )
-        val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         selectionHolder.set(paymentSelection)
         val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Makes EmbeddedSelectionHolder an interface. EmbeddedPaymentElement + EmbeddedSheetActivity use the default, CheckoutController uses CheckoutControllerStateHolder as a single source of truth, where embedded has a lot of states all over the place.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Prepare for using EmbeddedContentHelper to show embedded content / launch payment options in the sheet.