### PR TITLE
Cleanup CoroutineScopes in tests

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     ksp libs.daggerCompiler
 
+    testImplementation project(':payments-core-testing')
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.composeUi
     testImplementation testLibs.androidx.fragment

--- a/identity/src/test/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactoryTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactoryTest.kt
@@ -31,8 +31,10 @@ import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentExperiment
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.testing.CleanupTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
@@ -49,6 +51,10 @@ import org.robolectric.RobolectricTestRunner
 class IdentityAnalyticsRequestFactoryTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     private val mockIdentityRepository = mock<IdentityRepository>()
     private val mockArgs = mock<IdentityVerificationSheetContract.Args> {
         on { verificationSessionId }.thenReturn(VERIFICATION_SESSION)
@@ -59,7 +65,7 @@ class IdentityAnalyticsRequestFactoryTest {
         ApplicationProvider.getApplicationContext(),
         mockArgs,
         mockIdentityRepository,
-        CoroutineScope(UnconfinedTestDispatcher())
+        coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher()))
     )
 
     private val mockPageScreenPresented = mock<VerificationPage> {

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/DefaultPaymentMethodMessagingCoordinatorTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/DefaultPaymentMethodMessagingCoordinatorTest.kt
@@ -9,15 +9,21 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentmethodmessaging.element.analytics.FakeEventReporter
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class DefaultPaymentMethodMessagingCoordinatorTest {
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `configure returns no content if single and multi partner null`() = runScenario {
@@ -133,7 +139,7 @@ internal class DefaultPaymentMethodMessagingCoordinatorTest {
             stripeRepository = repository,
             paymentConfiguration = paymentConfig,
             eventReporter = FakeEventReporter(),
-            viewModelScope = CoroutineScope(UnconfinedTestDispatcher()),
+            viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = errorReporter
         )
 

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
@@ -16,11 +16,13 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElement.Appearance.Theme
 import com.stripe.android.paymentmethodmessaging.element.analytics.FakeEventReporter
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.allOf
@@ -32,6 +34,9 @@ import org.robolectric.RobolectricTestRunner
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentMethodMessagingContentTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
     val composeRule = createComposeRule()
 
@@ -97,7 +102,7 @@ internal class PaymentMethodMessagingContentTest {
             stripeRepository = FakeStripeRepository(),
             paymentConfiguration = { PaymentConfiguration("key") },
             eventReporter = FakeEventReporter(),
-            viewModelScope = CoroutineScope(UnconfinedTestDispatcher()),
+            viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = FakeErrorReporter()
         )
 

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessageAnalyticsTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessageAnalyticsTest.kt
@@ -12,11 +12,13 @@ import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingC
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElement
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElementPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -27,6 +29,9 @@ import org.robolectric.RobolectricTestRunner
 @OptIn(ExperimentalCoroutinesApi::class, PaymentMethodMessagingElementPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentMethodMessageAnalyticsTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
     val composeRule = createComposeRule()
 
@@ -189,7 +194,7 @@ internal class PaymentMethodMessageAnalyticsTest {
             stripeRepository = FakeStripeRepository(),
             paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_123_test") },
             eventReporter = eventReporter,
-            viewModelScope = CoroutineScope(UnconfinedTestDispatcher()),
+            viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = errorReporter
         )
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/CleanupTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/CleanupTestRule.kt
@@ -3,7 +3,7 @@ package com.stripe.android.testing
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
-internal class CleanupTestRule<T>(
+class CleanupTestRule<T>(
     private val cleanup: T.() -> Unit,
 ) : TestWatcher() {
     private val tracked = mutableListOf<T>()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeStripeImageLoader
@@ -33,8 +34,10 @@ import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -45,6 +48,9 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutStateLoaderTest {
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `loadInitial commits state with payment method metadata`() = runScenario {
@@ -191,7 +197,7 @@ internal class CheckoutStateLoaderTest {
                     savedStateHandle = savedStateHandle,
                 ),
                 eventReporter = FakeEventReporter(),
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                 internalRowSelectionCallback = { null },
             )
         },

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -13,9 +13,12 @@ import com.stripe.android.common.nfcscan.tapzone.TapZone
 import com.stripe.android.common.nfcscan.ui.NfcScanningStatus
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -29,6 +32,12 @@ internal class NfcScanningViewModelTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `viewState contains tap zone from resolver`() = runScenario(
@@ -184,13 +193,13 @@ internal class NfcScanningViewModelTest {
 
     @Test
     fun `onCleared cancels view model scope`() = runTest(dispatcher) {
-        val viewModelScope = CoroutineScope(dispatcher + Job())
+        val viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher + Job()))
         val viewModel = NfcScanningViewModel(
             viewModelScope = viewModelScope,
             tapZoneResolver = FakeTapZoneResolver(),
             cardScanner = FakeNfcCardScanner(),
             eventReporter = FakeNfcScanningEventReporter(),
-        )
+        ).also { viewModelStoreRule.track(it) }
         val viewModelStore = ViewModelStore().apply {
             put("test", viewModel)
         }
@@ -208,11 +217,11 @@ internal class NfcScanningViewModelTest {
         val fakeCardScanner = FakeNfcCardScanner(stateFlow = scannerState)
         val fakeEventReporter = FakeNfcScanningEventReporter()
         val viewModel = NfcScanningViewModel(
-            viewModelScope = CoroutineScope(dispatcher),
+            viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)),
             tapZoneResolver = FakeTapZoneResolver(tapZone),
             cardScanner = fakeCardScanner,
             eventReporter = fakeEventReporter,
-        )
+        ).also { viewModelStoreRule.track(it) }
 
         assertThat(fakeEventReporter.onNfcScanStartedCalls.awaitItem()).isNotNull()
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardScannerTest.kt
@@ -7,8 +7,10 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.hardware.FakeNfcHardwareDelegate
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -20,6 +22,9 @@ internal class DefaultNfcCardScannerTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `scanner emits Scanning then Complete when card read & validator succeeds`() = runScenario(
@@ -168,7 +173,7 @@ internal class DefaultNfcCardScannerTest {
             cardReader = fakeCardReader,
             cardValidator = fakeCardValidator,
             transceiverFactory = fakeTransceiverFactory,
-            viewModelScope = CoroutineScope(dispatcher),
+            viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)),
             workContext = dispatcher,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardTest.kt
@@ -9,6 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.ui.TapToAddCard
 import com.stripe.android.common.taptoadd.ui.TapToAddTheme
 import com.stripe.android.model.CardBrand
+import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -21,6 +22,9 @@ internal class TapToAddCardTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val testBitmap = TapToAddImageRepository.CardArt(
         bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888),

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.utils.FakeActivityResultLauncher
@@ -33,7 +34,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
-import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -69,12 +69,8 @@ class LinkControllerInteractorTest {
 
     // Each created interactor owns a scope with a perpetual collector in its init; track and cancel
     // them so the scopes don't outlive the test.
-    private val trackedScopes = mutableListOf<CoroutineScope>()
-
-    @After
-    fun cancelTrackedScopes() {
-        trackedScopes.forEach { it.cancel() }
-    }
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `Initial state is correct`() = runTest {
@@ -1035,7 +1031,7 @@ class LinkControllerInteractorTest {
     }
 
     private fun createInteractor(): LinkControllerInteractor {
-        val coroutineScope = CoroutineScope(dispatcher).also { trackedScopes.add(it) }
+        val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher))
         return LinkControllerInteractor(
             application = application,
             logger = logger,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.link.ui.paymentmenthod.PAYMENT_METHOD_ERROR_TAG
 import com.stripe.android.link.ui.paymentmenthod.PaymentMethodScreen
 import com.stripe.android.link.ui.paymentmenthod.PaymentMethodViewModel
 import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.NoOpCardScanEventsReporter
@@ -54,6 +55,9 @@ internal class PaymentMethodScreenTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `form fields are displayed correctly`() = runScenario {
@@ -192,7 +196,7 @@ internal class PaymentMethodScreenTest {
             dismissalCoordinator = dismissalCoordinator,
             linkLaunchMode = LinkLaunchMode.Full,
             dismissWithResult = {}
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     private fun onPayButton() =

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -38,11 +39,15 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import com.stripe.android.link.confirmation.Result as LinkConfirmationResult
 
 class PaymentMethodViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Before
     fun setUp() {
@@ -284,6 +289,6 @@ class PaymentMethodViewModelTest {
                 dismissalCoordinator = dismissalCoordinator,
                 linkLaunchMode = LinkLaunchMode.Full
             ),
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.theme.DefaultLinkTheme
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -49,6 +50,9 @@ internal class SignUpScreenTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `only email field displayed when controllers are empty`() = runTest(dispatcher) {
@@ -361,7 +365,7 @@ internal class SignUpScreenTest {
             linkLaunchMode = LinkLaunchMode.Full,
             dismissWithResult = {},
             verifyDuringSignUp = {},
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     private fun onEmailField() = composeTestRule.onNodeWithText("Email")

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.uicore.utils.collectAsState
@@ -46,6 +47,9 @@ internal class VerificationScreenTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `title, email and otp should be displayed on screen load`() = runTest(dispatcher) {
@@ -311,7 +315,7 @@ internal class VerificationScreenTest {
             onChangeEmailRequested = {},
             onDismissClicked = onDismissClicked,
             dismissWithResult = dismissWithResult
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     private fun onTitleField() = composeTestRule.onNodeWithTag(VERIFICATION_TITLE_TAG)

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -49,6 +49,7 @@ import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.ui.core.elements.CvcController
@@ -73,6 +74,9 @@ internal class WalletScreenTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `wallet list is collapsed on start`() = runTest(dispatcher) {
@@ -821,7 +825,7 @@ internal class WalletScreenTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkLaunchMode = linkLaunchMode
             )
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 
     private fun onWalletCollapsedHeader() =

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -53,6 +54,9 @@ class LinkFormElementTest {
 
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `If initial user input is provided, should be displayed to the user when alongside SFU`() {
@@ -185,10 +189,12 @@ class LinkFormElementTest {
     }
 
     private fun createLinkConfigurationCoordinator(): LinkConfigurationCoordinator {
-        return FakeLinkConfigurationCoordinator
+        return FakeLinkConfigurationCoordinator(viewModelStoreRule)
     }
 
-    private object FakeLinkConfigurationCoordinator : LinkConfigurationCoordinator {
+    private class FakeLinkConfigurationCoordinator(
+        private val viewModelStoreRule: ViewModelStoreTestRule,
+    ) : LinkConfigurationCoordinator {
         override val accountFlow: StateFlow<LinkAccount?>
             get() = stateFlowOf(null)
 
@@ -205,6 +211,7 @@ class LinkFormElementTest {
                 inlineSignupViewModelFactory = FakeLinkInlineSignupAssistedViewModelFactory(
                     linkAccountManager = linkAccountManager,
                     configuration = configuration,
+                    viewModelStoreRule = viewModelStoreRule,
                 )
             )
         }
@@ -251,6 +258,7 @@ class LinkFormElementTest {
     private class FakeLinkInlineSignupAssistedViewModelFactory(
         private val linkAccountManager: LinkAccountManager,
         private val configuration: LinkConfiguration,
+        private val viewModelStoreRule: ViewModelStoreTestRule,
     ) : LinkInlineSignupAssistedViewModelFactory {
         override fun create(
             signupMode: LinkSignupMode,
@@ -266,7 +274,7 @@ class LinkFormElementTest {
                 logger = Logger.noop(),
                 lookupDelay = 0L,
                 previousLinkSignupCheckboxSelection = previousLinkSignupCheckboxSelection,
-            )
+            ).also { viewModelStoreRule.track(it) }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
@@ -23,6 +24,7 @@ import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -38,6 +40,9 @@ import kotlin.time.Duration.Companion.seconds
 class DefaultConfirmationHandlerTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `On initial register, should create launchers for each definition`() = test(shouldRegister = false) {
@@ -603,7 +608,7 @@ class DefaultConfirmationHandlerTest {
         ) {
             confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
-            val job = CoroutineScope(dispatcher).launch {
+            val job = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)).launch {
                 val result = confirmationHandler.awaitResult().assertSucceeded()
 
                 assertThat(result.intent).isEqualTo(PAYMENT_INTENT)
@@ -781,7 +786,7 @@ class DefaultConfirmationHandlerTest {
                             definition = someOtherDefinitionScenario.definition,
                         ),
                     ),
-                    coroutineScope = CoroutineScope(dispatcher),
+                    coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)),
                     errorReporter = errorReporter,
                     savedStateHandle = savedStateHandle,
                     ioContext = dispatcher,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -26,18 +26,24 @@ import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.RadarOptionsFactory
 import com.stripe.android.utils.FakeActivityResultLauncher
 import com.stripe.attestation.IntegrityRequestManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import kotlin.coroutines.CoroutineContext
 
 internal class AttestationConfirmationDefinitionTest {
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `'key' should be 'Attestation'`() {
@@ -617,7 +623,7 @@ internal class AttestationConfirmationDefinitionTest {
     private fun createAttestationConfirmationDefinition(
         errorReporter: ErrorReporter = FakeErrorReporter(),
         integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager(),
-        coroutineScope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+        coroutineScope: CoroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
         workContext: CoroutineContext = UnconfinedTestDispatcher(),
         publishableKey: String = launcherArgs.publishableKey,
         productUsage: Set<String> = launcherArgs.productUsage,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
@@ -18,15 +18,21 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import kotlin.test.Test
 
 internal class DefaultEmbeddedConfigurationCoordinatorTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     private val defaultConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
     private val defaultInitializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
         PaymentSheet.IntentConfiguration(
@@ -201,7 +207,7 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(
             savedStateHandle = savedStateHandle,
             selectionHolder = selectionHolder,
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
         )
         val stateHelper = FakeEmbeddedStateHelper()
 
@@ -213,7 +219,7 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
                 selectionChooser(newSelection)
             },
             stateHelper = stateHelper,
-            viewModelScope = CoroutineScope(UnconfinedTestDispatcher()),
+            viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
@@ -18,12 +18,14 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -31,6 +33,9 @@ import org.junit.Test
 internal class DefaultEmbeddedSelectionChooserTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     private val defaultConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
         .build()
@@ -487,7 +492,7 @@ internal class DefaultEmbeddedSelectionChooserTest {
             chooser = DefaultEmbeddedSelectionChooser(
                 savedStateHandle = savedStateHandle,
                 formHelperFactory = formHelperFactory,
-                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 eventReporter = FakeEventReporter(),
                 internalRowSelectionCallback = { internalRowSelectionCallback }
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
 import com.stripe.android.testing.FakeErrorReporter
@@ -41,6 +42,7 @@ import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -59,9 +61,12 @@ internal class DefaultEmbeddedSheetLauncherTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
     private val networkRule = NetworkRule()
 
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
     val ruleChain: RuleChain = RuleChain
         .outerRule(networkRule)
+        .around(coroutineScopeCleanupRule)
         .around(PaymentConfigurationTestRule(applicationContext))
         .around(CheckoutInstancesTestRule())
 
@@ -795,7 +800,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             stateHelper = stateHelper
         )
         val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             internalRowSelectionCallback = { { rowSelectionCallbackInvoked = true } }
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.createComposeCleanupRule
@@ -31,6 +32,7 @@ import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -53,6 +55,9 @@ internal class EmbeddedContentUiTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `rowStyle FlatWithDisclosure, dataLoaded emits embeddedContent event that passes validation`() =
@@ -146,13 +151,13 @@ internal class EmbeddedContentUiTest {
         val errorReporter = FakeErrorReporter()
         val immediateActionHandler =
             DefaultEmbeddedRowSelectionImmediateActionHandler(
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                 internalRowSelectionCallback = { null }
             )
 
         val embeddedContentHelper =
             DefaultEmbeddedContentHelper(
-                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 savedStateHandle = savedStateHandle,
                 eventReporter = eventReporter,
                 workContext = Dispatchers.Unconfined,
@@ -176,7 +181,7 @@ internal class EmbeddedContentUiTest {
                 confirmationStateHolder = EmbeddedConfirmationStateHolder(
                     savedStateHandle = savedStateHandle,
                     selectionHolder = selectionHolder,
-                    coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+                    coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 ),
                 rowSelectionImmediateActionHandler = immediateActionHandler,
                 errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLay
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -50,6 +51,9 @@ internal class EmbeddedNavigatorTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `initial state is correct`() = testScenario {
@@ -111,7 +115,7 @@ internal class EmbeddedNavigatorTest {
 
     @Test
     fun `cancelling the coroutine scope closes the root screen when nothing was navigated to`() = runTest {
-        val scope = CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler))
+        val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
         val manageInteractor = FakeManageScreenInteractor()
         EmbeddedNavigator(
@@ -130,7 +134,7 @@ internal class EmbeddedNavigatorTest {
 
     @Test
     fun `cancelling the coroutine scope closes every screen remaining on the back stack`() = runTest {
-        val scope = CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler))
+        val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
         val manageInteractor = FakeManageScreenInteractor()
         val updateInteractor = FakeUpdatePaymentMethodInteractor()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
@@ -42,6 +43,7 @@ import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.shouldAutomaticallyLaunchCardScan
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
@@ -57,6 +59,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
 
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `should not AutomaticallyLaunchCardScan if card form will be filled PaymentSheet`() {
@@ -178,7 +183,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 mode = EventReporter.Mode.Complete,
                 errorReporter = FakeErrorReporter(),
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
-                customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
             )
@@ -232,7 +237,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 tapToAddHelperFactory = FakeTapToAddHelper.Factory.noOp(),
                 mode = EventReporter.Mode.Complete,
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
-                customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
@@ -43,6 +44,7 @@ import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -59,6 +61,9 @@ internal class FormHelperTest {
         featureFlag = FeatureFlags.enableKlarnaFormRemoval,
         isEnabled = false
     )
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `formElementsForCode with unknown code returns empty list`() = runTest {
@@ -705,7 +710,7 @@ internal class FormHelperTest {
         selectionUpdater: (PaymentSelection?) -> Unit = { throw AssertionError("Not implemented") },
     ): FormHelper {
         return DefaultFormHelper(
-            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,
             newPaymentSelectionProvider = newPaymentSelectionProvider,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/MandateHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/MandateHandlerTest.kt
@@ -6,16 +6,22 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class MandateHandlerTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @Test
     fun `updateMandateText ignores showAbove if in vertical mode`() = runScenario(
         isVerticalMode = true,
@@ -136,7 +142,7 @@ class MandateHandlerTest {
             val selection = MutableStateFlow<PaymentSelection?>(null)
             Scenario(
                 handler = MandateHandler(
-                    coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                    coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                     selection = selection,
                     merchantDisplayName = "Example, Inc.",
                     isVerticalModeProvider = { isVerticalMode },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.NewPaymentMethodTabLayoutUI
 import com.stripe.android.paymentsheet.ui.TEST_TAG_ICON_FROM_RES
 import com.stripe.android.testing.FakeStripeImageLoader
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.image.TEST_TAG_IMAGE_FROM_URL
 import kotlinx.coroutines.test.runTest
@@ -19,6 +20,9 @@ import kotlin.test.Test
 class PaymentMethodsUITest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val workingUrl = "working-url"
     private val brokenUrl = "broken-url"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -55,6 +55,7 @@ import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.RetryRule
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
@@ -69,6 +70,7 @@ import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityStarter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
@@ -89,10 +91,12 @@ internal class PaymentOptionsActivityTest {
 
     private val composeTestRule = createEmptyComposeRule()
     private val networkRule = NetworkRule()
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @get:Rule
     val rule = RuleChain.emptyRuleChain()
         .around(InstantTaskExecutorRule())
+        .around(coroutineScopeCleanupRule)
         .around(composeTestRule)
         .around(networkRule)
         .around(CheckoutInstancesTestRule())
@@ -572,7 +576,7 @@ internal class PaymentOptionsActivityTest {
                 mode = EventReporter.Mode.Complete,
                 errorReporter = FakeErrorReporter(),
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
-                customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 placesClient = null,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -65,6 +65,7 @@ import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
@@ -76,6 +77,7 @@ import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -103,6 +105,9 @@ internal class PaymentOptionsViewModelTest {
 
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val standardTestDispatcher = StandardTestDispatcher()
@@ -1466,7 +1471,7 @@ internal class PaymentOptionsViewModelTest {
                     return customerStateHolder ?: DefaultCustomerStateHolder.Factory.create(viewModel)
                 }
             },
-            customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+            customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             placesClient = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -99,6 +99,7 @@ import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.ui.UPDATE_PM_REMOVE_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.createComposeCleanupRule
@@ -117,6 +118,7 @@ import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -159,6 +161,9 @@ internal class PaymentSheetActivityTest {
 
     @get:Rule
     val networkRule = NetworkRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -1313,7 +1318,7 @@ internal class PaymentSheetActivityTest {
         ) { linkHandler, savedStateHandle ->
             PaymentSheetViewModel(
                 args = args,
-                customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 eventReporter = eventReporter,
                 paymentElementLoader = FakePaymentElementLoader(
                     stripeIntent = paymentIntent,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -116,6 +116,7 @@ import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.paymentsheet.utils.prefillCreate
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
@@ -135,6 +136,7 @@ import com.stripe.android.utils.PaymentElementCallbackTestRule
 import com.stripe.android.utils.RelayingPaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -175,8 +177,11 @@ internal class PaymentSheetViewModelTest {
 
     private val viewModelStoreRule = ViewModelStoreTestRule()
 
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
     val rule = RuleChain.emptyRuleChain()
+        .around(coroutineScopeCleanupRule)
         .around(viewModelStoreRule)
         .around(InstantTaskExecutorRule())
         .around(SessionTestRule())
@@ -3495,7 +3500,7 @@ internal class PaymentSheetViewModelTest {
                         return customerStateHolder ?: DefaultCustomerStateHolder.Factory.create(viewModel)
                     }
                 },
-                customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -19,21 +19,27 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 
 @Suppress("LargeClass")
 class SavedPaymentMethodMutatorTest {
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `canEdit is correct when no payment methods`() = runScenario {
@@ -971,7 +977,7 @@ class SavedPaymentMethodMutatorTest {
             val savedPaymentMethodMutator = SavedPaymentMethodMutator(
                 paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
                 eventReporter = eventReporter,
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                 workContext = coroutineContext,
                 uiContext = coroutineContext,
                 savedPaymentMethodRepository = savedPaymentMethodRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
@@ -26,9 +27,11 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class AutocompleteScreenTest {
     val composeTestRule = createComposeRule()
+    private val viewModelStoreRule = ViewModelStoreTestRule()
 
     @get:Rule
     val rules: RuleChain = RuleChain.emptyRuleChain()
+        .around(viewModelStoreRule)
         .around(createComposeCleanupRule())
         .around(composeTestRule)
         .around(CoroutineTestRule())
@@ -112,7 +115,7 @@ class AutocompleteScreenTest {
         application = ApplicationProvider.getApplicationContext(),
         eventReporter = TestAddressLauncherEventReporter,
         autocompleteArgs = AutocompleteViewModel.Args(country = "US")
-    )
+    ).also { viewModelStoreRule.track(it) }
 
     private class TestPlacesClientProxy(
         private val findAutocompletePredictionsResponse: Result<FindAutocompletePredictionsResponse> =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
@@ -2,12 +2,14 @@ package com.stripe.android.paymentsheet.analytics
 
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.testing.CleanupTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -18,6 +20,9 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import kotlin.test.Test
 
 class PaymentSheetAnalyticsListenerTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @Test
     fun `cannotProperlyReturnFromLinkAndOtherLPMs should report event at maximum once`() = runScenario {
         analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
@@ -127,7 +132,7 @@ class PaymentSheetAnalyticsListenerTest {
             val eventReporter = mock<EventReporter>()
             val currentScreen = MutableStateFlow<PaymentSheetScreen>(PaymentSheetScreen.Loading)
             val currentPaymentMethodTypeProvider = { "card" }
-            val coroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
+            val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(coroutineContext + SupervisorJob()))
             val analyticsListener = PaymentSheetAnalyticsListener(
                 savedStateHandle = SavedStateHandle(),
                 eventReporter = eventReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.AffirmHeaderElement
@@ -38,6 +39,7 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -48,6 +50,9 @@ import com.stripe.android.uicore.R as UiCoreR
 @RunWith(RobolectricTestRunner::class)
 internal class FormViewModelTest {
     private val emailSection = EmailSpec()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `Verify completeFormValues is not null when no elements exist`() = runTest {
@@ -859,5 +864,5 @@ internal class FormViewModelTest {
     ) = FormViewModel(
         formArguments = arguments,
         formElements = formElements,
-    )
+    ).also { viewModelStoreRule.track(it) }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -2,12 +2,14 @@ package com.stripe.android.paymentsheet.navigation
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.CleanupTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -16,6 +18,9 @@ import java.io.Closeable
 import kotlin.time.Duration.Companion.milliseconds
 
 internal class NavigationHandlerTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @Test
     fun `currentScreen is initialized to Loading`() = runTest {
         val navigationHandler = NavigationHandler<PaymentSheetScreen>(this, PaymentSheetScreen.Loading) {}
@@ -332,7 +337,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `cancelling the coroutine scope closes all closable screens in the backstack`() = runTest {
-        val scope = CoroutineScope(Job())
+        val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job()))
         val navigationHandler = NavigationHandler<PaymentSheetScreen>(scope, PaymentSheetScreen.Loading) {}
         navigationHandler.currentScreen.test {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
@@ -380,7 +385,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `cancelling the coroutine scope closes a pending delayed transition that has not been applied`() = runTest {
-        val scope = CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler))
+        val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val navigationHandler = NavigationHandler<PaymentSheetScreen>(
             coroutineScope = scope,
             initialScreen = PaymentSheetScreen.Loading,
@@ -417,7 +422,7 @@ internal class NavigationHandlerTest {
 
     @Test
     fun `cancelling the coroutine scope closes the screens on the backstack`() = runTest {
-        val scope = CoroutineScope(Job())
+        val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job()))
         val initialScreen = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
         NavigationHandler<PaymentSheetScreen>(scope, initialScreen) {}
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.polling.IntentStatusPoller
 import com.stripe.android.testing.FakePollingAnalyticsEventReporter
 import com.stripe.android.utils.InjectableActivityScenario
@@ -40,6 +41,9 @@ internal class PollingActivityTest {
 
     @get:Rule
     val composeTestRule = createEmptyComposeRule()
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `Displays loading screen when activity is opened`() {
@@ -281,6 +285,7 @@ internal class PollingActivityTest {
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
     ): PollingViewModel {
         return PollingViewModel(args, poller, timeProvider, savedStateHandle, FakePollingAnalyticsEventReporter())
+            .also { viewModelStoreRule.track(it) }
     }
 
     private fun waitForActivityFinish() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
@@ -36,7 +36,7 @@ class PollingViewModelTest {
 
         val viewModel = createPollingViewModel(
             timeLimit = timeLimit,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit)
     }
@@ -47,7 +47,7 @@ class PollingViewModelTest {
 
         val viewModel = createPollingViewModel(
             timeLimit = timeLimit,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit)
 
@@ -66,7 +66,7 @@ class PollingViewModelTest {
 
         val viewModel = createPollingViewModel(
             poller = fakePoller,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
 
@@ -82,7 +82,7 @@ class PollingViewModelTest {
 
         val viewModel = createPollingViewModel(
             poller = fakePoller,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
 
@@ -100,7 +100,7 @@ class PollingViewModelTest {
         val viewModel = createPollingViewModel(
             poller = fakePoller,
             timeLimit = 10.seconds,
-        ).also { viewModelStoreRule.track(it) }
+        )
         assertThat(fakePoller.pollingTurbine.awaitItem()).isTrue()
 
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
@@ -122,7 +122,7 @@ class PollingViewModelTest {
 
         val viewModel = createPollingViewModel(
             poller = fakePoller,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         advanceTimeBy(5.seconds + 1.milliseconds)
 
@@ -143,7 +143,7 @@ class PollingViewModelTest {
 
         val viewModel = createPollingViewModel(
             poller = fakePoller,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         advanceTimeBy(5.seconds + 1.milliseconds)
 
@@ -177,7 +177,7 @@ class PollingViewModelTest {
             timeLimit = timeLimit,
             timeProvider = timeProvider,
             savedStateHandle = savedStateHandle,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         val remainingTime = timeLimit - alreadyPassed
         assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(remainingTime)
@@ -191,7 +191,7 @@ class PollingViewModelTest {
             timeLimit = 5.minutes,
             poller = fakePoller,
             initialDelay = ZERO,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(fakePoller.pollingTurbine.awaitItem()).isTrue()
 
@@ -423,7 +423,7 @@ class PollingViewModelTest {
     fun `QR code shown on start when QR code available`() = runTest(testDispatcher) {
         val viewModel = createPollingViewModel(
             qrCodeUrl = "valid_url"
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.shouldShowQrCode).isTrue()
     }
@@ -432,7 +432,7 @@ class PollingViewModelTest {
     fun `QR code hidden on start when QR code not available`() = runTest(testDispatcher) {
         val viewModel = createPollingViewModel(
             qrCodeUrl = null,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.shouldShowQrCode).isFalse()
     }
@@ -441,7 +441,7 @@ class PollingViewModelTest {
     fun `QR code hidden on cancel`() = runTest(testDispatcher) {
         val viewModel = createPollingViewModel(
             qrCodeUrl = "valid_url"
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         viewModel.handleCancel()
 
@@ -452,7 +452,7 @@ class PollingViewModelTest {
     fun `QR code hidden on hide QR code`() = runTest(testDispatcher) {
         val viewModel = createPollingViewModel(
             qrCodeUrl = "valid_url"
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         viewModel.hideQrCode()
 
@@ -465,7 +465,7 @@ class PollingViewModelTest {
         val viewModel = createPollingViewModel(
             qrCodeUrl = "valid_url",
             poller = fakePoller,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.shouldShowQrCode).isTrue()
         assertThat(fakePoller.pollingTurbine.awaitItem()).isTrue()
@@ -482,7 +482,7 @@ class PollingViewModelTest {
         val viewModel = createPollingViewModel(
             qrCodeUrl = "valid_url",
             poller = fakePoller,
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         assertThat(viewModel.uiState.value.shouldShowQrCode).isTrue()
 
@@ -495,31 +495,31 @@ class PollingViewModelTest {
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
         assertThat(viewModel.uiState.value.shouldShowQrCode).isFalse()
     }
-}
 
-private fun createPollingViewModel(
-    timeLimit: Duration = 5.minutes,
-    initialDelay: Duration = 5.seconds,
-    poller: IntentStatusPoller = FakeIntentStatusPoller(),
-    timeProvider: TimeProvider = FakeTimeProvider(),
-    savedStateHandle: SavedStateHandle = SavedStateHandle(),
-    qrCodeUrl: String? = null,
-    pollingAnalyticsEventReporter: FakePollingAnalyticsEventReporter = FakePollingAnalyticsEventReporter(),
-    paymentMethodType: String = "blik",
-): PollingViewModel {
-    return PollingViewModel(
-        args = PollingViewModel.Args(
-            clientSecret = "secret",
-            timeLimit = timeLimit,
-            initialDelay = initialDelay,
-            ctaText = R.string.stripe_blik_confirm_payment,
-            stripeAccountId = null,
-            qrCodeUrl = qrCodeUrl,
-            paymentMethodType = paymentMethodType,
-        ),
-        poller = poller,
-        timeProvider = timeProvider,
-        savedStateHandle = savedStateHandle,
-        pollingAnalyticsEventReporter = pollingAnalyticsEventReporter,
-    )
+    private fun createPollingViewModel(
+        timeLimit: Duration = 5.minutes,
+        initialDelay: Duration = 5.seconds,
+        poller: IntentStatusPoller = FakeIntentStatusPoller(),
+        timeProvider: TimeProvider = FakeTimeProvider(),
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        qrCodeUrl: String? = null,
+        pollingAnalyticsEventReporter: FakePollingAnalyticsEventReporter = FakePollingAnalyticsEventReporter(),
+        paymentMethodType: String = "blik",
+    ): PollingViewModel {
+        return PollingViewModel(
+            args = PollingViewModel.Args(
+                clientSecret = "secret",
+                timeLimit = timeLimit,
+                initialDelay = initialDelay,
+                ctaText = R.string.stripe_blik_confirm_payment,
+                stripeAccountId = null,
+                qrCodeUrl = qrCodeUrl,
+                paymentMethodType = paymentMethodType,
+            ),
+            poller = poller,
+            timeProvider = timeProvider,
+            savedStateHandle = savedStateHandle,
+            pollingAnalyticsEventReporter = pollingAnalyticsEventReporter,
+        ).also { viewModelStoreRule.track(it) }
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.ButtonThemes.LinkButtonTheme
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -46,6 +47,7 @@ import com.stripe.android.utils.AnalyticEventCallbackRule
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -63,6 +65,9 @@ class DefaultWalletButtonsInteractorTest {
 
     @get:Rule
     val analyticsEventCallbackRule = AnalyticEventCallbackRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `on init with no arguments, state should be empty`() = runTest {
@@ -948,7 +953,7 @@ class DefaultWalletButtonsInteractorTest {
         return DefaultWalletButtonsInteractor(
             arguments = stateFlowOf(arguments),
             confirmationHandler = confirmationHandler,
-            coroutineScope = CoroutineScope(testDispatcher),
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(testDispatcher)),
             errorReporter = errorReporter,
             eventReporter = eventReporter,
             linkInlineInteractor = NoOpLinkInlineInteractor(),


### PR DESCRIPTION
# Summary
Cancels/clears `CoroutineScope`s and `ViewModel`s created directly in unit tests so they don't leak across tests. Extracted from `jaynewstrom/cleanup-coroutines-in-tests` **without** the new `TestResourceCleanup` lint rule or any lint wiring — those remain on that branch to be reviewed/landed separately.

Key changes:
- Move `CleanupTestRule` from `paymentsheet/src/test` → `payments-core-testing/src/main` and make it public so it can be shared across modules.
- Add the `payments-core-testing` test dependency to `identity`.
- Track test-created `CoroutineScope`s / `ViewModel`s via `CleanupTestRule` / `ViewModelStoreTestRule` so they're cancelled/cleared after each test.

# Motivation
Tests that construct their own `CoroutineScope` (or `ViewModel`) without cancelling it leak launched coroutines/threads between tests, which can cause flakiness and cross-test interference. This ensures those resources are torn down deterministically.

This PR intentionally leaves out the lint enforcement so the mechanical cleanup can be reviewed on its own:
- `build-configuration/lint.gradle` enforcement wiring
- `lint` module: `TestResourceCleanupDetector` (+ test), `StripeIssueRegistry` registration, `ComposeCleanupRuleUsageDetector` (+ test)
- The `FakeBaseSheetViewModel` `@Suppress("TestResourceCleanup")` annotation

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Test-only change (plus the `CleanupTestRule` move and an `identity` test dependency). No production code is affected.

# Screenshots
N/A

# Changelog
N/A — test-only change, no user-facing impact.