### PR TITLE
Ensure destroy() clears committed state in CheckoutController.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -290,6 +290,7 @@ class CheckoutController @Inject internal constructor(
 
     fun destroy() {
         viewModelScope.cancel()
+        stateHolder.state = null
     }
 
     fun clearPaymentOption() {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -231,6 +231,18 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `destroy clears the committed state`() = runConfigureScenario {
+        result.getOrThrow()
+        // Pre-condition: configure committed a non-null state so the clear is observable.
+        assertThat(committedState).isNotNull()
+
+        controller.destroy()
+
+        assertThat(committedState).isNull()
+        assertThat(controller.checkoutSession.value).isNull()
+    }
+
+    @Test
     fun `callback identifier is generated and stored when absent`() = runTest {
         val savedStateHandle = SavedStateHandle()
         createController(savedStateHandle)


### PR DESCRIPTION
# Summary
This PR updates CheckoutController to ensure that calling destroy() sets the committed state to null, in addition to cancelling the viewModelScope. Associated unit test coverage is also added.

# Motivation
Previously, destroy() only cancelled the scope but did not clear the committed state, which could lead to unintended persistence of state after the controller is destroyed.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
- [Fixed] destroy() on CheckoutController now also clears the committed state.