### PR TITLE
Address post-merge review feedback from #13183

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -246,19 +246,23 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         var stripeIntentResult: Result<T>? = null
         var lastObservedStatus: StripeIntent.Status? = null
 
+        suspend fun retrieveAndTrackStatus(): Result<T> {
+            val result = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
+            lastObservedStatus = result.getOrNull()?.status ?: lastObservedStatus
+            return result
+        }
+
         val timeRemaining = getPollingDurationForPaymentMethod(originalIntent) -
             (System.currentTimeMillis() - initialRetrieveIntentStartTime)
 
         withTimeoutOrNull(timeRemaining) {
-            stripeIntentResult = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
-            lastObservedStatus = stripeIntentResult?.getOrNull()?.status ?: lastObservedStatus
+            stripeIntentResult = retrieveAndTrackStatus()
             while (shouldRetry(stripeIntentResult)) {
                 // We want to delay a maximum of 1s between requests, including the time the request took.
                 // e.g. if the previous request took 250ms, the delay will be 750ms
                 delay(POLLING_DELAY - (System.currentTimeMillis() - timeOfLastRequest))
                 timeOfLastRequest = System.currentTimeMillis()
-                stripeIntentResult = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
-                lastObservedStatus = stripeIntentResult?.getOrNull()?.status ?: lastObservedStatus
+                stripeIntentResult = retrieveAndTrackStatus()
             }
         }
 
@@ -266,8 +270,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         // request took longer than the polling duration for the payment method. Ensures we always call retrieve
         // at least once after the polling duration
         if (shouldRetry(stripeIntentResult) || stripeIntentResult == null) {
-            stripeIntentResult = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
-            lastObservedStatus = stripeIntentResult?.getOrNull()?.status ?: lastObservedStatus
+            stripeIntentResult = retrieveAndTrackStatus()
 
             if (shouldRetry(stripeIntentResult)) {
                 pollingAnalyticsEventReporter.onPollingTimedOut(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -52,10 +52,11 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
         host: AuthActivityStarterHost,
         requestOptions: ApiRequest.Options
     ): PollingContract.Args {
-        val paymentMethodType = requireNotNull(actionable.paymentMethod?.type?.code) {
-            "Received null payment method type in PollingAuthenticator"
-        }
-        return when (actionable.paymentMethod?.type) {
+        return when (
+            val paymentMethodType = requireNotNull(actionable.paymentMethod?.type) {
+                "Received null payment method type in PollingAuthenticator"
+            }
+        ) {
             PaymentMethod.Type.Blik ->
                 PollingContract.Args(
                     clientSecret = requireNotNull(actionable.clientSecret),
@@ -65,7 +66,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     ctaText = R.string.stripe_blik_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
                     qrCodeUrl = null,
-                    paymentMethodType = paymentMethodType,
+                    paymentMethodType = paymentMethodType.code,
                 )
             PaymentMethod.Type.PayNow ->
                 PollingContract.Args(
@@ -76,7 +77,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     ctaText = R.string.stripe_qrcode_lpm_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
                     qrCodeUrl = getQrCodeForPayNow(actionable),
-                    paymentMethodType = paymentMethodType,
+                    paymentMethodType = paymentMethodType.code,
                 )
             PaymentMethod.Type.PromptPay ->
                 PollingContract.Args(
@@ -87,12 +88,12 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     ctaText = R.string.stripe_qrcode_lpm_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
                     qrCodeUrl = getQrCodeForPromptPay(actionable),
-                    paymentMethodType = paymentMethodType,
+                    paymentMethodType = paymentMethodType.code,
                 )
             else ->
                 error(
                     "Received invalid payment method type " +
-                        "$paymentMethodType in PollingAuthenticator"
+                        "${paymentMethodType.code} in PollingAuthenticator"
                 )
         }
     }


### PR DESCRIPTION
## Summary
Follow-up cleanup addressing two post-merge review comments left on #13183 after it was already approved and merged:

- **[#13183 review comment](https://github.com/stripe/stripe-android/pull/13183#discussion_r3589873134)**: `PaymentFlowResultProcessor.pollStripeIntentUntilTerminalState` set `lastObservedStatus` right after each of 3 separate `retrieveStripeIntent` calls. Extracted a local `retrieveAndTrackStatus()` closure so a future new retrieve call site can't forget to update it.
- **[#13183 review comments](https://github.com/stripe/stripe-android/pull/13183#discussion_r3589908251)** / **[rationale](https://github.com/stripe/stripe-android/pull/13183#discussion_r3589914874)**: `PollingNextActionHandler.getArgsForPaymentMethod` read `actionable.paymentMethod?.type` twice (once via `?.code` for a string, once directly in the `when` subject). Now binds it once via `when (val paymentMethodType = requireNotNull(...))`, so the value being switched on and the value used in each branch can't drift apart. Same error messages, same branching — behavior-preserving.

Both changes are small, low-risk, and behavior-preserving refactors — no new functionality.

## Test plan
- [x] `PaymentIntentFlowResultProcessorTest`, `SetupIntentFlowResultProcessorTest` pass
- [x] Full `:paymentsheet:testDebugUnitTest` suite passes
- [x] `apiCheck` and `detekt` pass for both modules
