### PR TITLE
Refactor CvcRecollection interactor tests for coroutine scope management.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreenScreenshotTest.kt
@@ -4,20 +4,29 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 class CvcRecollectionScreenScreenshotTest {
-    @get:Rule
-    val paparazziRule = PaparazziRule(
+    private val paparazziRule = PaparazziRule(
         SystemAppearance.entries,
         PaymentSheetAppearance.entries,
         FontSize.entries
     )
+
+    private val scopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(scopeCleanupRule)
+        .around(paparazziRule)
 
     private fun interactor(cvc: String = "", isTestMode: Boolean = true): CvcRecollectionInteractor {
         return DefaultCvcRecollectionInteractor(
@@ -26,7 +35,7 @@ class CvcRecollectionScreenScreenshotTest {
             cvc = cvc,
             isTestMode = isTestMode,
             processing = stateFlowOf(false),
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = scopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/DefaultCvcRecollectionInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/DefaultCvcRecollectionInteractorTest.kt
@@ -7,14 +7,14 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class DefaultCvcRecollectionInteractorTest {
 
     private fun createInteractor(
-        processing: StateFlow<Boolean> = stateFlowOf(false)
+        scope: CoroutineScope,
+        processing: StateFlow<Boolean> = stateFlowOf(false),
     ): DefaultCvcRecollectionInteractor {
         return DefaultCvcRecollectionInteractor(
             lastFour = "4242",
@@ -22,13 +22,13 @@ class DefaultCvcRecollectionInteractorTest {
             cvc = "",
             isTestMode = true,
             processing = processing,
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = scope,
         )
     }
 
     @Test
     fun `view state initialized properly on init`() = runTest {
-        val interactor = createInteractor()
+        val interactor = createInteractor(scope = backgroundScope)
 
         interactor.viewState.test {
             val viewState = awaitItem()
@@ -40,7 +40,7 @@ class DefaultCvcRecollectionInteractorTest {
 
     @Test
     fun `view state updated with CVC onCvcChanged`() = runTest {
-        val interactor = createInteractor()
+        val interactor = createInteractor(scope = backgroundScope)
 
         interactor.viewState.test {
             assertThat(awaitItem().cvcState.cvc).isEqualTo("")
@@ -52,7 +52,7 @@ class DefaultCvcRecollectionInteractorTest {
     @Test
     fun `view state updated with enabled when processing changes`() = runTest {
         val processingSource = MutableStateFlow(false)
-        val interactor = createInteractor(processing = processingSource)
+        val interactor = createInteractor(scope = backgroundScope, processing = processingSource)
 
         interactor.viewState.test {
             assertThat(awaitItem().isEnabled).isTrue()
@@ -65,7 +65,7 @@ class DefaultCvcRecollectionInteractorTest {
 
     @Test
     fun `on confirm pressed interactor emits confirmed result`() = runTest {
-        val interactor = createInteractor()
+        val interactor = createInteractor(scope = backgroundScope)
 
         interactor.cvcCompletionState.test {
             assertThat(awaitItem()).isEqualTo(CvcCompletionState.Incomplete)


### PR DESCRIPTION
# Summary
Refactored the CvcRecollectionScreenScreenshotTest and DefaultCvcRecollectionInteractorTest to improve coroutine scope management and cleanup during testing.

# Motivation
Ensures that coroutines are properly cleaned up between tests, prevents scope leaks, and makes test lifecycle more robust. This also helps prevent flakes and improper coroutine usage in tests.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog