### PR TITLE
Reconcile billing_address_collection on the CheckoutController path (MOBILESDK-4636)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapper.kt
@@ -3,6 +3,21 @@ package com.stripe.android.checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 
+/**
+ * Upgrades [address] to [BillingDetailsCollectionConfiguration.AddressCollectionMode.Full] when the
+ * checkout session requires a billing address but the merchant only asked for [Automatic][BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic]
+ * collection, so the required address is still collected. Leaves the config untouched otherwise.
+ */
+@OptIn(CheckoutSessionPreview::class)
+internal fun BillingDetailsCollectionConfiguration.State.reconcile(
+    requiresBillingAddress: Boolean,
+): BillingDetailsCollectionConfiguration.State =
+    if (requiresBillingAddress && address == BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic) {
+        copy(address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+    } else {
+        this
+    }
+
 @OptIn(CheckoutSessionPreview::class)
 internal fun BillingDetailsCollectionConfiguration.State.asPaymentSheet():
     PaymentSheet.BillingDetailsCollectionConfiguration =

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -56,6 +56,7 @@ internal class CheckoutStateLoader @Inject constructor(
             )
             .billingDetailsCollectionConfiguration(
                 configuration.paymentElementConfiguration.billingDetailsCollectionConfiguration
+                    .reconcile(response.requiresBillingAddress)
                     .asPaymentSheet()
             )
             .googlePay(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -29,6 +29,7 @@ internal data class CheckoutSessionResponse(
     val automaticTaxEnabled: Boolean,
     val taxAddressSource: TaxAddressSource?,
     val allowedShippingCountries: List<String>?,
+    val requiresBillingAddress: Boolean,
 ) : StripeModel {
 
     val shouldDisableWalletsForAutomaticTaxBilling: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -83,6 +83,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             json.optJSONObject(FIELD_ADAPTIVE_PRICING_INFO)
         )
         val allowedShippingCountries = parseAllowedShippingCountries(json)
+        val requiresBillingAddress = json.optString(FIELD_BILLING_ADDRESS_COLLECTION) == "required"
 
         return CheckoutSessionResponse(
             id = sessionId,
@@ -105,6 +106,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             automaticTaxEnabled = automaticTaxEnabled,
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
+            requiresBillingAddress = requiresBillingAddress,
         )
     }
 
@@ -582,4 +584,5 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_PRESENTMENT_EXCHANGE_RATE = "presentment_exchange_rate"
     private const val FIELD_SHIPPING_ADDRESS_COLLECTION = "shipping_address_collection"
     private const val FIELD_ALLOWED_COUNTRIES = "allowed_countries"
+    private const val FIELD_BILLING_ADDRESS_COLLECTION = "billing_address_collection"
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
@@ -80,4 +80,49 @@ internal class BillingDetailsCollectionConfigurationMapperTest {
         assertThat(mapped.address)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
     }
+
+    @Test
+    fun `reconcile upgrades Automatic to Full when the session requires a billing address`() {
+        val state = BillingDetailsCollectionConfiguration()
+            .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic)
+            .build()
+
+        val reconciled = state.reconcile(requiresBillingAddress = true)
+
+        assertThat(reconciled.address).isEqualTo(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+    }
+
+    @Test
+    fun `reconcile leaves Full unchanged when the session requires a billing address`() {
+        val state = BillingDetailsCollectionConfiguration()
+            .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+            .build()
+
+        val reconciled = state.reconcile(requiresBillingAddress = true)
+
+        assertThat(reconciled.address).isEqualTo(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+    }
+
+    @Test
+    fun `reconcile leaves Automatic unchanged when the session does not require a billing address`() {
+        val state = BillingDetailsCollectionConfiguration()
+            .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic)
+            .build()
+
+        val reconciled = state.reconcile(requiresBillingAddress = false)
+
+        assertThat(reconciled.address)
+            .isEqualTo(BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic)
+    }
+
+    @Test
+    fun `reconcile leaves Full unchanged when the session does not require a billing address`() {
+        val state = BillingDetailsCollectionConfiguration()
+            .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+            .build()
+
+        val reconciled = state.reconcile(requiresBillingAddress = false)
+
+        assertThat(reconciled.address).isEqualTo(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -150,6 +151,28 @@ internal class CheckoutControllerTest {
             result.getOrThrow()
             assertThat(committedState?.embeddedConfiguration?.embeddedViewDisplaysMandateText)
                 .isFalse()
+        }
+
+    @Test
+    fun `configure upgrades Automatic to Full when session requires billing address`() =
+        runConfigureScenario(
+            configuration = CheckoutController.Configuration().paymentElement(
+                PaymentElement.Configuration().billingDetailsCollectionConfiguration(
+                    BillingDetailsCollectionConfiguration()
+                        .address(BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic)
+                )
+            ),
+            networkSetup = {
+                networkRule.checkoutInit(
+                    responseFactory = successResponseFactory { json ->
+                        json.put("billing_address_collection", "required")
+                    },
+                )
+            },
+        ) {
+            result.getOrThrow()
+            assertThat(committedState?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
 @OptIn(CheckoutSessionPreview::class)
@@ -124,6 +125,38 @@ internal class CheckoutStateLoaderTest {
             .isEqualTo(PaymentSheet.GooglePayConfiguration.ButtonType.Checkout)
         assertThat(actual.additionalEnabledNetworks).containsExactly("INTERAC")
     }
+
+    @Test
+    fun `loadInitial upgrades Automatic to Full when the session requires a billing address`() =
+        runScenario {
+            val configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Automatic))
+                )
+                .build()
+            val response = CheckoutSessionResponseFactory.create(requiresBillingAddress = true)
+
+            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response)
+
+            assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+                .isEqualTo(PSFull)
+        }
+
+    @Test
+    fun `loadInitial leaves Automatic unchanged when the session does not require a billing address`() =
+        runScenario {
+            val configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Automatic))
+                )
+                .build()
+            val response = CheckoutSessionResponseFactory.create(requiresBillingAddress = false)
+
+            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response)
+
+            assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
+                .isEqualTo(PSAutomatic)
+        }
 
     @Test
     fun `reload routes the selection through the chooser`() = runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -28,6 +28,7 @@ internal object CheckoutSessionResponseFactory {
         automaticTaxEnabled: Boolean = false,
         taxAddressSource: CheckoutSessionResponse.TaxAddressSource? = null,
         allowedShippingCountries: List<String>? = null,
+        requiresBillingAddress: Boolean = false,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -50,6 +51,7 @@ internal object CheckoutSessionResponseFactory {
             automaticTaxEnabled = automaticTaxEnabled,
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
+            requiresBillingAddress = requiresBillingAddress,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1330,6 +1330,81 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
+    fun `parse requiresBillingAddress true when billing_address_collection is required`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "billing_address_collection": "required"
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isTrue()
+    }
+
+    @Test
+    fun `parse requiresBillingAddress false when billing_address_collection is auto`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "billing_address_collection": "auto"
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isFalse()
+    }
+
+    @Test
+    fun `parse requiresBillingAddress false when billing_address_collection is absent`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isFalse()
+    }
+
+    @Test
+    fun `parse requiresBillingAddress false when billing_address_collection is JSON null`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "billing_address_collection": null
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.requiresBillingAddress).isFalse()
+    }
+
+    @Test
     fun `parse allowedShippingCountries is empty list when allowed_countries is empty array`() {
         val json = JSONObject(
             """

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerMetadataTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -259,7 +260,7 @@ internal class CreateCustomerMetadataTest {
         ): PaymentElementLoader.InitializationMode.CheckoutSession {
             return PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "instances_test",
-                checkoutSessionResponse = CheckoutSessionResponse(
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                     id = "cs_test_123",
                     amount = 1000,
                     currency = "usd",


### PR DESCRIPTION
# Summary
Implements [MOBILESDK-4636](https://jira.corp.stripe.com/browse/MOBILESDK-4636): reconcile the CheckoutSession's `billing_address_collection` with the checkout-owned `BillingDetailsCollectionConfiguration`, **scoped to the CheckoutController path only**.

Supersedes #13420 (which reconciled all three CheckoutSession paths). The FlowController/Embedded CheckoutSession entry points are being removed, so this deliberately does **not** touch the shared merger, `DefaultFlowController`, or `EmbeddedPaymentElement`.

## Behavior
`billing_address_collection` is parsed onto `CheckoutSessionResponse.requiresBillingAddress`. In `CheckoutStateLoader`, the merchant's checkout-owned BDCC is reconciled **before** it's mapped to the internal `PaymentSheet` type:

| `billing_address_collection` | BDCC `address` | Result |
| --- | --- | --- |
| `required` | `Automatic` | upgraded to `Full` |
| `required` | `Full` | `Full` (unchanged) |
| `auto` | `Automatic` | `Automatic` (unchanged) |
| `auto` | `Full` | `Full` (unchanged) |

The checkout-owned `AddressCollectionMode` has no `Never` (unrepresentable → no rejection path needed). `attachDefaultsToPaymentMethod` is already forced true by the existing `asPaymentSheet()` mapper.

## Design
- `reconcile(requiresBillingAddress)` operates directly on the checkout-owned `BillingDetailsCollectionConfiguration.State` (not `PaymentSheet.BillingDetailsCollectionConfiguration`), applied in `CheckoutStateLoader` before `asPaymentSheet()`. The shared `CheckoutConfigurationMerger` is unchanged.

## Testing
- [x] Added tests
- [ ] Manually verified

- Reconcile unit test: the 4 `auto`/`required` × `Automatic`/`Full` cases.
- `CheckoutStateLoaderTest`: `loadInitial` upgrades `Automatic → Full` when required; leaves `Automatic` when not.
- `CheckoutControllerTest`: `configure` upgrades to `Full` end-to-end (network test injecting `billing_address_collection = required`).
- Parser: `requiresBillingAddress` for `required`/`auto`/absent/JSON-null.

`:paymentsheet:testDebugUnitTest` (checkout/parser/metadata) + `:paymentsheet:detekt` + `:paymentsheet:apiCheck` all pass. android-code-reviewer: APPROVE.

# Changelog
N/A. `@RestrictTo(LIBRARY_GROUP)` (private preview); no public API change.