### PR TITLE
Scope embedded sheet launcher and content to one checkout presenter instance.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -7,11 +7,14 @@ import androidx.annotation.RestrictTo
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
+import com.stripe.android.common.ui.PaymentElementActivityResultCaller
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.validateShippingCountry
+import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -40,6 +43,7 @@ class CheckoutController @Inject internal constructor(
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) {
     val checkoutSession: StateFlow<CheckoutSession?>
         get() = stateHolder.checkoutSession
@@ -293,7 +297,18 @@ class CheckoutController @Inject internal constructor(
     }
 
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {
-        return checkoutPresenterSubcomponentFactory.create().presenter
+        val subcomponent = checkoutPresenterSubcomponentFactory.create(
+            // Register against the activity's ActivityResultRegistry directly (rather than
+            // activity.registerForActivityResult) so a presenter can be created after the activity
+            // is STARTED/RESUMED, e.g. from a composable.
+            activityResultCaller = PaymentElementActivityResultCaller(
+                key = "CheckoutController(instance = $paymentElementCallbackIdentifier)",
+                registryOwner = activity,
+            ),
+            lifecycleOwner = activity,
+        )
+        subcomponent.initializer.initialize(activity.applicationIsTaskOwner())
+        return subcomponent.presenter
     }
 
     fun destroy() {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -2,16 +2,24 @@ package com.stripe.android.checkout
 
 import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContent
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentBuilder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperDataSource
 import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -26,7 +34,12 @@ import javax.inject.Singleton
 internal class CheckoutControllerStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val errorReporter: ErrorReporter,
-) : EmbeddedSelectionHolder {
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+    // Provider + lazy break the DI/construction cycle: EmbeddedContentBuilder -> CustomerStateHolder
+    // -> EmbeddedSelectionHolder, which is this class. Building lazily defers construction of the
+    // builder until after this singleton is cached, so the selection-holder edge resolves to it.
+    private val contentBuilder: Provider<EmbeddedContentBuilder>,
+) : EmbeddedSelectionHolder, EmbeddedContentHelperDataSource {
     var state: CheckoutControllerState?
         get() = savedStateHandle[STATE_KEY]
         set(value) {
@@ -38,6 +51,31 @@ internal class CheckoutControllerStateHolder @Inject constructor(
 
     val checkoutSession: StateFlow<CheckoutSession?> =
         stateFlow.mapAsStateFlow { it?.asCheckoutSession() }
+
+    override val embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?> =
+        stateFlow.mapAsStateFlow { state ->
+            state?.let {
+                EmbeddedConfirmationStateHolder.State(
+                    paymentMethodMetadata = it.paymentMethodMetadata,
+                    selection = it.paymentSelection,
+                    configuration = it.embeddedConfiguration,
+                )
+            }
+        }
+
+    private val contentFlows: EmbeddedContentBuilder.ContentFlows by lazy {
+        contentBuilder.get().build(
+            coroutineScope = coroutineScope,
+            dataSource = this,
+            embeddedConfirmationState = embeddedConfirmationState,
+        )
+    }
+
+    override val embeddedContent: StateFlow<EmbeddedContent?>
+        get() = contentFlows.embeddedContent
+
+    override val walletButtonsContent: StateFlow<WalletButtonsContent?>
+        get() = contentFlows.walletButtonsContent
 
     override val selection: StateFlow<PaymentSelection?> =
         stateFlow.mapAsStateFlow { it?.paymentSelection }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentElementInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentElementInitializer.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.checkout.injection.CheckoutPresenterScope
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener.Companion.PREVIOUSLY_SENT_DEEP_LINK_EVENT
+import javax.inject.Inject
+
+/**
+ * Binds the activity-scoped [EmbeddedSheetLauncher] onto the (singleton) [EmbeddedContentHelper]
+ * facade so checkout's content interactors and `presentPaymentOptions()` can launch sheets, and
+ * clears it (plus the callback references) when the presenter's activity is destroyed. Mirrors
+ * [com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementInitializer].
+ */
+@CheckoutPresenterScope
+internal class CheckoutPaymentElementInitializer @Inject constructor(
+    private val sheetLauncher: EmbeddedSheetLauncher,
+    private val contentHelper: EmbeddedContentHelper,
+    private val lifecycleOwner: LifecycleOwner,
+    private val savedStateHandle: SavedStateHandle,
+    private val eventReporter: EventReporter,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+) {
+    private var previouslySentDeepLinkEvent: Boolean
+        get() = savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] ?: false
+        set(value) {
+            savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] = value
+        }
+
+    fun initialize(applicationIsTaskOwner: Boolean) {
+        if (!applicationIsTaskOwner && !previouslySentDeepLinkEvent) {
+            eventReporter.onCannotProperlyReturnFromLinkAndOtherLPMs()
+            previouslySentDeepLinkEvent = true
+        }
+
+        contentHelper.setSheetLauncher(sheetLauncher)
+
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    PaymentElementCallbackReferences.remove(paymentElementCallbackIdentifier)
+                    contentHelper.clearSheetLauncher()
+                }
+            }
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -1,0 +1,233 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.checkout.injection.CheckoutPresenterScope
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.state.CustomerState
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * Checkout's [EmbeddedSheetLauncher]: launches the embedded payment-options / form / manage sheets
+ * (via [EmbeddedSheetContract]) for the checkout integration and folds their results back into the
+ * shared [EmbeddedSelectionHolder] / [CustomerStateHolder].
+ *
+ * This mirrors [com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSheetLauncher] but
+ * deliberately omits the embedded result-callback plumbing: confirmation isn't wired for checkout
+ * yet, so a confirmed result is not surfaced anywhere (see the `TODO(confirm)` markers).
+ */
+@CheckoutPresenterScope
+internal class CheckoutSheetLauncher @Inject constructor(
+    activityResultCaller: ActivityResultCaller,
+    lifecycleOwner: LifecycleOwner,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
+    private val customerStateHolder: CustomerStateHolder,
+    private val sheetStateHolder: SheetStateHolder,
+    private val errorReporter: ErrorReporter,
+    @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+) : EmbeddedSheetLauncher {
+
+    init {
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    activityLauncher.unregister()
+                    super.onDestroy(owner)
+                }
+            }
+        )
+    }
+
+    private val activityLauncher: ActivityResultLauncher<EmbeddedActivityArgs> =
+        activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
+            sheetStateHolder.sheetIsOpen = false
+            when (result.launchMode) {
+                is EmbeddedLaunchMode.Form -> {
+                    selectionHolder.setTemporarySelection(null)
+                    handleFormResult(result)
+                }
+                is EmbeddedLaunchMode.Manage -> handleManageResult(result)
+                is EmbeddedLaunchMode.PaymentOptions -> handlePaymentOptionsResult(result)
+            }
+        }
+
+    private fun handleFormResult(result: EmbeddedActivityResult) {
+        when (result) {
+            is EmbeddedActivityResult.Complete -> {
+                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setSelection(result.selection)
+                if (result.hasBeenConfirmed) {
+                    // TODO(confirm): surface a completed result once checkout confirmation is wired.
+                } else {
+                    result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+                }
+            }
+            is EmbeddedActivityResult.Cancelled -> {
+                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                // TODO(confirm): surface a canceled result once checkout confirmation is wired.
+            }
+            is EmbeddedActivityResult.Error -> Unit
+        }
+    }
+
+    private fun handleManageResult(result: EmbeddedActivityResult) {
+        when (result) {
+            is EmbeddedActivityResult.Complete -> {
+                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setSelection(result.selection)
+                if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
+                    rowSelectionImmediateActionHandler.invoke()
+                }
+            }
+            is EmbeddedActivityResult.Cancelled -> Unit
+            is EmbeddedActivityResult.Error -> Unit
+        }
+    }
+
+    private fun handlePaymentOptionsResult(result: EmbeddedActivityResult) {
+        when (result) {
+            is EmbeddedActivityResult.Complete -> {
+                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setSelection(result.selection)
+                if (result.hasBeenConfirmed) {
+                    // TODO(confirm): surface a completed result once checkout confirmation is wired.
+                }
+            }
+            is EmbeddedActivityResult.Cancelled -> {
+                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                clearStaleSelection()
+            }
+            is EmbeddedActivityResult.Error -> Unit
+        }
+    }
+
+    private fun clearStaleSelection() {
+        val currentSelection = selectionHolder.selection.value
+        if (currentSelection is PaymentSelection.Saved) {
+            val paymentMethodId = currentSelection.paymentMethod.id
+            val stillExists = customerStateHolder.paymentMethods.value.any { it.id == paymentMethodId }
+            if (!stillExists) {
+                selectionHolder.setSelection(null)
+            }
+        }
+    }
+
+    override fun launchForm(
+        code: String,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        customerState: CustomerState?,
+        promotion: PaymentMethodMessagePromotion?,
+    ) {
+        markIntegrationLaunched(paymentMethodMetadata)
+        if (embeddedConfirmationState == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+            )
+            return
+        }
+        if (sheetStateHolder.sheetIsOpen) return
+        sheetStateHolder.sheetIsOpen = true
+        selectionHolder.setTemporarySelection(code)
+        val currentSelection = (selectionHolder.selection.value as? PaymentSelection.New?)
+            .takeIf { it?.paymentMethodType == code }
+            ?: selectionHolder.getPreviousNewSelection(code)
+        val args = EmbeddedActivityArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = embeddedConfirmationState.configuration,
+            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+            statusBarColor = statusBarColor,
+            selection = currentSelection,
+            customerState = customerState,
+            promotion = promotion,
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = code),
+        )
+        activityLauncher.launch(args)
+    }
+
+    override fun launchManage(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerState: CustomerState,
+        selection: PaymentSelection?,
+        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+    ) {
+        markIntegrationLaunched(paymentMethodMetadata)
+        if (embeddedConfirmationState == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+            )
+            return
+        }
+        if (sheetStateHolder.sheetIsOpen) return
+        sheetStateHolder.sheetIsOpen = true
+        val args = EmbeddedActivityArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = embeddedConfirmationState.configuration,
+            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+            statusBarColor = statusBarColor,
+            selection = selection,
+            customerState = customerState,
+            promotion = null,
+            launchMode = EmbeddedLaunchMode.Manage,
+        )
+        activityLauncher.launch(args)
+    }
+
+    override fun launchPaymentOptions(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerState: CustomerState?,
+        selection: PaymentSelection?,
+        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+    ) {
+        markIntegrationLaunched(paymentMethodMetadata)
+        if (embeddedConfirmationState == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+            )
+            return
+        }
+        if (sheetStateHolder.sheetIsOpen) return
+        sheetStateHolder.sheetIsOpen = true
+        val args = EmbeddedActivityArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = embeddedConfirmationState.configuration,
+            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+            statusBarColor = statusBarColor,
+            selection = selection,
+            customerState = customerState,
+            promotion = null,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+        activityLauncher.launch(args)
+    }
+
+    private fun markIntegrationLaunched(paymentMethodMetadata: PaymentMethodMetadata) {
+        val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
+        if (checkoutSession != null) {
+            CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
+            CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -4,27 +4,33 @@ import android.graphics.drawable.Drawable
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.AnnotatedString
 import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.image.rememberDrawablePainter
+import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class PaymentElement @Inject internal constructor() {
+class PaymentElement @Inject internal constructor(
+    private val contentHelper: EmbeddedContentHelper,
+) {
 
     @Composable
     fun PaymentOptionsContent() {
-        TODO("Not yet implemented")
+        val embeddedContent by contentHelper.embeddedContent.collectAsState()
+        embeddedContent?.Content()
     }
 
     fun presentPaymentOptions() {
-        TODO("Not yet implemented")
+        contentHelper.presentPaymentOptions()
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -31,22 +31,32 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedLinkHelper
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedWalletsHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperDataSource
+import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
+import com.stripe.android.paymentelement.embedded.content.EmbeddedWalletsHelper
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
-import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
-import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
@@ -70,6 +80,7 @@ import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.TapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.TapToAddConnectionStarterModule
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -101,6 +112,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ExtendedPaymentElementConfirmationModule::class,
     ],
 )
 internal interface CheckoutControllerComponent {
@@ -186,6 +198,22 @@ internal interface CheckoutControllerModule {
     @Binds
     fun bindsEmbeddedSelectionHolder(impl: CheckoutControllerStateHolder): EmbeddedSelectionHolder
 
+    @Binds
+    fun bindsEmbeddedContentHelperDataSource(
+        impl: CheckoutControllerStateHolder
+    ): EmbeddedContentHelperDataSource
+
+    @Binds
+    fun bindsLinkHelper(helper: DefaultEmbeddedLinkHelper): EmbeddedLinkHelper
+
+    @Binds
+    fun bindsWalletsHelper(helper: DefaultEmbeddedWalletsHelper): EmbeddedWalletsHelper
+
+    @Binds
+    fun bindsEmbeddedRowSelectionImmediateActionHandler(
+        handler: DefaultEmbeddedRowSelectionImmediateActionHandler
+    ): EmbeddedRowSelectionImmediateActionHandler
+
     companion object {
         private const val CALLBACK_IDENTIFIER_KEY = "CheckoutController_CallbackIdentifier"
 
@@ -239,16 +267,42 @@ internal interface CheckoutControllerModule {
         }
 
         @Provides
-        @Singleton
-        fun provideCvcRecollectionHandler(): CvcRecollectionHandler {
-            return CvcRecollectionHandlerImpl()
-        }
-
-        @Provides
         fun providePaymentMethodMetadata(
             stateHolder: CheckoutControllerStateHolder,
         ): PaymentMethodMetadata? {
             return stateHolder.state?.paymentMethodMetadata
+        }
+
+        // These stay at component scope because the content-building singletons
+        // (EmbeddedContentBuilder, CustomerStateHolder) depend on them; PaymentElementModule lives
+        // in the per-presenter subcomponent and can't own @Singleton bindings.
+        @Provides
+        @Singleton
+        fun provideConfirmationHandler(
+            confirmationHandlerFactory: ConfirmationHandler.Factory,
+            @ViewModelScope coroutineScope: CoroutineScope,
+        ): ConfirmationHandler {
+            return confirmationHandlerFactory.create(coroutineScope)
+        }
+
+        @Provides
+        @Named(STATUS_BAR_COLOR)
+        fun provideStatusBarColor(): Int? = null
+
+        @Provides
+        @Singleton
+        fun provideCustomerStateHolder(
+            savedStateHandle: SavedStateHandle,
+            selectionHolder: EmbeddedSelectionHolder,
+            stateHolder: CheckoutControllerStateHolder,
+        ): CustomerStateHolder {
+            val paymentMethodMetadataFlow = stateHolder.stateFlow.mapAsStateFlow { it?.paymentMethodMetadata }
+            return DefaultCustomerStateHolder(
+                savedStateHandle = savedStateHandle,
+                selection = selectionHolder.selection,
+                customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow { it?.customerMetadata },
+                paymentMethodMetadataFlow = paymentMethodMetadataFlow,
+            )
         }
 
         @OptIn(ExperimentalAnalyticEventCallbackApi::class)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterScope.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterScope.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.checkout.injection
+
+import javax.inject.Scope
+
+/**
+ * Scopes the per-presenter graph created by [CheckoutPresenterSubcomponent] — the activity-bound
+ * pieces (sheet launcher, initializer) that must share a single instance for one
+ * [android.app.Activity] and be recreated when a new presenter is created.
+ */
+@Scope
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class CheckoutPresenterScope

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
@@ -2,16 +2,30 @@
 
 package com.stripe.android.checkout.injection
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.checkout.CheckoutPaymentElementInitializer
 import com.stripe.android.checkout.CheckoutPresenter
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import dagger.BindsInstance
 import dagger.Subcomponent
 
-@Subcomponent(modules = [CurrencySelectorElementModule::class])
+@CheckoutPresenterScope
+@Subcomponent(
+    modules = [
+        CurrencySelectorElementModule::class,
+        PaymentElementModule::class,
+    ]
+)
 internal interface CheckoutPresenterSubcomponent {
     val presenter: CheckoutPresenter
+    val initializer: CheckoutPaymentElementInitializer
 
     @Subcomponent.Factory
     interface Factory {
-        fun create(): CheckoutPresenterSubcomponent
+        fun create(
+            @BindsInstance activityResultCaller: ActivityResultCaller,
+            @BindsInstance lifecycleOwner: LifecycleOwner,
+        ): CheckoutPresenterSubcomponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.checkout.injection
+
+import com.stripe.android.checkout.CheckoutSheetLauncher
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
+import dagger.Binds
+import dagger.Module
+
+@Module
+internal interface PaymentElementModule {
+    @Binds
+    fun bindsEmbeddedContentHelper(
+        helper: DefaultEmbeddedContentHelper
+    ): EmbeddedContentHelper
+
+    @Binds
+    fun bindsSheetLauncher(
+        launcher: CheckoutSheetLauncher
+    ): EmbeddedSheetLauncher
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentBuilder.kt
@@ -1,0 +1,316 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.UIContext
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.verification.NoOpLinkInlineInteractor
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.AnalyticEventCallback
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.FormHelper.FormType
+import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
+import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
+import com.stripe.android.paymentsheet.ui.WalletButtonsContent
+import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
+import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
+import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Builds the observable content ([EmbeddedContent] + [WalletButtonsContent]) rendered by an
+ * [EmbeddedContentHelperDataSource] from its [embeddedConfirmationState]. Kept separate from any one
+ * data source so each integration
+ * ([EmbeddedPaymentElement][com.stripe.android.paymentelement.EmbeddedPaymentElement] and checkout)
+ * can own its own confirmation-state source while sharing this content-building logic.
+ */
+@OptIn(ExperimentalAnalyticEventCallbackApi::class)
+@Singleton
+internal class EmbeddedContentBuilder @Inject constructor(
+    private val eventReporter: EventReporter,
+    private val errorReporter: ErrorReporter,
+    @IOContext private val workContext: CoroutineContext,
+    @UIContext private val uiContext: CoroutineContext,
+    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val embeddedLinkHelper: EmbeddedLinkHelper,
+    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
+    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
+    private val analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
+    private val embeddedWalletsHelper: EmbeddedWalletsHelper,
+    private val customerStateHolder: CustomerStateHolder,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    private val confirmationHandler: ConfirmationHandler,
+    private val linkPaymentLauncher: LinkPaymentLauncher,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+) {
+
+    /**
+     * The content flows derived from an [EmbeddedContentHelperDataSource]'s confirmation state.
+     */
+    data class ContentFlows(
+        val embeddedContent: StateFlow<EmbeddedContent?>,
+        val walletButtonsContent: StateFlow<WalletButtonsContent?>,
+    )
+
+    /**
+     * Wires collectors on [coroutineScope] that keep the returned flows in sync with
+     * [embeddedConfirmationState]. [dataSource] is the owning data source (used by the wallet-button
+     * interactor to read the raw confirmation state and content flows back).
+     */
+    fun build(
+        coroutineScope: CoroutineScope,
+        dataSource: EmbeddedContentHelperDataSource,
+        embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?>,
+    ): ContentFlows {
+        val state: StateFlow<EmbeddedContentState?> =
+            embeddedConfirmationState.mapAsStateFlow { it?.toEmbeddedContentState() }
+
+        val embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
+        val walletButtonsContent = MutableStateFlow<WalletButtonsContent?>(null)
+
+        coroutineScope.launch {
+            state.collect { state ->
+                embeddedContent.value = if (state == null) {
+                    null
+                } else {
+                    val isImmediateAction = internalRowSelectionCallback.get() != null
+                    EmbeddedContent(
+                        interactor = createInteractor(
+                            coroutineScope = coroutineScope,
+                            embeddedConfirmationState = embeddedConfirmationState,
+                            paymentMethodMetadata = state.paymentMethodMetadata,
+                            walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
+                            isImmediateAction = isImmediateAction,
+                            embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
+                        ),
+                        embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
+                        appearance = state.appearance,
+                        isImmediateAction = isImmediateAction,
+                    )
+                }
+            }
+        }
+
+        coroutineScope.launch {
+            state.collect { state ->
+                walletButtonsContent.value = if (state == null) {
+                    null
+                } else {
+                    WalletButtonsContent(
+                        interactor = createWalletButtonsInteractor(
+                            coroutineScope = coroutineScope,
+                            dataSource = dataSource,
+                        ),
+                    )
+                }
+            }
+        }
+
+        return ContentFlows(
+            embeddedContent = embeddedContent.asStateFlow(),
+            walletButtonsContent = walletButtonsContent.asStateFlow(),
+        )
+    }
+
+    private fun createWalletButtonsInteractor(
+        coroutineScope: CoroutineScope,
+        dataSource: EmbeddedContentHelperDataSource,
+    ): WalletButtonsInteractor {
+        return DefaultWalletButtonsInteractor.create(
+            embeddedLinkHelper = embeddedLinkHelper,
+            contentHelperDataSource = dataSource,
+            confirmationHandler = confirmationHandler,
+            coroutineScope = coroutineScope,
+            errorReporter = errorReporter,
+            eventReporter = eventReporter,
+            linkPaymentLauncher = linkPaymentLauncher,
+            linkAccountHolder = linkAccountHolder,
+            linkInlineInteractor = NoOpLinkInlineInteractor(),
+            analyticsCallbackProvider = analyticsCallbackProvider,
+        )
+    }
+
+    @Suppress("LongMethod")
+    private fun createInteractor(
+        coroutineScope: CoroutineScope,
+        embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?>,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        walletsState: StateFlow<WalletsState?>,
+        isImmediateAction: Boolean,
+        embeddedViewDisplaysMandateText: Boolean,
+    ): PaymentMethodVerticalLayoutInteractor {
+        val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
+            incentive = paymentMethodMetadata.paymentMethodIncentive,
+        )
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = coroutineScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            // Card scan auto-launch is only relevant in the form, not the list (as the form helper is used in here).
+            automaticallyLaunchedCardScanFormDataHelper = null,
+            tapToAddHelper = null,
+            selectionUpdater = {
+                setSelection(it)
+                invokeRowSelectionCallback()
+            },
+            // Not important for determining formType so set to default value
+            setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+        )
+        val savedPaymentMethodMutator = createSavedPaymentMethodMutator(
+            coroutineScope = coroutineScope,
+            embeddedConfirmationState = embeddedConfirmationState,
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerStateHolder = customerStateHolder,
+        )
+
+        return DefaultPaymentMethodVerticalLayoutInteractor(
+            paymentMethodMetadata = paymentMethodMetadata,
+            processing = combineAsStateFlow(
+                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
+                embeddedConfirmationState.mapAsStateFlow { it != null },
+            ) { confirmationStateValid, configurationStateValid ->
+                confirmationStateValid && configurationStateValid
+            },
+            temporarySelection = selectionHolder.temporarySelection,
+            selection = selectionHolder.selection,
+            paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
+            formTypeForCode = { code ->
+                formHelper.formTypeForCode(code)
+            },
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            transitionToManageScreen = {
+                sheetLauncherHolder.sheetLauncher?.launchManage(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    customerState = requireNotNull(customerStateHolder.customer.value),
+                    selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = embeddedConfirmationState.value,
+                )
+            },
+            transitionToFormScreen = { code ->
+                sheetLauncherHolder.sheetLauncher?.launchForm(
+                    code = code,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    embeddedConfirmationState = embeddedConfirmationState.value,
+                    customerState = customerStateHolder.customer.value,
+                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
+                        code = code,
+                        metadata = paymentMethodMetadata
+                    )
+                )
+            },
+            paymentMethods = customerStateHolder.paymentMethods,
+            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
+            canRemove = customerStateHolder.canRemove,
+            canUpdateCardExpiryAndBillingDetails = customerStateHolder.canUpdateCardExpiryAndBillingDetails,
+            canChangeCbc = customerStateHolder.canChangeCbc,
+            walletsState = walletsState,
+            updateSelection = { updatedSelection, requiresConfirmation ->
+                setSelection(updatedSelection)
+            },
+            isCurrentScreen = stateFlowOf(true),
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportFormShown = eventReporter::onPaymentMethodFormShown,
+            onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
+            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
+                val isConfirmFlow = embeddedConfirmationState.value
+                    ?.configuration?.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm
+                if (isConfirmFlow) {
+                    val requiresFormScreen = paymentMethodCode != null &&
+                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
+                    !requiresFormScreen
+                } else {
+                    true
+                }
+            },
+            invokeRowSelectionCallback = ::invokeRowSelectionCallback,
+            displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = walletsState.value,
+                    isVerticalLayout = true,
+                )
+            },
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+        )
+    }
+
+    private fun createSavedPaymentMethodMutator(
+        coroutineScope: CoroutineScope,
+        embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?>,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerStateHolder: CustomerStateHolder,
+    ): SavedPaymentMethodMutator {
+        return SavedPaymentMethodMutator(
+            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
+            eventReporter = eventReporter,
+            coroutineScope = coroutineScope,
+            workContext = workContext,
+            uiContext = uiContext,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
+            selection = selectionHolder.selection,
+            setSelection = ::setSelection,
+            customerStateHolder = customerStateHolder,
+            prePaymentMethodRemoveActions = {},
+            postPaymentMethodRemoveActions = {},
+            onUpdatePaymentMethod = { _, _, _, _, _ ->
+                sheetLauncherHolder.sheetLauncher?.launchManage(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    customerState = requireNotNull(customerStateHolder.customer.value),
+                    selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = embeddedConfirmationState.value,
+                )
+            },
+            isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
+            isNotPaymentFlow = false,
+            accountLinkBrandFlow = linkAccountHolder.linkAccountInfo.mapAsStateFlow { it.account?.linkBrand },
+        )
+    }
+
+    private fun invokeRowSelectionCallback() {
+        rowSelectionImmediateActionHandler.invoke()
+    }
+
+    private fun setSelection(paymentSelection: PaymentSelection?) {
+        selectionHolder.setSelection(paymentSelection)
+    }
+}
+
+private fun EmbeddedConfirmationStateHolder.State.toEmbeddedContentState(): EmbeddedContentState {
+    return EmbeddedContentState(
+        paymentMethodMetadata = paymentMethodMetadata,
+        appearance = configuration.appearance.embeddedAppearance,
+        embeddedViewDisplaysMandateText = configuration.embeddedViewDisplaysMandateText,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperDataSource.kt
@@ -1,54 +1,18 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.ViewModelScope
-import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.link.verification.NoOpLinkInlineInteractor
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
-import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.FormHelper.FormType
-import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
-import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
-import com.stripe.android.paymentsheet.state.WalletsState
-import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
-import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
-import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
-import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import com.stripe.android.uicore.utils.combineAsStateFlow
-import com.stripe.android.uicore.utils.mapAsStateFlow
-import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Supplies everything [DefaultEmbeddedContentHelper] renders: the raw [embeddedConfirmationState]
  * (which the wallet buttons and sheet-launch args still read directly) and the derived
- * [embeddedContent] / [walletButtonsContent] built from it. The content-building lives here rather
- * than in the helper so each integration
+ * [embeddedContent] / [walletButtonsContent] built from it. The content-building lives in
+ * [EmbeddedContentBuilder] rather than in the helper so each integration
  * ([EmbeddedPaymentElement][com.stripe.android.paymentelement.EmbeddedPaymentElement] today, checkout
  * later) can supply this one abstraction while the helper stays a thin facade over it.
  */
@@ -58,246 +22,23 @@ internal interface EmbeddedContentHelperDataSource {
     val walletButtonsContent: StateFlow<WalletButtonsContent?>
 }
 
-@OptIn(ExperimentalAnalyticEventCallbackApi::class)
 @Singleton
 internal class DefaultEmbeddedContentHelperDataSource @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val eventReporter: EventReporter,
-    private val errorReporter: ErrorReporter,
-    @IOContext private val workContext: CoroutineContext,
-    @UIContext private val uiContext: CoroutineContext,
-    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
-    private val selectionHolder: EmbeddedSelectionHolder,
-    private val embeddedLinkHelper: EmbeddedLinkHelper,
-    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
-    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
-    private val analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
-    private val embeddedWalletsHelper: EmbeddedWalletsHelper,
-    private val customerStateHolder: CustomerStateHolder,
-    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
-    private val confirmationHandler: ConfirmationHandler,
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
-    private val linkPaymentLauncher: LinkPaymentLauncher,
-    private val linkAccountHolder: LinkAccountHolder,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
-    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+    private val contentBuilder: EmbeddedContentBuilder,
 ) : EmbeddedContentHelperDataSource {
 
     override val embeddedConfirmationState: StateFlow<EmbeddedConfirmationStateHolder.State?> =
         confirmationStateHolder.stateFlow
 
-    private val state: StateFlow<EmbeddedContentState?> =
-        embeddedConfirmationState.mapAsStateFlow { it?.toEmbeddedContentState() }
-
-    private val _embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
-    override val embeddedContent: StateFlow<EmbeddedContent?> = _embeddedContent.asStateFlow()
-
-    private val _walletButtonsContent = MutableStateFlow<WalletButtonsContent?>(null)
-    override val walletButtonsContent: StateFlow<WalletButtonsContent?> = _walletButtonsContent.asStateFlow()
-
-    init {
-        coroutineScope.launch {
-            state.collect { state ->
-                _embeddedContent.value = if (state == null) {
-                    null
-                } else {
-                    val isImmediateAction = internalRowSelectionCallback.get() != null
-                    EmbeddedContent(
-                        interactor = createInteractor(
-                            coroutineScope = coroutineScope,
-                            paymentMethodMetadata = state.paymentMethodMetadata,
-                            walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
-                            isImmediateAction = isImmediateAction,
-                            embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
-                        ),
-                        embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
-                        appearance = state.appearance,
-                        isImmediateAction = isImmediateAction,
-                    )
-                }
-            }
-        }
-
-        coroutineScope.launch {
-            state.collect { state ->
-                _walletButtonsContent.value = if (state == null) {
-                    null
-                } else {
-                    WalletButtonsContent(
-                        interactor = createWalletButtonsInteractor(
-                            coroutineScope = coroutineScope,
-                        ),
-                    )
-                }
-            }
-        }
-    }
-
-    private fun createWalletButtonsInteractor(
-        coroutineScope: CoroutineScope,
-    ): WalletButtonsInteractor {
-        return DefaultWalletButtonsInteractor.create(
-            embeddedLinkHelper = embeddedLinkHelper,
-            contentHelperDataSource = this,
-            confirmationHandler = confirmationHandler,
-            coroutineScope = coroutineScope,
-            errorReporter = errorReporter,
-            eventReporter = eventReporter,
-            linkPaymentLauncher = linkPaymentLauncher,
-            linkAccountHolder = linkAccountHolder,
-            linkInlineInteractor = NoOpLinkInlineInteractor(),
-            analyticsCallbackProvider = analyticsCallbackProvider,
-        )
-    }
-
-    private fun createInteractor(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        walletsState: StateFlow<WalletsState?>,
-        isImmediateAction: Boolean,
-        embeddedViewDisplaysMandateText: Boolean,
-    ): PaymentMethodVerticalLayoutInteractor {
-        val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
-            incentive = paymentMethodMetadata.paymentMethodIncentive,
-        )
-        val formHelper = embeddedFormHelperFactory.create(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = eventReporter,
-            // Card scan auto-launch is only relevant in the form, not the list (as the form helper is used in here).
-            automaticallyLaunchedCardScanFormDataHelper = null,
-            tapToAddHelper = null,
-            selectionUpdater = {
-                setSelection(it)
-                invokeRowSelectionCallback()
-            },
-            // Not important for determining formType so set to default value
-            setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-        )
-        val savedPaymentMethodMutator = createSavedPaymentMethodMutator(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            customerStateHolder = customerStateHolder,
-        )
-
-        return DefaultPaymentMethodVerticalLayoutInteractor(
-            paymentMethodMetadata = paymentMethodMetadata,
-            processing = combineAsStateFlow(
-                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
-                embeddedConfirmationState.mapAsStateFlow { it != null },
-            ) { confirmationStateValid, configurationStateValid ->
-                confirmationStateValid && configurationStateValid
-            },
-            temporarySelection = selectionHolder.temporarySelection,
-            selection = selectionHolder.selection,
-            paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
-            formTypeForCode = { code ->
-                formHelper.formTypeForCode(code)
-            },
-            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
-            transitionToManageScreen = {
-                sheetLauncherHolder.sheetLauncher?.launchManage(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = requireNotNull(customerStateHolder.customer.value),
-                    selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = embeddedConfirmationState.value,
-                )
-            },
-            transitionToFormScreen = { code ->
-                sheetLauncherHolder.sheetLauncher?.launchForm(
-                    code = code,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    embeddedConfirmationState = embeddedConfirmationState.value,
-                    customerState = customerStateHolder.customer.value,
-                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
-                        code = code,
-                        metadata = paymentMethodMetadata
-                    )
-                )
-            },
-            paymentMethods = customerStateHolder.paymentMethods,
-            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
-            canRemove = customerStateHolder.canRemove,
-            canUpdateCardExpiryAndBillingDetails = customerStateHolder.canUpdateCardExpiryAndBillingDetails,
-            canChangeCbc = customerStateHolder.canChangeCbc,
-            walletsState = walletsState,
-            updateSelection = { updatedSelection, requiresConfirmation ->
-                setSelection(updatedSelection)
-            },
-            isCurrentScreen = stateFlowOf(true),
-            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
-            reportFormShown = eventReporter::onPaymentMethodFormShown,
-            onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
-            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
-                val isConfirmFlow = embeddedConfirmationState.value
-                    ?.configuration?.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm
-                if (isConfirmFlow) {
-                    val requiresFormScreen = paymentMethodCode != null &&
-                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
-                    !requiresFormScreen
-                } else {
-                    true
-                }
-            },
-            invokeRowSelectionCallback = ::invokeRowSelectionCallback,
-            displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
-            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
-                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
-                    visiblePaymentMethods = visiblePaymentMethods,
-                    hiddenPaymentMethods = hiddenPaymentMethods,
-                    walletsState = walletsState.value,
-                    isVerticalLayout = true,
-                )
-            },
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-        )
-    }
-
-    private fun createSavedPaymentMethodMutator(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        customerStateHolder: CustomerStateHolder,
-    ): SavedPaymentMethodMutator {
-        return SavedPaymentMethodMutator(
-            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
-            eventReporter = eventReporter,
-            coroutineScope = coroutineScope,
-            workContext = workContext,
-            uiContext = uiContext,
-            savedPaymentMethodRepository = savedPaymentMethodRepository,
-            selection = selectionHolder.selection,
-            setSelection = ::setSelection,
-            customerStateHolder = customerStateHolder,
-            prePaymentMethodRemoveActions = {},
-            postPaymentMethodRemoveActions = {},
-            onUpdatePaymentMethod = { _, _, _, _, _ ->
-                sheetLauncherHolder.sheetLauncher?.launchManage(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = requireNotNull(customerStateHolder.customer.value),
-                    selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = embeddedConfirmationState.value,
-                )
-            },
-            isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
-            isNotPaymentFlow = false,
-            accountLinkBrandFlow = linkAccountHolder.linkAccountInfo.mapAsStateFlow { it.account?.linkBrand },
-        )
-    }
-
-    private fun invokeRowSelectionCallback() {
-        rowSelectionImmediateActionHandler.invoke()
-    }
-
-    private fun setSelection(paymentSelection: PaymentSelection?) {
-        selectionHolder.setSelection(paymentSelection)
-    }
-}
-
-private fun EmbeddedConfirmationStateHolder.State.toEmbeddedContentState(): EmbeddedContentState {
-    return EmbeddedContentState(
-        paymentMethodMetadata = paymentMethodMetadata,
-        appearance = configuration.appearance.embeddedAppearance,
-        embeddedViewDisplaysMandateText = configuration.embeddedViewDisplaysMandateText,
+    private val contentFlows: EmbeddedContentBuilder.ContentFlows = contentBuilder.build(
+        coroutineScope = coroutineScope,
+        dataSource = this,
+        embeddedConfirmationState = embeddedConfirmationState,
     )
+
+    override val embeddedContent: StateFlow<EmbeddedContent?> = contentFlows.embeddedContent
+
+    override val walletButtonsContent: StateFlow<WalletButtonsContent?> = contentFlows.walletButtonsContent
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderContentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderContentTest.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentBuilder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncherHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.AnalyticEventCallbackRule
+import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
+import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import com.stripe.android.utils.RecordingLinkPaymentLauncher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import javax.inject.Provider
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class, ExperimentalAnalyticEventCallbackApi::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutControllerStateHolderContentTest {
+
+    @Test
+    fun `embeddedContent emits content when a state is committed and null when cleared`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.embeddedContent.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.state = committedState()
+            assertThat(awaitItem()).isNotNull()
+            stateHolder.state = null
+            assertThat(awaitItem()).isNull()
+        }
+    }
+
+    @Test
+    fun `walletButtonsContent emits content when a state is committed`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.walletButtonsContent.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.state = committedState()
+            assertThat(awaitItem()).isNotNull()
+        }
+    }
+
+    private fun createStateHolder(): CheckoutControllerStateHolder {
+        // The builder's own selection holder is independent of the state holder here; content is
+        // driven by the confirmation state the state holder derives from its committed state.
+        val builderSavedStateHandle = SavedStateHandle()
+        val builderSelectionHolder =
+            com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder(builderSavedStateHandle)
+        val contentBuilder = EmbeddedContentBuilder(
+            eventReporter = FakeEventReporter(),
+            workContext = Dispatchers.Unconfined,
+            uiContext = Dispatchers.Unconfined,
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
+            selectionHolder = builderSelectionHolder,
+            embeddedLinkHelper = object : EmbeddedLinkHelper {
+                override val linkEmail: StateFlow<String?> = stateFlowOf(null)
+            },
+            embeddedWalletsHelper = { stateFlowOf(null) },
+            customerStateHolder = DefaultCustomerStateHolder(
+                savedStateHandle = builderSavedStateHandle,
+                selection = builderSelectionHolder.selection,
+                customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
+                paymentMethodMetadataFlow = stateFlowOf(null),
+            ),
+            embeddedFormHelperFactory = EmbeddedFormHelperFactory(
+                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+                embeddedSelectionHolder = builderSelectionHolder,
+                savedStateHandle = builderSavedStateHandle,
+            ),
+            confirmationHandler = FakeConfirmationHandler(),
+            rowSelectionImmediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                internalRowSelectionCallback = { null },
+            ),
+            errorReporter = FakeErrorReporter(),
+            internalRowSelectionCallback = { null },
+            linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
+            analyticsCallbackProvider = { AnalyticEventCallbackRule() },
+            linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
+        )
+        return createTestCheckoutControllerStateHolder(
+            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+            contentBuilder = Provider { contentBuilder },
+        )
+    }
+
+    private fun committedState(
+        paymentSelection: PaymentSelection? = null,
+    ) = CheckoutControllerState(
+        key = "test_key",
+        configuration = CheckoutController.Configuration().build(),
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+        flagImages = null,
+        collectedDetails = CheckoutCollectedDetails(),
+        integrationLaunched = false,
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        paymentSelection = paymentSelection,
+        temporarySelection = null,
+        previousNewSelections = android.os.Bundle(),
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -125,9 +125,8 @@ internal class CheckoutControllerStateHolderTest {
                 putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
             },
         )
-        val stateHolder = CheckoutControllerStateHolder(
+        val stateHolder = createTestCheckoutControllerStateHolder(
             savedStateHandle = SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restored)),
-            errorReporter = FakeErrorReporter(),
         )
 
         assertThat(stateHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
@@ -159,7 +158,7 @@ internal class CheckoutControllerStateHolderTest {
     ) = runTest {
         val errorReporter = FakeErrorReporter()
         Scenario(
-            stateHolder = CheckoutControllerStateHolder(SavedStateHandle(), errorReporter),
+            stateHolder = createTestCheckoutControllerStateHolder(errorReporter = errorReporter),
             errorReporter = errorReporter,
         ).block()
         errorReporter.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTestFactory.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentBuilder
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import javax.inject.Provider
+
+/**
+ * Builds a [CheckoutControllerStateHolder] for tests that only exercise its state/selection
+ * behavior. The [EmbeddedContentBuilder] is built lazily (only when `embeddedContent` /
+ * `walletButtonsContent` is first collected), so the default throwing provider is never invoked
+ * unless a test opts into content. Tests that assert on content should pass a real builder.
+ */
+internal fun createTestCheckoutControllerStateHolder(
+    savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    errorReporter: ErrorReporter = FakeErrorReporter(),
+    coroutineScope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+    contentBuilder: Provider<EmbeddedContentBuilder> = Provider {
+        error("EmbeddedContentBuilder not configured for this test")
+    },
+): CheckoutControllerStateHolder = CheckoutControllerStateHolder(
+    savedStateHandle = savedStateHandle,
+    errorReporter = errorReporter,
+    coroutineScope = coroutineScope,
+    contentBuilder = contentBuilder,
+)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.CleanupTestRule
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -200,7 +199,7 @@ internal class CheckoutControllerTest {
         val savedStateHandle = SavedStateHandle()
         val controller = createController(savedStateHandle)
         assertThat(controller.checkoutSession.value).isNull()
-        assertThat(CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state).isNull()
+        assertThat(createTestCheckoutControllerStateHolder(savedStateHandle).state).isNull()
     }
 
     @Test
@@ -225,7 +224,7 @@ internal class CheckoutControllerTest {
 
         // A fresh state holder over the same SavedStateHandle simulates the controller being
         // rebuilt after process death: the committed state is read back from persisted storage.
-        val state = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state
+        val state = createTestCheckoutControllerStateHolder(savedStateHandle).state
         assertThat(state).isNotNull()
         assertThat(state!!.embeddedConfiguration.merchantDisplayName)
             .isEqualTo(expectedMerchantDisplayName)
@@ -962,7 +961,7 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         val committedState: CheckoutControllerState?
-            get() = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state
+            get() = createTestCheckoutControllerStateHolder(savedStateHandle).state
     }
 
     // Configures a controller from a fresh init, then hands it to [block] alongside the shared
@@ -1019,12 +1018,12 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         fun committedState(): CheckoutControllerState =
-            requireNotNull(CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state)
+            requireNotNull(createTestCheckoutControllerStateHolder(savedStateHandle).state)
 
         // Simulates a presented payment flow by flipping the committed state's integrationLaunched
         // flag, which the mutation guard reads back through the same SavedStateHandle.
         fun markIntegrationLaunched() {
-            val stateHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter())
+            val stateHolder = createTestCheckoutControllerStateHolder(savedStateHandle)
             stateHolder.state = committedState().copy(integrationLaunched = true)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -1,0 +1,219 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.asCallbackFor
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.DummyActivityResultCaller
+import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutSheetLauncherTest {
+
+    @Test
+    fun `launchPaymentOptions launches activity with correct parameters and opens the sheet`() = testScenario {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val state = EmbeddedConfirmationStateFixtures.defaultState()
+        val selection = PaymentSelection.GooglePay
+        val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+        val expectedArgs = EmbeddedActivityArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = state.configuration,
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+            statusBarColor = null,
+            selection = selection,
+            customerState = customerState,
+            promotion = null,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerState = customerState,
+            selection = selection,
+            embeddedConfirmationState = state,
+        )
+
+        assertThat(dummyActivityResultCallerScenario.awaitLaunchCall()).isEqualTo(expectedArgs)
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchForm launches activity with correct parameters and sets temporary selection`() = testScenario {
+        val code = "test_code"
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val state = EmbeddedConfirmationStateFixtures.defaultState()
+
+        sheetLauncher.launchForm(
+            code = code,
+            paymentMethodMetadata = paymentMethodMetadata,
+            embeddedConfirmationState = state,
+            customerState = createCustomerState(),
+            promotion = null,
+        )
+
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(launchCall.launchMode).isEqualTo(EmbeddedLaunchMode.Form(selectedPaymentMethodCode = code))
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+        assertThat(selectionHolder.temporarySelection.value).isEqualTo(code)
+    }
+
+    @Test
+    fun `launch logs error and does not open the sheet when confirmation state is null`() = testScenario {
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = null,
+            selection = null,
+            embeddedConfirmationState = null,
+        )
+
+        val loggedErrors = errorReporter.getLoggedErrors()
+        assertThat(loggedErrors.size).isEqualTo(1)
+        assertThat(loggedErrors.first())
+            .isEqualTo("unexpected_error.embedded.embedded_sheet_launcher.embedded_state_is_null")
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Test
+    fun `paymentOptions complete result writes selection and customer state back and closes the sheet`() =
+        testScenario {
+            sheetStateHolder.sheetIsOpen = true
+            val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+            val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            val result = EmbeddedActivityResult.Complete(
+                customerState = customerState,
+                selection = selection,
+                hasBeenConfirmed = false,
+                shouldInvokeSelectionCallback = false,
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
+            )
+
+            registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+            assertThat(customerStateHolder.customer.value).isEqualTo(customerState)
+            assertThat(selectionHolder.selection.value).isEqualTo(selection)
+            assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        }
+
+    @Test
+    fun `paymentOptions cancelled result clears a stale saved selection`() = testScenario {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        selectionHolder.setSelection(PaymentSelection.Saved(paymentMethod))
+        customerStateHolder.setCustomerState(createCustomerState(paymentMethods = listOf(paymentMethod)))
+
+        sheetStateHolder.sheetIsOpen = true
+        val result = EmbeddedActivityResult.Cancelled(
+            customerState = createCustomerState(paymentMethods = emptyList()),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+        assertThat(selectionHolder.selection.value).isNull()
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Test
+    fun `onDestroy unregisters the launcher`() = testScenario {
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        val unregisteredLauncher = dummyActivityResultCallerScenario.awaitNextUnregisteredLauncher()
+
+        assertThat(unregisteredLauncher).isEqualTo(launcher)
+    }
+
+    private fun testScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val lifecycleOwner = TestLifecycleOwner()
+        val savedStateHandle = SavedStateHandle()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        )
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
+        val errorReporter = FakeErrorReporter()
+        val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            internalRowSelectionCallback = { null },
+        )
+
+        DummyActivityResultCaller.test {
+            val sheetLauncher = CheckoutSheetLauncher(
+                activityResultCaller = activityResultCaller,
+                lifecycleOwner = lifecycleOwner,
+                selectionHolder = selectionHolder,
+                rowSelectionImmediateActionHandler = immediateActionHandler,
+                customerStateHolder = customerStateHolder,
+                sheetStateHolder = sheetStateHolder,
+                errorReporter = errorReporter,
+                statusBarColor = null,
+                paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+            )
+            val registerCall = awaitRegisterCall()
+            val launcher = awaitNextRegisteredLauncher()
+
+            assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
+
+            Scenario(
+                selectionHolder = selectionHolder,
+                lifecycleOwner = lifecycleOwner,
+                customerStateHolder = customerStateHolder,
+                dummyActivityResultCallerScenario = this,
+                registerCall = registerCall,
+                launcher = launcher,
+                sheetLauncher = sheetLauncher,
+                sheetStateHolder = sheetStateHolder,
+                errorReporter = errorReporter,
+            ).block()
+        }
+    }
+
+    private class Scenario(
+        val selectionHolder: EmbeddedSelectionHolder,
+        val lifecycleOwner: TestLifecycleOwner,
+        val customerStateHolder: CustomerStateHolder,
+        val dummyActivityResultCallerScenario: DummyActivityResultCaller.Scenario,
+        val registerCall: RegisterCall<*, *>,
+        val launcher: ActivityResultLauncher<*>,
+        val sheetLauncher: CheckoutSheetLauncher,
+        val sheetStateHolder: SheetStateHolder,
+        val errorReporter: FakeErrorReporter,
+    )
+
+    private companion object {
+        const val CALLBACK_IDENTIFIER = "CheckoutSheetLauncherTestIdentifier"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
@@ -126,7 +125,7 @@ internal class CheckoutStateLoaderTest {
                 savedStateHandle = savedStateHandle,
                 formHelperFactory = EmbeddedFormHelperFactory(
                     linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-                    embeddedSelectionHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()),
+                    embeddedSelectionHolder = createTestCheckoutControllerStateHolder(savedStateHandle),
                     cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                     savedStateHandle = savedStateHandle,
                 ),
@@ -289,7 +288,7 @@ internal class CheckoutStateLoaderTest {
             ),
         )
         val savedStateHandle = SavedStateHandle()
-        val stateHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter())
+        val stateHolder = createTestCheckoutControllerStateHolder(savedStateHandle)
         val recordingChooser = RecordingSelectionChooser(chosenSelection)
         val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
         val loader = CheckoutStateLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperDataSourceTest.kt
@@ -148,8 +148,7 @@ internal class DefaultEmbeddedContentHelperDataSourceTest {
             internalRowSelectionCallback = { null }
         )
 
-        val dataSource = DefaultEmbeddedContentHelperDataSource(
-            coroutineScope = backgroundScope,
+        val contentBuilder = EmbeddedContentBuilder(
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
             uiContext = Dispatchers.Unconfined,
@@ -167,7 +166,6 @@ internal class DefaultEmbeddedContentHelperDataSourceTest {
             ),
             embeddedFormHelperFactory = embeddedFormHelperFactory,
             confirmationHandler = confirmationHandler,
-            confirmationStateHolder = confirmationStateHolder,
             rowSelectionImmediateActionHandler = immediateActionHandler,
             errorReporter = FakeErrorReporter(),
             internalRowSelectionCallback = { null },
@@ -176,6 +174,11 @@ internal class DefaultEmbeddedContentHelperDataSourceTest {
             linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
+        )
+        val dataSource = DefaultEmbeddedContentHelperDataSource(
+            coroutineScope = backgroundScope,
+            confirmationStateHolder = confirmationStateHolder,
+            contentBuilder = contentBuilder,
         )
         Scenario(
             dataSource = dataSource,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -155,40 +155,64 @@ internal class EmbeddedContentUiTest {
         val dataSource =
             DefaultEmbeddedContentHelperDataSource(
                 coroutineScope = CoroutineScope(Dispatchers.Unconfined),
-                eventReporter = eventReporter,
-                workContext = Dispatchers.Unconfined,
-                uiContext = Dispatchers.Unconfined,
-                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
-                selectionHolder = selectionHolder,
-                embeddedLinkHelper = object : EmbeddedLinkHelper {
-                    override val linkEmail: StateFlow<String?> = stateFlowOf(null)
-                },
-                embeddedWalletsHelper = { stateFlowOf(null) },
-                customerStateHolder = DefaultCustomerStateHolder(
-                    savedStateHandle = savedStateHandle,
-                    selection = selectionHolder.selection,
-                    customerMetadata = stateFlowOf(
-                        PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
-                    ),
-                    paymentMethodMetadataFlow = stateFlowOf(null),
-                ),
-                embeddedFormHelperFactory = embeddedFormHelperFactory,
-                confirmationHandler = confirmationHandler,
                 confirmationStateHolder = confirmationStateHolder,
-                rowSelectionImmediateActionHandler = immediateActionHandler,
-                errorReporter = errorReporter,
-                internalRowSelectionCallback = { internalRowSelectionCallback },
-                linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
-                analyticsCallbackProvider = { AnalyticEventCallbackRule() },
-                linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
-                sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
+                contentBuilder = createContentBuilder(
+                    savedStateHandle = savedStateHandle,
+                    selectionHolder = selectionHolder,
+                    embeddedFormHelperFactory = embeddedFormHelperFactory,
+                    confirmationHandler = confirmationHandler,
+                    eventReporter = eventReporter,
+                    errorReporter = errorReporter,
+                    immediateActionHandler = immediateActionHandler,
+                    internalRowSelectionCallback = internalRowSelectionCallback,
+                ),
             )
         Scenario(
             dataSource = dataSource,
             confirmationStateHolder = confirmationStateHolder,
         ).block()
     }
+
+    @Suppress("LongParameterList")
+    @OptIn(ExperimentalAnalyticEventCallbackApi::class)
+    private fun createContentBuilder(
+        savedStateHandle: SavedStateHandle,
+        selectionHolder: DefaultEmbeddedSelectionHolder,
+        embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+        confirmationHandler: FakeConfirmationHandler,
+        eventReporter: FakeEventReporter,
+        errorReporter: FakeErrorReporter,
+        immediateActionHandler: DefaultEmbeddedRowSelectionImmediateActionHandler,
+        internalRowSelectionCallback: InternalRowSelectionCallback?,
+    ) = EmbeddedContentBuilder(
+        eventReporter = eventReporter,
+        workContext = Dispatchers.Unconfined,
+        uiContext = Dispatchers.Unconfined,
+        savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
+        selectionHolder = selectionHolder,
+        embeddedLinkHelper = object : EmbeddedLinkHelper {
+            override val linkEmail: StateFlow<String?> = stateFlowOf(null)
+        },
+        embeddedWalletsHelper = { stateFlowOf(null) },
+        customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(
+                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
+            ),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        ),
+        embeddedFormHelperFactory = embeddedFormHelperFactory,
+        confirmationHandler = confirmationHandler,
+        rowSelectionImmediateActionHandler = immediateActionHandler,
+        errorReporter = errorReporter,
+        internalRowSelectionCallback = { internalRowSelectionCallback },
+        linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
+        analyticsCallbackProvider = { AnalyticEventCallbackRule() },
+        linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+        paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+        sheetLauncherHolder = EmbeddedSheetLauncherHolder(),
+    )
 
     private fun confirmationState(
         appearance: Embedded,


### PR DESCRIPTION
# Summary

Refactors Checkout's embedded sheet/content implementation, moving the sheet launcher and content wiring to a per-presenter (per-Activity) DI subcomponent. CheckoutControllerStateHolder now exposes embedded content/wallet state. Cleanup and code sharing with PaymentElement content continues to improve.

# Motivation

Ensures that activity-bound resources (sheet launcher, confirmation callbacks, content flows) are properly scoped so they are reset when a new checkout presenter is created on new Activity starts/restarts. This avoids leaks, misuse, and multiple registration issues. Also brings parity and code sharing with the PaymentElement implementation.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
- [Changed] Checkout content and embedded sheet launching are now scoped per Activity, resolving improper callback registration and wiring.