### PR TITLE
Enable detekt ktlint Indentation rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 ktlint_standard_import-ordering = disabled
 ktlint_standard_trailing-comma-on-call-site = disabled
 ktlint_standard_trailing-comma-on-declaration-site = disabled
-ktlint_standard_indent = disabled
 ktlint_standard_string-template-indent = disabled
 ktlint_standard_no-semi = disabled
 ktlint_standard_multiline-expression-wrapping = disabled

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -679,7 +679,7 @@ ktlint:
   ImportOrdering:
     active: true
   Indentation:
-    active: false
+    active: true
   Kdoc:
     active: false
   MaximumLineLength:

--- a/crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
+++ b/crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
@@ -422,8 +422,8 @@ internal class OnrampViewModel(
                         screen = Screen.AuthenticatedOperations,
                         linkAuthIntentId = null,
                         consentedLinkAuthIntentIds =
-                            currentState.consentedLinkAuthIntentIds +
-                                listOfNotNull(currentState.linkAuthIntentId),
+                        currentState.consentedLinkAuthIntentIds +
+                            listOfNotNull(currentState.linkAuthIntentId),
                         loadingMessage = null
                     )
                 }
@@ -600,7 +600,7 @@ internal class OnrampViewModel(
                             screen = Screen.AuthenticatedOperations,
                             loadingMessage = null,
                             missingIdentifiersSummary =
-                                formatIdentifierRequirements(result.requirements)
+                            formatIdentifierRequirements(result.requirements)
                         )
                     }
                 }
@@ -636,7 +636,7 @@ internal class OnrampViewModel(
                             screen = Screen.AuthenticatedOperations,
                             loadingMessage = null,
                             submitIdentifiersSummary =
-                                formatSubmitIdentifiersResult(result.result)
+                            formatSubmitIdentifiersResult(result.result)
                         )
                     }
                 }

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -669,7 +669,7 @@ internal class OnrampInteractor @Inject constructor(
                         sublabel = it.sublabel,
                         type = it.type.toDisplayType()
                     ),
-                        kycInfo = null
+                    kycInfo = null
                 )
             } ?: run {
                 val error = mapError(

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/CryptoOnrampApiException.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/CryptoOnrampApiException.kt
@@ -24,7 +24,7 @@ abstract class CryptoOnrampApiException internal constructor(
     cause = apiErrorContext.underlyingError,
     message = userMessage,
 ),
-StripeCryptoOnrampError {
+    StripeCryptoOnrampError {
     final override val docUrl: String?
         get() = apiErrorContext.docUrl
 

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/OnrampErrorLogger.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/OnrampErrorLogger.kt
@@ -20,8 +20,8 @@ internal class OnrampErrorLogger @Inject constructor(
         return (this as? StripeCryptoOnrampError)?.developerMessage
             ?: (
                 "Inspect the returned failure error for details. Error type: ${javaClass.simpleName}.\n" +
-                "Message: ${this.message}\n" +
-                "Cause: ${this.cause?.message}"
-            )
+                    "Message: ${this.message}\n" +
+                    "Cause: ${this.cause?.message}"
+                )
     }
 }

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -467,7 +467,7 @@ internal class CryptoApiRepository @Inject constructor(
             statusCode = response.code,
             message = stripeError?.message
                 ?: "Request failed with status code ${response.code} and non-JSON error " +
-                    "body."
+                "body."
         )
     }
 

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -558,7 +558,7 @@ class OnrampInteractorTest {
                     "reason" to "app_not_play_recognized",
                     "user_message" to
                         "This app couldn't be verified. Install it from Google Play " +
-                            "and try again."
+                        "and try again."
                 )
             ),
             requestId = "req_123",

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodMessagePromotionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodMessagePromotionJsonParserTest.kt
@@ -27,9 +27,9 @@ class PaymentMethodMessagePromotionJsonParserTest {
         assertThat(promotions.promotions[0].learnMore.message).isEqualTo("Learn more")
         assertThat(promotions.promotions[0].learnMore.url).isEqualTo(
             "https://b.stripecdn.com/payment-method-" +
-            "messaging-statics-srv/assets/learn-more/index.html?amount=10000&country=US&currency=USD&key=" +
-            "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
-            "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=klarna"
+                "messaging-statics-srv/assets/learn-more/index.html?amount=10000&country=US&currency=USD&key=" +
+                "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
+                "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=klarna"
         )
     }
 
