### PR TITLE
Add lint for enforced test resource cleanup and update test rules.

### DIFF
--- a/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivityViewModelTest.kt
+++ b/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivityViewModelTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.stripe3ds2.transaction.ChallengeRequestResult
 import com.stripe.android.stripe3ds2.transaction.ChallengeRequestResultFixures
 import com.stripe.android.stripe3ds2.transaction.FakeTransactionTimer
 import com.stripe.android.stripe3ds2.transaction.TransactionTimer
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.cancel
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -20,6 +21,9 @@ import kotlin.test.Test
 class ChallengeActivityViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val actionHandler = object : ChallengeActionHandler {
         override suspend fun submit(action: ChallengeAction): ChallengeRequestResult {
@@ -69,6 +73,6 @@ class ChallengeActivityViewModelTest {
             actionHandler,
             transactionTimer,
             FakeErrorReporter(),
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 }

--- a/3ds2sdk/src/test/kotlin/com/stripe/android/testing/ViewModelStoreTestRule.kt
+++ b/3ds2sdk/src/test/kotlin/com/stripe/android/testing/ViewModelStoreTestRule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.testing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Clears the [ViewModel]s built during a test when the test finishes.
+ *
+ * ViewModels launch perpetual collectors on their `viewModelScope` (and on any injected
+ * `customViewModelScope`) that only stop when the ViewModel is cleared. Unit tests construct
+ * ViewModels directly rather than through a [androidx.lifecycle.ViewModelProvider], so nothing ever
+ * clears them and those scopes leak across tests. Registering each ViewModel here and calling
+ * [ViewModelStore.clear] on finish cancels `viewModelScope` and invokes `onCleared()`, matching what
+ * the framework does when the owner is destroyed.
+ *
+ * Register ViewModels via [track].
+ */
+class ViewModelStoreTestRule : TestWatcher() {
+    private val viewModelStore = ViewModelStore()
+    private var trackedCount = 0
+
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also {
+        viewModelStore.put("tracked_${trackedCount++}", it)
+    }
+
+    override fun finished(description: Description) {
+        viewModelStore.clear()
+        super.finished(description)
+    }
+}

--- a/build-configuration/lint.gradle
+++ b/build-configuration/lint.gradle
@@ -1,3 +1,65 @@
+import groovy.xml.XmlSlurper
+
+def enforcedUnitTestLintIssueIds = [
+    'ComposeCleanupRuleUsageIssue',
+    'TestResourceCleanup',
+] as Set
+
 dependencies {
     lintChecks project(":lint")
+}
+
+afterEvaluate {
+    def unitTestLintTask = tasks.findByName('lintAnalyzeReleaseUnitTest')
+    def lintReleaseTask = tasks.findByName('lintRelease')
+
+    if (unitTestLintTask != null && lintReleaseTask != null) {
+        def reportFile = layout.buildDirectory.file(
+            'intermediates/unit_test_lint_partial_results/release/lintAnalyzeReleaseUnitTest/out/lint-definite.xml'
+        )
+        def testSourceDir = project.layout.projectDirectory.dir('src/test/java').asFile.absolutePath
+        def checkTask = tasks.register('checkReleaseUnitTestCustomLint') {
+            dependsOn unitTestLintTask
+            // Use files() (not file()) so a missing lint-definite.xml — which lint only
+            // emits when there are definite incidents — is tolerated instead of failing
+            // task input validation. file().optional() does not help here because the
+            // provider always resolves to a value (a path), so Gradle still validates
+            // that path exists.
+            inputs.files(reportFile)
+
+            doLast {
+                def file = reportFile.get().asFile
+
+                if (!file.exists() || file.length() == 0L) {
+                    return
+                }
+
+                def incidents = new XmlSlurper(false, false)
+                    .parse(file)
+                    .incident
+                    .findAll { incident ->
+                        incident.@id.text() in enforcedUnitTestLintIssueIds
+                    }
+
+                if (!incidents.isEmpty()) {
+                    def failures = incidents.collect { incident ->
+                        def location = incident.location[0]
+                        def filePath = location.@file.text()
+                            .replaceFirst('^\\$\\{[^}]+}/', "${testSourceDir}/")
+                        def line = location.@line.text()
+                        def message = incident.@message.text()
+
+                        "${filePath}:${line}: ${message}"
+                    }
+
+                    throw new GradleException(
+                        "Unit-test lint found enforced custom lint violations:\n" +
+                            failures.join('\n')
+                    )
+                }
+            }
+        }
+
+        lintReleaseTask.dependsOn(checkTask)
+    }
 }

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.connect.webview.serialization.SetOnLoaderStart
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.toCollection
@@ -40,6 +41,7 @@ import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.JsonNull
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -61,6 +63,9 @@ import kotlin.test.assertTrue
 @Suppress("TooManyFunctions")
 @RunWith(RobolectricTestRunner::class)
 class StripeConnectWebViewContainerViewModelTest {
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -102,7 +107,7 @@ class StripeConnectWebViewContainerViewModelTest {
             stripeIntentLauncher = mockStripeIntentLauncher,
             logger = mockLogger,
             createWebView = { _, _, _ -> webView }
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     @After
@@ -120,7 +125,7 @@ class StripeConnectWebViewContainerViewModelTest {
             analyticsService = analyticsService,
             logger = Logger.noop(),
             // Default `createWebView` value
-        )
+        ).also { viewModelStoreRule.track(it) }
         assertThat(viewModel.webView.delegate).isEqualTo(viewModel.delegate)
     }
 

--- a/connect/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
+++ b/connect/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.testing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Clears the [ViewModel]s built during a test when the test finishes.
+ *
+ * ViewModels launch perpetual collectors on their `viewModelScope` (and on any injected
+ * `customViewModelScope`) that only stop when the ViewModel is cleared. Unit tests construct
+ * ViewModels directly rather than through a [androidx.lifecycle.ViewModelProvider], so nothing ever
+ * clears them and those scopes leak across tests. Registering each ViewModel here and calling
+ * [ViewModelStore.clear] on finish cancels `viewModelScope` and invokes `onCleared()`, matching what
+ * the framework does when the owner is destroyed.
+ *
+ * Register ViewModels via [track].
+ */
+class ViewModelStoreTestRule : TestWatcher() {
+    private val viewModelStore = ViewModelStore()
+    private var trackedCount = 0
+
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also {
+        viewModelStore.put("tracked_${trackedCount++}", it)
+    }
+
+    override fun finished(description: Description) {
+        viewModelStore.clear()
+        super.finished(description)
+    }
+}

--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/FinancialConnectionsLiteViewModelTest.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/FinancialConnectionsLiteViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.financialconnections.lite.TextFixtures.configuration
 import com.stripe.android.financialconnections.lite.TextFixtures.financialConnectionsSessionNoAccounts
 import com.stripe.android.financialconnections.lite.TextFixtures.syncResponse
 import com.stripe.android.financialconnections.lite.repository.FinancialConnectionsLiteRepository
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -26,6 +27,9 @@ class FinancialConnectionsLiteViewModelTest {
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
@@ -43,7 +47,7 @@ class FinancialConnectionsLiteViewModelTest {
         repository = repository,
         workContext = testDispatcher,
         applicationId = "com.example"
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `test view model initializes with correct state`() = testScope.runTest {

--- a/financial-connections-lite/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.testing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Clears the [ViewModel]s built during a test when the test finishes.
+ *
+ * ViewModels launch perpetual collectors on their `viewModelScope` (and on any injected
+ * `customViewModelScope`) that only stop when the ViewModel is cleared. Unit tests construct
+ * ViewModels directly rather than through a [androidx.lifecycle.ViewModelProvider], so nothing ever
+ * clears them and those scopes leak across tests. Registering each ViewModel here and calling
+ * [ViewModelStore.clear] on finish cancels `viewModelScope` and invokes `onCleared()`, matching what
+ * the framework does when the owner is destroyed.
+ *
+ * Register ViewModels via [track].
+ */
+class ViewModelStoreTestRule : TestWatcher() {
+    private val viewModelStore = ViewModelStore()
+    private var trackedCount = 0
+
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also {
+        viewModelStore.put("tracked_${trackedCount++}", it)
+    }
+
+    override fun finished(description: Description) {
+        viewModelStore.clear()
+        super.finished(description)
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.financialconnections.presentation.withState
 import com.stripe.android.financialconnections.utils.TestIntegrityRequestManager
 import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkMode
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.attestation.IntegrityRequestManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -60,6 +61,9 @@ class FinancialConnectionsSheetViewModelTest {
 
     @get:Rule
     val rule: TestRule = CoroutineTestRule(testDispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val eventReporter = mock<FinancialConnectionsEventReporter>()
     private val configuration = FinancialConnectionsSheetConfiguration(
@@ -1039,6 +1043,6 @@ class FinancialConnectionsSheetViewModelTest {
             integrityVerdictManager = mock(),
             logger = Logger.noop(),
             ioDispatcher = testDispatcher,
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModelTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.financialconnections.presentation.withState
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -42,6 +43,9 @@ internal class AccountPickerViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val pollAuthorizationSessionAccounts = mock<PollAuthorizationSessionAccounts>()
     private val getSync = mock<GetOrFetchSync>()
@@ -67,7 +71,7 @@ internal class AccountPickerViewModelTest {
         consumerSessionProvider = { cachedConsumerSession() },
         currentLinkBrand = FakeCurrentLinkBrand(),
         presentSheet = mock(),
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - if PartnerAccounts response returns skipAccountSelection, state includes it`() =

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelFactory.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelFactory.kt
@@ -12,12 +12,14 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.features.notice.PresentSheet
 import com.stripe.android.financialconnections.ui.HandleClickableUrl
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.navigation.NavigationManager
 import org.mockito.kotlin.mock
 
 internal object ConsentViewModelFactory {
 
     fun create(
+        viewModelStoreTestRule: ViewModelStoreTestRule,
         initialState: ConsentState = ConsentState(),
         nativeAuthFlowCoordinator: NativeAuthFlowCoordinator = NativeAuthFlowCoordinator(),
         acceptConsent: AcceptConsent = mock(),
@@ -43,6 +45,6 @@ internal object ConsentViewModelFactory {
             lookupAccount = lookupAccount,
             isLinkWithStripe = isLinkWithStripe,
             prefillDetails = prefillDetails,
-        )
+        ).also { viewModelStoreTestRule.track(it) }
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.model.VisualUpdate
 import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.navigation.NavigationIntent
 import com.stripe.android.uicore.navigation.NavigationManagerImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,6 +33,9 @@ class ConsentViewModelTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
 
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     @Test
     fun `Navigates to Link warmup pane if recognizing a returning Link consumer from prefill details`() = runTest {
         val navigationManager = NavigationManagerImpl()
@@ -46,6 +50,7 @@ class ConsentViewModelTest {
 
         navigationManager.navigationFlow.test {
             val viewModel = ConsentViewModelFactory.create(
+                viewModelStoreTestRule = viewModelStoreRule,
                 isLinkWithStripe = { true },
                 navigationManager = navigationManager,
                 getOrFetchSync = getOrFetchSync,
@@ -84,6 +89,7 @@ class ConsentViewModelTest {
 
         navigationManager.navigationFlow.test {
             val viewModel = ConsentViewModelFactory.create(
+                viewModelStoreTestRule = viewModelStoreRule,
                 isLinkWithStripe = { true },
                 navigationManager = navigationManager,
                 getOrFetchSync = getOrFetchSync,
@@ -121,6 +127,7 @@ class ConsentViewModelTest {
 
         navigationManager.navigationFlow.test {
             val viewModel = ConsentViewModelFactory.create(
+                viewModelStoreTestRule = viewModelStoreRule,
                 isLinkWithStripe = { false },
                 navigationManager = navigationManager,
                 getOrFetchSync = getOrFetchSync,
@@ -158,6 +165,7 @@ class ConsentViewModelTest {
 
         navigationManager.navigationFlow.test {
             val viewModel = ConsentViewModelFactory.create(
+                viewModelStoreTestRule = viewModelStoreRule,
                 isLinkWithStripe = { true },
                 navigationManager = navigationManager,
                 getOrFetchSync = getOrFetchSync,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.financialconnections.presentation.Async
 import com.stripe.android.financialconnections.presentation.withState
 import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -48,6 +49,9 @@ internal class InstitutionPickerViewModelTest {
 
     @get:Rule
     val rule: TestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val searchInstitutions = mock<SearchInstitutions>()
     private val featuredInstitutions = mock<FeaturedInstitutions>()
@@ -81,7 +85,7 @@ internal class InstitutionPickerViewModelTest {
             handleError = handleError,
             initialState = state,
             nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModelTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.financialconnections.model.ShareNetworkedAccountsRespo
 import com.stripe.android.financialconnections.model.TextUpdate
 import com.stripe.android.financialconnections.navigation.destination
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.navigation.PopUpToBehavior
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -49,6 +50,9 @@ class LinkAccountPickerViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val getSync = mock<GetOrFetchSync>()
     private val navigationManager = TestNavigationManager()
@@ -76,7 +80,7 @@ class LinkAccountPickerViewModelTest {
             nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
             presentSheet = presentSheet,
             acceptConsent = mock()
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModelTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.financialconnections.presentation.Async.Success
 import com.stripe.android.financialconnections.presentation.withState
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.test.runTest
@@ -40,6 +41,9 @@ import org.mockito.kotlin.whenever
 class ManualEntryViewModelTest {
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val getSync = mock<GetOrFetchSync>()
     private val navigationManager = TestNavigationManager()
@@ -58,7 +62,7 @@ class ManualEntryViewModelTest {
         navigationManager = navigationManager,
         updateCachedAccounts = updateCachedAccounts,
         logger = Logger.noop(),
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - when custom manual entry, Complete events is emitted`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.financialconnections.repository.ConsumerSessionProvide
 import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.navigation.PopUpToBehavior
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -32,6 +33,9 @@ class NetworkingLinkLoginWarmupViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val getOrFetchSync = mock<GetOrFetchSync>()
     private val navigationManager = TestNavigationManager()
@@ -55,7 +59,7 @@ class NetworkingLinkLoginWarmupViewModelTest {
         lookupAccount = lookupAccount,
         prefillDetails = null,
         consumerSessionProvider = consumerSessionProvider,
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - payload error navigates to error screen`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.LinkMode
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.navigation.NavigationIntent
 import com.stripe.android.uicore.navigation.NavigationManagerImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -54,6 +55,9 @@ class NetworkingLinkSignupViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val getOrFetchSync = mock<GetOrFetchSync>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
@@ -79,7 +83,7 @@ class NetworkingLinkSignupViewModelTest {
         linkSignupHandler = signupHandler,
         elementsSessionContext = elementsSessionContext,
         handleError = handleError,
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - creates controllers with prefilled account holder email`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import com.stripe.android.financialconnections.utils.TestNavigationManager
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -41,6 +42,9 @@ class NetworkingLinkVerificationViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val getOrFetchSync = mock<GetOrFetchSync>()
     private val navigationManager = TestNavigationManager()
@@ -70,7 +74,7 @@ class NetworkingLinkVerificationViewModelTest {
         isLinkWithStripe = { isLinkWithStripe },
         attachConsumerToLinkAccountSession = attachConsumerToLinkAccountSession,
         handleError = handleError,
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - starts SMS verification with consumer session secret`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -39,6 +40,9 @@ class NetworkingSaveToLinkVerificationViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val navigationManager = TestNavigationManager()
     private val confirmVerification = mock<ConfirmVerification>()
@@ -69,7 +73,7 @@ class NetworkingSaveToLinkVerificationViewModelTest {
         attachedPaymentAccountRepository = attachedPaymentAccountRepository,
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
         currentLinkBrand = FakeCurrentLinkBrand(),
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - starts verification with consumer session secret from cached session`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModelTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.financialconnections.presentation.Async
 import com.stripe.android.financialconnections.repository.CoreAuthorizationPendingNetworkingRepairRepository
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.financialconnections.utils.UriUtils
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.navigation.NavigationManager
 import com.stripe.android.uicore.navigation.PopUpToBehavior
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,6 +36,9 @@ class PartnerAuthViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `Creates auth session when in partner auth flow`() = runTest {
@@ -189,6 +193,6 @@ class PartnerAuthViewModelTest {
             nativeAuthFlowCoordinator = NativeAuthFlowCoordinator(),
             pendingRepairRepository = pendingRepairRepository,
             repairAuthSession = repairAuthSession,
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/SupportabilityViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/SupportabilityViewModelTest.kt
@@ -29,6 +29,7 @@ import com.stripe.android.financialconnections.repository.CoreAuthorizationPendi
 import com.stripe.android.financialconnections.utils.TestHandleError
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.financialconnections.utils.UriUtils
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -48,6 +49,9 @@ internal class SupportabilityViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val applicationId = "com.sample.applicationid"
     private val getOrFetchSync = mock<GetOrFetchSync>()
@@ -325,6 +329,6 @@ internal class SupportabilityViewModelTest {
                 logger = Logger.noop(),
             ),
             repairAuthSession = mock(),
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/success/SuccessViewModelTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Complete
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.repository.SuccessContentRepository
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.test.runTest
@@ -29,6 +30,9 @@ internal class SuccessViewModelTest {
 
     @get:Rule
     val testRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val getOrFetchSync = mock<GetOrFetchSync>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
@@ -45,7 +49,7 @@ internal class SuccessViewModelTest {
         nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
         successContentRepository = SuccessContentRepository(SavedStateHandle()),
         getCachedAccounts = getCachedAccounts,
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `init - when skipSuccessPane is true, complete session and emit Finish`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.financialconnections.ui.theme.Theme
 import com.stripe.android.financialconnections.utils.TestNavigationManager
 import com.stripe.android.financialconnections.utils.UriUtils
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -62,6 +63,9 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
 
     @get:Rule
     val rule: TestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
     private val completeFinancialConnectionsSession = mock<CompleteFinancialConnectionsSession>()
@@ -594,5 +598,5 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
         savedStateHandle = SavedStateHandle(),
         initialState = initialState,
         createInstantDebitsResult = createInstantDebitsResult,
-    )
+    ).also { viewModelStoreRule.track(it) }
 }

--- a/financial-connections/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
+++ b/financial-connections/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.testing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Clears the [ViewModel]s built during a test when the test finishes.
+ *
+ * ViewModels launch perpetual collectors on their `viewModelScope` (and on any injected
+ * `customViewModelScope`) that only stop when the ViewModel is cleared. Unit tests construct
+ * ViewModels directly rather than through a [androidx.lifecycle.ViewModelProvider], so nothing ever
+ * clears them and those scopes leak across tests. Registering each ViewModel here and calling
+ * [ViewModelStore.clear] on finish cancels `viewModelScope` and invokes `onCleared()`, matching what
+ * the framework does when the owner is destroyed.
+ *
+ * Register ViewModels via [track].
+ */
+class ViewModelStoreTestRule : TestWatcher() {
+    private val viewModelStore = ViewModelStore()
+    private var trackedCount = 0
+
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also {
+        viewModelStore.put("tracked_${trackedCount++}", it)
+    }
+
+    override fun finished(description: Description) {
+        viewModelStore.clear()
+        super.finished(description)
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/ui/BottomSheetTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/BottomSheetTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.identity.networking.models.VerificationPageIconType
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentBottomSheetContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentBottomSheetLineContent
 import com.stripe.android.identity.viewmodel.BottomSheetViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,6 +28,9 @@ internal class BottomSheetTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private companion object {
         const val TITLE = "TITLE"

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConfirmationScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConfirmationScreenTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentTextPage
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,6 +32,9 @@ import org.robolectric.annotation.Config
 class ConfirmationScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val verificationPage = mock<VerificationPage>().also {
         whenever(it.success).thenReturn(

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.identity.networking.models.VerificationPageRequirement
 import com.stripe.android.identity.networking.models.VerificationPageStaticConsentLineContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
@@ -45,6 +46,9 @@ import org.robolectric.annotation.Config
 class ConsentScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val verificationPageLiveData =
         MutableLiveData<Resource<VerificationPage>>(Resource.idle())

--- a/identity/src/test/java/com/stripe/android/identity/ui/CountryNotListedScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/CountryNotListedScreenTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentCountryNotListedPage
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,6 +40,9 @@ import org.robolectric.annotation.Config
 class CountryNotListedScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val verificationPage = mock<VerificationPage>().also {
         whenever(it.countryNotListedPage).thenReturn(

--- a/identity/src/test/java/com/stripe/android/identity/ui/DebugScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DebugScreenTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.identity.networking.models.Requirement
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageRequirements
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -43,6 +44,9 @@ import org.robolectric.annotation.Config
 class DebugScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val verificationPageData = MutableLiveData<Resource<VerificationPage>>()
     private val mockNavController = mock<NavController>()

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocWarmupScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocWarmupScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.TestApplication
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentSelectPage
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,6 +25,10 @@ import org.robolectric.annotation.Config
 class DocWarmupScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val onContinueClickMock: () -> Unit = mock()
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
@@ -29,6 +29,7 @@ import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewmodel.DocumentScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -55,6 +56,9 @@ import java.io.File
 class DocumentScanScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val mockNavController = mock<NavController>()

--- a/identity/src/test/java/com/stripe/android/identity/ui/ErrorScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ErrorScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onChildAt
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.stripe.android.identity.TestApplication
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +23,9 @@ import org.robolectric.annotation.Config
 class ErrorScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val mockTopButtonClicked: () -> Unit = mock()
     private val mockBottomButtonClicked: () -> Unit = mock()

--- a/identity/src/test/java/com/stripe/android/identity/ui/IndividualScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/IndividualScreenTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.identity.networking.models.Requirement
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentIndividualPage
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.elements.PHONE_NUMBER_TEXT_FIELD_TAG
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -47,6 +48,9 @@ class IndividualScreenTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val verificationPage = mock<VerificationPage>().also {
         whenever(it.individual).thenReturn(

--- a/identity/src/test/java/com/stripe/android/identity/ui/IndividualWelcomeScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/IndividualWelcomeScreenTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.identity.networking.models.VerificationPageIconType
 import com.stripe.android.identity.networking.models.VerificationPageStaticConsentLineContent
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentIndividualWelcomePage
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,6 +41,9 @@ import org.robolectric.annotation.Config
 class IndividualWelcomeScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val mockVerificationArgs = mock<IdentityVerificationSheetContract.Args> {
         on { brandLogo } doReturn mock()

--- a/identity/src/test/java/com/stripe/android/identity/ui/InitialLoadingScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/InitialLoadingScreenTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.identity.networking.models.Requirement
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageRequirements
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +35,9 @@ import org.robolectric.annotation.Config
 class InitialLoadingScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val mockFallbackUrlLauncher = mock<FallbackUrlLauncher>()
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/LiveCaptureLaunchedEffectTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/LiveCaptureLaunchedEffectTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.identity.networking.models.VerificationPageStaticConte
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
@@ -42,6 +43,9 @@ import org.robolectric.annotation.Config
 class LiveCaptureLaunchedEffectTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val mockDocumentCapture = mock<VerificationPageStaticContentDocumentCapturePage> {
         on { requireLiveCapture } doReturn true

--- a/identity/src/test/java/com/stripe/android/identity/ui/OTPScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/OTPScreenTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.OTPViewModel
 import com.stripe.android.identity.viewmodel.OTPViewState
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
@@ -52,6 +53,9 @@ import org.robolectric.annotation.Config
 class OTPScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val verificationPageOTP = mock<VerificationPage>().also {
         whenever(it.phoneOtp).thenReturn(

--- a/identity/src/test/java/com/stripe/android/identity/ui/SelfieScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/SelfieScreenTest.kt
@@ -29,6 +29,7 @@ import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.SelfieScanViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -52,6 +53,9 @@ import org.robolectric.annotation.Config
 class SelfieScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/SelfieWarmupScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/SelfieWarmupScreenTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Com
 import com.stripe.android.identity.analytics.ScreenTracker
 import com.stripe.android.identity.navigation.SelfieDestination
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,6 +29,9 @@ import org.robolectric.annotation.Config
 class SelfieWarmupScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val mockNavController = mock<NavController>()
     private val mockScreenTracker = mock<ScreenTracker>()

--- a/identity/src/test/java/com/stripe/android/identity/ui/UploadScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/UploadScreenTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.utils.IdentityImageHandler
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
@@ -39,6 +40,9 @@ import org.robolectric.annotation.Config
 class UploadScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val mockNavController = mock<NavController>()
     private val onPhotoSelected = mock<(UploadMethod) -> Unit>()

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -65,6 +65,7 @@ import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.viewmodel.IdentityViewModel.Companion.BACK
 import com.stripe.android.identity.viewmodel.IdentityViewModel.Companion.FRONT
 import com.stripe.android.mlcore.base.InterpreterInitializer
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
@@ -92,6 +93,9 @@ import kotlin.test.assertFailsWith
 internal class IdentityViewModelTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val mockVerificationPage = mock<VerificationPage> {
         on { documentCapture }.thenReturn(DOCUMENT_CAPTURE)
@@ -160,7 +164,7 @@ internal class IdentityViewModelTest {
         mock(),
         UnconfinedTestDispatcher(),
         mock()
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     private fun mockUploadSuccess() = runBlocking {
         whenever(mockIdentityRepository.uploadImage(any(), any(), any(), any(), any())).thenReturn(

--- a/identity/src/test/java/com/stripe/android/testing/ComposeCleanupRule.kt
+++ b/identity/src/test/java/com/stripe/android/testing/ComposeCleanupRule.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.testing
+
+import junit.framework.Assert.assertFalse
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import kotlin.coroutines.CoroutineContext
+
+/*
+ * This rule is a workaround for https://github.com/robolectric/robolectric/issues/7055. It will cleanup any remaining
+ * resources from Jetpack Compose after completing a test. Ideally, this is handled by Robolectric. If Robolectric
+ * does handle cleanup in a new version, this rule should be removed.
+ *
+ * See https://github.com/robolectric/robolectric/issues/7055#issuecomment-1482789098 for explanation on the issue
+ * that is occurring.
+ *
+ * Pulled from: https://github.com/robolectric/robolectric/issues/7055#issuecomment-1551119229
+ */
+private class ComposeCleanupRule : TestWatcher() {
+    override fun starting(description: Description?) {
+        val clazz = javaClass.classLoader!!.loadClass("androidx.compose.ui.platform.AndroidUiDispatcher")
+        val combinedContextClass = javaClass.classLoader!!.loadClass("kotlin.coroutines.CombinedContext")
+        val companionClazz = clazz.getDeclaredField("Companion").get(clazz)
+        val combinedContext = companionClazz.javaClass.getDeclaredMethod("getMain")
+            .invoke(companionClazz) as CoroutineContext
+
+        val androidUiDispatcher = combinedContextClass.getDeclaredField("element")
+            .apply { isAccessible = true }
+            .get(combinedContext)
+            .let { clazz.cast(it) }
+
+        var scheduledFrameDispatch = clazz.getDeclaredField("scheduledFrameDispatch")
+            .apply { isAccessible = true }
+            .getBoolean(androidUiDispatcher)
+        var scheduledTrampolineDispatch = clazz.getDeclaredField("scheduledTrampolineDispatch")
+            .apply { isAccessible = true }
+            .getBoolean(androidUiDispatcher)
+
+        val dispatchCallback = clazz.getDeclaredField("dispatchCallback")
+            .apply { isAccessible = true }
+            .get(androidUiDispatcher) as Runnable
+
+        if (scheduledFrameDispatch || scheduledTrampolineDispatch) {
+            dispatchCallback.run()
+            scheduledFrameDispatch = clazz.getDeclaredField("scheduledFrameDispatch")
+                .apply { isAccessible = true }
+                .getBoolean(androidUiDispatcher)
+            scheduledTrampolineDispatch = clazz.getDeclaredField("scheduledTrampolineDispatch")
+                .apply { isAccessible = true }
+                .getBoolean(androidUiDispatcher)
+        }
+
+        assertFalse(scheduledFrameDispatch)
+        assertFalse(scheduledTrampolineDispatch)
+
+        super.finished(description)
+    }
+}
+
+fun createComposeCleanupRule(): TestWatcher = ComposeCleanupRule()

--- a/identity/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
+++ b/identity/src/test/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.testing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Clears the [ViewModel]s built during a test when the test finishes.
+ *
+ * ViewModels launch perpetual collectors on their `viewModelScope` (and on any injected
+ * `customViewModelScope`) that only stop when the ViewModel is cleared. Unit tests construct
+ * ViewModels directly rather than through a [androidx.lifecycle.ViewModelProvider], so nothing ever
+ * clears them and those scopes leak across tests. Registering each ViewModel here and calling
+ * [ViewModelStore.clear] on finish cancels `viewModelScope` and invokes `onCleared()`, matching what
+ * the framework does when the owner is destroyed.
+ *
+ * Register ViewModels via [track].
+ */
+class ViewModelStoreTestRule : TestWatcher() {
+    private val viewModelStore = ViewModelStore()
+    private var trackedCount = 0
+
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also {
+        viewModelStore.put("tracked_${trackedCount++}", it)
+    }
+
+    override fun finished(description: Description) {
+        viewModelStore.clear()
+        super.finished(description)
+    }
+}

--- a/lint/src/main/java/com/stripe/android/lint/ComposeCleanupRuleUsageDetector.kt
+++ b/lint/src/main/java/com/stripe/android/lint/ComposeCleanupRuleUsageDetector.kt
@@ -11,6 +11,7 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UFile
+import java.util.EnumSet
 
 internal class ComposeCleanupRuleUsageDetector : Detector(), SourceCodeScanner {
     override fun getApplicableUastTypes(): List<Class<out UElement>> =
@@ -22,7 +23,7 @@ internal class ComposeCleanupRuleUsageDetector : Detector(), SourceCodeScanner {
     companion object {
         private val IMPLEMENTATION = Implementation(
             ComposeCleanupRuleUsageDetector::class.java,
-            Scope.JAVA_FILE_SCOPE
+            EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)
         )
 
         @JvmField

--- a/lint/src/main/java/com/stripe/android/lint/ComposeCleanupRuleUsageVisitor.kt
+++ b/lint/src/main/java/com/stripe/android/lint/ComposeCleanupRuleUsageVisitor.kt
@@ -25,15 +25,20 @@ internal class ComposeCleanupRuleUsageVisitor(
         private var hasCleanupComposeCall: Boolean = false
 
         override fun visitImportStatement(node: UImportStatement): Boolean {
-            when (node.importReference?.asSourceString()) {
-                ROBOLECTRIC_TEST_RUNNER_FULL_NAME,
-                PARAMETERIZED_ROBOLECTRIC_TEST_RUNNER_FULL_NAME -> {
+            val importReference = node.importReference?.asSourceString()
+
+            when {
+                importReference == ROBOLECTRIC_TEST_RUNNER_FULL_NAME ||
+                    importReference == PARAMETERIZED_ROBOLECTRIC_TEST_RUNNER_FULL_NAME -> {
                     isRobolectricTest = true
                 }
-                COMPOSE_RULE_FULL_NAME -> {
+                importReference == COMPOSE_RULE_FULL_NAME -> {
                     createComposeCall = node
                 }
-                COMPOSE_CLEANUP_RULE_FULL_NAME -> {
+                // Match the cleanup rule by its simple function name rather than a fully-qualified
+                // name. Modules that can't depend on payments-core-testing keep a local
+                // createComposeCleanupRule, so any package satisfies the check.
+                importReference?.substringAfterLast('.') == COMPOSE_CLEANUP_RULE_SIMPLE_NAME -> {
                     hasCleanupComposeCall = true
                 }
                 else -> Unit
@@ -69,6 +74,6 @@ internal class ComposeCleanupRuleUsageVisitor(
             "org.robolectric.ParameterizedRobolectricTestRunner"
 
         private const val COMPOSE_RULE_FULL_NAME = "androidx.compose.ui.test.junit4.createComposeRule"
-        private const val COMPOSE_CLEANUP_RULE_FULL_NAME = "com.stripe.android.testing.createComposeCleanupRule"
+        private const val COMPOSE_CLEANUP_RULE_SIMPLE_NAME = "createComposeCleanupRule"
     }
 }

--- a/lint/src/main/java/com/stripe/android/lint/StripeIssueRegistry.kt
+++ b/lint/src/main/java/com/stripe/android/lint/StripeIssueRegistry.kt
@@ -11,6 +11,7 @@ internal class StripeIssueRegistry : IssueRegistry() {
         DangerousManifestConfigurationDetector.ISSUE,
         ComposeCleanupRuleUsageDetector.ISSUE,
         EagerApiHostUsageDetector.ISSUE,
+        TestResourceCleanupDetector.ISSUE,
     )
 
     override val vendor = Vendor(

--- a/lint/src/main/java/com/stripe/android/lint/TestResourceCleanupDetector.kt
+++ b/lint/src/main/java/com/stripe/android/lint/TestResourceCleanupDetector.kt
@@ -1,0 +1,325 @@
+package com.stripe.android.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiClass
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UFile
+import org.jetbrains.uast.ULambdaExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.USimpleNameReferenceExpression
+import org.jetbrains.uast.UVariable
+import org.jetbrains.uast.UastCallKind
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+import java.util.EnumSet
+
+internal class TestResourceCleanupDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UFile::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        return object : UElementHandler() {
+            override fun visitFile(node: UFile) {
+                if (context.isInTestSourceSet().not()) {
+                    return
+                }
+
+                node.accept(TestResourceCleanupVisitor(context))
+            }
+        }
+    }
+
+    private class TestResourceCleanupVisitor(
+        private val context: JavaContext,
+    ) : AbstractUastVisitor() {
+        private val trackedVariables = mutableMapOf<CleanupKind, MutableSet<String>>()
+        private val instantiations = mutableListOf<Instantiation>()
+
+        override fun visitCallExpression(node: UCallExpression): Boolean {
+            node.trackingKind()?.let { trackingKind ->
+                node.valueArguments.singleOrNull()?.variableName()?.let { variableName ->
+                    trackedVariables.getOrPut(trackingKind) { mutableSetOf() }.add(variableName)
+                }
+            }
+
+            if (node.kind == UastCallKind.CONSTRUCTOR_CALL && node.isSuperTypeConstructorCall().not()) {
+                val constructedClass = node.resolve()?.containingClass
+                val cleanupKind = constructedClass?.cleanupKind(context)
+
+                if (
+                    cleanupKind != null &&
+                    (cleanupKind != CleanupKind.VIEW_MODEL || node.isInsideViewModelFactory().not())
+                ) {
+                    instantiations.add(
+                        Instantiation(
+                            call = node,
+                            cleanupKind = cleanupKind,
+                            variableName = node.assignedVariableName(),
+                        )
+                    )
+                }
+            }
+
+            return super.visitCallExpression(node)
+        }
+
+        override fun afterVisitFile(node: UFile) {
+            instantiations
+                .filterNot { it.isTracked(trackedVariables) }
+                .forEach { instantiation ->
+                    context.report(
+                        issue = ISSUE,
+                        scope = instantiation.call,
+                        location = context.getNameLocation(instantiation.call),
+                        message = instantiation.cleanupKind.message,
+                    )
+                }
+        }
+
+        private fun Instantiation.isTracked(
+            trackedVariables: Map<CleanupKind, Set<String>>,
+        ): Boolean {
+            return call.isInsideTrackCall(cleanupKind) ||
+                call.isTrackedByScopeFunction(cleanupKind) ||
+                variableName in trackedVariables[cleanupKind].orEmpty()
+        }
+
+        private fun UCallExpression.isInsideTrackCall(cleanupKind: CleanupKind): Boolean {
+            return generateSequence(uastParent) { it.uastParent }
+                .filterIsInstance<UCallExpression>()
+                .any { parentCall -> parentCall.trackingKind() == cleanupKind }
+        }
+
+        private fun UCallExpression.isTrackedByScopeFunction(cleanupKind: CleanupKind): Boolean {
+            return generateSequence(uastParent) { it.uastParent }
+                .mapNotNull { parent ->
+                    when (parent) {
+                        is UCallExpression -> parent
+                        is UQualifiedReferenceExpression -> parent.selector as? UCallExpression
+                        else -> null
+                    }
+                }
+                .filter { parentCall -> parentCall.methodName in SCOPE_FUNCTIONS }
+                .any { scopeFunction ->
+                    val trackedNames = scopeFunction.valueArguments
+                        .filterIsInstance<ULambdaExpression>()
+                        .flatMap { lambdaExpression -> scopeFunction.trackedLambdaNames(lambdaExpression) }
+                        .ifEmpty { listOf("it", "this") }
+                        .toSet()
+
+                    scopeFunction.hasTrackingCall(
+                        cleanupKind = cleanupKind,
+                        variableNames = trackedNames,
+                    )
+                }
+        }
+
+        private fun UCallExpression.trackedLambdaNames(lambdaExpression: ULambdaExpression): Set<String> {
+            val lambdaParameters = lambdaExpression.valueParameters.mapNotNull { parameter ->
+                parameter.name.takeIf { it.isNotBlank() }
+            }
+
+            return when (methodName) {
+                "also", "let" -> lambdaParameters.ifEmpty { listOf("it") }.toSet()
+                "apply", "run" -> lambdaParameters.toSet() + "this"
+                else -> emptySet()
+            }
+        }
+
+        private fun UElement.hasTrackingCall(
+            cleanupKind: CleanupKind,
+            variableNames: Set<String>,
+        ): Boolean {
+            var foundTrackingCall = false
+
+            accept(
+                object : AbstractUastVisitor() {
+                    override fun visitCallExpression(node: UCallExpression): Boolean {
+                        if (node.trackingKind() == cleanupKind) {
+                            val argumentName = node.valueArguments.singleOrNull()?.variableName()
+
+                            if (argumentName in variableNames) {
+                                foundTrackingCall = true
+                            }
+                        }
+
+                        return super.visitCallExpression(node)
+                    }
+                }
+            )
+
+            return foundTrackingCall
+        }
+
+        private fun UCallExpression.trackingKind(): CleanupKind? {
+            if (methodName != "track") {
+                return null
+            }
+
+            // Match the cleanup rule by its simple class name rather than a fully-qualified name.
+            // The rule is enforced repo-wide, but the canonical rules live in modules that lower
+            // modules (e.g. 3ds2sdk, financial-connections) can't depend on, so those modules keep a
+            // local copy. Matching by name lets any `ViewModelStoreTestRule`/`CleanupTestRule` satisfy
+            // the check regardless of package.
+            return when (resolve()?.containingClass?.name) {
+                CLEANUP_TEST_RULE_NAME -> CleanupKind.CLOSEABLE
+                VIEW_MODEL_STORE_TEST_RULE_NAME -> CleanupKind.VIEW_MODEL
+                else -> null
+            }
+        }
+
+        private fun UElement.variableName(): String? {
+            if (this is USimpleNameReferenceExpression) {
+                return identifier
+            }
+
+            return asSourceString()
+                .trim()
+                .removeSurrounding("(", ")")
+                .takeIf { name -> name.matches(VARIABLE_NAME_REGEX) }
+        }
+
+        private fun UCallExpression.assignedVariableName(): String? {
+            return generateSequence(uastParent) { it.uastParent }
+                .filterIsInstance<UVariable>()
+                .firstOrNull()
+                ?.name
+        }
+
+        private fun UCallExpression.isInsideViewModelFactory(): Boolean {
+            return generateSequence(uastParent) { it.uastParent }
+                .any { parent ->
+                    when (parent) {
+                        is UCallExpression -> parent.methodName in VIEW_MODEL_FACTORY_FUNCTIONS
+                        is UMethod -> parent.isViewModelProviderFactoryCreate()
+                        else -> false
+                    }
+                }
+        }
+
+        private fun UMethod.isViewModelProviderFactoryCreate(): Boolean {
+            return name == "create" && javaPsi.containingClass?.let { containingClass ->
+                this@TestResourceCleanupVisitor.context.evaluator.extendsClass(
+                    containingClass,
+                    VIEW_MODEL_PROVIDER_FACTORY,
+                    false,
+                )
+            } == true
+        }
+
+        private fun UCallExpression.isSuperTypeConstructorCall(): Boolean {
+            var current = sourcePsi
+
+            while (current != null) {
+                if (current is KtSuperTypeCallEntry) {
+                    return true
+                }
+
+                current = current.parent
+            }
+
+            return false
+        }
+    }
+
+    private enum class CleanupKind(
+        val message: String,
+    ) {
+        CLOSEABLE(
+            "Closeable test instances must be tracked with `CleanupTestRule.track(...)` " +
+                "so they are closed when the test finishes."
+        ),
+        VIEW_MODEL(
+            "ViewModel test instances must be tracked with `ViewModelStoreTestRule.track(...)` " +
+                "so they are cleared when the test finishes."
+        )
+    }
+
+    private data class Instantiation(
+        val call: UCallExpression,
+        val cleanupKind: CleanupKind,
+        val variableName: String?,
+    )
+
+    companion object {
+        private const val CLEANUP_TEST_RULE_NAME = "CleanupTestRule"
+        private const val VIEW_MODEL = "androidx.lifecycle.ViewModel"
+        private const val VIEW_MODEL_PROVIDER_FACTORY = "androidx.lifecycle.ViewModelProvider.Factory"
+        private const val VIEW_MODEL_STORE_TEST_RULE_NAME = "ViewModelStoreTestRule"
+
+        private val SCOPE_FUNCTIONS = setOf("also", "apply", "let", "run")
+        private val VIEW_MODEL_FACTORY_FUNCTIONS = setOf("initializer", "viewModelFactory")
+        private val VARIABLE_NAME_REGEX = Regex("[A-Za-z_][A-Za-z0-9_]*")
+
+        private val IMPLEMENTATION = Implementation(
+            TestResourceCleanupDetector::class.java,
+            EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)
+        )
+
+        @JvmField
+        val ISSUE = Issue.create(
+            id = "TestResourceCleanup",
+            priority = 8,
+            briefDescription = "Closeable and ViewModel test instances must be cleaned up",
+            explanation = """
+                Tests that directly create closeable objects or ViewModels can leak work into later tests when the
+                instance is not closed or cleared. Track closeable instances with CleanupTestRule.track(...) and
+                ViewModels with ViewModelStoreTestRule.track(...).
+            """,
+            category = Category.CORRECTNESS,
+            severity = Severity.ERROR,
+            androidSpecific = false,
+            implementation = IMPLEMENTATION
+        )
+
+        private fun JavaContext.isInTestSourceSet(): Boolean {
+            val path = file.path.replace('\\', '/')
+            return "/src/test/" in path || "/src/androidTest/" in path
+        }
+
+        private fun PsiClass.cleanupKind(context: JavaContext): CleanupKind? {
+            if (qualifiedName == null || isTestDouble()) {
+                return null
+            }
+
+            if (context.evaluator.extendsClass(this, VIEW_MODEL, false)) {
+                return CleanupKind.VIEW_MODEL
+            }
+
+            if (hasNoArgumentCloseMethod() && isInteractor()) {
+                return CleanupKind.CLOSEABLE
+            }
+
+            return null
+        }
+
+        private fun PsiClass.hasNoArgumentCloseMethod(): Boolean {
+            return findMethodsByName("close", true).any { method ->
+                method.parameterList.parametersCount == 0
+            }
+        }
+
+        private fun PsiClass.isTestDouble(): Boolean {
+            return name?.let { className ->
+                className.startsWith("Fake") ||
+                    className.startsWith("Mock") ||
+                    className.startsWith("Test")
+            } ?: false
+        }
+
+        private fun PsiClass.isInteractor(): Boolean {
+            return name?.endsWith("Interactor") == true ||
+                supers.any { superClass -> superClass.name?.endsWith("Interactor") == true }
+        }
+    }
+}

--- a/lint/src/test/java/com/stripe/android/lint/ComposeCleanupRuleUsageDetectorTest.kt
+++ b/lint/src/test/java/com/stripe/android/lint/ComposeCleanupRuleUsageDetectorTest.kt
@@ -2,9 +2,20 @@ package com.stripe.android.lint
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.detector.api.Scope
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.EnumSet
 
 class ComposeCleanupRuleUsageDetectorTest {
+    @Test
+    fun `issue is registered for test source analysis`() {
+        assertEquals(
+            EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+            ComposeCleanupRuleUsageDetector.ISSUE.implementation.scope,
+        )
+    }
+
     @Test
     fun `should not lint in Robolectric test without compose context`() {
         lint().files(
@@ -69,6 +80,30 @@ class ComposeCleanupRuleUsageDetectorTest {
                     import org.robolectric.RobolectricTestRunner
                     import androidx.compose.ui.test.junit4.createComposeRule
                     import com.stripe.android.testing.createComposeCleanupRule
+
+                    @RunWith(RobolectricTestRunner::class)
+                    class TestingWithCompose {}
+                    """
+            ).indented(),
+        )
+            .issues(ComposeCleanupRuleUsageDetector.ISSUE)
+            .allowCompilationErrors()
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should not lint when 'createComposeCleanupRule' from another package is used`() {
+        lint().files(
+            kotlin(
+                """
+                    package com.stripe.android.uicore.elements
+
+                    import org.junit.runner.RunWith
+                    import org.robolectric.RobolectricTestRunner
+                    import androidx.compose.ui.test.junit4.createComposeRule
+                    import com.stripe.android.identity.testing.createComposeCleanupRule
 
                     @RunWith(RobolectricTestRunner::class)
                     class TestingWithCompose {}

--- a/lint/src/test/java/com/stripe/android/lint/TestResourceCleanupDetectorTest.kt
+++ b/lint/src/test/java/com/stripe/android/lint/TestResourceCleanupDetectorTest.kt
@@ -1,0 +1,586 @@
+package com.stripe.android.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.detector.api.Scope
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TestResourceCleanupDetectorTest {
+    @Test
+    fun `issue is registered for test source analysis`() {
+        assertEquals(
+            java.util.EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+            TestResourceCleanupDetector.ISSUE.implementation.scope,
+        )
+    }
+
+    @Test
+    fun `should detect closeable instance that is not tracked`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.CloseableInteractor
+
+                    class CloseableInteractorTest {
+                        fun test() {
+                            val interactor = CloseableInteractor()
+                        }
+                    }
+                """
+            ),
+            closeableInteractorStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectErrorCount(1)
+            .expectMatches("Closeable test instances must be tracked")
+    }
+
+    @Test
+    fun `should detect interactor whose close method comes from interface`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.DefaultExampleInteractor
+
+                    class DefaultExampleInteractorTest {
+                        fun test() {
+                            val interactor = DefaultExampleInteractor()
+                        }
+                    }
+                """
+            ),
+            interactorInterfaceStub(),
+            defaultInteractorStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectErrorCount(1)
+            .expectMatches("Closeable test instances must be tracked")
+    }
+
+    @Test
+    fun `should ignore closeable instance that is not an interactor`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.CloseableScreen
+
+                    class CloseableScreenTest {
+                        fun test() {
+                            val screen = CloseableScreen()
+                        }
+                    }
+                """
+            ),
+            closeableScreenStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should not detect closeable instance tracked directly`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.CloseableInteractor
+                    import com.stripe.android.testing.CleanupTestRule
+
+                    class CloseableInteractorTest {
+                        private val cleanupRule = CleanupTestRule(CloseableInteractor::close)
+
+                        fun test() {
+                            val interactor = cleanupRule.track(CloseableInteractor())
+                        }
+                    }
+                """
+            ),
+            closeableInteractorStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should not detect closeable instance tracked with also`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.CloseableInteractor
+                    import com.stripe.android.testing.CleanupTestRule
+
+                    class CloseableInteractorTest {
+                        private val cleanupRule = CleanupTestRule(CloseableInteractor::close)
+
+                        fun test() {
+                            val interactor = CloseableInteractor()
+                                .also { cleanupRule.track(it) }
+                        }
+                    }
+                """
+            ),
+            closeableInteractorStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should not detect closeable instance tracked after assignment`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.CloseableInteractor
+                    import com.stripe.android.testing.CleanupTestRule
+
+                    class CloseableInteractorTest {
+                        private val cleanupRule = CleanupTestRule(CloseableInteractor::close)
+
+                        fun test() {
+                            val interactor = CloseableInteractor()
+                            cleanupRule.track(interactor)
+                        }
+                    }
+                """
+            ),
+            closeableInteractorStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should detect viewModel instance that is not tracked`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.ExampleViewModel
+
+                    class ExampleViewModelTest {
+                        fun test() {
+                            val viewModel = ExampleViewModel()
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            exampleViewModelStub(),
+            viewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectErrorCount(1)
+            .expectMatches("ViewModel test instances must be tracked")
+    }
+
+    @Test
+    fun `should not detect viewModel instance tracked with viewModelStoreTestRule`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.ExampleViewModel
+                    import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+
+                    class ExampleViewModelTest {
+                        private val viewModelStoreRule = ViewModelStoreTestRule()
+
+                        fun test() {
+                            val viewModel = ExampleViewModel()
+                                .also { viewModelStoreRule.track(it) }
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            exampleViewModelStub(),
+            viewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should not detect viewModel tracked with viewModelStoreTestRule from another package`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.ExampleViewModel
+                    import com.stripe.android.example.testing.ViewModelStoreTestRule
+
+                    class ExampleViewModelTest {
+                        private val viewModelStoreRule = ViewModelStoreTestRule()
+
+                        fun test() {
+                            val viewModel = ExampleViewModel()
+                                .also { viewModelStoreRule.track(it) }
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            exampleViewModelStub(),
+            localViewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should not detect viewModel instance returned from factory result that is tracked`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.ExampleViewModel
+                    import com.stripe.android.example.TestViewModelFactory
+                    import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+
+                    class ExampleViewModelTest {
+                        private val viewModelStoreRule = ViewModelStoreTestRule()
+
+                        fun test() {
+                            val viewModel = TestViewModelFactory.create {
+                                ExampleViewModel()
+                            }
+                            viewModelStoreRule.track(viewModel)
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            exampleViewModelStub(),
+            testViewModelFactoryStub(),
+            viewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should ignore viewModel instance created by viewModelProvider factory`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import androidx.lifecycle.ViewModel
+                    import androidx.lifecycle.ViewModelProvider
+                    import com.stripe.android.example.ExampleViewModel
+
+                    class ExampleViewModelTest {
+                        fun test(): ViewModelProvider.Factory {
+                            return object : ViewModelProvider.Factory {
+                                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                                    return ExampleViewModel() as T
+                                }
+                            }
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            viewModelProviderFactoryStub(),
+            exampleViewModelStub(),
+            viewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should ignore viewModel instance created by viewModelFactory initializer`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import androidx.lifecycle.viewmodel.initializer
+                    import androidx.lifecycle.viewmodel.viewModelFactory
+                    import com.stripe.android.example.ExampleViewModel
+
+                    class ExampleViewModelTest {
+                        fun test() = viewModelFactory {
+                            initializer {
+                                ExampleViewModel()
+                            }
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            viewModelProviderFactoryStub(),
+            viewModelFactoryDslStub(),
+            exampleViewModelStub(),
+            viewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should ignore production source`() {
+        lint().files(
+            kotlin(
+                "src/main/java/com/stripe/android/example/CloseableInteractorUsage.kt",
+                """
+                    package com.stripe.android.example
+
+                    class CloseableInteractorUsage {
+                        fun create() {
+                            CloseableInteractor()
+                        }
+                    }
+                """
+            ).indented(),
+            closeableInteractorStub(),
+            cleanupTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should ignore test doubles`() {
+        lint().files(
+            testFile(
+                """
+                    package com.stripe.android.example
+
+                    import com.stripe.android.example.FakeViewModel
+
+                    class FakeViewModelTest {
+                        fun test() {
+                            val viewModel = FakeViewModel()
+                        }
+                    }
+                """
+            ),
+            viewModelStub(),
+            fakeViewModelStub(),
+            viewModelStoreTestRuleStub(),
+        )
+            .issues(TestResourceCleanupDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    private fun testFile(source: String) = kotlin(
+        "src/test/java/com/stripe/android/example/ExampleTest.kt",
+        source
+    ).indented()
+
+    private fun closeableInteractorStub() = kotlin(
+        "src/main/java/com/stripe/android/example/CloseableInteractor.kt",
+        """
+            package com.stripe.android.example
+
+            class CloseableInteractor {
+                fun close() {}
+            }
+        """
+    ).indented()
+
+    private fun interactorInterfaceStub() = kotlin(
+        "src/main/java/com/stripe/android/example/ExampleInteractor.kt",
+        """
+            package com.stripe.android.example
+
+            interface ExampleInteractor {
+                fun close()
+            }
+        """
+    ).indented()
+
+    private fun defaultInteractorStub() = kotlin(
+        "src/main/java/com/stripe/android/example/DefaultExampleInteractor.kt",
+        """
+            package com.stripe.android.example
+
+            class DefaultExampleInteractor : ExampleInteractor {
+                override fun close() {}
+            }
+        """
+    ).indented()
+
+    private fun closeableScreenStub() = kotlin(
+        "src/main/java/com/stripe/android/example/CloseableScreen.kt",
+        """
+            package com.stripe.android.example
+
+            class CloseableScreen {
+                fun close() {}
+            }
+        """
+    ).indented()
+
+    private fun cleanupTestRuleStub() = kotlin(
+        "src/test/java/com/stripe/android/testing/CleanupTestRule.kt",
+        """
+            package com.stripe.android.testing
+
+            class CleanupTestRule<T>(
+                private val cleanup: T.() -> Unit,
+            ) {
+                fun track(objectToCleanup: T): T = objectToCleanup
+            }
+        """
+    ).indented()
+
+    private fun viewModelStub() = kotlin(
+        "src/main/java/androidx/lifecycle/ViewModel.kt",
+        """
+            package androidx.lifecycle
+
+            open class ViewModel
+        """
+    ).indented()
+
+    private fun viewModelProviderFactoryStub() = kotlin(
+        "src/main/java/androidx/lifecycle/ViewModelProvider.kt",
+        """
+            package androidx.lifecycle
+
+            class ViewModelProvider {
+                interface Factory {
+                    fun <T : ViewModel> create(modelClass: Class<T>): T
+                }
+            }
+        """
+    ).indented()
+
+    private fun viewModelFactoryDslStub() = kotlin(
+        "src/main/java/androidx/lifecycle/viewmodel/ViewModelFactoryDsl.kt",
+        """
+            package androidx.lifecycle.viewmodel
+
+            import androidx.lifecycle.ViewModel
+            import androidx.lifecycle.ViewModelProvider
+
+            fun viewModelFactory(builder: InitializerViewModelFactoryBuilder.() -> Unit): ViewModelProvider.Factory {
+                return object : ViewModelProvider.Factory {
+                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                        error("Not implemented")
+                    }
+                }
+            }
+
+            class InitializerViewModelFactoryBuilder
+
+            fun <T : ViewModel> InitializerViewModelFactoryBuilder.initializer(initializer: () -> T) {}
+        """
+    ).indented()
+
+    private fun exampleViewModelStub() = kotlin(
+        "src/main/java/com/stripe/android/example/ExampleViewModel.kt",
+        """
+            package com.stripe.android.example
+
+            import androidx.lifecycle.ViewModel
+
+            class ExampleViewModel : ViewModel()
+        """
+    ).indented()
+
+    private fun testViewModelFactoryStub() = kotlin(
+        "src/test/java/com/stripe/android/example/TestViewModelFactory.kt",
+        """
+            package com.stripe.android.example
+
+            import androidx.lifecycle.ViewModel
+
+            object TestViewModelFactory {
+                fun <T : ViewModel> create(createViewModel: () -> T): T {
+                    return createViewModel()
+                }
+            }
+        """
+    ).indented()
+
+    private fun fakeViewModelStub() = kotlin(
+        "src/test/java/com/stripe/android/example/FakeViewModel.kt",
+        """
+            package com.stripe.android.example
+
+            import androidx.lifecycle.ViewModel
+
+            class FakeViewModel : ViewModel()
+        """
+    ).indented()
+
+    private fun viewModelStoreTestRuleStub() = kotlin(
+        "src/test/java/com/stripe/android/paymentsheet/utils/ViewModelStoreTestRule.kt",
+        """
+            package com.stripe.android.paymentsheet.utils
+
+            import androidx.lifecycle.ViewModel
+
+            class ViewModelStoreTestRule {
+                fun <T : ViewModel> track(viewModel: T): T = viewModel
+            }
+        """
+    ).indented()
+
+    private fun localViewModelStoreTestRuleStub() = kotlin(
+        "src/test/java/com/stripe/android/example/testing/ViewModelStoreTestRule.kt",
+        """
+            package com.stripe.android.example.testing
+
+            import androidx.lifecycle.ViewModel
+
+            class ViewModelStoreTestRule {
+                fun <T : ViewModel> track(viewModel: T): T = viewModel
+            }
+        """
+    ).indented()
+}

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/ViewModelStoreTestRule.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.testing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Clears the [ViewModel]s built during a test when the test finishes.
+ *
+ * ViewModels launch perpetual collectors on their `viewModelScope` (and on any injected
+ * `customViewModelScope`) that only stop when the ViewModel is cleared. Unit tests construct
+ * ViewModels directly rather than through a [androidx.lifecycle.ViewModelProvider], so nothing ever
+ * clears them and those scopes leak across tests. Registering each ViewModel here and calling
+ * [ViewModelStore.clear] on finish cancels `viewModelScope` and invokes `onCleared()`, matching what
+ * the framework does when the owner is destroyed.
+ *
+ * Register ViewModels via [track].
+ */
+class ViewModelStoreTestRule : TestWatcher() {
+    private val viewModelStore = ViewModelStore()
+    private var trackedCount = 0
+
+    // ViewModelStore.put is restricted to the androidx.lifecycle library group, but registering the
+    // ViewModel here is exactly how the framework tracks it so [ViewModelStore.clear] can later cancel
+    // viewModelScope and invoke onCleared(). This is intentional test-infrastructure use.
+    @Suppress("RestrictedApi")
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also {
+        viewModelStore.put("tracked_${trackedCount++}", it)
+    }
+
+    override fun finished(description: Description) {
+        viewModelStore.clear()
+        super.finished(description)
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModelTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter.UnexpectedErrorE
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -36,6 +37,9 @@ internal class IntentConfirmationChallengeViewModelTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `when Ready event is received, bridgeReady emits value`() = testScenario {
@@ -304,7 +308,7 @@ internal class IntentConfirmationChallengeViewModelTest {
         requestOptions = REQUEST_OPTIONS,
         fireAndForgetScope = TestScope(testDispatcher),
         logger = Logger.noop(),
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     private class FakeStripeRepository(
         private val cancelResult: Result<StripeIntent>,

--- a/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeViewModelTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.hcaptcha.FakeHCaptchaService
 import com.stripe.android.hcaptcha.HCaptchaService
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -19,6 +20,9 @@ internal class PassiveChallengeViewModelTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val fakeHCaptchaService = FakeHCaptchaService()
     private val fakeActivity = object : FragmentActivity() {}
@@ -91,5 +95,5 @@ internal class PassiveChallengeViewModelTest {
     ) = PassiveChallengeViewModel(
         passiveCaptchaParams = passiveCaptchaParams,
         hCaptchaService = hCaptchaService
-    )
+    ).also { viewModelStoreRule.track(it) }
 }

--- a/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerViewModelTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.hcaptcha.FakeHCaptchaService
 import com.stripe.android.hcaptcha.HCaptchaService
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -20,6 +21,9 @@ internal class PassiveChallengeWarmerViewModelTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val fakeHCaptchaService = FakeHCaptchaService()
     private val fakeActivity = object : FragmentActivity() {}
@@ -70,5 +74,5 @@ internal class PassiveChallengeWarmerViewModelTest {
     ) = PassiveChallengeWarmerViewModel(
         passiveCaptchaParams = passiveCaptchaParams,
         hCaptchaService = hCaptchaService
-    )
+    ).also { viewModelStoreRule.track(it) }
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -30,9 +30,11 @@ import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.AbsPaymentController
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
@@ -45,6 +47,9 @@ import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayLauncherViewModelTest {
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     private val savedStateHandle = SavedStateHandle()
     private val googlePayJsonFactory = GooglePayJsonFactory(
         googlePayConfig = GooglePayConfig(
@@ -273,7 +278,7 @@ class GooglePayLauncherViewModelTest {
         savedStateHandle = savedStateHandle,
         errorReporter = FakeErrorReporter(),
         workContext = testDispatcher,
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     private class FakePaymentController : AbsPaymentController() {
         override fun shouldHandlePaymentResult(

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -28,8 +28,10 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.testing.fakeCreationExtras
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -41,6 +43,9 @@ import kotlin.test.assertNotNull
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayPaymentMethodLauncherViewModelTest {
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val stripeRepository = FakeStripeRepository()
     private val googlePayJsonFactory = GooglePayJsonFactory(
@@ -71,7 +76,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
         googlePayJsonFactory,
         googlePayRepository,
         SavedStateHandle()
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     @Test
     fun `createPaymentMethod() should return expected result`() = runTest {
@@ -110,7 +115,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             googlePayJsonFactory,
             googlePayRepository,
             SavedStateHandle()
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         viewModelWithEmail.createPaymentMethod(
             PaymentData.fromJson(
@@ -133,7 +138,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             googlePayJsonFactory,
             googlePayRepository,
             SavedStateHandle()
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         viewModelWithEmail.createPaymentMethod(
             PaymentData.fromJson(
@@ -246,7 +251,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             googlePayJsonFactory,
             googlePayRepository,
             SavedStateHandle()
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         val paymentDataRequest = viewModel.createPaymentDataRequest()
 
@@ -268,7 +273,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             googlePayJsonFactory,
             googlePayRepository,
             SavedStateHandle()
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         val paymentDataRequest = viewModel.createPaymentDataRequest()
 

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -13,12 +13,17 @@ import com.stripe.android.core.browser.BrowserCapabilities
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.testing.ViewModelStoreTestRule
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class StripeBrowserLauncherViewModelTest {
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     private val application = ApplicationProvider.getApplicationContext<Application>()
     private val analyticsRequests = mutableListOf<AnalyticsRequest>()
     private val analyticsRequestExecutor = AnalyticsRequestExecutor {
@@ -103,7 +108,7 @@ class StripeBrowserLauncherViewModelTest {
             customTabsPackage = null,
             resolveErrorMessage = "Unable to resolve things",
             savedStateHandle = savedStateHandle,
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -24,8 +24,10 @@ import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.O
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
+import com.stripe.android.testing.ViewModelStoreTestRule
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -39,6 +41,9 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 
 @RunWith(RobolectricTestRunner::class)
 class CollectBankAccountViewModelTest {
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val createFinancialConnectionsSession: CreateFinancialConnectionsSession = mock()
     private val attachFinancialConnectionsSession: AttachFinancialConnectionsSession = mock()
@@ -514,7 +519,7 @@ class CollectBankAccountViewModelTest {
         logger = Logger.noop(),
         savedStateHandle = SavedStateHandle(),
         _viewEffect = viewEffect
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     private fun paymentIntentConfiguration(
         attachToIntent: Boolean = true

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
@@ -21,9 +21,11 @@ import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.testing.fakeCreationExtras
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -35,6 +37,9 @@ import kotlin.test.assertNotNull
 
 @RunWith(RobolectricTestRunner::class)
 class Stripe3ds2TransactionViewModelTest {
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     private val context = ApplicationProvider.getApplicationContext<Application>()
     private val stripeRepository = mock<StripeRepository>()
 
@@ -109,7 +114,7 @@ class Stripe3ds2TransactionViewModelTest {
             workContext = Dispatchers.IO,
             savedStateHandle = mock(),
             isInstantApp = false
-        )
+        ).also { viewModelStoreRule.track(it) }
 
     private companion object {
         const val ENABLE_LOGGING = false

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
 import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.payments.core.authentication.PaymentNextActionHandlerRegistry
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.testing.fakeCreationExtras
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -62,6 +63,9 @@ import kotlin.test.assertNotNull
 class PaymentLauncherViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     internal class TestFragment : Fragment()
 
@@ -132,7 +136,7 @@ class PaymentLauncherViewModelTest {
             durationProvider,
         ).apply {
             register(activityResultCaller, lifecycleOwner)
-        }
+        }.also { viewModelStoreRule.track(it) }
 
     @Before
     fun setUpMocks() = runTest {

--- a/payments-core/src/test/java/com/stripe/android/utils/CardElementTestHelper.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/CardElementTestHelper.kt
@@ -7,12 +7,14 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.view.CardWidgetViewModel
 
 internal object CardElementTestHelper {
 
     fun createViewModelStoreOwner(
         isCbcEligible: Boolean,
+        viewModelStoreTestRule: ViewModelStoreTestRule,
     ): ViewModelStoreOwner {
         val cardWidgetViewModel = CardWidgetViewModel(
             paymentConfigProvider = {
@@ -35,7 +37,7 @@ internal object CardElementTestHelper {
                     )
                 }
             }
-        )
+        ).also { viewModelStoreTestRule.track(it) }
 
         val viewModelStore = ViewModelStore().apply {
             val className = CardWidgetViewModel::class.java.canonicalName

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.utils.CardElementTestHelper
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
@@ -46,8 +47,12 @@ internal class CardFormViewTest {
     @get:Rule
     val testActivityRule = createTestActivityRule<CardFormViewTestActivity>(useMaterial = true)
 
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     @Before
     fun setup() {
+        CardFormViewTestActivity.viewModelStoreTestRule = viewModelStoreRule
         PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
     }
 
@@ -587,7 +592,10 @@ internal class CardFormViewTestActivity : AppCompatActivity() {
         CardFormView(this, attributes).apply {
             id = VIEW_ID
 
-            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(isCbcEligible = args.isCbcEligible)
+            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(
+                isCbcEligible = args.isCbcEligible,
+                viewModelStoreTestRule = viewModelStoreTestRule,
+            )
             viewModelStoreOwner = storeOwner
         }
     }
@@ -604,5 +612,7 @@ internal class CardFormViewTestActivity : AppCompatActivity() {
 
     companion object {
         const val VIEW_ID = 12345
+
+        lateinit var viewModelStoreTestRule: ViewModelStoreTestRule
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -38,6 +38,8 @@ import com.stripe.android.model.Networks
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.testing.ViewModelStoreTestRule
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.utils.CardElementTestHelper
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
@@ -67,6 +69,12 @@ internal class CardInputWidgetTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     private val testDispatcher = StandardTestDispatcher()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -76,6 +84,8 @@ internal class CardInputWidgetTest {
 
     @BeforeTest
     fun setup() {
+        CardInputWidgetTestActivity.viewModelStoreTestRule = viewModelStoreRule
+
         // The input date here will be invalid after 2050. Please update the test.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2050)
             .isTrue()
@@ -1921,7 +1931,10 @@ internal class CardInputWidgetTestActivity : AppCompatActivity() {
             layoutWidthCalculator = CardInputWidget.LayoutWidthCalculator { text, _ -> text.length * 10 }
             frameWidthSupplier = { 500 }
 
-            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(isCbcEligible = args.isCbcEligible)
+            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(
+                isCbcEligible = args.isCbcEligible,
+                viewModelStoreTestRule = viewModelStoreTestRule,
+            )
             viewModelStoreOwner = storeOwner
             cardNumberEditText.viewModelStoreOwner = storeOwner
 
@@ -1948,5 +1961,7 @@ internal class CardInputWidgetTestActivity : AppCompatActivity() {
 
     companion object {
         const val VIEW_ID = 12345
+
+        lateinit var viewModelStoreTestRule: ViewModelStoreTestRule
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -40,6 +40,7 @@ import com.stripe.android.model.Networks
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.utils.CardElementTestHelper
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
@@ -76,8 +77,13 @@ internal class CardMultilineWidgetTest {
     @get:Rule
     val testActivityRule = createTestActivityRule<CardMultilineWidgetTestActivity>()
 
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     @BeforeTest
     fun setup() {
+        CardMultilineWidgetTestActivity.viewModelStoreTestRule = viewModelStoreRule
+
         // The input date here will be invalid after 2050. Please update the test.
         assertThat(Calendar.getInstance().get(Calendar.YEAR) < 2050)
             .isTrue()
@@ -1411,7 +1417,10 @@ internal class CardMultilineWidgetTestActivity : AppCompatActivity() {
         CardMultilineWidget(this, shouldShowPostalCode = true).apply {
             id = VIEW_ID
 
-            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(isCbcEligible = args.isCbcEligible)
+            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(
+                isCbcEligible = args.isCbcEligible,
+                viewModelStoreTestRule = viewModelStoreTestRule,
+            )
             viewModelStoreOwner = storeOwner
             cardNumberEditText.viewModelStoreOwner = storeOwner
         }
@@ -1421,7 +1430,10 @@ internal class CardMultilineWidgetTestActivity : AppCompatActivity() {
         CardMultilineWidget(this, shouldShowPostalCode = false).apply {
             id = NO_ZIP_VIEW_ID
 
-            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(isCbcEligible = args.isCbcEligible)
+            val storeOwner = CardElementTestHelper.createViewModelStoreOwner(
+                isCbcEligible = args.isCbcEligible,
+                viewModelStoreTestRule = viewModelStoreTestRule,
+            )
             viewModelStoreOwner = storeOwner
             cardNumberEditText.viewModelStoreOwner = storeOwner
         }
@@ -1449,5 +1461,7 @@ internal class CardMultilineWidgetTestActivity : AppCompatActivity() {
     companion object {
         const val VIEW_ID = 12345
         const val NO_ZIP_VIEW_ID = 12346
+
+        lateinit var viewModelStoreTestRule: ViewModelStoreTestRule
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -43,6 +43,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardFunding
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.testharness.ViewTestUtils
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeCardElementConfigRepository
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -78,6 +79,9 @@ internal class CardNumberEditTextTest {
 
     @get:Rule
     val testActivityRule = createTestActivityRule<TestActivity>()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private var completionCallbackInvocations = 0
     private val completionCallback: () -> Unit = { completionCallbackInvocations++ }
@@ -1075,7 +1079,7 @@ internal class CardNumberEditTextTest {
             paymentConfigProvider = { PaymentConfiguration.getInstance(context) },
             stripeRepository = repository,
             dispatcher = dispatcher
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         val store = ViewModelStore().apply {
             val className = CardWidgetViewModel::class.java.canonicalName

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -3,9 +3,11 @@ package com.stripe.android.view
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.utils.FakeCardElementConfigRepository
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 
 private val paymentConfig = PaymentConfiguration(
@@ -14,6 +16,9 @@ private val paymentConfig = PaymentConfiguration(
 )
 
 class CardWidgetViewModelTest {
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -26,7 +31,7 @@ class CardWidgetViewModelTest {
                 paymentConfigProvider = { paymentConfig },
                 stripeRepository = stripeRepository,
                 dispatcher = testDispatcher
-            )
+            ).also { viewModelStoreRule.track(it) }
 
             viewModel.isCbcEligible.test {
                 assertThat(awaitItem()).isFalse()
@@ -44,7 +49,7 @@ class CardWidgetViewModelTest {
                 paymentConfigProvider = { paymentConfig },
                 stripeRepository = stripeRepository,
                 dispatcher = testDispatcher
-            )
+            ).also { viewModelStoreRule.track(it) }
 
             viewModel.isCbcEligible.test {
                 assertThat(awaitItem()).isFalse()
@@ -61,7 +66,7 @@ class CardWidgetViewModelTest {
             paymentConfigProvider = { paymentConfig },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         viewModel.isCbcEligible.test {
             assertThat(awaitItem()).isFalse()
@@ -78,7 +83,7 @@ class CardWidgetViewModelTest {
             paymentConfigProvider = { paymentConfig },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         viewModel.isCbcEligible.test {
             assertThat(awaitItem()).isFalse()
@@ -96,7 +101,7 @@ class CardWidgetViewModelTest {
             paymentConfigProvider = { paymentConfig },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         stripeRepository.enqueueEligible()
 

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -11,12 +11,17 @@ import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
+import com.stripe.android.testing.ViewModelStoreTestRule
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class PaymentAuthWebViewActivityViewModelTest {
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
     private val analyticsRequests = mutableListOf<AnalyticsRequest>()
     private val analyticsRequestExecutor = AnalyticsRequestExecutor { analyticsRequests.add(it) }
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
@@ -143,7 +148,7 @@ class PaymentAuthWebViewActivityViewModelTest {
             args,
             analyticsRequestExecutor,
             analyticsRequestFactory
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     private companion object {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
@@ -26,6 +27,9 @@ internal class CardDetailsSectionElementUITest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     @Test
     fun `CardDetailsSectionElement shows custom action and not card scan when cardDetailsAction is provided`() {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.events.AnalyticsEventReporter
 import com.stripe.android.ui.core.elements.events.CardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReporter
@@ -61,6 +62,9 @@ import com.stripe.android.uicore.R as StripeUiCoreR
 internal class CardNumberControllerTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
@@ -15,6 +15,7 @@ import app.cash.turbine.Turbine
 import com.google.android.gms.wallet.CreditCardExpirationDate
 import com.google.android.gms.wallet.PaymentCardRecognitionResult
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.cardscan.FakeCardScanEventsReporter
 import com.stripe.android.ui.core.cardscan.FakePaymentCardRecognitionClient
 import com.stripe.android.ui.core.cardscan.LocalCardScanEventsReporter
@@ -33,6 +34,9 @@ import kotlin.test.Test
 internal class CardScanActionTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     @Test
     fun `automatically launches card scan and gets result`() {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/ScanCardButtonUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/ScanCardButtonUITest.kt
@@ -17,6 +17,7 @@ import app.cash.turbine.Turbine
 import com.google.android.gms.wallet.CreditCardExpirationDate
 import com.google.android.gms.wallet.PaymentCardRecognitionResult
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.cardscan.CardScanGoogleLauncher.Companion.rememberCardScanGoogleLauncher
 import com.stripe.android.ui.core.cardscan.CardScanLauncher
 import com.stripe.android.ui.core.cardscan.FakeCardScanEventsReporter
@@ -35,6 +36,9 @@ import org.robolectric.RobolectricTestRunner
 internal class ScanCardButtonUITest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     @Test
     fun `ScanCardButtonUI should launch Google launcher when GPCR is available`() = runScenario(


### PR DESCRIPTION
# Summary
Adds custom lint rules that enforce tracking and cleanup of Closeable and ViewModel test instances, improving test isolation and preventing leaks. Updates tests to use CleanupTestRule and ViewModelStoreTestRule consistently.

# Motivation
Tests that instantiate Closeables or ViewModels without proper cleanup can leak work into subsequent tests, causing hard-to-debug failures and unreliable test results. Automating enforcement ensures best practices and prevents regressions.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
