### PR TITLE
Wire up confirmation handler and add CheckoutPresenter confirmation logic.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationHelper.kt
@@ -1,0 +1,100 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
+import com.stripe.android.paymentelement.confirmation.toConfirmationOption
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStarter
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.utils.reportPaymentResult
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+internal interface CheckoutConfirmationHelper {
+    fun confirm()
+}
+
+/**
+ * Drives confirmation for [CheckoutPresenter], mirroring [com.stripe.android.paymentelement.embedded.content.
+ * DefaultEmbeddedConfirmationHelper]. The current [CheckoutControllerState] is read from [stateHolder] (the
+ * controller's single source of truth) to build [ConfirmationHandler.Args], the confirmation is started through the
+ * shared [EmbeddedConfirmationStarter], and each terminal [ConfirmationHandler.Result] is mapped to a
+ * [CheckoutController.Result] and delivered to the merchant's [CheckoutController.ResultCallback].
+ */
+internal class DefaultCheckoutConfirmationHelper @Inject constructor(
+    private val confirmationStarter: EmbeddedConfirmationStarter,
+    private val activityResultCaller: ActivityResultCaller,
+    private val lifecycleOwner: LifecycleOwner,
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val resultCallback: CheckoutController.ResultCallback,
+    private val eventReporter: EventReporter,
+) : CheckoutConfirmationHelper {
+    init {
+        confirmationStarter.register(
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
+        )
+
+        lifecycleOwner.lifecycleScope.launch {
+            confirmationStarter.result.collect { result ->
+                eventReporter.reportPaymentResult(result, stateHolder.selection.value)
+                // Let the merchant mutate/retry the session again once a non-successful attempt settles.
+                if (result !is ConfirmationHandler.Result.Succeeded) {
+                    setIntegrationLaunched(false)
+                }
+                resultCallback.onResult(result.asCheckoutResult())
+            }
+        }
+    }
+
+    override fun confirm() {
+        val args = confirmationArgs() ?: run {
+            resultCallback.onResult(
+                CheckoutController.Result.Failed(IllegalStateException("Not in a state that's confirmable."))
+            )
+            return
+        }
+        // Block session mutations while confirmation is in flight (see CheckoutController.withCheckoutState).
+        setIntegrationLaunched(true)
+        confirmationStarter.start(args)
+    }
+
+    private fun confirmationArgs(): ConfirmationHandler.Args? {
+        val state = stateHolder.state ?: return null
+        val metadata = state.paymentMethodMetadata
+        val configuration = state.embeddedConfiguration.asCommonConfiguration()
+
+        val confirmationOption = state.paymentSelection?.toConfirmationOption(
+            configuration = configuration,
+            linkConfiguration = metadata.linkState?.configuration,
+            cardFundingFilter = metadata.cardFundingFilter,
+            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(metadata),
+            googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
+                configuration = configuration,
+                paymentMethodMetadata = metadata,
+            ),
+        ) ?: return null
+
+        return ConfirmationHandler.Args(
+            confirmationOption = confirmationOption,
+            paymentMethodMetadata = metadata,
+        )
+    }
+
+    private fun setIntegrationLaunched(integrationLaunched: Boolean) {
+        stateHolder.state = stateHolder.state?.copy(integrationLaunched = integrationLaunched)
+    }
+}
+
+private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result = when (this) {
+    is ConfirmationHandler.Result.Succeeded -> CheckoutController.Result.Completed()
+    is ConfirmationHandler.Result.Canceled -> CheckoutController.Result.Canceled()
+    is ConfirmationHandler.Result.Failed -> CheckoutController.Result.Failed(cause)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -7,8 +7,10 @@ import androidx.annotation.RestrictTo
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
+import com.stripe.android.common.ui.PaymentElementActivityResultCaller
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.validateShippingCountry
@@ -40,6 +42,7 @@ class CheckoutController @Inject internal constructor(
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) {
     val checkoutSession: StateFlow<CheckoutSession?>
         get() = stateHolder.checkoutSession
@@ -293,7 +296,16 @@ class CheckoutController @Inject internal constructor(
     }
 
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {
-        return checkoutPresenterSubcomponentFactory.create().presenter
+        return checkoutPresenterSubcomponentFactory.create(
+            // Register through the activity's ActivityResultRegistry directly rather than passing the
+            // activity as the caller, so confirmation can be wired up even after the activity is
+            // STARTED (mirrors rememberEmbeddedPaymentElement).
+            activityResultCaller = PaymentElementActivityResultCaller(
+                key = "CheckoutController(instance = $paymentElementCallbackIdentifier)",
+                registryOwner = activity,
+            ),
+            lifecycleOwner = activity,
+        ).presenter
     }
 
     fun destroy() {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
@@ -12,6 +12,9 @@ class CheckoutPresenter @Inject internal constructor(
     private val currencySelectorElementProvider: Provider<CurrencySelectorElement>,
     private val shippingAddressElementProvider: Provider<ShippingAddressElement>,
     private val expressCheckoutElementProvider: Provider<ExpressCheckoutElement>,
+    // Injected eagerly (not a Provider) so its init registers the confirmation handler with the
+    // activity as soon as the presenter is created.
+    private val confirmationHelper: CheckoutConfirmationHelper,
 ) {
 
     fun paymentElement(): PaymentElement {
@@ -31,6 +34,6 @@ class CheckoutPresenter @Inject internal constructor(
     }
 
     fun confirm() {
-        TODO("Not yet implemented")
+        confirmationHelper.confirm()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -31,6 +31,8 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
@@ -38,6 +40,7 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
@@ -45,8 +48,6 @@ import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
-import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
-import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
@@ -101,6 +102,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ExtendedPaymentElementConfirmationModule::class,
     ],
 )
 internal interface CheckoutControllerComponent {
@@ -234,14 +236,23 @@ internal interface CheckoutControllerModule {
         fun provideAllowsManualConfirmation(): Boolean = true
 
         @Provides
-        fun provideEventReporterMode(): EventReporter.Mode {
-            return EventReporter.Mode.Embedded
+        @Singleton
+        fun provideConfirmationHandler(
+            confirmationHandlerFactory: ConfirmationHandler.Factory,
+            @ViewModelScope coroutineScope: CoroutineScope,
+        ): ConfirmationHandler {
+            return confirmationHandlerFactory.create(coroutineScope)
         }
 
+        // Checkout is not launched with a status-bar-color argument; the payment launcher treats a
+        // null color as "don't override".
         @Provides
-        @Singleton
-        fun provideCvcRecollectionHandler(): CvcRecollectionHandler {
-            return CvcRecollectionHandlerImpl()
+        @Named(STATUS_BAR_COLOR)
+        fun provideStatusBarColor(): Int? = null
+
+        @Provides
+        fun provideEventReporterMode(): EventReporter.Mode {
+            return EventReporter.Mode.Embedded
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
@@ -2,12 +2,20 @@
 
 package com.stripe.android.checkout.injection
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.checkout.CheckoutConfirmationHelper
 import com.stripe.android.checkout.CheckoutPresenter
+import com.stripe.android.checkout.DefaultCheckoutConfirmationHelper
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import dagger.Binds
+import dagger.BindsInstance
+import dagger.Module
 import dagger.Subcomponent
 
 @Subcomponent(
     modules = [
+        CheckoutPresenterModule::class,
         CurrencySelectorElementModule::class,
         ExpressCheckoutElementModule::class,
     ]
@@ -17,6 +25,17 @@ internal interface CheckoutPresenterSubcomponent {
 
     @Subcomponent.Factory
     interface Factory {
-        fun create(): CheckoutPresenterSubcomponent
+        fun create(
+            @BindsInstance activityResultCaller: ActivityResultCaller,
+            @BindsInstance lifecycleOwner: LifecycleOwner,
+        ): CheckoutPresenterSubcomponent
     }
+}
+
+@Module
+internal interface CheckoutPresenterModule {
+    @Binds
+    fun bindsConfirmationHelper(
+        confirmationHelper: DefaultCheckoutConfirmationHelper
+    ): CheckoutConfirmationHelper
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import kotlinx.coroutines.test.runTest
+import org.mockito.kotlin.mock
+import javax.inject.Provider
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutPresenterTest {
+
+    @Test
+    fun `confirm delegates to the confirmation helper`() = runTest {
+        val confirmationHelper = FakeCheckoutConfirmationHelper()
+        val presenter = CheckoutPresenter(
+            paymentElementProvider = Provider { mock() },
+            currencySelectorElementProvider = Provider { mock() },
+            shippingAddressElementProvider = Provider { mock() },
+            expressCheckoutElementProvider = Provider { mock() },
+            confirmationHelper = confirmationHelper,
+        )
+
+        presenter.confirm()
+
+        confirmationHelper.confirmCalls.awaitItem()
+        confirmationHelper.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutConfirmationHelperTest.kt
@@ -1,0 +1,189 @@
+package com.stripe.android.checkout
+
+import android.os.Bundle
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStarter
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultCheckoutConfirmationHelperTest {
+
+    @Test
+    fun `confirm builds args from the state and starts the confirmation handler`() = testScenario {
+        confirmationHelper.confirm()
+
+        val args = confirmationHandler.startTurbine.awaitItem()
+        assertThat(args.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
+        assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
+        // Session mutations are blocked while confirmation is in flight.
+        assertThat(stateHolder.state?.integrationLaunched).isTrue()
+    }
+
+    @Test
+    fun `confirm builds a saved payment method option from the selection`() = testScenario(
+        state = committedState(
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        ),
+    ) {
+        confirmationHelper.confirm()
+
+        val args = confirmationHandler.startTurbine.awaitItem()
+        assertThat(args.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
+        assertThat(stateHolder.state?.integrationLaunched).isTrue()
+    }
+
+    @Test
+    fun `confirm reports Failed and does not start when there is no selection`() = testScenario(
+        state = committedState(paymentSelection = null),
+    ) {
+        confirmationHelper.confirm()
+
+        assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Failed>()
+        assertThat(stateHolder.state?.integrationLaunched).isFalse()
+    }
+
+    @Test
+    fun `confirm reports Failed and does not start when there is no committed state`() = testScenario(
+        state = null,
+    ) {
+        confirmationHelper.confirm()
+
+        assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Failed>()
+    }
+
+    @Test
+    fun `succeeded confirmation maps to Completed`() = testScenario {
+        confirmationHandler.state.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(intent = PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+
+        assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `failed confirmation maps to Failed and re-enables mutations`() = testScenario(
+        state = committedState(integrationLaunched = true),
+    ) {
+        val cause = IllegalStateException("Boom.")
+        confirmationHandler.state.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Failed(
+                cause = cause,
+                message = "Boom.".resolvableString,
+                type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+            )
+        )
+
+        assertThat(results.awaitItem()).isEqualTo(CheckoutController.Result.Failed(cause))
+        assertThat(stateHolder.state?.integrationLaunched).isFalse()
+    }
+
+    @Test
+    fun `canceled confirmation maps to Canceled and re-enables mutations`() = testScenario(
+        state = committedState(integrationLaunched = true),
+    ) {
+        confirmationHandler.state.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.InformCancellation)
+        )
+
+        assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(stateHolder.state?.integrationLaunched).isFalse()
+    }
+
+    private fun committedState(
+        paymentSelection: PaymentSelection? = PaymentSelection.GooglePay,
+        integrationLaunched: Boolean = false,
+    ) = CheckoutControllerState(
+        key = "test_key",
+        configuration = CheckoutController.Configuration().build(),
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+        flagImages = null,
+        collectedDetails = CheckoutCollectedDetails(),
+        integrationLaunched = integrationLaunched,
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+            .googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "US",
+                )
+            )
+            .build(),
+        paymentSelection = paymentSelection,
+        temporarySelection = null,
+        previousNewSelections = Bundle(),
+    )
+
+    private fun testScenario(
+        state: CheckoutControllerState? = committedState(),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val confirmationHandler = FakeConfirmationHandler()
+        val stateHolder = CheckoutControllerStateHolder(
+            savedStateHandle = SavedStateHandle(),
+            errorReporter = FakeErrorReporter(),
+        )
+        stateHolder.state = state
+        val results = Turbine<CheckoutController.Result>()
+
+        val activityResultCaller = mock<ActivityResultCaller>()
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined)
+        val confirmationHelper = DefaultCheckoutConfirmationHelper(
+            confirmationStarter = EmbeddedConfirmationStarter(
+                confirmationHandler = confirmationHandler,
+                coroutineScope = backgroundScope,
+            ),
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
+            stateHolder = stateHolder,
+            resultCallback = { results.add(it) },
+            eventReporter = FakeEventReporter(),
+        )
+        // The handler is registered with the activity's caller and lifecycle when the helper is created.
+        val registerCall = confirmationHandler.registerTurbine.awaitItem()
+        assertThat(registerCall.activityResultCaller).isSameInstanceAs(activityResultCaller)
+        assertThat(registerCall.lifecycleOwner).isSameInstanceAs(lifecycleOwner)
+
+        Scenario(
+            confirmationHelper = confirmationHelper,
+            confirmationHandler = confirmationHandler,
+            stateHolder = stateHolder,
+            results = results,
+        ).block()
+
+        results.ensureAllEventsConsumed()
+        confirmationHandler.validate()
+    }
+
+    private class Scenario(
+        val confirmationHelper: CheckoutConfirmationHelper,
+        val confirmationHandler: FakeConfirmationHandler,
+        val stateHolder: CheckoutControllerStateHolder,
+        val results: Turbine<CheckoutController.Result>,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutConfirmationHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutConfirmationHelper.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+
+internal class FakeCheckoutConfirmationHelper : CheckoutConfirmationHelper {
+    val confirmCalls = Turbine<Unit>()
+
+    override fun confirm() {
+        confirmCalls.add(Unit)
+    }
+
+    fun ensureAllEventsConsumed() {
+        confirmCalls.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary
Add wiring for the confirmation handler in the new Checkout flow and implement confirm logic in CheckoutPresenter. Add tests to validate confirmation flow and handler behavior.

# Motivation
Implement core Checkout confirmation logic, ensuring the confirmation starter is registered and properly processes CheckoutController states, enabling confirmation, error propagation, and retry handling in the new CheckoutPresenter design.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
- [Added] CheckoutPresenter now delegates confirm to a confirmation handler.