### PR TITLE
Add NFC scanning emulator tests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcHardwareDelegateTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcHardwareDelegateTestRule.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import android.nfc.NfcAntennaInfo
+import android.nfc.Tag
+import androidx.appcompat.app.AppCompatActivity
+import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegate
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+internal class NfcHardwareDelegateTestRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                NfcHardwareDelegate.override = AvailableNfcHardwareDelegate()
+                try {
+                    base.evaluate()
+                } finally {
+                    NfcHardwareDelegate.override = null
+                }
+            }
+        }
+    }
+}
+
+private class AvailableNfcHardwareDelegate : NfcHardwareDelegate {
+    override fun isAvailable(): Boolean = true
+
+    override fun antenna(): NfcAntennaInfo? = null
+
+    override fun start(
+        activity: AppCompatActivity,
+        onTagDiscovered: (Tag) -> Unit,
+    ) {
+        throw IllegalStateException("Should not be called!")
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningCardFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningCardFormPage.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performClick
+import com.stripe.android.common.taptoadd.TAP_TO_BUTTON_UI_TEST_TAG
+
+internal class NfcScanningCardFormPage(
+    private val composeTestRule: ComposeTestRule,
+) {
+    fun clickOnNfcScan() {
+        composeTestRule.waitUntil(UI_TIMEOUT_MS) {
+            composeTestRule.onAllNodes(hasTestTag(TAP_TO_BUTTON_UI_TEST_TAG))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .size == 1
+        }
+
+        composeTestRule.onNode(hasTestTag(TAP_TO_BUTTON_UI_TEST_TAG))
+            .assertIsEnabled()
+            .performClick()
+    }
+
+    fun fillRemainingCardDetails(
+        cvc: String = "123",
+        zipCode: String = "12345",
+    ) {
+        composeTestRule.onNode(hasText("CVC")).performTextReplacement(cvc)
+        composeTestRule.onNode(hasText("ZIP Code")).performTextReplacement(zipCode)
+        composeTestRule.waitForIdle()
+    }
+
+    fun assertScannedCardShown(
+        lastFourDigits: String,
+    ) {
+        composeTestRule.waitUntil(UI_TIMEOUT_MS) {
+            composeTestRule.onAllNodes(hasText("•••• $lastFourDigits"))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithText("•••• $lastFourDigits").assertExists()
+        composeTestRule.onNodeWithContentDescription(CLEAR_SCANNED_CARD_CONTENT_DESCRIPTION).assertExists()
+    }
+
+    private companion object {
+        const val UI_TIMEOUT_MS = 5_000L
+        const val CLEAR_SCANNED_CARD_CONTENT_DESCRIPTION = "Clear scanned card"
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunner.kt
@@ -1,0 +1,117 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.paymentelement.assertCompleted as assertEmbeddedCompleted
+import com.stripe.android.paymentelement.runEmbeddedPaymentElementTest
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.runFlowControllerTest
+import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+
+internal fun runNfcScanningIntegrationTest(
+    networkRule: NetworkRule,
+    composeTestRule: ComposeTestRule,
+    integrationType: NfcScanningIntegrationType,
+    block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
+) {
+    integrationType.runner.run(
+        networkRule = networkRule,
+        composeTestRule = composeTestRule,
+        block = block,
+    )
+}
+
+internal sealed class NfcScanningIntegrationTestRunner {
+    fun run(
+        networkRule: NetworkRule,
+        composeTestRule: ComposeTestRule,
+        block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
+    ) {
+        runTest(
+            networkRule = networkRule,
+            composeTestRule = composeTestRule,
+            block = block,
+        )
+    }
+
+    protected abstract fun runTest(
+        networkRule: NetworkRule,
+        composeTestRule: ComposeTestRule,
+        block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
+    )
+
+    object PaymentSheetRunner : NfcScanningIntegrationTestRunner() {
+        override fun runTest(
+            networkRule: NetworkRule,
+            composeTestRule: ComposeTestRule,
+            block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
+        ) {
+            runPaymentSheetTest(
+                networkRule = networkRule,
+                builder = {
+                    createIntentCallback(NfcScanningIntegrationTestRunner.createIntentCallback)
+                },
+                resultCallback = ::assertCompleted,
+            ) { context ->
+                block(
+                    NfcScanningIntegrationTestRunnerContext.Sheet.PaymentSheet(
+                        composeTestRule = composeTestRule,
+                        context = context,
+                    )
+                )
+            }
+        }
+    }
+
+    object FlowControllerRunner : NfcScanningIntegrationTestRunner() {
+        override fun runTest(
+            networkRule: NetworkRule,
+            composeTestRule: ComposeTestRule,
+            block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
+        ) {
+            runFlowControllerTest(
+                networkRule = networkRule,
+                builder = {
+                    createIntentCallback(NfcScanningIntegrationTestRunner.createIntentCallback)
+                },
+                resultCallback = ::assertCompleted,
+            ) { context ->
+                block(
+                    NfcScanningIntegrationTestRunnerContext.Sheet.FlowController(
+                        composeTestRule = composeTestRule,
+                        context = context,
+                    )
+                )
+            }
+        }
+    }
+
+    object EmbeddedRunner : NfcScanningIntegrationTestRunner() {
+        override fun runTest(
+            networkRule: NetworkRule,
+            composeTestRule: ComposeTestRule,
+            block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
+        ) {
+            runEmbeddedPaymentElementTest(
+                networkRule = networkRule,
+                createIntentCallback = createIntentCallback,
+                resultCallback = ::assertEmbeddedCompleted,
+            ) { context ->
+                block(
+                    NfcScanningIntegrationTestRunnerContext.Embedded(
+                        composeTestRule = composeTestRule,
+                        context = context,
+                    )
+                )
+            }
+        }
+    }
+
+    companion object {
+        val createIntentCallback = CreateIntentCallback { _, _ ->
+            CreateIntentResult.Success("pi_example_secret_example")
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunnerContext.kt
@@ -1,0 +1,146 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.EmbeddedContentPage
+import com.stripe.android.paymentelement.EmbeddedFormPage
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
+import com.stripe.android.paymentsheet.PaymentSheet as StripePaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetPage
+import com.stripe.android.paymentsheet.utils.FlowControllerTestRunnerContext
+import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
+
+internal sealed class NfcScanningIntegrationTestRunnerContext(
+    protected val composeTestRule: ComposeTestRule,
+) {
+    protected val intentConfiguration = StripePaymentSheet.IntentConfiguration(
+        mode = StripePaymentSheet.IntentConfiguration.Mode.Payment(
+            amount = 5099,
+            currency = "usd",
+        )
+    )
+
+    protected val customerConfig = StripePaymentSheet.CustomerConfiguration.createWithCustomerSession(
+        id = "cus_12345",
+        clientSecret = "cuss_654321",
+    )
+
+    abstract suspend fun launchFlow()
+
+    abstract fun openCardForm()
+
+    abstract fun clickPrimaryButton()
+
+    abstract suspend fun completeCheckout(cardLastFour: String)
+
+    sealed class Sheet(
+        composeTestRule: ComposeTestRule,
+    ) : NfcScanningIntegrationTestRunnerContext(composeTestRule) {
+        protected val configuration = StripePaymentSheet.Configuration.Builder(
+            merchantDisplayName = "Merchant, Inc.",
+        )
+            .paymentMethodLayout(PaymentMethodLayout.Vertical)
+            .customer(customerConfig)
+            .build()
+
+        protected val paymentSheetPage = PaymentSheetPage(composeTestRule)
+
+        final override fun openCardForm() {
+            paymentSheetPage.waitForCardForm()
+        }
+
+        final override fun clickPrimaryButton() {
+            paymentSheetPage.clickPrimaryButton()
+        }
+
+        class PaymentSheet(
+            composeTestRule: ComposeTestRule,
+            private val context: PaymentSheetTestRunnerContext,
+        ) : Sheet(composeTestRule) {
+            override suspend fun launchFlow() {
+                context.presentPaymentSheet {
+                    presentWithIntentConfiguration(
+                        intentConfiguration = intentConfiguration,
+                        configuration = configuration,
+                    )
+                }
+            }
+
+            override suspend fun completeCheckout(cardLastFour: String) {
+                // Payment Sheet completes after the primary button is clicked.
+            }
+        }
+
+        class FlowController(
+            composeTestRule: ComposeTestRule,
+            private val context: FlowControllerTestRunnerContext,
+        ) : Sheet(composeTestRule) {
+            override suspend fun launchFlow() {
+                context.configureFlowController {
+                    configureWithIntentConfiguration(
+                        intentConfiguration = intentConfiguration,
+                        configuration = configuration,
+                        callback = { success, error ->
+                            assertThat(success).isTrue()
+                            assertThat(error).isNull()
+                            presentPaymentOptions()
+                        },
+                    )
+                }
+            }
+
+            override suspend fun completeCheckout(cardLastFour: String) {
+                context.consumePaymentOptionEventForFlowController(
+                    paymentMethodType = "card",
+                    label = cardLastFour,
+                )
+                context.consumeNullPaymentOptionEventForFlowController()
+            }
+        }
+    }
+
+    class Embedded(
+        composeTestRule: ComposeTestRule,
+        private val context: EmbeddedPaymentElementTestRunnerContext,
+    ) : NfcScanningIntegrationTestRunnerContext(composeTestRule) {
+        private val embeddedContentPage = EmbeddedContentPage(composeTestRule)
+        private val embeddedFormPage = EmbeddedFormPage(composeTestRule)
+
+        override suspend fun launchFlow() {
+            context.configure(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 5099,
+                        currency = "usd",
+                    )
+                ),
+                configurationMutator = {
+                    customer(customerConfig)
+                    formSheetAction(EmbeddedPaymentElement.FormSheetAction.Continue)
+                }
+            )
+        }
+
+        override fun openCardForm() {
+            embeddedContentPage.clickOnLpm("card")
+            embeddedFormPage.waitUntilVisible()
+        }
+
+        override fun clickPrimaryButton() {
+            embeddedFormPage.clickPrimaryButton()
+            embeddedFormPage.waitUntilMissing()
+        }
+
+        override suspend fun completeCheckout(cardLastFour: String) {
+            context.consumePaymentOptionEvent(
+                paymentMethodType = "card",
+                label = cardLastFour,
+            )
+            context.confirm()
+            assertThat(context.paymentOptionTurbine.awaitItem()).isNull()
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationType.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+
+internal enum class NfcScanningIntegrationType(
+    val runner: NfcScanningIntegrationTestRunner,
+) {
+    PaymentSheet(NfcScanningIntegrationTestRunner.PaymentSheetRunner),
+    FlowController(NfcScanningIntegrationTestRunner.FlowControllerRunner),
+    Embedded(NfcScanningIntegrationTestRunner.EmbeddedRunner);
+
+    internal object Provider : TestParameterValuesProvider() {
+        override fun provideValues(context: Context?): List<NfcScanningIntegrationType> {
+            return entries
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntentsHelper.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntentsHelper.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import com.stripe.android.common.nfcscan.NfcScanningActivity
+import com.stripe.android.common.nfcscan.NfcScanningContract
+
+internal object NfcScanningIntentsHelper {
+    private const val UI_TIMEOUT_MS = 5_000L
+
+    fun intendingNfcScanningToComplete(
+        result: NfcScanningContract.Result.Complete,
+    ) {
+        intending(hasComponent(NfcScanningActivity::class.java.name)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent().putExtras(result.toBundle()),
+            )
+        )
+    }
+
+    fun intendedNfcScanningToBeLaunched(
+        composeTestRule: ComposeTestRule,
+    ) {
+        composeTestRule.waitUntil(UI_TIMEOUT_MS) {
+            try {
+                intended(hasComponent(NfcScanningActivity::class.java.name))
+                true
+            } catch (_: AssertionError) {
+                false
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningTest.kt
@@ -1,0 +1,106 @@
+package com.stripe.android.paymentelement.nfcscan
+
+import androidx.test.espresso.intent.rule.IntentsRule
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.common.nfcscan.NfcScanningContract
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.elementsSession
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.testing.FeatureFlagTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+internal class NfcScanningTest {
+    private val networkRule = NetworkRule()
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(
+        networkRule = networkRule,
+    ) {
+        around(NfcHardwareDelegateTestRule())
+            .around(FeatureFlagTestRule(FeatureFlags.enableNfcScanning, isEnabled = true))
+            .around(FeatureFlagTestRule(FeatureFlags.disableNfcScanningSecurity, isEnabled = true))
+            .around(IntentsRule())
+    }
+
+    private val composeTestRule = testRules.compose
+    private val nfcScanningCardFormPage = NfcScanningCardFormPage(composeTestRule)
+
+    @Test
+    fun success(
+        @TestParameter(valuesProvider = NfcScanningIntegrationType.Provider::class)
+        integrationType: NfcScanningIntegrationType,
+    ) = runNfcScanningIntegrationTest(
+        integrationType = integrationType,
+        composeTestRule = composeTestRule,
+        networkRule = networkRule,
+    ) {
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-nfc.json")
+        }
+
+        NfcScanningIntentsHelper.intendingNfcScanningToComplete(
+            result = NfcScanningContract.Result.Complete(
+                cardNumber = SCANNED_CARD_NUMBER,
+                expirationMonth = SCANNED_EXPIRATION_MONTH,
+                expirationYear = SCANNED_EXPIRATION_YEAR,
+            )
+        )
+
+        launchFlow()
+        openCardForm()
+
+        nfcScanningCardFormPage.clickOnNfcScan()
+
+        NfcScanningIntentsHelper.intendedNfcScanningToBeLaunched(composeTestRule)
+
+        nfcScanningCardFormPage.assertScannedCardShown(
+            lastFourDigits = SCANNED_CARD_LAST_FOUR,
+        )
+
+        nfcScanningCardFormPage.fillRemainingCardDetails()
+
+        enqueueConfirmRequests()
+
+        clickPrimaryButton()
+
+        completeCheckout(cardLastFour = SCANNED_CARD_LAST_FOUR)
+    }
+
+    private fun enqueueConfirmRequests() {
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/payment_intents/pi_example"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+    }
+
+    private companion object {
+        const val SCANNED_CARD_NUMBER = "4111111111111111"
+        const val SCANNED_CARD_LAST_FOUR = "1111"
+        const val SCANNED_EXPIRATION_MONTH = 9
+        const val SCANNED_EXPIRATION_YEAR = 2030
+    }
+}

--- a/paymentsheet/src/androidTest/resources/elements-sessions-nfc.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-nfc.json
@@ -1,0 +1,100 @@
+{
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card"
+  ],
+  "flags": {
+    "elements_mobile_android_nfc_scanning_enabled": true
+  },
+  "customer": {
+    "payment_methods": [],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 1899787184,
+      "customer": "cus_12345",
+      "components": {
+        "mobile_payment_element": {
+          "enabled": true,
+          "features": {
+            "payment_method_save": "enabled",
+            "payment_method_remove": "enabled",
+            "payment_method_save_allow_redisplay_override": null
+          }
+        },
+        "customer_sheet": {
+          "enabled": false,
+          "features": null
+        }
+      }
+    },
+    "default_payment_method": null
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card"
+    ],
+    "payment_intent": {
+      "id": "pi_example",
+      "object": "payment_intent",
+      "amount": 5099,
+      "amount_details": {
+        "tip": {}
+      },
+      "automatic_payment_methods": {
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_example_secret_example",
+      "confirmation_method": "automatic",
+      "created": 1674750417,
+      "currency": "usd",
+      "description": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "status": "requires_payment_method"
+    },
+    "type": "payment_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegate.kt
@@ -7,11 +7,11 @@ import android.nfc.Tag
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import javax.inject.Inject
 
 internal interface NfcHardwareDelegate {
     fun isAvailable(): Boolean
@@ -23,9 +23,18 @@ internal interface NfcHardwareDelegate {
         activity: AppCompatActivity,
         onTagDiscovered: (Tag) -> Unit,
     )
+
+    companion object {
+        @VisibleForTesting
+        var override: NfcHardwareDelegate? = null
+
+        fun create(application: Application): NfcHardwareDelegate {
+            return override ?: DefaultNfcHardwareDelegate(application)
+        }
+    }
 }
 
-internal class DefaultNfcHardwareDelegate @Inject constructor(
+internal class DefaultNfcHardwareDelegate(
     application: Application
 ) : NfcHardwareDelegate {
     private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(application)

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/hardware/NfcHardwareDelegateModule.kt
@@ -1,12 +1,13 @@
 package com.stripe.android.common.nfcscan.hardware
 
-import dagger.Binds
+import android.app.Application
 import dagger.Module
+import dagger.Provides
 
 @Module
-internal interface NfcHardwareDelegateModule {
-    @Binds
-    fun bindsNfcHardwareDelegate(
-        delegate: DefaultNfcHardwareDelegate
-    ): NfcHardwareDelegate
+internal class NfcHardwareDelegateModule {
+    @Provides
+    fun providesNfcHardwareDelegate(
+        application: Application
+    ): NfcHardwareDelegate = NfcHardwareDelegate.create(application)
 }


### PR DESCRIPTION
# Summary
Add NFC scanning emulator tests. NFC scanning logic is being tested in `NfcScanningActivityTest` while the tests here check how the Payment Element integrations handle results from `NfcScanningActivity`.

# Motivation
Ensures proper handling of `NfcScanningActivity` in Payment Element integrations.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified