### PR TITLE
Refactor tests to use CleanupTestRule for interactor resource cleanup.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.uicore.elements.Controller
@@ -25,10 +26,18 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class DefaultTapToAddCardAddedInteractorTest {
+    private val cleanupRule = CleanupTestRule(DefaultTapToAddCardAddedInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(cleanupRule)
+
     @Test
     fun `Continue mode with Link disabled`() = runScenario(
         paymentMethod = PaymentMethodFactory.card().update(
@@ -217,7 +226,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
                 savedPaymentMethodLinkFormHelper = fakeLinkFormHelper,
                 onContinue = { onContinueCalls.add(it) },
                 onConfirm = { pm, linkInput -> onConfirmCalls.add(pm to linkInput) },
-            ),
+            ).also { cleanupRule.track(it) },
             fakeLinkFormHelper = fakeLinkFormHelper,
             fakeEventReporter = fakeEventReporter,
             onContinueCalls = onContinueCalls,
@@ -228,7 +237,6 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         onContinueCalls.ensureAllEventsConsumed()
         onConfirmCalls.ensureAllEventsConsumed()
         fakeEventReporter.validate()
-        scenario.interactor.close()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
@@ -33,10 +34,18 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class DefaultTapToAddConfirmationInteractorTest {
+    private val cleanupRule = CleanupTestRule(DefaultTapToAddConfirmationInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(cleanupRule)
+
     @Test
     fun `CancelPressed reports tap to add canceled with confirmation source`() = runScenario(
         paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
@@ -553,6 +562,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                     onCompleteCalls.add(Unit)
                 },
             )
+            cleanupRule.track(interactor)
 
             block(
                 Scenario(
@@ -568,7 +578,6 @@ internal class DefaultTapToAddConfirmationInteractorTest {
 
             eventReporter.validate()
             onCompleteCalls.ensureAllEventsConsumed()
-            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentsheet.ui.AddPaymentMethodInitialVisibilityTrack
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodInitialVisibilityTrackerDataFixtures.TWO_ITEMS
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodInitialVisibilityTrackerDataFixtures.TWO_ITEMS_EXPECTED_VISIBLE
 import com.stripe.android.paymentsheet.utils.errorTest
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.EmailElement
@@ -43,11 +44,19 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.mockito.Mockito.mock
 import kotlin.test.Test
 import com.stripe.android.uicore.R as UiCoreR
 
 class DefaultAddPaymentMethodInteractorTest {
+    private val cleanupRule = CleanupTestRule(DefaultAddPaymentMethodInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(cleanupRule)
+
     @Test
     fun handleViewAction_ReportFieldInteraction_reportsFieldInteraction() {
         runScenario {
@@ -422,6 +431,7 @@ class DefaultAddPaymentMethodInteractorTest {
                 initialVisibilityTrackerTurbine.add(Pair(visible, hidden))
             }
         )
+        cleanupRule.track(interactor)
 
         TestParams(
             interactor = interactor,
@@ -437,7 +447,6 @@ class DefaultAddPaymentMethodInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
-            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -12,14 +12,23 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.utils.BankFormScreenStateFactory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.mockito.kotlin.mock
 
 class DefaultSelectSavedPaymentMethodsInteractorTest {
+
+    private val cleanupRule = CleanupTestRule(DefaultSelectSavedPaymentMethodsInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(cleanupRule)
 
     @Test
     fun initialState_isCorrect() {
@@ -534,6 +543,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             isLiveMode = true,
             linkBrand = LinkBrand.Link,
         )
+        cleanupRule.track(interactor)
 
         TestParams(
             interactor = interactor,
@@ -546,7 +556,6 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
-            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.setDefaultPaymentMethodErrorMessage
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updateCardBrandErrorMessage
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updatesFailedErrorMessage
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -25,14 +26,18 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 @Suppress("LargeClass")
 class DefaultUpdatePaymentMethodInteractorTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val cleanupRule = CleanupTestRule(DefaultUpdatePaymentMethodInteractor::close)
+
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+    val ruleChain: RuleChain = RuleChain.outerRule(CoroutineTestRule(testDispatcher))
+        .around(cleanupRule)
 
     @Test
     fun removeViewAction_removesPmAndNavigatesBack() {
@@ -777,6 +782,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             allowedBillingCountries = allowedBillingCountries,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
+        cleanupRule.track(interactor)
 
         TestParams(
             interactor = interactor,
@@ -784,7 +790,6 @@ class DefaultUpdatePaymentMethodInteractorTest {
         ).apply {
             runTest { testBlock() }
             ensureAllEventsConsumed()
-            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -12,15 +12,24 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 class DefaultManageScreenInteractorTest {
+
+    private val closeInteractorRule = CleanupTestRule(DefaultManageScreenInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(closeInteractorRule)
 
     @Test
     fun initializeState_nullCurrentSelection() {
@@ -362,6 +371,7 @@ class DefaultManageScreenInteractorTest {
             defaultPaymentMethodId = defaultPaymentMethodId,
             dispatcher = dispatcher
         )
+        closeInteractorRule.track(interactor)
 
         TestParams(
             interactor = interactor,
@@ -377,7 +387,6 @@ class DefaultManageScreenInteractorTest {
                 testBlock()
             }
             ensureAllEventsConsumed()
-            interactor.close()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.utils.errorTest
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor.ViewAction
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
@@ -53,15 +54,18 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TestRule
+import org.junit.rules.RuleChain
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verifyNoMoreInteractions
 import com.stripe.android.uicore.R as UiCoreR
 
 internal class DefaultVerticalModeFormInteractorTest {
 
+    private val closeInteractorRule = CleanupTestRule(DefaultVerticalModeFormInteractor::close)
+
     @get:Rule
-    val rule: TestRule = CoroutineTestRule()
+    val ruleChain: RuleChain = RuleChain.outerRule(CoroutineTestRule())
+        .around(closeInteractorRule)
 
     @Test
     fun `state is updated when processing emits`() = runScenario(selectedPaymentMethodCode = "card") {
@@ -374,6 +378,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             paymentMethodIncentive = stateFlowOf(null),
             uiContext = UnconfinedTestDispatcher(),
         )
+        closeInteractorRule.track(interactor)
 
         TestParams(
             interactor = interactor,
@@ -390,7 +395,6 @@ internal class DefaultVerticalModeFormInteractorTest {
         verifyNoMoreInteractions(formArguments, usBankAccountArguments)
         onFormFieldValuesChangedTurbine.ensureAllEventsConsumed()
         reportFieldInteractionTurbine.ensureAllEventsConsumed()
-        interactor.close()
     }
 
     private class TestParams(


### PR DESCRIPTION
# Summary

Refactored multiple interactor test classes to use `CleanupTestRule` for resource cleanup, ensuring interactors are properly closed after each test. This eliminates manual calls to `close()` and makes the tests more robust.

# Motivation

Improves reliability and maintainability of tests by automating resource management, preventing potential leaks or interference between tests, and simplifying test teardown logic.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog