### PR TITLE
Move currency toggle analytics from Checkout to repository layer.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -15,21 +15,16 @@ import com.stripe.android.checkout.Checkout.Companion.configure
 import com.stripe.android.checkout.Checkout.Companion.createWithState
 import com.stripe.android.checkout.injection.CheckoutComponent
 import com.stripe.android.checkout.injection.DaggerCheckoutComponent
-import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.validateShippingCountry
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorToggle
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
@@ -527,16 +522,8 @@ class Checkout private constructor(
         }
     }
 
-    internal suspend fun updateCurrency(currency: String): Result<Unit> {
-        val result = withInternalState { sessionId ->
-            component.checkoutSessionRepository.updateCurrency(sessionId, currency)
-        }
-        result.onSuccess {
-            fireEvent(PaymentSheetEvent.AdaptivePricingCurrencyToggled())
-        }.onFailure {
-            fireEvent(PaymentSheetEvent.AdaptivePricingCurrencyToggledFailed(error = it.safeAnalyticsMessage))
-        }
-        return result
+    internal suspend fun updateCurrency(currency: String): Result<Unit> = withInternalState { sessionId ->
+        component.checkoutSessionRepository.updateCurrency(sessionId, currency)
     }
 
     internal fun markIntegrationLaunched() {
@@ -632,16 +619,5 @@ class Checkout private constructor(
             errorMessage = errorMessage?.resolve(),
             appearance = appearanceState,
         )
-    }
-
-    private fun fireEvent(event: PaymentSheetEvent) {
-        CoroutineScope(Dispatchers.IO).launch {
-            component.analyticsRequestExecutor.executeAsync(
-                component.paymentAnalyticsRequestFactory.createRequest(
-                    event = event,
-                    additionalParams = event.params,
-                )
-            )
-        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -2,15 +2,19 @@ package com.stripe.android.paymentsheet.repositories
 
 import com.stripe.android.Stripe
 import com.stripe.android.checkout.Address
+import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.executeRequestWithResultParser
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import java.util.TimeZone
 import java.util.UUID
 import javax.inject.Inject
@@ -20,6 +24,8 @@ import javax.inject.Named
 internal class CheckoutSessionRepository @Inject constructor(
     private val clientParams: ElementsSessionClientParams,
     private val stripeNetworkClient: StripeNetworkClient,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
 ) {
@@ -184,7 +190,20 @@ internal class CheckoutSessionRepository @Inject constructor(
             "updated_currency" to currencyCode,
             "elements_session_client[is_aggregation_expected]" to "true",
         ),
-    )
+    ).onSuccess {
+        fireEvent(PaymentSheetEvent.AdaptivePricingCurrencyToggled())
+    }.onFailure {
+        fireEvent(PaymentSheetEvent.AdaptivePricingCurrencyToggledFailed(error = it.safeAnalyticsMessage))
+    }
+
+    private fun fireEvent(event: PaymentSheetEvent) {
+        analyticsRequestExecutor.executeAsync(
+            paymentAnalyticsRequestFactory.createRequest(
+                event = event,
+                additionalParams = event.params,
+            )
+        )
+    }
 
     private companion object {
         private const val UNSUPPORTED_UPDATE_ERROR =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -18,6 +18,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
@@ -48,6 +49,7 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.utils.RecordingLinkStore
 import kotlinx.coroutines.Dispatchers
@@ -158,6 +160,11 @@ internal suspend fun createIntentConfirmationInterceptor(
                             mobileSessionIdProvider = { "test_session" },
                         ),
                         stripeNetworkClient = DefaultStripeNetworkClient(),
+                        analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+                        paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                            context = ApplicationProvider.getApplicationContext(),
+                            publishableKey = "pk",
+                        ),
                         publishableKeyProvider = { "pk" },
                         stripeAccountIdProvider = { null },
                     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
@@ -42,6 +43,7 @@ import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationO
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
 import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
@@ -513,6 +515,11 @@ class CheckoutSessionConfirmationInterceptorTest {
                 mobileSessionIdProvider = { "test_session" },
             ),
             stripeNetworkClient = DefaultStripeNetworkClient(),
+            analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKey = "pk_test_123",
+            ),
             publishableKeyProvider = { "pk_test_123" },
             stripeAccountIdProvider = { null },
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -1,14 +1,17 @@
 package com.stripe.android.paymentsheet.repositories
 
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -29,6 +32,11 @@ class CheckoutSessionRepositoryTest {
     private val repository = CheckoutSessionRepository(
         clientParams = clientParams,
         stripeNetworkClient = DefaultStripeNetworkClient(),
+        analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+        paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+            context = ApplicationProvider.getApplicationContext(),
+            publishableKey = "pk_test_123",
+        ),
         publishableKeyProvider = { "pk_test_123" },
         stripeAccountIdProvider = { null },
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
@@ -8,11 +9,13 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentB
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -320,6 +323,11 @@ class DefaultSavedPaymentMethodRepositoryTest {
                 mobileSessionIdProvider = { "test_session" },
             ),
             stripeNetworkClient = DefaultStripeNetworkClient(),
+            analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKey = "pk_test_123",
+            ),
             publishableKeyProvider = { "pk_test_123" },
             stripeAccountIdProvider = { null },
         )


### PR DESCRIPTION
# Summary
Moves analytics event firing for currency toggling from the Checkout class to the CheckoutSessionRepository. Updates tests and dependency injection accordingly.

# Motivation
Centralizes the analytics logic within the repository layer and simplifies the Checkout class, aligning with typical architecture patterns for analytics and event reporting.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog