### PR TITLE
Split EmbeddedContentHelper into a thin facade and a new DataSource.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -53,7 +53,7 @@
     <ID>LongMethod:ElementsSessionJsonParserTest.kt:ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response if 'customer_sheet' is null`</ID>
     <ID>LongMethod:ElementsSessionJsonParserTest.kt:ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response`</ID>
     <ID>LongMethod:ElementsSessionRepository.kt:internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams: ElementsSessionParams</ID>
-    <ID>LongMethod:EmbeddedContentHelper.kt:DefaultEmbeddedContentHelper$private fun createInteractor: PaymentMethodVerticalLayoutInteractor</ID>
+    <ID>LongMethod:EmbeddedContentHelperDataSource.kt:DefaultEmbeddedContentHelperDataSource$private fun createInteractor: PaymentMethodVerticalLayoutInteractor</ID>
     <ID>LongMethod:FormViewModelTest.kt:FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`</ID>
     <ID>LongMethod:FormViewModelTest.kt:FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`</ID>
     <ID>LongMethod:FullScreenContent.kt:@Composable internal fun FullScreenContent</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
@@ -15,22 +15,18 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Supplies the confirmation-launch state the reused embedded UI reads to build its launch args — the
- * sheet launcher (via [DefaultEmbeddedContentHelper]) and the wallet buttons. Each integration owns
- * its own source: [EmbeddedPaymentElement][com.stripe.android.paymentelement.EmbeddedPaymentElement]
- * uses [EmbeddedConfirmationStateHolder] (written imperatively as it loads), while checkout has
- * [com.stripe.android.checkout.CheckoutControllerStateHolder] project its already-owned state.
+ * Owns the confirmation-launch state for
+ * [EmbeddedPaymentElement][com.stripe.android.paymentelement.EmbeddedPaymentElement], written
+ * imperatively as it loads and persisted in [SavedStateHandle]. It's the raw-state input to
+ * [DefaultEmbeddedContentHelperDataSource] (which projects it into the rendered content) and is read
+ * directly for the sheet-launch args and the wallet buttons.
  */
