### PR TITLE
Support allowRedisplay param for Google Pay payment method creation.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -261,6 +261,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         publishableKey: String? = null,
         displayItems: List<com.stripe.android.GooglePayJsonFactory.DisplayItem> = emptyList(),
         billingEmailOverride: String? = null,
+        allowRedisplay: PaymentMethod.AllowRedisplay? = null,
     ) {
         check(skipReadyCheck || isReady) {
             "present() may only be called when Google Pay is available on this device."
@@ -280,6 +281,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
                 publishableKey = publishableKey,
                 displayItems = displayItems,
                 billingEmailOverride = billingEmailOverride,
+                allowRedisplay = allowRedisplay,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -60,6 +60,7 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val publishableKey: String? = null,
         internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
         internal val billingEmailOverride: String? = null,
+        internal val allowRedisplay: PaymentMethod.AllowRedisplay? = null,
     ) : Parcelable {
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -146,6 +146,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
             googlePayPaymentData = paymentDataJson,
             clientAttributionMetadata = args.clientAttributionMetadata,
             billingEmailOverride = args.billingEmailOverride,
+            allowRedisplay = args.allowRedisplay,
         )
 
         return stripeRepository.createPaymentMethod(params, requestOptions).fold(

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1048,6 +1048,7 @@ constructor(
                 googlePayPaymentData = googlePayPaymentData,
                 clientAttributionMetadata = null,
                 billingEmailOverride = null,
+                allowRedisplay = null,
             )
         }
 
@@ -1056,6 +1057,7 @@ constructor(
             googlePayPaymentData: JSONObject,
             clientAttributionMetadata: ClientAttributionMetadata?,
             billingEmailOverride: String?,
+            allowRedisplay: PaymentMethod.AllowRedisplay?,
         ): PaymentMethodCreateParams {
             val googlePayResult = GooglePayResult.fromJson(googlePayPaymentData)
             val token = googlePayResult.token
@@ -1072,7 +1074,7 @@ constructor(
                     email = billingEmailOverride ?: googlePayResult.email,
                     phone = googlePayResult.phoneNumber
                 ),
-                allowRedisplay = null,
+                allowRedisplay = allowRedisplay,
                 metadata = null,
                 clientAttributionMetadata = clientAttributionMetadata,
             )

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -146,6 +146,29 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     @Test
+    fun `createPaymentMethod() forwards allowRedisplay from args`() = runTest {
+        val viewModelWithAllowRedisplay = GooglePayPaymentMethodLauncherViewModel(
+            ApplicationProvider.getApplicationContext(),
+            paymentsClient,
+            REQUEST_OPTIONS,
+            ARGS.copy(allowRedisplay = PaymentMethod.AllowRedisplay.LIMITED),
+            stripeRepository,
+            googlePayJsonFactory,
+            googlePayRepository,
+            SavedStateHandle()
+        )
+
+        viewModelWithAllowRedisplay.createPaymentMethod(
+            PaymentData.fromJson(
+                GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS.toString()
+            )
+        )
+
+        assertThat(stripeRepository.getCreateParams()?.allowRedisplay)
+            .isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
+    }
+
+    @Test
     fun `createTransactionInfo() with amount should create expected TransactionInfo`() {
         val transactionInfo = viewModel.createTransactionInfo(ARGS)
         assertThat(transactionInfo)

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -31,6 +31,7 @@ class PaymentMethodCreateParamsTest {
             googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
             clientAttributionMetadata = null,
             billingEmailOverride = "checkout@example.com",
+            allowRedisplay = null,
         )
 
         assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
@@ -42,6 +43,7 @@ class PaymentMethodCreateParamsTest {
             googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS,
             clientAttributionMetadata = null,
             billingEmailOverride = "checkout@example.com",
+            allowRedisplay = null,
         )
 
         assertThat(params.billingDetails?.email).isEqualTo("checkout@example.com")
@@ -53,9 +55,22 @@ class PaymentMethodCreateParamsTest {
             googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
             clientAttributionMetadata = null,
             billingEmailOverride = null,
+            allowRedisplay = null,
         )
 
         assertThat(params.billingDetails?.email).isEqualTo("stripe@example.com")
+    }
+
+    @Test
+    fun createFromGooglePay_setsAllowRedisplayWhenProvided() {
+        val params = PaymentMethodCreateParams.createFromGooglePay(
+            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            clientAttributionMetadata = null,
+            billingEmailOverride = null,
+            allowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
+        )
+
+        assertThat(params.allowRedisplay).isEqualTo(PaymentMethod.AllowRedisplay.LIMITED)
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -9,6 +9,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -17,6 +18,7 @@ import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherA
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
@@ -88,6 +90,16 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             confirmationArgs = confirmationArgs,
         )
 
+        // Google Pay does not present a "save for future use" choice, so the customer never
+        // explicitly requests reuse. The allow_redisplay value is derived from the intent's
+        // setup_future_usage and the Customer Session save-consent behavior, mirroring the
+        // form-based add-payment-method path. Setting it is required for the payment method to
+        // be saved when confirming a Customer Session intent (e.g. a subscription).
+        val allowRedisplay = confirmationArgs.paymentMethodMetadata.allowRedisplay(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            code = PaymentMethod.Type.Card.code,
+        )
+
         googlePayLauncher.present(
             currencyCode = intent.asPaymentIntent()?.currency
                 ?: config.merchantCurrencyCode.orEmpty(),
@@ -101,6 +113,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             isElements = true,
             displayItems = config.displayItems,
             billingEmailOverride = config.billingEmailOverride,
+            allowRedisplay = allowRedisplay,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -411,6 +412,7 @@ class GooglePayConfirmationDefinitionTest {
                 label = null,
                 clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                 isElements = true,
+                allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
             )
         }
     }
@@ -448,6 +450,7 @@ class GooglePayConfirmationDefinitionTest {
                 label = "Merchant Inc.",
                 clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                 isElements = true,
+                allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
             )
         }
     }
@@ -486,6 +489,7 @@ class GooglePayConfirmationDefinitionTest {
                 label = "Merchant Inc.",
                 clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                 isElements = true,
+                allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
             )
         }
     }
@@ -537,6 +541,54 @@ class GooglePayConfirmationDefinitionTest {
                 clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                 isElements = true,
                 displayItems = displayItems,
+                allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+            )
+        }
+    }
+
+    @Test
+    fun `On 'launch', passes allowRedisplay derived from a Customer Session subscription intent`() = runTest {
+        val googlePayLauncher = mock<GooglePayPaymentMethodLauncher>()
+
+        RecordingGooglePayPaymentMethodLauncherFactory.test(googlePayLauncher) {
+            val definition = createGooglePayConfirmationDefinition(factory)
+            val launcher = FakeActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>()
+
+            // Subscription-style intent: setup_future_usage is set, so the payment method must be
+            // saved. With a Customer Session that has payment method save disabled, allow_redisplay
+            // resolves to LIMITED and must be sent so the confirmation is not rejected.
+            val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PAYMENT_INTENT.copy(
+                    currency = "usd",
+                    setupFutureUsage = StripeIntent.Usage.OffSession,
+                ),
+                hasCustomerConfiguration = true,
+                saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
+            )
+
+            definition.launch(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                    config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                        merchantCurrencyCode = "USD",
+                    ),
+                ),
+                confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                ),
+                arguments = EmptyConfirmationLauncherArgs,
+                launcher = launcher,
+            )
+
+            assertThat(createGooglePayPaymentMethodLauncherCalls.awaitItem()).isNotNull()
+
+            verify(googlePayLauncher, times(1)).present(
+                currencyCode = "usd",
+                amount = 1000L,
+                transactionId = "pi_12345",
+                label = null,
+                clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+                isElements = true,
+                allowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
@@ -74,6 +75,7 @@ class GooglePayConfirmationFlowTest {
                     label = null,
                     clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                     isElements = true,
+                    allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
                 )
             }
         }


### PR DESCRIPTION
# Summary
Added support for forwarding the `allowRedisplay` parameter during Google Pay payment method creation and intent confirmation, including plumbing changes and updated tests.

# Motivation
To enable correctly saving payment methods with Google Pay in Customer Session flows, the `allowRedisplay` field needs to be set according to intent and consent configuration. This mirrors logic used for other add-payment-method paths, fixing issues where Google Pay payment methods were not properly saved.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Fixed] Google Pay now supports the allowRedisplay parameter for customer session saves.