### PR TITLE
Derive embedded content state from a confirmation state data source

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
@@ -14,12 +14,23 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Supplies the confirmation-launch state the reused embedded UI reads to build its launch args — the
+ * sheet launcher (via [DefaultEmbeddedContentHelper]) and the wallet buttons. Each integration owns
+ * its own source: [EmbeddedPaymentElement][com.stripe.android.paymentelement.EmbeddedPaymentElement]
+ * uses [EmbeddedConfirmationStateHolder] (written imperatively as it loads), while checkout has
+ * [com.stripe.android.checkout.CheckoutControllerStateHolder] project its already-owned state.
+ */
+internal interface EmbeddedConfirmationStateDataSource {
+    val embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?>
+}
+
 @Singleton
 internal class EmbeddedConfirmationStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val selectionHolder: EmbeddedSelectionHolder,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-) {
+) : EmbeddedConfirmationStateDataSource {
     var state: State?
         get() = savedStateHandle[CONFIRMATION_STATE_KEY]
         set(value) {
@@ -28,6 +39,9 @@ internal class EmbeddedConfirmationStateHolder @Inject constructor(
 
     val stateFlow: StateFlow<State?>
         get() = savedStateHandle.getStateFlow(CONFIRMATION_STATE_KEY, null)
+
+    override val embeddedConfirmationState: StateFlow<State?>
+        get() = stateFlow
 
     init {
         coroutineScope.launch {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import android.os.Parcelable
-import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.ViewModelScope
@@ -20,7 +18,6 @@ import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.FormHelper.FormType
-import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -42,7 +39,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -51,14 +47,6 @@ import kotlin.coroutines.CoroutineContext
 internal interface EmbeddedContentHelper {
     val embeddedContent: StateFlow<EmbeddedContent?>
     val walletButtonsContent: StateFlow<WalletButtonsContent?>
-
-    fun dataLoaded(
-        paymentMethodMetadata: PaymentMethodMetadata,
-        appearance: Embedded,
-        embeddedViewDisplaysMandateText: Boolean,
-    )
-
-    fun clearEmbeddedContent()
 
     fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher)
 
@@ -71,7 +59,6 @@ internal interface EmbeddedContentHelper {
 @Singleton
 internal class DefaultEmbeddedContentHelper @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val savedStateHandle: SavedStateHandle,
     private val eventReporter: EventReporter,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
@@ -86,16 +73,14 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     private val customerStateHolder: CustomerStateHolder,
     private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
     private val confirmationHandler: ConfirmationHandler,
-    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    private val confirmationStateDataSource: EmbeddedConfirmationStateDataSource,
     private val linkPaymentLauncher: LinkPaymentLauncher,
     private val linkAccountHolder: LinkAccountHolder,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
 ) : EmbeddedContentHelper {
 
-    private val state: StateFlow<State?> = savedStateHandle.getStateFlow(
-        key = STATE_KEY_EMBEDDED_CONTENT,
-        initialValue = null
-    )
+    private val state: StateFlow<EmbeddedContentState?> =
+        confirmationStateDataSource.embeddedConfirmationState.mapAsStateFlow { it?.toEmbeddedContentState() }
 
     private val _embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
     override val embeddedContent: StateFlow<EmbeddedContent?> = _embeddedContent.asStateFlow()
@@ -143,23 +128,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
         }
     }
 
-    override fun dataLoaded(
-        paymentMethodMetadata: PaymentMethodMetadata,
-        appearance: Embedded,
-        embeddedViewDisplaysMandateText: Boolean,
-    ) {
-        eventReporter.onShowNewPaymentOptions()
-        savedStateHandle[STATE_KEY_EMBEDDED_CONTENT] = State(
-            paymentMethodMetadata = paymentMethodMetadata,
-            appearance = appearance,
-            embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
-        )
-    }
-
-    override fun clearEmbeddedContent() {
-        savedStateHandle[STATE_KEY_EMBEDDED_CONTENT] = null
-    }
-
     override fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher) {
         this.sheetLauncher = sheetLauncher
     }
@@ -187,7 +155,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             paymentMethodMetadata = state.paymentMethodMetadata,
             customerState = customerStateHolder.customer.value,
             selection = selectionHolder.selection.value,
-            embeddedConfirmationState = confirmationStateHolder.state,
+            embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
         )
     }
 
@@ -196,7 +164,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     ): WalletButtonsInteractor {
         return DefaultWalletButtonsInteractor.create(
             embeddedLinkHelper = embeddedLinkHelper,
-            confirmationStateHolder = confirmationStateHolder,
+            confirmationStateDataSource = confirmationStateDataSource,
             confirmationHandler = confirmationHandler,
             coroutineScope = coroutineScope,
             errorReporter = errorReporter,
@@ -243,7 +211,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             paymentMethodMetadata = paymentMethodMetadata,
             processing = combineAsStateFlow(
                 confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
-                confirmationStateHolder.stateFlow.mapAsStateFlow { it != null },
+                confirmationStateDataSource.embeddedConfirmationState.mapAsStateFlow { it != null },
             ) { confirmationStateValid, configurationStateValid ->
                 confirmationStateValid && configurationStateValid
             },
@@ -259,14 +227,14 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateHolder.state,
+                    embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
                 )
             },
             transitionToFormScreen = { code ->
                 sheetLauncher?.launchForm(
                     code = code,
                     paymentMethodMetadata = paymentMethodMetadata,
-                    embeddedConfirmationState = confirmationStateHolder.state,
+                    embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
                     customerState = customerStateHolder.customer.value,
                     promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
                         code = code,
@@ -288,8 +256,8 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             reportFormShown = eventReporter::onPaymentMethodFormShown,
             onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
             shouldUpdateVerticalModeSelection = { paymentMethodCode ->
-                val isConfirmFlow = confirmationStateHolder.state?.configuration?.formSheetAction ==
-                    EmbeddedPaymentElement.FormSheetAction.Confirm
+                val isConfirmFlow = confirmationStateDataSource.embeddedConfirmationState.value
+                    ?.configuration?.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm
                 if (isConfirmFlow) {
                     val requiresFormScreen = paymentMethodCode != null &&
                         formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
@@ -334,7 +302,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateHolder.state,
+                    embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
                 )
             },
             isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
@@ -350,15 +318,12 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     private fun setSelection(paymentSelection: PaymentSelection?) {
         selectionHolder.setSelection(paymentSelection)
     }
+}
 
-    @Parcelize
-    class State(
-        val paymentMethodMetadata: PaymentMethodMetadata,
-        val appearance: Embedded,
-        val embeddedViewDisplaysMandateText: Boolean,
-    ) : Parcelable
-
-    companion object {
-        const val STATE_KEY_EMBEDDED_CONTENT = "STATE_KEY_EMBEDDED_CONTENT"
-    }
+private fun EmbeddedConfirmationStateHolder.State.toEmbeddedContentState(): EmbeddedContentState {
+    return EmbeddedContentState(
+        paymentMethodMetadata = paymentMethodMetadata,
+        appearance = configuration.appearance.embeddedAppearance,
+        embeddedViewDisplaysMandateText = configuration.embeddedViewDisplaysMandateText,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentState.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+
+/**
+ * The narrowed slice of the confirmation state that [DefaultEmbeddedContentHelper] renders its
+ * content from, projected from [EmbeddedConfirmationStateDataSource.embeddedConfirmationState]. It
+ * is a `data class` so structural equality lets the derived content flow dedupe: a selection-only
+ * change to the confirmation state projects to an equal [EmbeddedContentState], so the content
+ * isn't rebuilt.
+ */
+internal data class EmbeddedContentState(
+    val paymentMethodMetadata: PaymentMethodMetadata,
+    val appearance: Embedded,
+    val embeddedViewDisplaysMandateText: Boolean,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -173,6 +173,11 @@ internal interface EmbeddedPaymentElementViewModelModule {
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
 
     @Binds
+    fun bindsEmbeddedConfirmationStateDataSource(
+        holder: EmbeddedConfirmationStateHolder
+    ): EmbeddedConfirmationStateDataSource
+
+    @Binds
     fun bindsEmbeddedRowSelectionImmediateActionHandler(
         handler: DefaultEmbeddedRowSelectionImmediateActionHandler
     ): EmbeddedRowSelectionImmediateActionHandler

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -5,6 +5,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.parseAppearance
 import javax.inject.Inject
 import javax.inject.Provider
@@ -17,7 +18,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
-    private val embeddedContentHelper: EmbeddedContentHelper,
+    private val eventReporter: EventReporter,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
     private val confirmationHandler: ConfirmationHandler
 ) : EmbeddedStateHelper {
@@ -51,11 +52,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
         customerStateHolder.setCustomerState(state.customer)
         selectionHolder.setPreviousNewSelections(state.previousNewSelections)
         selectionHolder.setSelection(state.confirmationState.selection)
-        embeddedContentHelper.dataLoaded(
-            paymentMethodMetadata = state.confirmationState.paymentMethodMetadata,
-            appearance = state.confirmationState.configuration.appearance.embeddedAppearance,
-            embeddedViewDisplaysMandateText = state.confirmationState.configuration.embeddedViewDisplaysMandateText,
-        )
+        eventReporter.onShowNewPaymentOptions()
         confirmationHandler.bootstrap(state.confirmationState.paymentMethodMetadata)
     }
 
@@ -78,7 +75,6 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     }
 
     private fun clearState() {
-        embeddedContentHelper.clearEmbeddedContent()
         confirmationStateHolder.state = null
         selectionHolder.setSelection(null)
         selectionHolder.previousNewSelections.clear()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -32,7 +32,7 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmail
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayIsEmailRequiredProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
-import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateDataSource
 import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -396,7 +396,7 @@ internal class DefaultWalletButtonsInteractor constructor(
         fun create(
             linkInlineInteractor: LinkInlineInteractor,
             embeddedLinkHelper: EmbeddedLinkHelper,
-            confirmationStateHolder: EmbeddedConfirmationStateHolder,
+            confirmationStateDataSource: EmbeddedConfirmationStateDataSource,
             confirmationHandler: ConfirmationHandler,
             coroutineScope: CoroutineScope,
             errorReporter: ErrorReporter,
@@ -410,7 +410,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                 eventReporter = eventReporter,
                 arguments = combineAsStateFlow(
                     embeddedLinkHelper.linkEmail,
-                    confirmationStateHolder.stateFlow,
+                    confirmationStateDataSource.embeddedConfirmationState,
                 ) { linkEmail, confirmationState ->
                     confirmationState?.let { state ->
                         Arguments(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -9,15 +9,14 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper.Companion.STATE_KEY_EMBEDDED_CONTENT
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -43,93 +42,71 @@ internal class DefaultEmbeddedContentHelperTest {
     val coroutineTestRule = CoroutineTestRule()
 
     @Test
-    fun `dataLoaded updates savedStateHandle with paymentMethodMetadata`() = testScenario {
-        assertThat(savedStateHandle.get<PaymentMethodMetadata?>(STATE_KEY_EMBEDDED_CONTENT))
-            .isNull()
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default)
-        embeddedContentHelper.dataLoaded(paymentMethodMetadata, appearance, embeddedViewDisplaysMandateText = true)
-        val state = savedStateHandle.get<DefaultEmbeddedContentHelper.State?>(STATE_KEY_EMBEDDED_CONTENT)
-        assertThat(state?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
-        assertThat(state?.appearance).isEqualTo(appearance)
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
-    }
-
-    @Test
-    fun `dataLoaded emits embeddedContent event`() = testScenario {
+    fun `embeddedContent emits content when state is present`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                embeddedViewDisplaysMandateText = true,
-            )
+            confirmationStateHolder.state = confirmationState()
             assertThat(awaitItem()).isNotNull()
         }
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
-    fun `dataLoaded emits walletButtonsContent event`() = testScenario {
+    fun `walletButtonsContent emits content when state is present`() = testScenario {
         embeddedContentHelper.walletButtonsContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                embeddedViewDisplaysMandateText = true,
-            )
+            confirmationStateHolder.state = confirmationState()
             assertThat(awaitItem()).isNotNull()
         }
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
-    fun `embeddedContent emits null when clearEmbeddedContent is called`() = testScenario {
+    fun `embeddedContent emits null when state is cleared`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                embeddedViewDisplaysMandateText = true,
-            )
+            confirmationStateHolder.state = confirmationState()
             assertThat(awaitItem()).isNotNull()
-            embeddedContentHelper.clearEmbeddedContent()
+            confirmationStateHolder.state = null
             assertThat(awaitItem()).isNull()
         }
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
-    fun `walletButtonsContent emits null when clearEmbeddedContent is called`() = testScenario {
+    fun `walletButtonsContent emits null when state is cleared`() = testScenario {
         embeddedContentHelper.walletButtonsContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                embeddedViewDisplaysMandateText = true,
-            )
+            confirmationStateHolder.state = confirmationState()
             assertThat(awaitItem()).isNotNull()
-            embeddedContentHelper.clearEmbeddedContent()
+            confirmationStateHolder.state = null
             assertThat(awaitItem()).isNull()
         }
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
-    fun `initializing embeddedContentHelper with paymentMethodMetadata emits correct initial event`() = testScenario(
-        setup = {
-            set(
-                STATE_KEY_EMBEDDED_CONTENT,
-                DefaultEmbeddedContentHelper.State(
-                    PaymentMethodMetadataFactory.create(),
-                    Embedded(Embedded.RowStyle.FloatingButton.default),
-                    embeddedViewDisplaysMandateText = true,
-                )
-            )
-        }
+    fun `initializing with existing state emits content`() = testScenario(
+        initialConfirmationState = confirmationState(),
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNotNull()
+        }
+    }
+
+    @Test
+    fun `embeddedContent is not rebuilt on a selection-only confirmation state change`() = testScenario(
+        initialConfirmationState = confirmationState(selection = null),
+    ) {
+        embeddedContentHelper.embeddedContent.test {
+            assertThat(awaitItem()).isNotNull()
+
+            // A selection-only change projects to an equal EmbeddedContentState, so the content flow
+            // dedupes via mapAsStateFlow's distinctUntilChanged and doesn't rebuild the payment method list.
+            confirmationStateHolder.state = confirmationStateHolder.state?.copy(
+                selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            )
+
+            expectNoEvents()
+            // The underlying state genuinely changed, so the absence of a re-emission is meaningful.
+            assertThat(confirmationStateHolder.state?.selection)
+                .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         }
     }
 
@@ -143,16 +120,7 @@ internal class DefaultEmbeddedContentHelperTest {
 
     @Test
     fun `presentPaymentOptions reports error when launcher is null`() = testScenario(
-        setup = {
-            set(
-                STATE_KEY_EMBEDDED_CONTENT,
-                DefaultEmbeddedContentHelper.State(
-                    PaymentMethodMetadataFactory.create(),
-                    Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                    embeddedViewDisplaysMandateText = true,
-                )
-            )
-        }
+        initialConfirmationState = confirmationState(),
     ) {
         embeddedContentHelper.presentPaymentOptions()
         assertThat(errorReporter.getLoggedErrors()).containsExactly(
@@ -165,16 +133,13 @@ internal class DefaultEmbeddedContentHelperTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = createCustomerState()
         val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+        val confirmationState = confirmationState(
+            paymentMethodMetadata = paymentMethodMetadata,
+            selection = selection,
+        )
         testScenario(
+            initialConfirmationState = confirmationState,
             setup = {
-                set(
-                    STATE_KEY_EMBEDDED_CONTENT,
-                    DefaultEmbeddedContentHelper.State(
-                        paymentMethodMetadata,
-                        Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                        embeddedViewDisplaysMandateText = true,
-                    )
-                )
                 set(CustomerStateHolder.SAVED_CUSTOMER, customerState)
                 set(DefaultEmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY, selection)
             }
@@ -188,22 +153,33 @@ internal class DefaultEmbeddedContentHelperTest {
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = customerState,
                     selection = selection,
-                    embeddedConfirmationState = null,
+                    embeddedConfirmationState = confirmationState,
                 )
             )
             assertThat(errorReporter.getLoggedErrors()).isEmpty()
         }
     }
 
+    private fun confirmationState(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        selection: PaymentSelection? = null,
+        configuration: EmbeddedPaymentElement.Configuration =
+            EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+    ) = EmbeddedConfirmationStateHolder.State(
+        paymentMethodMetadata = paymentMethodMetadata,
+        selection = selection,
+        configuration = configuration,
+    )
+
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
-        val savedStateHandle: SavedStateHandle,
-        val eventReporter: FakeEventReporter,
+        val confirmationStateHolder: EmbeddedConfirmationStateHolder,
         val errorReporter: FakeErrorReporter,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
     private fun testScenario(
+        initialConfirmationState: EmbeddedConfirmationStateHolder.State? = null,
         setup: SavedStateHandle.() -> Unit = {},
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
@@ -218,6 +194,12 @@ internal class DefaultEmbeddedContentHelperTest {
         val confirmationHandler = FakeConfirmationHandler()
         val eventReporter = FakeEventReporter()
         val errorReporter = FakeErrorReporter()
+        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+            savedStateHandle = savedStateHandle,
+            selectionHolder = selectionHolder,
+            coroutineScope = backgroundScope,
+        )
+        confirmationStateHolder.state = initialConfirmationState
         val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
             coroutineScope = backgroundScope,
             internalRowSelectionCallback = { null }
@@ -225,7 +207,6 @@ internal class DefaultEmbeddedContentHelperTest {
 
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
             coroutineScope = backgroundScope,
-            savedStateHandle = savedStateHandle,
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
             uiContext = Dispatchers.Unconfined,
@@ -238,18 +219,12 @@ internal class DefaultEmbeddedContentHelperTest {
             customerStateHolder = DefaultCustomerStateHolder(
                 savedStateHandle = savedStateHandle,
                 selection = selectionHolder.selection,
-                customerMetadata = stateFlowOf(
-                    PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
-                ),
+                customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
                 paymentMethodMetadataFlow = stateFlowOf(null),
             ),
             embeddedFormHelperFactory = embeddedFormHelperFactory,
             confirmationHandler = confirmationHandler,
-            confirmationStateHolder = EmbeddedConfirmationStateHolder(
-                savedStateHandle = savedStateHandle,
-                selectionHolder = selectionHolder,
-                coroutineScope = backgroundScope,
-            ),
+            confirmationStateDataSource = confirmationStateHolder,
             rowSelectionImmediateActionHandler = immediateActionHandler,
             errorReporter = errorReporter,
             internalRowSelectionCallback = { null },
@@ -260,8 +235,7 @@ internal class DefaultEmbeddedContentHelperTest {
         )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
-            savedStateHandle = savedStateHandle,
-            eventReporter = eventReporter,
+            confirmationStateHolder = confirmationStateHolder,
             errorReporter = errorReporter,
         ).block()
         confirmationHandler.validate()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.state.CustomerState
@@ -44,7 +45,8 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem().appearance)
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
+        assertThat(confirmationStateHolder.state?.configuration?.appearance?.embeddedAppearance)
             .isEqualTo(Embedded(Embedded.RowStyle.FlatWithRadio.default))
     }
 
@@ -64,6 +66,7 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
         assertThat(StripeTheme.colorsLightMutable.componentBorder)
             .isEqualTo(
                 Color(
@@ -73,7 +76,7 @@ internal class DefaultEmbeddedStateHelperTest {
 
         // Reset appearance
         PaymentSheet.Appearance().parseAppearance()
-        embeddedContentHelper.dataLoadedTurbine.awaitItem()
+        assertThat(confirmationStateHolder.state).isNotNull()
     }
 
     @Test
@@ -89,11 +92,11 @@ internal class DefaultEmbeddedStateHelperTest {
         selectionHolder.previousNewSelections.putParcelable("card", PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
         confirmationHandler.bootstrapTurbine.awaitItem()
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
         assertThat(stateHelper.state).isNotNull()
         assertThat(confirmationStateHolder.state).isNotNull()
         assertThat(customerStateHolder.customer.value).isEqualTo(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
         assertThat(selectionHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
 
         stateHelper.state = null
 
@@ -102,7 +105,6 @@ internal class DefaultEmbeddedStateHelperTest {
         assertThat(customerStateHolder.customer.value).isNull()
         assertThat(selectionHolder.selection.value).isNull()
         assertThat(selectionHolder.previousNewSelections.isEmpty).isTrue()
-        assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
@@ -117,7 +119,8 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
+        assertThat(confirmationStateHolder.state).isNotNull()
     }
 
     @Test
@@ -136,7 +139,8 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
+        assertThat(confirmationStateHolder.state).isNotNull()
     }
 
     @Test
@@ -156,7 +160,8 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
+        assertThat(confirmationStateHolder.state).isNotNull()
     }
 
     @Test
@@ -200,7 +205,7 @@ internal class DefaultEmbeddedStateHelperTest {
     fun `confirmation handler is bootstrapped when state is set`() = testScenario {
         setState()
         assertThat(confirmationHandler.bootstrapTurbine.awaitItem().paymentMethodMetadata).isNotNull()
-        embeddedContentHelper.dataLoadedTurbine.awaitItem()
+        eventReporter.showNewPaymentOptionsCalls.awaitItem()
     }
 
     private fun testScenario(
@@ -222,13 +227,13 @@ internal class DefaultEmbeddedStateHelperTest {
             selectionHolder = selectionHolder,
             coroutineScope = backgroundScope,
         )
-        val embeddedContentHelper = FakeEmbeddedContentHelper()
+        val eventReporter = FakeEventReporter()
         val confirmationHandler = FakeConfirmationHandler()
         val stateHelper = DefaultEmbeddedStateHelper(
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             confirmationStateHolder = confirmationStateHolder,
-            embeddedContentHelper = embeddedContentHelper,
+            eventReporter = eventReporter,
             internalRowSelectionCallback = { rowSelectionCallback },
             confirmationHandler = confirmationHandler,
         )
@@ -237,20 +242,20 @@ internal class DefaultEmbeddedStateHelperTest {
             confirmationStateHolder = confirmationStateHolder,
             customerStateHolder = customerStateHolder,
             selectionHolder = selectionHolder,
-            embeddedContentHelper = embeddedContentHelper,
+            eventReporter = eventReporter,
             stateHelper = stateHelper,
             confirmationHandler = confirmationHandler,
         ).block()
 
-        embeddedContentHelper.validate()
         confirmationHandler.validate()
+        eventReporter.validate()
     }
 
     private class Scenario(
         val confirmationStateHolder: EmbeddedConfirmationStateHolder,
         val customerStateHolder: CustomerStateHolder,
         val selectionHolder: EmbeddedSelectionHolder,
-        val embeddedContentHelper: FakeEmbeddedContentHelper,
+        val eventReporter: FakeEventReporter,
         val stateHelper: EmbeddedStateHelper,
         val confirmationHandler: FakeConfirmationHandler,
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
@@ -16,6 +17,7 @@ import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT
@@ -59,10 +61,8 @@ internal class EmbeddedContentUiTest {
         runScenario(internalRowSelectionCallback = {}) {
             embeddedContentHelper.embeddedContent.test {
                 assertThat(awaitItem()).isNull()
-                embeddedContentHelper.dataLoaded(
-                    PaymentMethodMetadataFactory.create(),
-                    Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                    embeddedViewDisplaysMandateText = true,
+                confirmationStateHolder.state = confirmationState(
+                    appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 )
                 val content = awaitItem()
                 assertThat(content).isNotNull()
@@ -82,10 +82,8 @@ internal class EmbeddedContentUiTest {
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                embeddedViewDisplaysMandateText = true,
+            confirmationStateHolder.state = confirmationState(
+                appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
             )
             val content = awaitItem()
             assertThat(content).isNotNull()
@@ -105,10 +103,8 @@ internal class EmbeddedContentUiTest {
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
-                embeddedViewDisplaysMandateText = true,
+            confirmationStateHolder.state = confirmationState(
+                appearance = Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
             )
             val content = awaitItem()
             assertThat(content).isNotNull()
@@ -126,6 +122,7 @@ internal class EmbeddedContentUiTest {
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
+        val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
@@ -150,10 +147,14 @@ internal class EmbeddedContentUiTest {
                 internalRowSelectionCallback = { null }
             )
 
+        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+            savedStateHandle = savedStateHandle,
+            selectionHolder = selectionHolder,
+            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+        )
         val embeddedContentHelper =
             DefaultEmbeddedContentHelper(
                 coroutineScope = CoroutineScope(Dispatchers.Unconfined),
-                savedStateHandle = savedStateHandle,
                 eventReporter = eventReporter,
                 workContext = Dispatchers.Unconfined,
                 uiContext = Dispatchers.Unconfined,
@@ -173,11 +174,7 @@ internal class EmbeddedContentUiTest {
                 ),
                 embeddedFormHelperFactory = embeddedFormHelperFactory,
                 confirmationHandler = confirmationHandler,
-                confirmationStateHolder = EmbeddedConfirmationStateHolder(
-                    savedStateHandle = savedStateHandle,
-                    selectionHolder = selectionHolder,
-                    coroutineScope = CoroutineScope(Dispatchers.Unconfined),
-                ),
+                confirmationStateDataSource = confirmationStateHolder,
                 rowSelectionImmediateActionHandler = immediateActionHandler,
                 errorReporter = errorReporter,
                 internalRowSelectionCallback = { internalRowSelectionCallback },
@@ -188,6 +185,19 @@ internal class EmbeddedContentUiTest {
             )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
+            confirmationStateHolder = confirmationStateHolder,
         ).block()
     }
+
+    private fun confirmationState(
+        appearance: Embedded,
+        embeddedViewDisplaysMandateText: Boolean = true,
+    ) = EmbeddedConfirmationStateHolder.State(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        selection = null,
+        configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+            .appearance(PaymentSheet.Appearance(embeddedAppearance = appearance))
+            .embeddedViewDisplaysMandateText(embeddedViewDisplaysMandateText)
+            .build(),
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelper.kt
@@ -1,9 +1,5 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import app.cash.turbine.ReceiveTurbine
-import app.cash.turbine.Turbine
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,30 +8,7 @@ internal class FakeEmbeddedContentHelper(
     override val embeddedContent: MutableStateFlow<EmbeddedContent?> = MutableStateFlow(null),
     override val walletButtonsContent: StateFlow<WalletButtonsContent?> = MutableStateFlow(null),
 ) : EmbeddedContentHelper {
-    private val _dataLoadedTurbine = Turbine<DefaultEmbeddedContentHelper.State>()
-    val dataLoadedTurbine: ReceiveTurbine<DefaultEmbeddedContentHelper.State> = _dataLoadedTurbine
-    private val _clearEmbeddedContentTurbine = Turbine<Unit>()
-    val clearEmbeddedContentTurbine: ReceiveTurbine<Unit> = _clearEmbeddedContentTurbine
-
     var testSheetLauncher: EmbeddedSheetLauncher? = null
-
-    override fun dataLoaded(
-        paymentMethodMetadata: PaymentMethodMetadata,
-        appearance: Embedded,
-        embeddedViewDisplaysMandateText: Boolean,
-    ) {
-        _dataLoadedTurbine.add(
-            DefaultEmbeddedContentHelper.State(
-                paymentMethodMetadata = paymentMethodMetadata,
-                appearance = appearance,
-                embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
-            )
-        )
-    }
-
-    override fun clearEmbeddedContent() {
-        _clearEmbeddedContentTurbine.add(Unit)
-    }
 
     override fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher) {
         this.testSheetLauncher = sheetLauncher
@@ -46,9 +19,4 @@ internal class FakeEmbeddedContentHelper(
     }
 
     override fun presentPaymentOptions() = Unit
-
-    fun validate() {
-        dataLoadedTurbine.ensureAllEventsConsumed()
-        clearEmbeddedContentTurbine.ensureAllEventsConsumed()
-    }
 }


### PR DESCRIPTION
Introduce EmbeddedConfirmationStateDataSource (implemented by EmbeddedConfirmationStateHolder) so DefaultEmbeddedContentHelper derives its render state (the new EmbeddedContentState) from the confirmation state instead of owning a second, savedStateHandle-backed copy populated imperatively via dataLoaded()/clearEmbeddedContent(). Those methods are removed from the helper's interface; EmbeddedStateHelper now reports onShowNewPaymentOptions directly and no longer depends on EmbeddedContentHelper. WalletButtonsInteractor reads the data source as well.

This is a behavior-preserving refactor pulled out of the jaynewstrom/sharing-embedded-state work so the checkout content/launcher sharing can build on top of it in a separate change.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
