### PR TITLE
Introduce checkout-owned BillingDetailsCollectionConfiguration (MOBILESDK-4636 pre-work)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/BillingDetailsCollectionConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/BillingDetailsCollectionConfiguration.kt
@@ -1,0 +1,101 @@
+package com.stripe.android.checkout
+
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Configuration for how billing details are collected during checkout.
+ */
+@CheckoutSessionPreview
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class BillingDetailsCollectionConfiguration {
+
+    private var name: CollectionMode = CollectionMode.Automatic
+    private var phone: CollectionMode = CollectionMode.Automatic
+    private var email: CollectionMode = CollectionMode.Automatic
+    private var address: AddressCollectionMode = AddressCollectionMode.Automatic
+
+    /** How to collect the name field. */
+    fun name(name: CollectionMode): BillingDetailsCollectionConfiguration = apply {
+        this.name = name
+    }
+
+    /** How to collect the phone field. */
+    fun phone(phone: CollectionMode): BillingDetailsCollectionConfiguration = apply {
+        this.phone = phone
+    }
+
+    /** How to collect the email field. */
+    fun email(email: CollectionMode): BillingDetailsCollectionConfiguration = apply {
+        this.email = email
+    }
+
+    /** How to collect the billing address. */
+    fun address(address: AddressCollectionMode): BillingDetailsCollectionConfiguration = apply {
+        this.address = address
+    }
+
+    @Parcelize
+    internal data class State(
+        val name: CollectionMode,
+        val phone: CollectionMode,
+        val email: CollectionMode,
+        val address: AddressCollectionMode,
+    ) : Parcelable
+
+    internal fun build(): State = State(
+        name = name,
+        phone = phone,
+        email = email,
+        address = address,
+    )
+
+    /**
+     * Billing details fields collection options.
+     */
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class CollectionMode {
+        /**
+         * The field will be collected depending on the Payment Method's requirements.
+         */
+        Automatic,
+
+        /**
+         * The field will never be collected.
+         * If this field is required by the Payment Method, you must provide it as part of
+         * the default billing details.
+         */
+        Never,
+
+        /**
+         * The field will always be collected, even if it isn't required for the Payment
+         * Method.
+         */
+        Always,
+    }
+
+    /**
+     * Billing address collection options.
+     */
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class AddressCollectionMode {
+        /**
+         * Only the fields required by the Payment Method will be collected, this may be
+         * none.
+         */
+        Automatic,
+
+        /**
+         * Collect the full billing address, regardless of the Payment Method requirements.
+         */
+        Full,
+
+        // Note: a `Never` mode is intentionally omitted for the CheckoutSession private
+        // preview — suppressing billing collection is not supported with a CheckoutSession.
+        // It can be added at public preview/GA if that use case is supported.
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapper.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun BillingDetailsCollectionConfiguration.State.asPaymentSheet():
+    PaymentSheet.BillingDetailsCollectionConfiguration =
+    PaymentSheet.BillingDetailsCollectionConfiguration(
+        name = name.asPaymentSheet(),
+        phone = phone.asPaymentSheet(),
+        email = email.asPaymentSheet(),
+        address = address.asPaymentSheet(),
+        // A CheckoutSession always attaches its billing details to the payment method.
+        attachDefaultsToPaymentMethod = true,
+    )
+
+@OptIn(CheckoutSessionPreview::class)
+private fun BillingDetailsCollectionConfiguration.CollectionMode.asPaymentSheet():
+    PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = when (this) {
+    BillingDetailsCollectionConfiguration.CollectionMode.Automatic ->
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
+    BillingDetailsCollectionConfiguration.CollectionMode.Never ->
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never
+    BillingDetailsCollectionConfiguration.CollectionMode.Always ->
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun BillingDetailsCollectionConfiguration.AddressCollectionMode.asPaymentSheet():
+    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode = when (this) {
+    BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic ->
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+    BillingDetailsCollectionConfiguration.AddressCollectionMode.Full ->
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -54,6 +54,10 @@ internal class CheckoutStateLoader @Inject constructor(
             .embeddedViewDisplaysMandateText(
                 configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
             )
+            .billingDetailsCollectionConfiguration(
+                configuration.paymentElementConfiguration.billingDetailsCollectionConfiguration
+                    .asPaymentSheet()
+            )
             .build()
 
         val embeddedConfig = CheckoutConfigurationMerger.EmbeddedConfiguration(baseConfig)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -31,6 +31,8 @@ class PaymentElement @Inject internal constructor() {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
         private var embeddedViewDisplaysMandateText: Boolean = true
+        private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
+            BillingDetailsCollectionConfiguration()
 
         fun embeddedViewDisplaysMandateText(
             embeddedViewDisplaysMandateText: Boolean
@@ -38,13 +40,21 @@ class PaymentElement @Inject internal constructor() {
             this.embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText
         }
 
+        fun billingDetailsCollectionConfiguration(
+            billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration
+        ): Configuration = apply {
+            this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
+        }
+
         @Parcelize
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
+            val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
         ) : Parcelable
 
         internal fun build(): State = State(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+            billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
@@ -1,0 +1,83 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class BillingDetailsCollectionConfigurationMapperTest {
+
+    @Test
+    fun `default owned config maps to PaymentSheet defaults with attachDefaults forced true`() {
+        val mapped = BillingDetailsCollectionConfiguration().build().asPaymentSheet()
+        assertThat(mapped)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration(attachDefaultsToPaymentMethod = true))
+    }
+
+    @Test
+    fun `CollectionMode Automatic maps to Automatic`() {
+        val mapped = BillingDetailsCollectionConfiguration()
+            .name(BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
+            .build()
+            .asPaymentSheet()
+        assertThat(mapped.name)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
+    }
+
+    @Test
+    fun `CollectionMode Never maps to Never`() {
+        val mapped = BillingDetailsCollectionConfiguration()
+            .name(BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            .build()
+            .asPaymentSheet()
+        assertThat(mapped.name)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+    }
+
+    @Test
+    fun `CollectionMode Always maps to Always`() {
+        val mapped = BillingDetailsCollectionConfiguration()
+            .name(BillingDetailsCollectionConfiguration.CollectionMode.Always)
+            .build()
+            .asPaymentSheet()
+        assertThat(mapped.name)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+    }
+
+    @Test
+    fun `all CollectionMode fields map 1 to 1`() {
+        val mapped = BillingDetailsCollectionConfiguration()
+            .name(BillingDetailsCollectionConfiguration.CollectionMode.Always)
+            .phone(BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            .email(BillingDetailsCollectionConfiguration.CollectionMode.Always)
+            .build()
+            .asPaymentSheet()
+        assertThat(mapped.name)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+        assertThat(mapped.phone)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+        assertThat(mapped.email)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+    }
+
+    @Test
+    fun `AddressCollectionMode Automatic maps to Automatic`() {
+        val mapped = BillingDetailsCollectionConfiguration()
+            .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic)
+            .build()
+            .asPaymentSheet()
+        assertThat(mapped.address)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic)
+    }
+
+    @Test
+    fun `AddressCollectionMode Full maps to Full`() {
+        val mapped = BillingDetailsCollectionConfiguration()
+            .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+            .build()
+            .asPaymentSheet()
+        assertThat(mapped.address)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -6,6 +6,9 @@ import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.BillingDetailsCollectionConfiguration
+import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -35,6 +38,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
@@ -77,6 +81,21 @@ internal class CheckoutStateLoaderTest {
 
             assertThat(stateHolder.state?.embeddedConfiguration?.embeddedViewDisplaysMandateText)
                 .isFalse()
+        }
+
+    @Test
+    fun `loadInitial propagates billingDetailsCollectionConfiguration from the payment element configuration`() =
+        runScenario {
+            val configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Full))
+                )
+                .build()
+
+            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+
+            assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+                .isEqualTo(PSFull)
         }
 
     @Test
@@ -205,6 +224,10 @@ internal class CheckoutStateLoaderTest {
     private fun defaultConfiguration() = CheckoutController.Configuration().build()
 
     private fun response() = CheckoutSessionResponseFactory.create()
+
+    private fun bdcc(
+        address: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
+    ) = BillingDetailsCollectionConfiguration().address(address)
 
     // A committed state as [CheckoutStateLoader] would produce it, for exercising reloads. The
     // resolved metadata/configuration are placeholders; reload recomputes and overwrites them.


### PR DESCRIPTION
# Summary
Pre-work refactor for [MOBILESDK-4636](https://jira.corp.stripe.com/browse/MOBILESDK-4636), per @jaynewstrom-stripe's principle: **no `paymentsheet` imports on the `PaymentElement` config surface**.

Introduces a checkout-owned `PaymentElement.Configuration.BillingDetailsCollectionConfiguration` (a copy with no `PaymentSheet` reference) and an internal `asPaymentSheet()` mapper. This lets the CheckoutController config carry BDCC without exposing `PaymentSheet` types; the mapper converts to the shared `PaymentSheet` type in `CheckoutStateLoader`.

This PR is **pure config plumbing** — it adds no reconciliation behavior. The `billing_address_collection` reconciliation lands on top in the stacked PR #13420.

## Deliberately narrowed for private preview
The checkout-owned type only models what a merchant can meaningfully set for a CheckoutSession:
- **`address` (`AddressCollectionMode`) exposes only `Automatic`/`Full`** — `Never` is omitted because suppressing billing collection isn't supported with a CheckoutSession. Omitting it makes that illegal state unrepresentable at compile time (vs a runtime error). Addable at public preview/GA if supported.
- **`attachDefaultsToPaymentMethod` is not exposed** — a CheckoutSession always attaches billing details to the payment method, so the mapper forces it on internally.

(This intentionally diverges from a 1:1 copy of `PaymentSheet.BillingDetailsCollectionConfiguration`; owning the type lets us model only the valid states.)

## Testing
- [x] Added tests
- [ ] Manually verified

- `BillingDetailsCollectionConfigurationMapperTest`: exhaustive 1:1 enum mapping for `CollectionMode` (name/phone/email) and `AddressCollectionMode` (address); asserts the mapper always sets `attachDefaultsToPaymentMethod = true`.
- `CheckoutStateLoaderTest`: the merchant's BDCC propagates through the mapper into the committed config (`address` survives to the loaded `EmbeddedPaymentElement.Configuration`).

`:paymentsheet:testDebugUnitTest` + `:paymentsheet:detekt` pass on the latest `master`. android-code-reviewer: APPROVE (behavior-preserving, mapper exhaustive, principle satisfied).

## Out of scope (pre-existing debt)
`PaymentOptionDisplayData.billingDetails: PaymentSheet.BillingDetails?` and `ExpressCheckoutElement`'s `PaymentSheet...Visibility` carry the same paymentsheet-on-surface debt — separate follow-ups.

# Changelog
N/A. `@RestrictTo(LIBRARY_GROUP)` (private preview); no public API change.