-internal interface EmbeddedConfirmationStateDataSource {
-    val embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?>
-}
-
 @Singleton
 internal class EmbeddedConfirmationStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val selectionHolder: EmbeddedSelectionHolder,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-) : EmbeddedConfirmationStateDataSource {
+) {
     var state: State?
         get() = savedStateHandle[CONFIRMATION_STATE_KEY]
         set(value) {
@@ -39,9 +35,6 @@ internal class EmbeddedConfirmationStateHolder @Inject constructor(
 
     val stateFlow: StateFlow<State?>
         get() = savedStateHandle.getStateFlow(CONFIRMATION_STATE_KEY, null)
-
-    override val embeddedConfirmationState: StateFlow<State?>
-        get() = stateFlow
 
     init {
         coroutineScope.launch {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -1,48 +1,12 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.UIContext
-import com.stripe.android.core.injection.ViewModelScope
-import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.link.verification.NoOpLinkInlineInteractor
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentelement.AnalyticEventCallback
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.FormHelper.FormType
-import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
-import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
-import com.stripe.android.paymentsheet.state.WalletsState
-import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
-import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
-import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
-import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import com.stripe.android.uicore.utils.combineAsStateFlow
-import com.stripe.android.uicore.utils.mapAsStateFlow
-import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 internal interface EmbeddedContentHelper {
     val embeddedContent: StateFlow<EmbeddedContent?>
@@ -55,96 +19,41 @@ internal interface EmbeddedContentHelper {
     fun presentPaymentOptions()
 }
 
-@OptIn(ExperimentalAnalyticEventCallbackApi::class)
+/**
+ * A thin facade over [EmbeddedContentHelperDataSource]: it exposes the derived content flows and owns
+ * the imperatively-set [EmbeddedSheetLauncher] (stored in [EmbeddedSheetLauncherHolder]) that the
+ * data source's interactors and [presentPaymentOptions] launch through.
+ */
 @Singleton
 internal class DefaultEmbeddedContentHelper @Inject constructor(
-    @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val eventReporter: EventReporter,
+    private val dataSource: EmbeddedContentHelperDataSource,
     private val errorReporter: ErrorReporter,
-    @IOContext private val workContext: CoroutineContext,
-    @UIContext private val uiContext: CoroutineContext,
-    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
-    private val selectionHolder: EmbeddedSelectionHolder,
-    private val embeddedLinkHelper: EmbeddedLinkHelper,
-    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
-    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
-    private val analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
-    private val embeddedWalletsHelper: EmbeddedWalletsHelper,
     private val customerStateHolder: CustomerStateHolder,
-    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
-    private val confirmationHandler: ConfirmationHandler,
-    private val confirmationStateDataSource: EmbeddedConfirmationStateDataSource,
-    private val linkPaymentLauncher: LinkPaymentLauncher,
-    private val linkAccountHolder: LinkAccountHolder,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
 ) : EmbeddedContentHelper {
 
-    private val state: StateFlow<EmbeddedContentState?> =
-        confirmationStateDataSource.embeddedConfirmationState.mapAsStateFlow { it?.toEmbeddedContentState() }
+    override val embeddedContent: StateFlow<EmbeddedContent?> = dataSource.embeddedContent
 
-    private val _embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
-    override val embeddedContent: StateFlow<EmbeddedContent?> = _embeddedContent.asStateFlow()
-
-    private val _walletButtonsContent = MutableStateFlow<WalletButtonsContent?>(null)
-    override val walletButtonsContent: StateFlow<WalletButtonsContent?> = _walletButtonsContent.asStateFlow()
-
-    private var sheetLauncher: EmbeddedSheetLauncher? = null
-
-    init {
-        coroutineScope.launch {
-            state.collect { state ->
-                _embeddedContent.value = if (state == null) {
-                    null
-                } else {
-                    val isImmediateAction = internalRowSelectionCallback.get() != null
-                    EmbeddedContent(
-                        interactor = createInteractor(
-                            coroutineScope = coroutineScope,
-                            paymentMethodMetadata = state.paymentMethodMetadata,
-                            walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
-                            isImmediateAction = isImmediateAction,
-                            embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
-                        ),
-                        embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
-                        appearance = state.appearance,
-                        isImmediateAction = isImmediateAction,
-                    )
-                }
-            }
-        }
-
-        coroutineScope.launch {
-            state.collect { state ->
-                _walletButtonsContent.value = if (state == null) {
-                    null
-                } else {
-                    WalletButtonsContent(
-                        interactor = createWalletButtonsInteractor(
-                            coroutineScope = coroutineScope,
-                        ),
-                    )
-                }
-            }
-        }
-    }
+    override val walletButtonsContent: StateFlow<WalletButtonsContent?> = dataSource.walletButtonsContent
 
     override fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher) {
-        this.sheetLauncher = sheetLauncher
+        sheetLauncherHolder.sheetLauncher = sheetLauncher
     }
 
     override fun clearSheetLauncher() {
-        sheetLauncher = null
+        sheetLauncherHolder.sheetLauncher = null
     }
 
     override fun presentPaymentOptions() {
-        val state = state.value
-        if (state == null) {
+        val confirmationState = dataSource.embeddedConfirmationState.value
+        if (confirmationState == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED
             )
             return
         }
-        val launcher = sheetLauncher
+        val launcher = sheetLauncherHolder.sheetLauncher
         if (launcher == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER
@@ -152,178 +61,10 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             return
         }
         launcher.launchPaymentOptions(
-            paymentMethodMetadata = state.paymentMethodMetadata,
+            paymentMethodMetadata = confirmationState.paymentMethodMetadata,
             customerState = customerStateHolder.customer.value,
             selection = selectionHolder.selection.value,
-            embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
+            embeddedConfirmationState = confirmationState,
         )
     }
-
-    private fun createWalletButtonsInteractor(
-        coroutineScope: CoroutineScope,
-    ): WalletButtonsInteractor {
-        return DefaultWalletButtonsInteractor.create(
-            embeddedLinkHelper = embeddedLinkHelper,
-            confirmationStateDataSource = confirmationStateDataSource,
-            confirmationHandler = confirmationHandler,
-            coroutineScope = coroutineScope,
-            errorReporter = errorReporter,
-            eventReporter = eventReporter,
-            linkPaymentLauncher = linkPaymentLauncher,
-            linkAccountHolder = linkAccountHolder,
-            linkInlineInteractor = NoOpLinkInlineInteractor(),
-            analyticsCallbackProvider = analyticsCallbackProvider,
-        )
-    }
-
-    private fun createInteractor(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        walletsState: StateFlow<WalletsState?>,
-        isImmediateAction: Boolean,
-        embeddedViewDisplaysMandateText: Boolean,
-    ): PaymentMethodVerticalLayoutInteractor {
-        val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
-            incentive = paymentMethodMetadata.paymentMethodIncentive,
-        )
-        val formHelper = embeddedFormHelperFactory.create(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = eventReporter,
-            // Card scan auto-launch is only relevant in the form, not the list (as the form helper is used in here).
-            automaticallyLaunchedCardScanFormDataHelper = null,
-            tapToAddHelper = null,
-            selectionUpdater = {
-                setSelection(it)
-                invokeRowSelectionCallback()
-            },
-            // Not important for determining formType so set to default value
-            setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-        )
-        val savedPaymentMethodMutator = createSavedPaymentMethodMutator(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            customerStateHolder = customerStateHolder,
-        )
-
-        return DefaultPaymentMethodVerticalLayoutInteractor(
-            paymentMethodMetadata = paymentMethodMetadata,
-            processing = combineAsStateFlow(
-                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
-                confirmationStateDataSource.embeddedConfirmationState.mapAsStateFlow { it != null },
-            ) { confirmationStateValid, configurationStateValid ->
-                confirmationStateValid && configurationStateValid
-            },
-            temporarySelection = selectionHolder.temporarySelection,
-            selection = selectionHolder.selection,
-            paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
-            formTypeForCode = { code ->
-                formHelper.formTypeForCode(code)
-            },
-            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
-            transitionToManageScreen = {
-                sheetLauncher?.launchManage(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = requireNotNull(customerStateHolder.customer.value),
-                    selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
-                )
-            },
-            transitionToFormScreen = { code ->
-                sheetLauncher?.launchForm(
-                    code = code,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
-                    customerState = customerStateHolder.customer.value,
-                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
-                        code = code,
-                        metadata = paymentMethodMetadata
-                    )
-                )
-            },
-            paymentMethods = customerStateHolder.paymentMethods,
-            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
-            canRemove = customerStateHolder.canRemove,
-            canUpdateCardExpiryAndBillingDetails = customerStateHolder.canUpdateCardExpiryAndBillingDetails,
-            canChangeCbc = customerStateHolder.canChangeCbc,
-            walletsState = walletsState,
-            updateSelection = { updatedSelection, requiresConfirmation ->
-                setSelection(updatedSelection)
-            },
-            isCurrentScreen = stateFlowOf(true),
-            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
-            reportFormShown = eventReporter::onPaymentMethodFormShown,
-            onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
-            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
-                val isConfirmFlow = confirmationStateDataSource.embeddedConfirmationState.value
-                    ?.configuration?.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm
-                if (isConfirmFlow) {
-                    val requiresFormScreen = paymentMethodCode != null &&
-                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
-                    !requiresFormScreen
-                } else {
-                    true
-                }
-            },
-            invokeRowSelectionCallback = ::invokeRowSelectionCallback,
-            displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
-            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
-                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
-                    visiblePaymentMethods = visiblePaymentMethods,
-                    hiddenPaymentMethods = hiddenPaymentMethods,
-                    walletsState = walletsState.value,
-                    isVerticalLayout = true,
-                )
-            },
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-        )
-    }
-
-    private fun createSavedPaymentMethodMutator(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        customerStateHolder: CustomerStateHolder,
-    ): SavedPaymentMethodMutator {
-        return SavedPaymentMethodMutator(
-            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
-            eventReporter = eventReporter,
-            coroutineScope = coroutineScope,
-            workContext = workContext,
-            uiContext = uiContext,
-            savedPaymentMethodRepository = savedPaymentMethodRepository,
-            selection = selectionHolder.selection,
-            setSelection = ::setSelection,
-            customerStateHolder = customerStateHolder,
-            prePaymentMethodRemoveActions = {},
-            postPaymentMethodRemoveActions = {},
-            onUpdatePaymentMethod = { _, _, _, _, _ ->
-                sheetLauncher?.launchManage(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = requireNotNull(customerStateHolder.customer.value),
-                    selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateDataSource.embeddedConfirmationState.value,
-                )
-            },
-            isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
-            isNotPaymentFlow = false,
-            accountLinkBrandFlow = linkAccountHolder.linkAccountInfo.mapAsStateFlow { it.account?.linkBrand },
-        )
-    }
-
-    private fun invokeRowSelectionCallback() {
-        rowSelectionImmediateActionHandler.invoke()
-    }
-
-    private fun setSelection(paymentSelection: PaymentSelection?) {
-        selectionHolder.setSelection(paymentSelection)
-    }
-}
-
-private fun EmbeddedConfirmationStateHolder.State.toEmbeddedContentState(): EmbeddedContentState {
-    return EmbeddedContentState(
-        paymentMethodMetadata = paymentMethodMetadata,
-        appearance = configuration.appearance.embeddedAppearance,
-        embeddedViewDisplaysMandateText = configuration.embeddedViewDisplaysMandateText,
-    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperDataSource.kt
@@ -1,0 +1,303 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.UIContext
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.verification.NoOpLinkInlineInteractor
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.AnalyticEventCallback
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.FormHelper.FormType
+import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
+import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
+import com.stripe.android.paymentsheet.ui.WalletButtonsContent
+import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
+import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
+import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Supplies everything [DefaultEmbeddedContentHelper] renders: the raw [embeddedConfirmationState]
+ * (which the wallet buttons and sheet-launch args still read directly) and the derived
+ * [embeddedContent] / [walletButtonsContent] built from it. The content-building lives here rather
+ * than in the helper so each integration
+ * ([EmbeddedPaymentElement][com.stripe.android.paymentelement.EmbeddedPaymentElement] today, checkout
+ * later) can supply this one abstraction while the helper stays a thin facade over it.
+ */
+internal interface EmbeddedContentHelperDataSource {
+    val embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?>
+    val embeddedContent: StateFlow<EmbeddedContent?>
+    val walletButtonsContent: StateFlow<WalletButtonsContent?>
+}
+
+@OptIn(ExperimentalAnalyticEventCallbackApi::class)
+@Singleton
+internal class DefaultEmbeddedContentHelperDataSource @Inject constructor(
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+    private val eventReporter: EventReporter,
+    private val errorReporter: ErrorReporter,
+    @IOContext private val workContext: CoroutineContext,
+    @UIContext private val uiContext: CoroutineContext,
+    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val embeddedLinkHelper: EmbeddedLinkHelper,
+    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
+    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
+    private val analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
+    private val embeddedWalletsHelper: EmbeddedWalletsHelper,
+    private val customerStateHolder: CustomerStateHolder,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    private val confirmationHandler: ConfirmationHandler,
+    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    private val linkPaymentLauncher: LinkPaymentLauncher,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+) : EmbeddedContentHelperDataSource {
+
+    override val embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?> =
+        confirmationStateHolder.stateFlow
+
+    private val state: StateFlow<EmbeddedContentState?> =
+        embeddedConfirmationState.mapAsStateFlow { it?.toEmbeddedContentState() }
+
+    private val _embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
+    override val embeddedContent: StateFlow<EmbeddedContent?> = _embeddedContent.asStateFlow()
+
+    private val _walletButtonsContent = MutableStateFlow<WalletButtonsContent?>(null)
+    override val walletButtonsContent: StateFlow<WalletButtonsContent?> = _walletButtonsContent.asStateFlow()
+
+    init {
+        coroutineScope.launch {
+            state.collect { state ->
+                _embeddedContent.value = if (state == null) {
+                    null
+                } else {
+                    val isImmediateAction = internalRowSelectionCallback.get() != null
+                    EmbeddedContent(
+                        interactor = createInteractor(
+                            coroutineScope = coroutineScope,
+                            paymentMethodMetadata = state.paymentMethodMetadata,
+                            walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
+                            isImmediateAction = isImmediateAction,
+                            embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
+                        ),
+                        embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
+                        appearance = state.appearance,
+                        isImmediateAction = isImmediateAction,
+                    )
+                }
+            }
+        }
+
+        coroutineScope.launch {
+            state.collect { state ->
+                _walletButtonsContent.value = if (state == null) {
+                    null
+                } else {
+                    WalletButtonsContent(
+                        interactor = createWalletButtonsInteractor(
+                            coroutineScope = coroutineScope,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun createWalletButtonsInteractor(
+        coroutineScope: CoroutineScope,
+    ): WalletButtonsInteractor {
+        return DefaultWalletButtonsInteractor.create(
+            embeddedLinkHelper = embeddedLinkHelper,
+            contentHelperDataSource = this,
+            confirmationHandler = confirmationHandler,
+            coroutineScope = coroutineScope,
+            errorReporter = errorReporter,
+            eventReporter = eventReporter,
+            linkPaymentLauncher = linkPaymentLauncher,
+            linkAccountHolder = linkAccountHolder,
+            linkInlineInteractor = NoOpLinkInlineInteractor(),
+            analyticsCallbackProvider = analyticsCallbackProvider,
+        )
+    }
+
+    private fun createInteractor(
+        coroutineScope: CoroutineScope,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        walletsState: StateFlow<WalletsState?>,
+        isImmediateAction: Boolean,
+        embeddedViewDisplaysMandateText: Boolean,
+    ): PaymentMethodVerticalLayoutInteractor {
+        val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
+            incentive = paymentMethodMetadata.paymentMethodIncentive,
+        )
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = coroutineScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            // Card scan auto-launch is only relevant in the form, not the list (as the form helper is used in here).
+            automaticallyLaunchedCardScanFormDataHelper = null,
+            tapToAddHelper = null,
+            selectionUpdater = {
+                setSelection(it)
+                invokeRowSelectionCallback()
+            },
+            // Not important for determining formType so set to default value
+            setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+        )
+        val savedPaymentMethodMutator = createSavedPaymentMethodMutator(
+            coroutineScope = coroutineScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerStateHolder = customerStateHolder,
+        )
+
+        return DefaultPaymentMethodVerticalLayoutInteractor(
+            paymentMethodMetadata = paymentMethodMetadata,
+            processing = combineAsStateFlow(
+                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
+                embeddedConfirmationState.mapAsStateFlow { it != null },
+            ) { confirmationStateValid, configurationStateValid ->
+                confirmationStateValid && configurationStateValid
+            },
+            temporarySelection = selectionHolder.temporarySelection,
+            selection = selectionHolder.selection,
+            paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
+            formTypeForCode = { code ->
+                formHelper.formTypeForCode(code)
+            },
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            transitionToManageScreen = {
+                sheetLauncherHolder.sheetLauncher?.launchManage(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    customerState = requireNotNull(customerStateHolder.customer.value),
+                    selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = embeddedConfirmationState.value,
+                )
+            },
+            transitionToFormScreen = { code ->
+                sheetLauncherHolder.sheetLauncher?.launchForm(
+                    code = code,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    embeddedConfirmationState = embeddedConfirmationState.value,
+                    customerState = customerStateHolder.customer.value,
+                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
+                        code = code,
+                        metadata = paymentMethodMetadata
+                    )
+                )
+            },
+            paymentMethods = customerStateHolder.paymentMethods,
+            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
+            canRemove = customerStateHolder.canRemove,
+            canUpdateCardExpiryAndBillingDetails = customerStateHolder.canUpdateCardExpiryAndBillingDetails,
+            canChangeCbc = customerStateHolder.canChangeCbc,
+            walletsState = walletsState,
+            updateSelection = { updatedSelection, requiresConfirmation ->
+                setSelection(updatedSelection)
+            },
+            isCurrentScreen = stateFlowOf(true),
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportFormShown = eventReporter::onPaymentMethodFormShown,
+            onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
+            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
+                val isConfirmFlow = embeddedConfirmationState.value
+                    ?.configuration?.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm
+                if (isConfirmFlow) {
+                    val requiresFormScreen = paymentMethodCode != null &&
+                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
+                    !requiresFormScreen
+                } else {
+                    true
+                }
+            },
+            invokeRowSelectionCallback = ::invokeRowSelectionCallback,
+            displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = walletsState.value,
+                    isVerticalLayout = true,
+                )
+            },
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+        )
+    }
+
+    private fun createSavedPaymentMethodMutator(
+        coroutineScope: CoroutineScope,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerStateHolder: CustomerStateHolder,
+    ): SavedPaymentMethodMutator {
+        return SavedPaymentMethodMutator(
+            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
+            eventReporter = eventReporter,
+            coroutineScope = coroutineScope,
+            workContext = workContext,
+            uiContext = uiContext,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
+            selection = selectionHolder.selection,
+            setSelection = ::setSelection,
+            customerStateHolder = customerStateHolder,
+            prePaymentMethodRemoveActions = {},
+            postPaymentMethodRemoveActions = {},
+            onUpdatePaymentMethod = { _, _, _, _, _ ->
+                sheetLauncherHolder.sheetLauncher?.launchManage(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    customerState = requireNotNull(customerStateHolder.customer.value),
+                    selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = embeddedConfirmationState.value,
+                )
+            },
+            isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
+            isNotPaymentFlow = false,
+            accountLinkBrandFlow = linkAccountHolder.linkAccountInfo.mapAsStateFlow { it.account?.linkBrand },
+        )
+    }
+
+    private fun invokeRowSelectionCallback() {
+        rowSelectionImmediateActionHandler.invoke()
+    }
+
+    private fun setSelection(paymentSelection: PaymentSelection?) {
+        selectionHolder.setSelection(paymentSelection)
+    }
+}
+
+private fun EmbeddedConfirmationStateHolder.State.toEmbeddedContentState(): EmbeddedContentState {
+    return EmbeddedContentState(
+        paymentMethodMetadata = paymentMethodMetadata,
+        appearance = configuration.appearance.embeddedAppearance,
+        embeddedViewDisplaysMandateText = configuration.embeddedViewDisplaysMandateText,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentState.kt
@@ -4,8 +4,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 
 /**
- * The narrowed slice of the confirmation state that [DefaultEmbeddedContentHelper] renders its
- * content from, projected from [EmbeddedConfirmationStateDataSource.embeddedConfirmationState]. It
+ * The narrowed slice of the confirmation state that [DefaultEmbeddedContentHelperDataSource] renders
+ * its content from, projected from [EmbeddedContentHelperDataSource.embeddedConfirmationState]. It
  * is a `data class` so structural equality lets the derived content flow dedupe: a selection-only
  * change to the confirmation state projects to an equal [EmbeddedContentState], so the content
  * isn't rebuilt.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -173,9 +173,9 @@ internal interface EmbeddedPaymentElementViewModelModule {
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
 
     @Binds
-    fun bindsEmbeddedConfirmationStateDataSource(
-        holder: EmbeddedConfirmationStateHolder
-    ): EmbeddedConfirmationStateDataSource
+    fun bindsEmbeddedContentHelperDataSource(
+        dataSource: DefaultEmbeddedContentHelperDataSource
+    ): EmbeddedContentHelperDataSource
 
     @Binds
     fun bindsEmbeddedRowSelectionImmediateActionHandler(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSheetLauncherHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSheetLauncherHolder.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds the imperatively-set [EmbeddedSheetLauncher] so the (singleton) content pieces can share it.
+ * The launcher is bound to an activity's [androidx.activity.result.ActivityResultCaller], so it can't
+ * be a constructor dependency of the singletons that outlive the activity: [DefaultEmbeddedContentHelper]
+ * sets/clears it across the activity lifecycle, while [DefaultEmbeddedContentHelperDataSource] reads it
+ * lazily from the payment-method-list interactor's navigation callbacks. This holder decouples the two
+ * so neither has to depend on the other.
+ */
+@Singleton
+internal class EmbeddedSheetLauncherHolder @Inject constructor() {
+    var sheetLauncher: EmbeddedSheetLauncher? = null
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -32,7 +32,7 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmail
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayIsEmailRequiredProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
-import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateDataSource
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperDataSource
 import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -396,7 +396,7 @@ internal class DefaultWalletButtonsInteractor constructor(
         fun create(
             linkInlineInteractor: LinkInlineInteractor,
             embeddedLinkHelper: EmbeddedLinkHelper,
-            confirmationStateDataSource: EmbeddedConfirmationStateDataSource,
+            contentHelperDataSource: EmbeddedContentHelperDataSource,
             confirmationHandler: ConfirmationHandler,
             coroutineScope: CoroutineScope,
             errorReporter: ErrorReporter,
@@ -410,7 +410,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                 eventReporter = eventReporter,
                 arguments = combineAsStateFlow(
                     embeddedLinkHelper.linkEmail,
-                    confirmationStateDataSource.embeddedConfirmationState,
+                    contentHelperDataSource.embeddedConfirmationState,
                 ) { linkEmail, confirmationState ->
                     confirmationState?.let { state ->
                         Arguments(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperDataSourceTest.kt
@@ -1,0 +1,187 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.AnalyticEventCallbackRule
+import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
+import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import com.stripe.android.utils.RecordingLinkPaymentLauncher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.Test
+
+internal class DefaultEmbeddedContentHelperDataSourceTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `embeddedContent emits content when state is present`() = testScenario {
+        dataSource.embeddedContent.test {
+            assertThat(awaitItem()).isNull()
+            confirmationStateHolder.state = confirmationState()
+            assertThat(awaitItem()).isNotNull()
+        }
+    }
+
+    @Test
+    fun `walletButtonsContent emits content when state is present`() = testScenario {
+        dataSource.walletButtonsContent.test {
+            assertThat(awaitItem()).isNull()
+            confirmationStateHolder.state = confirmationState()
+            assertThat(awaitItem()).isNotNull()
+        }
+    }
+
+    @Test
+    fun `embeddedContent emits null when state is cleared`() = testScenario {
+        dataSource.embeddedContent.test {
+            assertThat(awaitItem()).isNull()
+            confirmationStateHolder.state = confirmationState()
+            assertThat(awaitItem()).isNotNull()
+            confirmationStateHolder.state = null
+            assertThat(awaitItem()).isNull()
+        }
+    }
+
+    @Test
+    fun `walletButtonsContent emits null when state is cleared`() = testScenario {
+        dataSource.walletButtonsContent.test {
+            assertThat(awaitItem()).isNull()
+            confirmationStateHolder.state = confirmationState()
+            assertThat(awaitItem()).isNotNull()
+            confirmationStateHolder.state = null
+            assertThat(awaitItem()).isNull()
+        }
+    }
+
+    @Test
+    fun `initializing with existing state emits content`() = testScenario(
+        initialConfirmationState = confirmationState(),
+    ) {
+        dataSource.embeddedContent.test {
+            assertThat(awaitItem()).isNotNull()
+        }
+    }
+
+    @Test
+    fun `embeddedContent is not rebuilt on a selection-only confirmation state change`() = testScenario(
+        initialConfirmationState = confirmationState(selection = null),
+    ) {
+        dataSource.embeddedContent.test {
+            assertThat(awaitItem()).isNotNull()
+
+            // A selection-only change projects to an equal EmbeddedContentState, so the content flow
+            // dedupes via mapAsStateFlow's distinctUntilChanged and doesn't rebuild the payment method list.
+            confirmationStateHolder.state = confirmationStateHolder.state?.copy(
+                selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            )
+
+            expectNoEvents()
+            // The underlying state genuinely changed, so the absence of a re-emission is meaningful.
+            assertThat(confirmationStateHolder.state?.selection)
+                .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        }
+    }
+
+    private fun confirmationState(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        selection: PaymentSelection? = null,
+        configuration: EmbeddedPaymentElement.Configuration =
+            EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+    ) = EmbeddedConfirmationStateHolder.State(
+        paymentMethodMetadata = paymentMethodMetadata,
+        selection = selection,
+        configuration = configuration,
+    )
+
+    private class Scenario(
+        val dataSource: DefaultEmbeddedContentHelperDataSource,
+        val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    )
+
+    @OptIn(ExperimentalAnalyticEventCallbackApi::class)
+    private fun testScenario(
+        initialConfirmationState: EmbeddedConfirmationStateHolder.State? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest(UnconfinedTestDispatcher()) {
+        val savedStateHandle = SavedStateHandle()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+        val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+            embeddedSelectionHolder = selectionHolder,
+            savedStateHandle = savedStateHandle,
+        )
+        val confirmationHandler = FakeConfirmationHandler()
+        val eventReporter = FakeEventReporter()
+        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+            savedStateHandle = savedStateHandle,
+            selectionHolder = selectionHolder,
+            coroutineScope = backgroundScope,
+        )
+        confirmationStateHolder.state = initialConfirmationState
+        val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
+            coroutineScope = backgroundScope,
+            internalRowSelectionCallback = { null }
+        )
+
+        val dataSource = DefaultEmbeddedContentHelperDataSource(
+            coroutineScope = backgroundScope,
+            eventReporter = eventReporter,
+            workContext = Dispatchers.Unconfined,
+            uiContext = Dispatchers.Unconfined,
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
+            selectionHolder = selectionHolder,
+            embeddedLinkHelper = object : EmbeddedLinkHelper {
+                override val linkEmail: StateFlow<String?> = stateFlowOf(null)
+            },
+            embeddedWalletsHelper = { stateFlowOf(null) },
+            customerStateHolder = DefaultCustomerStateHolder(
+                savedStateHandle = savedStateHandle,
+                selection = selectionHolder.selection,
+                customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
+                paymentMethodMetadataFlow = stateFlowOf(null),
+            ),
+            embeddedFormHelperFactory = embeddedFormHelperFactory,
+            confirmationHandler = confirmationHandler,
+            confirmationStateHolder = confirmationStateHolder,
+            rowSelectionImmediateActionHandler = immediateActionHandler,
+            errorReporter = FakeErrorReporter(),
+            internalRowSelectionCallback = { null },
+            linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
+            analyticsCallbackProvider = { AnalyticEventCallbackRule() },
+            linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
+        )
+        Scenario(
+            dataSource = dataSource,
+            confirmationStateHolder = confirmationStateHolder,
+        ).block()
+        confirmationHandler.validate()
+        eventReporter.validate()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -1,37 +1,23 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import androidx.lifecycle.SavedStateHandle
-import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
-import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.utils.stateFlowOf
-import com.stripe.android.utils.AnalyticEventCallbackRule
-import com.stripe.android.utils.FakeLinkConfigurationCoordinator
-import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
-import com.stripe.android.utils.FakeSavedPaymentMethodRepository
-import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
-import com.stripe.android.utils.RecordingLinkPaymentLauncher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -42,72 +28,13 @@ internal class DefaultEmbeddedContentHelperTest {
     val coroutineTestRule = CoroutineTestRule()
 
     @Test
-    fun `embeddedContent emits content when state is present`() = testScenario {
-        embeddedContentHelper.embeddedContent.test {
-            assertThat(awaitItem()).isNull()
-            confirmationStateHolder.state = confirmationState()
-            assertThat(awaitItem()).isNotNull()
-        }
+    fun `embeddedContent delegates to the data source`() = testScenario {
+        assertThat(embeddedContentHelper.embeddedContent).isSameInstanceAs(dataSource.embeddedContent)
     }
 
     @Test
-    fun `walletButtonsContent emits content when state is present`() = testScenario {
-        embeddedContentHelper.walletButtonsContent.test {
-            assertThat(awaitItem()).isNull()
-            confirmationStateHolder.state = confirmationState()
-            assertThat(awaitItem()).isNotNull()
-        }
-    }
-
-    @Test
-    fun `embeddedContent emits null when state is cleared`() = testScenario {
-        embeddedContentHelper.embeddedContent.test {
-            assertThat(awaitItem()).isNull()
-            confirmationStateHolder.state = confirmationState()
-            assertThat(awaitItem()).isNotNull()
-            confirmationStateHolder.state = null
-            assertThat(awaitItem()).isNull()
-        }
-    }
-
-    @Test
-    fun `walletButtonsContent emits null when state is cleared`() = testScenario {
-        embeddedContentHelper.walletButtonsContent.test {
-            assertThat(awaitItem()).isNull()
-            confirmationStateHolder.state = confirmationState()
-            assertThat(awaitItem()).isNotNull()
-            confirmationStateHolder.state = null
-            assertThat(awaitItem()).isNull()
-        }
-    }
-
-    @Test
-    fun `initializing with existing state emits content`() = testScenario(
-        initialConfirmationState = confirmationState(),
-    ) {
-        embeddedContentHelper.embeddedContent.test {
-            assertThat(awaitItem()).isNotNull()
-        }
-    }
-
-    @Test
-    fun `embeddedContent is not rebuilt on a selection-only confirmation state change`() = testScenario(
-        initialConfirmationState = confirmationState(selection = null),
-    ) {
-        embeddedContentHelper.embeddedContent.test {
-            assertThat(awaitItem()).isNotNull()
-
-            // A selection-only change projects to an equal EmbeddedContentState, so the content flow
-            // dedupes via mapAsStateFlow's distinctUntilChanged and doesn't rebuild the payment method list.
-            confirmationStateHolder.state = confirmationStateHolder.state?.copy(
-                selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
-            )
-
-            expectNoEvents()
-            // The underlying state genuinely changed, so the absence of a re-emission is meaningful.
-            assertThat(confirmationStateHolder.state?.selection)
-                .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-        }
+    fun `walletButtonsContent delegates to the data source`() = testScenario {
+        assertThat(embeddedContentHelper.walletButtonsContent).isSameInstanceAs(dataSource.walletButtonsContent)
     }
 
     @Test
@@ -160,6 +87,19 @@ internal class DefaultEmbeddedContentHelperTest {
         }
     }
 
+    @Test
+    fun `clearSheetLauncher stops launches so presentPaymentOptions reports no launcher`() = testScenario(
+        initialConfirmationState = confirmationState(),
+    ) {
+        embeddedContentHelper.setSheetLauncher(RecordingEmbeddedSheetLauncher())
+        embeddedContentHelper.clearSheetLauncher()
+
+        embeddedContentHelper.presentPaymentOptions()
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            "unexpected_error.embedded.present_payment_options.no_launcher"
+        )
+    }
+
     private fun confirmationState(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         selection: PaymentSelection? = null,
@@ -173,11 +113,10 @@ internal class DefaultEmbeddedContentHelperTest {
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
-        val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+        val dataSource: FakeEmbeddedContentHelperDataSource,
         val errorReporter: FakeErrorReporter,
     )
 
-    @OptIn(ExperimentalAnalyticEventCallbackApi::class)
     private fun testScenario(
         initialConfirmationState: EmbeddedConfirmationStateHolder.State? = null,
         setup: SavedStateHandle.() -> Unit = {},
@@ -185,61 +124,28 @@ internal class DefaultEmbeddedContentHelperTest {
     ) = runTest(UnconfinedTestDispatcher()) {
         val savedStateHandle = SavedStateHandle().apply { setup() }
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
-        val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
-            embeddedSelectionHolder = selectionHolder,
-            savedStateHandle = savedStateHandle,
-        )
-        val confirmationHandler = FakeConfirmationHandler()
-        val eventReporter = FakeEventReporter()
         val errorReporter = FakeErrorReporter()
-        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+        val dataSource = FakeEmbeddedContentHelperDataSource(
+            embeddedConfirmationState = MutableStateFlow(initialConfirmationState),
+        )
+        val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
-            selectionHolder = selectionHolder,
-            coroutineScope = backgroundScope,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
+            paymentMethodMetadataFlow = stateFlowOf(null),
         )
-        confirmationStateHolder.state = initialConfirmationState
-        val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
-            coroutineScope = backgroundScope,
-            internalRowSelectionCallback = { null }
-        )
-
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
-            coroutineScope = backgroundScope,
-            eventReporter = eventReporter,
-            workContext = Dispatchers.Unconfined,
-            uiContext = Dispatchers.Unconfined,
-            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
-            selectionHolder = selectionHolder,
-            embeddedLinkHelper = object : EmbeddedLinkHelper {
-                override val linkEmail: StateFlow<String?> = stateFlowOf(null)
-            },
-            embeddedWalletsHelper = { stateFlowOf(null) },
-            customerStateHolder = DefaultCustomerStateHolder(
-                savedStateHandle = savedStateHandle,
-                selection = selectionHolder.selection,
-                customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
-                paymentMethodMetadataFlow = stateFlowOf(null),
-            ),
-            embeddedFormHelperFactory = embeddedFormHelperFactory,
-            confirmationHandler = confirmationHandler,
-            confirmationStateDataSource = confirmationStateHolder,
-            rowSelectionImmediateActionHandler = immediateActionHandler,
+            dataSource = dataSource,
             errorReporter = errorReporter,
-            internalRowSelectionCallback = { null },
-            linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
-            analyticsCallbackProvider = { AnalyticEventCallbackRule() },
-            linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
-            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+            customerStateHolder = customerStateHolder,
+            selectionHolder = selectionHolder,
+            sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
         )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
-            confirmationStateHolder = confirmationStateHolder,
+            dataSource = dataSource,
             errorReporter = errorReporter,
         ).block()
-        confirmationHandler.validate()
-        eventReporter.validate()
     }
 
     private class RecordingEmbeddedSheetLauncher : EmbeddedSheetLauncher {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -59,7 +59,7 @@ internal class EmbeddedContentUiTest {
     @Test
     fun `rowStyle FlatWithDisclosure, dataLoaded emits embeddedContent event that passes validation`() =
         runScenario(internalRowSelectionCallback = {}) {
-            embeddedContentHelper.embeddedContent.test {
+            dataSource.embeddedContent.test {
                 assertThat(awaitItem()).isNull()
                 confirmationStateHolder.state = confirmationState(
                     appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
@@ -80,7 +80,7 @@ internal class EmbeddedContentUiTest {
     fun `rowStyle not FlatWithDisclosure, dataLoaded emits event that passes validation`() = runScenario(
         internalRowSelectionCallback = null
     ) {
-        embeddedContentHelper.embeddedContent.test {
+        dataSource.embeddedContent.test {
             assertThat(awaitItem()).isNull()
             confirmationStateHolder.state = confirmationState(
                 appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
@@ -101,7 +101,7 @@ internal class EmbeddedContentUiTest {
     fun `dataLoaded emits embeddedContent event that fails validation`() = runScenario(
         internalRowSelectionCallback = null
     ) {
-        embeddedContentHelper.embeddedContent.test {
+        dataSource.embeddedContent.test {
             assertThat(awaitItem()).isNull()
             confirmationStateHolder.state = confirmationState(
                 appearance = Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
@@ -121,7 +121,7 @@ internal class EmbeddedContentUiTest {
     }
 
     private class Scenario(
-        val embeddedContentHelper: DefaultEmbeddedContentHelper,
+        val dataSource: DefaultEmbeddedContentHelperDataSource,
         val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     )
 
@@ -152,8 +152,8 @@ internal class EmbeddedContentUiTest {
             selectionHolder = selectionHolder,
             coroutineScope = CoroutineScope(Dispatchers.Unconfined),
         )
-        val embeddedContentHelper =
-            DefaultEmbeddedContentHelper(
+        val dataSource =
+            DefaultEmbeddedContentHelperDataSource(
                 coroutineScope = CoroutineScope(Dispatchers.Unconfined),
                 eventReporter = eventReporter,
                 workContext = Dispatchers.Unconfined,
@@ -174,17 +174,18 @@ internal class EmbeddedContentUiTest {
                 ),
                 embeddedFormHelperFactory = embeddedFormHelperFactory,
                 confirmationHandler = confirmationHandler,
-                confirmationStateDataSource = confirmationStateHolder,
+                confirmationStateHolder = confirmationStateHolder,
                 rowSelectionImmediateActionHandler = immediateActionHandler,
                 errorReporter = errorReporter,
                 internalRowSelectionCallback = { internalRowSelectionCallback },
                 linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
                 analyticsCallbackProvider = { AnalyticEventCallbackRule() },
                 linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
             )
         Scenario(
-            embeddedContentHelper = embeddedContentHelper,
+            dataSource = dataSource,
             confirmationStateHolder = confirmationStateHolder,
         ).block()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelperDataSource.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelperDataSource.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.paymentsheet.ui.WalletButtonsContent
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class FakeEmbeddedContentHelperDataSource(
+    override val embeddedConfirmationState: MutableStateFlow<EmbeddedConfirmationStateHolder.State?> =
+        MutableStateFlow(null),
+    override val embeddedContent: MutableStateFlow<EmbeddedContent?> = MutableStateFlow(null),
+    override val walletButtonsContent: MutableStateFlow<WalletButtonsContent?> = MutableStateFlow(null),
+) : EmbeddedContentHelperDataSource


### PR DESCRIPTION
# Summary

Refactors `EmbeddedContentHelper` to split the content-building logic into a new `EmbeddedContentHelperDataSource` class. The helper is now a thin facade delegating content-related state and flows to the data source, improving testability and separation of concerns. Also introduces `EmbeddedSheetLauncherHolder` to decouple sheet launching between lifecycle and data dependencies. Refactors usages and tests accordingly.

# Motivation

To decouple content-building (especially for payment methods and wallet buttons) from imperative UI coordination and navigation. This supports future extension and makes the code more modular, maintainable, and testable. The change also sets the stage for supporting multiple integrations and improves lifecycle awareness.

# Testing

- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog