### PR TITLE
Add Dagger subcomponent for CheckoutPresenter injection.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -38,6 +39,7 @@ class CheckoutController @Inject internal constructor(
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
+    private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
 ) {
     val checkoutSession: StateFlow<CheckoutSession?>
         get() = stateHolder.checkoutSession
@@ -285,7 +287,7 @@ class CheckoutController @Inject internal constructor(
     }
 
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {
-        TODO("Not yet implemented")
+        return checkoutPresenterSubcomponentFactory.create().presenter
     }
 
     fun destroy() {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
@@ -2,21 +2,27 @@ package com.stripe.android.checkout
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import javax.inject.Inject
+import javax.inject.Provider
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class CheckoutPresenter internal constructor() {
+class CheckoutPresenter @Inject internal constructor(
+    private val paymentElementProvider: Provider<PaymentElement>,
+    private val currencySelectorElementProvider: Provider<CurrencySelectorElement>,
+    private val shippingAddressElementProvider: Provider<ShippingAddressElement>,
+) {
 
     fun paymentElement(): PaymentElement {
-        TODO("Not yet implemented")
+        return paymentElementProvider.get()
     }
 
     fun currencySelectorElement(): CurrencySelectorElement {
-        TODO("Not yet implemented")
+        return currencySelectorElementProvider.get()
     }
 
     fun shippingAddressElement(): ShippingAddressElement {
-        TODO("Not yet implemented")
+        return shippingAddressElementProvider.get()
     }
 
     fun expressCheckoutElement(): ExpressCheckoutElement {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
@@ -9,10 +9,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class CurrencySelectorElement internal constructor() {
+class CurrencySelectorElement @Inject internal constructor() {
 
     @Composable
     fun Content() {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -12,10 +12,11 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.image.rememberDrawablePainter
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class PaymentElement internal constructor() {
+class PaymentElement @Inject internal constructor() {
 
     @Composable
     fun PaymentOptionsContent() {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ShippingAddressElement.kt
@@ -4,10 +4,11 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class ShippingAddressElement internal constructor() {
+class ShippingAddressElement @Inject internal constructor() {
 
     fun present() {
         TODO("Not yet implemented")

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -117,7 +117,7 @@ internal interface CheckoutControllerComponent {
 }
 
 @Suppress("TooManyFunctions")
-@Module
+@Module(subcomponents = [CheckoutPresenterSubcomponent::class])
 internal interface CheckoutControllerModule {
     @Binds
     fun bindPaymentElementLoader(loader: DefaultPaymentElementLoader): PaymentElementLoader

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
@@ -1,0 +1,17 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout.injection
+
+import com.stripe.android.checkout.CheckoutPresenter
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import dagger.Subcomponent
+
+@Subcomponent
+internal interface CheckoutPresenterSubcomponent {
+    val presenter: CheckoutPresenter
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(): CheckoutPresenterSubcomponent
+    }
+}


### PR DESCRIPTION
# Summary
Refactored CheckoutPresenter and related element classes to support Dagger injection. Introduced CheckoutPresenterSubcomponent for scoped dependencies.

# Motivation
To enable proper dependency injection for CheckoutPresenter and its elements, allowing easier testing and separation of concerns.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Changed] Refactored CheckoutPresenter and element classes to use Dagger injection via a new subcomponent.