### PR TITLE
[link] Fix icon in LinkController payment method preview

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampConfiguration.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampConfiguration.kt
@@ -88,7 +88,7 @@ class OnrampConfiguration {
             publishableKey = requireNotNull(publishableKey) {
                 "publishableKey must not be null"
             },
-            appearance = appearance ?: LinkAppearance(),
+            appearance = (appearance ?: LinkAppearance()).reduceLinkBranding(true),
             cryptoCustomerId = cryptoCustomerId,
             googlePayConfig = googlePayConfig,
             additionalSdkVersions = additionalSdkVersions

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -74,6 +74,7 @@ import com.stripe.android.crypto.onramp.ui.UserAttestationScreenAction
 import com.stripe.android.crypto.onramp.ui.VerifyKycActivityResult
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowResult
+import com.stripe.android.link.LinkAppearance
 import com.stripe.android.link.LinkController
 import com.stripe.android.link.exceptions.LinkUnavailableException
 import com.stripe.android.model.DateOfBirth
@@ -1702,7 +1703,7 @@ class OnrampInteractorTest {
         OnrampConfiguration()
             .merchantDisplayName("merchant-display-name")
             .publishableKey("pk_test_12345")
-            .appearance(mock())
+            .appearance(LinkAppearance())
             .cryptoCustomerId(cryptoCustomerId)
             .additionalSdkVersions(additionalSdkVersions)
             .build()

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkAppearance.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkAppearance.kt
@@ -26,6 +26,7 @@ class LinkAppearance {
     private var darkColors: Colors? = null
     private var style: Style = Style.AUTOMATIC
     private var primaryButton: PrimaryButton? = null
+    private var reduceLinkBranding: Boolean = false
 
     fun lightColors(lightColors: Colors) = apply {
         this.lightColors = lightColors
@@ -43,6 +44,10 @@ class LinkAppearance {
         this.primaryButton = primaryButton
     }
 
+    fun reduceLinkBranding(reduceLinkBranding: Boolean) = apply {
+        this.reduceLinkBranding = reduceLinkBranding
+    }
+
     @Poko
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -51,6 +56,7 @@ class LinkAppearance {
         val darkColors: Colors.State,
         val style: Style,
         val primaryButton: PrimaryButton.State,
+        val reduceLinkBranding: Boolean,
     ) : Parcelable
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -60,6 +66,7 @@ class LinkAppearance {
             darkColors = (darkColors ?: Colors()).build(isDark = true),
             style = style,
             primaryButton = (primaryButton ?: PrimaryButton()).build(),
+            reduceLinkBranding = reduceLinkBranding,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -145,17 +145,25 @@ internal class LinkControllerInteractor @Inject constructor(
 
     val selectedPaymentMethodPreview: StateFlow<LinkController.PaymentMethodPreview?> =
         _state.mapAsStateFlow { state ->
-            state.selectedPaymentMethod?.details?.toPreview(application, cachedIconLoader)
+            state.selectedPaymentMethod?.details?.toPreview(
+                context = application,
+                iconLoader = cachedIconLoader,
+                reduceLinkBranding = state.linkConfiguration?.linkAppearance?.reduceLinkBranding ?: false,
+            )
         }
 
     fun state(context: Context): StateFlow<LinkController.State> {
         return combineAsStateFlow(_internalLinkAccount, _state) { account, state ->
             LinkController.State(
-                elementsSessionId = state.linkComponent?.configuration?.elementsSessionId,
+                elementsSessionId = state.linkConfiguration?.elementsSessionId,
                 internalLinkAccount = account,
-                merchantLogoUrl = state.linkComponent?.configuration?.merchantLogoUrl,
+                merchantLogoUrl = state.linkConfiguration?.merchantLogoUrl,
                 selectedPaymentMethodPreview = state.selectedPaymentMethod?.details
-                    ?.toPreview(context, cachedIconLoader),
+                    ?.toPreview(
+                        context = context,
+                        iconLoader = cachedIconLoader,
+                        reduceLinkBranding = state.linkConfiguration?.linkAppearance?.reduceLinkBranding ?: false,
+                    ),
                 createdPaymentMethod = state.createdPaymentMethod,
             )
         }
@@ -871,7 +879,8 @@ internal fun PaymentMethodPreviewDetails.toPreview(
 
 internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
     context: Context,
-    iconLoader: PaymentSelection.IconLoader
+    iconLoader: PaymentSelection.IconLoader,
+    reduceLinkBranding: Boolean,
 ): LinkController.PaymentMethodPreview {
     val label = context.getString(com.stripe.android.R.string.stripe_link)
     val sublabel = buildString {
@@ -882,7 +891,11 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
         append(" •••• ")
         append(last4)
     }
-    val drawableResourceId = getIconDrawableRes(context.isSystemDarkTheme())
+    val drawableResourceId = if (reduceLinkBranding) {
+        getIconDrawableRes(context.isSystemDarkTheme())
+    } else {
+        getLinkIconArrow()
+    }
 
     val type = when (this@toPreview) {
         is ConsumerPaymentDetails.Card, is ConsumerPaymentDetails.Passthrough -> {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
@@ -56,7 +56,8 @@ class LinkControllerPaymentMethodPreviewScreenshotTest {
                                 iconLoader = PaymentSelection.IconLoader(
                                     resources = LocalResources.current,
                                     imageLoader = DefaultStripeImageLoader(context),
-                                )
+                                ),
+                                reduceLinkBranding = true,
                             )
                         )
                     }


### PR DESCRIPTION
# Summary
Uses Link icon by default. Use underlying payment method icon in CryptoOnramp, keeping existing behavior.

# Motivation
[RUN_LINK_MOBILE-213](https://go/RUN_LINK_MOBILE-213)

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

## LinkController
<img width="1134" height="2168" alt="CleanShot 2026-07-15 at 15 38 40@2x" src="https://github.com/user-attachments/assets/1718ae30-9ca9-4450-9bc5-88b08ccf70f0" />

## Onramp
<img width="1134" height="2168" alt="CleanShot 2026-07-15 at 15 38 30@2x" src="https://github.com/user-attachments/assets/3f402282-b747-4404-89db-d1295107c0eb" />