@@ -46,9 +46,9 @@ class PaymentMethodMessagePromotionJsonParserTest {
         assertThat(promotions.promotions[0].learnMore.message).isEqualTo("Learn more")
         assertThat(promotions.promotions[0].learnMore.url).isEqualTo(
             "https://b.stripecdn.com/payment-method-" +
-            "messaging-statics-srv/assets/learn-more/index.html?amount=9000&country=US&currency=USD&key=" +
-            "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
-            "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=afterpay_clearpay"
+                "messaging-statics-srv/assets/learn-more/index.html?amount=9000&country=US&currency=USD&key=" +
+                "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
+                "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=afterpay_clearpay"
         )
 
         assertThat(promotions.promotions[1].paymentMethodType).isEqualTo("AFFIRM")
@@ -56,9 +56,9 @@ class PaymentMethodMessagePromotionJsonParserTest {
         assertThat(promotions.promotions[1].learnMore.message).isEqualTo("Learn more")
         assertThat(promotions.promotions[1].learnMore.url).isEqualTo(
             "https://b.stripecdn.com/payment-method-" +
-            "messaging-statics-srv/assets/learn-more/index.html?amount=9000&country=US&currency=USD&key=" +
-            "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
-            "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=affirm"
+                "messaging-statics-srv/assets/learn-more/index.html?amount=9000&country=US&currency=USD&key=" +
+                "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
+                "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=affirm"
         )
 
         assertThat(promotions.promotions[2].paymentMethodType).isEqualTo("KLARNA")
@@ -66,9 +66,9 @@ class PaymentMethodMessagePromotionJsonParserTest {
         assertThat(promotions.promotions[2].learnMore.message).isEqualTo("Learn more")
         assertThat(promotions.promotions[2].learnMore.url).isEqualTo(
             "https://b.stripecdn.com/payment-method-" +
-            "messaging-statics-srv/assets/learn-more/index.html?amount=9000&country=US&currency=USD&key=" +
-            "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
-            "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=klarna"
+                "messaging-statics-srv/assets/learn-more/index.html?amount=9000&country=US&currency=USD&key=" +
+                "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFf" +
+                "B7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=klarna"
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -194,7 +194,7 @@ internal class DefaultTapToAddConnectionManager(
                             reportError(
                                 error = e,
                                 errorEvent =
-                                    ErrorReporter.ExpectedErrorEvent.TAP_TO_ADD_DISCOVER_READERS_CALL_FAILURE,
+                                ErrorReporter.ExpectedErrorEvent.TAP_TO_ADD_DISCOVER_READERS_CALL_FAILURE,
                             )
 
                             continuation.resumeWith(Result.failure(e))
@@ -220,7 +220,7 @@ internal class DefaultTapToAddConnectionManager(
                             reportError(
                                 error = e,
                                 errorEvent =
-                                    ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_DISCOVER_READERS_CANCEL_FAILURE,
+                                ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_DISCOVER_READERS_CANCEL_FAILURE,
                             )
                         }
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddErrorMessageBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddErrorMessageBuilder.kt
@@ -50,7 +50,7 @@ internal object TapToAddErrorMessageBuilder {
              * https://stripe.sourcegraphcloud.com/r/stripe-internal/android/-/blob/terminalsdk/cots/modules/common/src/main/kotlin/com/stripe/cots/common/CotsError.kt?L13-16
              */
             TerminalErrorCode.TAP_TO_PAY_INSECURE_ENVIRONMENT
-                if error.errorMessage.contains(DEVELOPER_OPTIONS_SUBSTRING) -> {
+            if error.errorMessage.contains(DEVELOPER_OPTIONS_SUBSTRING) -> {
                 TapToAddErrorMessage(
                     title = StripeCoreR.string.stripe_error.resolvableString,
                     action = R.string.stripe_tap_to_add_developer_options_error_action.resolvableString,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCard.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCard.kt
@@ -66,7 +66,7 @@ private fun Card(
     val imageRepository = LocalTapToAddImageRepository.current
 
     val state: MutableState<TapToAddImageRepository.CardArt?> = remember {
-       mutableStateOf(imageRepository?.get(cardBrand))
+        mutableStateOf(imageRepository?.get(cardBrand))
     }
 
     imageRepository?.let { repository ->

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
@@ -64,7 +64,7 @@ internal class DefaultTapToAddCollectingInteractor(
             is TapToAddCollectionHandler.CollectionState.Collected -> {
                 eventReporter.onCardAddedWithTapToAdd(
                     canCollectLinkInput =
-                        linkInlineSignupAvailability.availability() is LinkInlineSignupAvailability.Result.Available
+                    linkInlineSignupAvailability.availability() is LinkInlineSignupAvailability.Result.Available
                 )
 
                 onCollected(collectionState.paymentMethod)

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -209,7 +209,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
                                     autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
                                     isInlineAutocompleteEnabled =
-                                        FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
+                                    FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
                                 ),
                                 placesClient = null,
                                 coroutineScope = null,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/Icon.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/Icon.kt
@@ -20,14 +20,14 @@ fun Icon(
 ) {
     BoxWithConstraints(modifier = modifier.clip(shape = RoundedCornerShape(3.dp))) {
         iconUrl?.let {
-                StripeImage(
-                    url = iconUrl,
-                    imageLoader = LocalStripeImageLoader.current,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Fit,
-                    errorContent = errorContent
-                )
+            StripeImage(
+                url = iconUrl,
+                imageLoader = LocalStripeImageLoader.current,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit,
+                errorContent = errorContent
+            )
         } ?: errorContent()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -219,7 +219,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 enableMlKitCardScan = metadata.enableMlKitCardScan,
                 disableSsdOcrCardScan = metadata.disableSsdOcrCardScan,
                 automaticallyLaunchedCardScanFormDataHelper =
-                    arguments.automaticallyLaunchedCardScanFormDataHelper,
+                arguments.automaticallyLaunchedCardScanFormDataHelper,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -41,10 +41,10 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
             automaticallyLaunchedCardScanFormDataHelper =
-                embeddedFormHelperFactory.createAutomaticallyLaunchedCardScanFormDataHelper(
-                    selectedPaymentMethodCode = paymentMethodCode,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                ),
+            embeddedFormHelperFactory.createAutomaticallyLaunchedCardScanFormDataHelper(
+                selectedPaymentMethodCode = paymentMethodCode,
+                paymentMethodMetadata = paymentMethodMetadata,
+            ),
             selectionUpdater = { embeddedSelectionHolder.setSelection(it) },
             tapToAddHelper = tapToAddHelper,
             // If no saved payment methods, then first saved payment method is automatically set as default

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -174,7 +174,7 @@ internal class EmbeddedNavigator private constructor(
             private val launchMode: EmbeddedLaunchMode.Form,
         ) : Screen(), Closeable {
             override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
-                    PaymentSheetTopBarState(
+                PaymentSheetTopBarState(
                     showTestModeLabel = !formInteractor.isLiveMode,
                     showEditMenu = false,
                     isEditing = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -385,7 +385,7 @@ internal class SavedPaymentMethodMutator(
                             cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance),
                             addressCollectionMode = viewModel.config.billingDetailsCollectionConfiguration.address,
                             allowedBillingCountries =
-                                viewModel.config.billingDetailsCollectionConfiguration.allowedBillingCountries,
+                            viewModel.config.billingDetailsCollectionConfiguration.allowedBillingCountries,
                             removeExecutor = { method ->
                                 performRemove()
                             },
@@ -405,7 +405,7 @@ internal class SavedPaymentMethodMutator(
                             isDefaultPaymentMethod = (
                                 displayableSavedPaymentMethod.isDefaultPaymentMethod(
                                     defaultPaymentMethodId =
-                                        viewModel.customerStateHolder.customer.value?.defaultPaymentMethodId
+                                    viewModel.customerStateHolder.customer.value?.defaultPaymentMethodId
                                 )
                                 ),
                             removeMessage = paymentMethodMetadata?.customerMetadata?.removePaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -297,7 +297,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         allowDefaultOptIn = elementsSession.allowLinkDefaultOptIn,
         googlePlacesApiKey = configuration.googlePlacesApiKey,
         collectMissingBillingDetailsForExistingPaymentMethods =
-            configuration.link.collectMissingBillingDetailsForExistingPaymentMethods,
+        configuration.link.collectMissingBillingDetailsForExistingPaymentMethods,
         allowUserEmailEdits = configuration.link.allowUserEmailEdits,
         allowLogOut = configuration.link.allowLogOut,
         customerId = elementsSession.customer?.session?.customerId,
@@ -306,7 +306,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         forceSetupFutureUseBehaviorAndNewMandate = elementsSession
             .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
         linkSupportedPaymentMethodsOnboardingEnabled =
-            elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
+        elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
         clientAttributionMetadata = clientAttributionMetadata,
         linkBrand = elementsSession.linkBrand,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -49,7 +49,7 @@ internal class CreateCustomerState @Inject constructor(
                 }
             }
             is CustomerMetadata.LegacyEphemeralKey -> {
-               createForLegacyEphemeralKey(
+                createForLegacyEphemeralKey(
                     paymentMethods = retrieveCustomerPaymentMethods(
                         metadata = metadata,
                         prefetchedPaymentMethods = prefetchedPaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -195,7 +195,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
             cardBrandFilter = cardBrandFilter,
             isCbcModifiable = shouldShowCardBrandDropdown,
             areExpiryDateAndAddressModificationSupported =
-                isModifiablePaymentMethod && canUpdateCardExpiryAndBillingDetails,
+            isModifiablePaymentMethod && canUpdateCardExpiryAndBillingDetails,
         )
         return editCardDetailsInteractorFactory.create(
             payload = payload,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -386,7 +386,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                 linkPaymentLauncher = walletsButtonLinkLauncher,
                 linkAccountHolder = flowControllerViewModel.flowControllerStateComponent.linkAccountHolder,
                 analyticsCallbackProvider =
-                    flowControllerViewModel.flowControllerStateComponent.analyticEventCallbackProvider,
+                flowControllerViewModel.flowControllerStateComponent.analyticEventCallbackProvider,
                 onWalletButtonsRenderStateChanged = { isRendered ->
                     flowControllerViewModel.walletButtonsRendered = isRendered
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -310,7 +310,7 @@ class DefaultTapToAddConnectionManagerTest {
             )
         }
     ) {
-       val connectionResult = testScope.async {
+        val connectionResult = testScope.async {
             assertFailsWith<IllegalStateException> {
                 manager.connect(testConnectionConfig)
             }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
@@ -32,7 +32,7 @@ internal class FakeTapToAddConnectionManager private constructor(
             connectResult: Result<Unit> = Result.success(Unit),
             block: suspend Scenario.() -> Unit
         ) {
-           test(isSupported, listOf(connectResult), block)
+            test(isSupported, listOf(connectResult), block)
         }
 
         suspend fun test(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -988,7 +988,7 @@ class TapToAddCollectionHandlerTest {
         assertThat(collectPaymentMethodCall.config).isEqualTo(
             CollectSetupIntentConfiguration.Builder()
                 .build()
-            )
+        )
         collectPaymentMethodCall.callback.onSuccess(collectedIntent)
         return collectedIntent
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementConfigurationTest.kt
@@ -83,8 +83,8 @@ class EmbeddedPaymentElementConfigurationTest {
             .filterNot { it.name.startsWith("$") }
             .size
         // When a new property is added, this count will change, signaling that:
-            // 1. newBuilder() needs to propagate the new property
-            // 2. The round-trip test above needs a non-default value for it
-            assertThat(propertyCount).isEqualTo(23)
+        // 1. newBuilder() needs to propagate the new property
+        // 2. The round-trip test above needs a non-default value for it
+        assertThat(propertyCount).isEqualTo(23)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
@@ -301,9 +301,9 @@ internal class CreateCustomerMetadataTest {
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodSaveEnabled = false,
                             paymentMethodRemove =
-                                ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             paymentMethodRemoveLast =
-                                ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = null,
                             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
                         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -210,21 +210,21 @@ internal class DefaultCreateLinkStateTest {
     }
 
     private val customerWithEmail = ElementsSession.Customer(
-            paymentMethods = emptyList(),
-            defaultPaymentMethod = null,
-            email = "customer@example.com",
-            session = ElementsSession.Customer.Session(
-                id = "cuss_123",
-                liveMode = false,
-                apiKey = "ek_test_123",
-                apiKeyExpiry = 999999999,
-                customerId = "cus_123",
-                components = ElementsSession.Customer.Components(
-                    mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
-                    customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
-                )
-            ),
-        )
+        paymentMethods = emptyList(),
+        defaultPaymentMethod = null,
+        email = "customer@example.com",
+        session = ElementsSession.Customer.Session(
+            id = "cuss_123",
+            liveMode = false,
+            apiKey = "ek_test_123",
+            apiKeyExpiry = 999999999,
+            customerId = "cus_123",
+            components = ElementsSession.Customer.Components(
+                mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
+                customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+            )
+        ),
+    )
 
     private class FakeCardFundingFilterFactory : CardFundingFilter.Factory<List<PaymentSheet.CardFundingType>> {
         var invokedWith: List<PaymentSheet.CardFundingType>? = null

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/PrefetchedPaymentMethodMessagePromotionsHelperTest.kt
@@ -19,14 +19,14 @@ class PrefetchedPaymentMethodMessagePromotionsHelperTest {
             PaymentMethod.Type.Affirm.code,
             PaymentMethodMetadataFactory.create(
                 experimentsData = ElementsSession.ExperimentsData(
-                        arbId = "arb_123",
-                        experimentAssignments = mapOf(
-                            ElementsSession.ExperimentAssignment
-                                .OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS to "treatment"
-                        )
+                    arbId = "arb_123",
+                    experimentAssignments = mapOf(
+                        ElementsSession.ExperimentAssignment
+                            .OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS to "treatment"
                     )
                 )
             )
+        )
 
         assertThat(result).isEqualTo(promotion)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodRowButtonScreenshotTest.kt
@@ -208,6 +208,6 @@ internal class SavedPaymentMethodRowButtonScreenshotTest {
                     )
                 )
             ),
-            )
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -69,7 +69,7 @@ internal class FakePaymentElementLoader(
             linkState = linkState,
             passiveCaptchaParams = passiveCaptchaParams,
             clientAttributionMetadata =
-                clientAttributionMetadata ?: PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            clientAttributionMetadata ?: PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             shippingDetails = shippingDetails,
             experimentsData = experimentsData,
             integrationMetadata = integrationMetadata
@@ -81,7 +81,7 @@ internal class FakePaymentElementLoader(
                     integrationConfiguration.configuration.paymentMethodLayout
             }
         )
-        }
+    }
 
     override suspend fun load(
         initializationMode: PaymentElementLoader.InitializationMode,

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -115,85 +115,85 @@ internal class DefaultCardScanEventsReporterTest {
     @Test
     fun testMlKitFoundPanSentOncePerSession() =
         runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
-        defaultCardScanEventsReporter.scanStarted()
-        ShadowSystemClock.advanceBy(2, TimeUnit.SECONDS)
+            defaultCardScanEventsReporter.scanStarted()
+            ShadowSystemClock.advanceBy(2, TimeUnit.SECONDS)
 
-        defaultCardScanEventsReporter.scanMlKitFoundPan()
-        defaultCardScanEventsReporter.scanMlKitFoundPan()
+            defaultCardScanEventsReporter.scanMlKitFoundPan()
+            defaultCardScanEventsReporter.scanMlKitFoundPan()
 
-        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+            val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
-        assertThat(loggedRequests).hasSize(2)
-        val loggedParams = loggedRequests.last().params
-        assertThat(loggedParams["event"]).isEqualTo("cardscan_mlkit_found_pan")
-        assertThat(loggedParams["duration"]).isEqualTo(2f)
-        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
-    }
+            assertThat(loggedRequests).hasSize(2)
+            val loggedParams = loggedRequests.last().params
+            assertThat(loggedParams["event"]).isEqualTo("cardscan_mlkit_found_pan")
+            assertThat(loggedParams["duration"]).isEqualTo(2f)
+            assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+        }
 
     @Test
     fun testMlKitFoundExpSentOncePerSession() =
         runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
-        defaultCardScanEventsReporter.scanStarted()
-        ShadowSystemClock.advanceBy(3, TimeUnit.SECONDS)
+            defaultCardScanEventsReporter.scanStarted()
+            ShadowSystemClock.advanceBy(3, TimeUnit.SECONDS)
 
-        defaultCardScanEventsReporter.scanMlKitFoundExp()
-        defaultCardScanEventsReporter.scanMlKitFoundExp()
+            defaultCardScanEventsReporter.scanMlKitFoundExp()
+            defaultCardScanEventsReporter.scanMlKitFoundExp()
 
-        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+            val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
-        assertThat(loggedRequests).hasSize(2)
-        val loggedParams = loggedRequests.last().params
-        assertThat(loggedParams["event"]).isEqualTo("cardscan_mlkit_found_exp")
-        assertThat(loggedParams["duration"]).isEqualTo(3f)
-        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
-    }
+            assertThat(loggedRequests).hasSize(2)
+            val loggedParams = loggedRequests.last().params
+            assertThat(loggedParams["event"]).isEqualTo("cardscan_mlkit_found_exp")
+            assertThat(loggedParams["duration"]).isEqualTo(3f)
+            assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+        }
 
     @Test
     fun testDarkniteFoundPanSentOncePerSession() =
         runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
-        defaultCardScanEventsReporter.scanStarted()
-        ShadowSystemClock.advanceBy(4, TimeUnit.SECONDS)
+            defaultCardScanEventsReporter.scanStarted()
+            ShadowSystemClock.advanceBy(4, TimeUnit.SECONDS)
 
-        defaultCardScanEventsReporter.scanDarkniteFoundPan()
-        defaultCardScanEventsReporter.scanDarkniteFoundPan()
+            defaultCardScanEventsReporter.scanDarkniteFoundPan()
+            defaultCardScanEventsReporter.scanDarkniteFoundPan()
 
-        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+            val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
-        assertThat(loggedRequests).hasSize(2)
-        val loggedParams = loggedRequests.last().params
-        assertThat(loggedParams["event"]).isEqualTo("cardscan_darknite_found_pan")
-        assertThat(loggedParams["duration"]).isEqualTo(4f)
-        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
-    }
+            assertThat(loggedRequests).hasSize(2)
+            val loggedParams = loggedRequests.last().params
+            assertThat(loggedParams["event"]).isEqualTo("cardscan_darknite_found_pan")
+            assertThat(loggedParams["duration"]).isEqualTo(4f)
+            assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+        }
 
     @Test
     fun testModelsDisagreeSentOncePerSession() =
         runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
-        defaultCardScanEventsReporter.scanStarted()
-        ShadowSystemClock.advanceBy(5, TimeUnit.SECONDS)
+            defaultCardScanEventsReporter.scanStarted()
+            ShadowSystemClock.advanceBy(5, TimeUnit.SECONDS)
 
-        defaultCardScanEventsReporter.scanModelsDisagree()
-        defaultCardScanEventsReporter.scanModelsDisagree()
+            defaultCardScanEventsReporter.scanModelsDisagree()
+            defaultCardScanEventsReporter.scanModelsDisagree()
 
-        val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
+            val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
-        assertThat(loggedRequests).hasSize(2)
-        val loggedParams = loggedRequests.last().params
-        assertThat(loggedParams["event"]).isEqualTo("cardscan_models_disagree")
-        assertThat(loggedParams["duration"]).isEqualTo(5f)
-        assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
-    }
+            assertThat(loggedRequests).hasSize(2)
+            val loggedParams = loggedRequests.last().params
+            assertThat(loggedParams["event"]).isEqualTo("cardscan_models_disagree")
+            assertThat(loggedParams["duration"]).isEqualTo(5f)
+            assertThat(loggedParams["elements_session_id"]).isEqualTo(ELEMENTS_SESSION_ID)
+        }
 
     @Test
     fun testMilestonesDoNotEmitWithoutActiveSession() =
         runScenario { defaultCardScanEventsReporter, fakeAnalyticsRequestExecutor ->
-        defaultCardScanEventsReporter.scanMlKitFoundPan()
-        defaultCardScanEventsReporter.scanMlKitFoundExp()
-        defaultCardScanEventsReporter.scanDarkniteFoundPan()
-        defaultCardScanEventsReporter.scanModelsDisagree()
+            defaultCardScanEventsReporter.scanMlKitFoundPan()
+            defaultCardScanEventsReporter.scanMlKitFoundExp()
+            defaultCardScanEventsReporter.scanDarkniteFoundPan()
+            defaultCardScanEventsReporter.scanModelsDisagree()
 
-        assertThat(fakeAnalyticsRequestExecutor.getExecutedRequests()).isEmpty()
-    }
+            assertThat(fakeAnalyticsRequestExecutor.getExecutedRequests()).isEmpty()
+        }
 
     private fun runScenario(
         testBlock: (DefaultCardScanEventsReporter, FakeAnalyticsRequestExecutor) -> Unit

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardCollectionTestHelper.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardCollectionTestHelper.kt
@@ -46,9 +46,9 @@ class TapToAddCardCollectionTestHelper(
                 readerSupportResult = ReaderSupportResult.Supported,
                 retrieveSetupIntentResult = TerminalTestDelegate.SetupIntentResult.Success(setupIntent),
                 collectSetupIntentPaymentMethodResult =
-                    TerminalTestDelegate.SetupIntentResult.Success(setupIntent),
+                TerminalTestDelegate.SetupIntentResult.Success(setupIntent),
                 confirmSetupIntentResult =
-                    TerminalTestDelegate.SetupIntentResult.Success(confirmedIntent),
+                TerminalTestDelegate.SetupIntentResult.Success(confirmedIntent),
             )
         )
 


### PR DESCRIPTION
## Summary

The ktlint `Indentation` rule was disabled in **both** `config/detekt/detekt.yml` and `.editorconfig`, so incorrect indentation (e.g. 3 spaces instead of 4) was never flagged by detekt. detekt's ktlint wrapper delegates to ktlint's engine, which reads `.editorconfig`, so the rule has to be enabled in both files to take effect (they were already documented to stay in sync).

This PR:
- Enables `Indentation` in `config/detekt/detekt.yml` (`active: true`).
- Removes `ktlint_standard_indent = disabled` from `.editorconfig`.
- Auto-corrects the resulting pre-existing violations across the codebase via `./gradlew detektFormat`.

New indentation mistakes (like 3 spaces instead of 4) will now fail the `detekt` task.

## Notes

- All `.kt` changes are **whitespace-only** — verified with `git diff -w` (empty). Only the two config files have semantic edits.
- `./gradlew detekt` passes green after formatting.

## Testing

- `./gradlew detektFormat` — auto-corrected 33 `.kt` files.
- `./gradlew detekt` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)