### PR TITLE
Separate setup intent confirmation from payment method selection step

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -251,7 +251,6 @@ public final class com/stripe/android/link/LinkController$Configuration {
 	public final fun allowLogout (Z)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun email (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun phoneNumber (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
-	public final fun setupIntentClientSecret (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun supportedPaymentMethodTypes (Ljava/util/List;)Lcom/stripe/android/link/LinkController$Configuration;
 }
 
@@ -335,7 +334,7 @@ public final class com/stripe/android/link/LinkController$PresentResult$Failed :
 
 public final class com/stripe/android/link/LinkController$Presenter {
 	public static final field $stable I
-	public final fun createPaymentMethodAndConfirmSetupIntent ()V
+	public final fun confirmSetupIntent (Ljava/lang/String;)V
 	public final fun present ()V
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -21,13 +21,8 @@ internal class DefaultLinkConfigurationLoader @Inject constructor(
     private val tag = "LinkConfigurationLoader"
 
     override suspend fun load(configuration: LinkController.Configuration.State): Result<LinkMetadata> {
-        val initializationMode = if (configuration.setupIntentClientSecret != null) {
-            PaymentElementLoader.InitializationMode.SetupIntent(configuration.setupIntentClientSecret)
-        } else {
-            PaymentElementLoader.InitializationMode.CryptoOnramp
-        }
         return paymentElementLoader.load(
-            initializationMode = initializationMode,
+            initializationMode = PaymentElementLoader.InitializationMode.CryptoOnramp,
             integrationConfiguration = PaymentElementLoader.Configuration.CryptoOnramp(configuration),
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = savedStateHandle.contains(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -226,7 +226,6 @@ class LinkController @Inject internal constructor(
             ConfigurationDefaults.billingDetailsCollectionConfiguration
         private var allowUserEmailEdits: Boolean = true
         private var allowLogout: Boolean = true
-        private var setupIntentClientSecret: String? = null
 
         constructor(
             publishableKey: String,
@@ -283,11 +282,6 @@ class LinkController @Inject internal constructor(
 
         fun allowLogout(allowLogout: Boolean) = apply { this.allowLogout = allowLogout }
 
-        @LinkControllerPreview
-        fun setupIntentClientSecret(setupIntentClientSecret: String?) = apply {
-            this.setupIntentClientSecret = setupIntentClientSecret
-        }
-
         @Parcelize
         @Poko
         internal class State(
@@ -303,7 +297,6 @@ class LinkController @Inject internal constructor(
             internal val email: String?,
             internal val phoneNumber: String?,
             internal val supportedPaymentMethodTypes: List<PaymentMethodType>?,
-            internal val setupIntentClientSecret: String? = null,
         ) : Parcelable
 
         internal fun build(): State = State(
@@ -319,7 +312,6 @@ class LinkController @Inject internal constructor(
             allowUserEmailEdits = allowUserEmailEdits,
             allowLogout = allowLogout,
             linkAppearance = appearance?.build(),
-            setupIntentClientSecret = setupIntentClientSecret,
         )
 
         internal companion object {
@@ -411,19 +403,19 @@ class LinkController @Inject internal constructor(
         }
 
         /**
-         * Creates a payment method from the currently selected Link payment method and confirms
-         * the SetupIntent configured via [Configuration.setupIntentClientSecret].
+         * Confirm a SetupIntent using the payment method from the most recent successful [present] call.
          *
-         * This combines payment method creation with SetupIntent confirmation in a single operation.
-         * Requires that [Configuration.setupIntentClientSecret] was provided during configuration
-         * and a payment method was selected via [presentPaymentMethods].
+         * This uses the payment method already created during the [present] flow to confirm the
+         * provided SetupIntent. Requires that [present] has completed successfully first; otherwise
+         * the result is [ConfirmSetupIntentResult.Failed].
          *
          * The result will be communicated through the [ConfirmSetupIntentCallback] provided
-         * during presenter creation. If [Configuration.setupIntentClientSecret] was not provided,
-         * the callback will receive [ConfirmSetupIntentResult.Failed].
+         * during presenter creation.
+         *
+         * @param clientSecret The client secret of the SetupIntent to confirm.
          */
-        fun createPaymentMethodAndConfirmSetupIntent() {
-            coordinator.createPaymentMethodAndConfirmSetupIntent()
+        fun confirmSetupIntent(clientSecret: String) {
+            coordinator.confirmSetupIntent(clientSecret)
         }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -793,7 +785,7 @@ class LinkController @Inject internal constructor(
     }
 
     /**
-     * Callback for receiving results from [Presenter.createPaymentMethodAndConfirmSetupIntent].
+     * Callback for receiving results from [Presenter.confirmSetupIntent].
      */
     @LinkControllerPreview
     fun interface ConfirmSetupIntentCallback {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
@@ -84,33 +84,23 @@ internal class LinkControllerCoordinator @Inject constructor(
         )
     }
 
-    fun createPaymentMethodAndConfirmSetupIntent() {
+    fun confirmSetupIntent(clientSecret: String) {
         lifecycleOwner.lifecycleScope.launch {
-            val setupIntentClientSecret = interactor.setupIntentClientSecret
-            if (setupIntentClientSecret == null) {
+            val paymentMethod = interactor.lastCreatedPaymentMethod
+            if (paymentMethod?.id == null) {
                 interactor.emitConfirmSetupIntentResult(
                     LinkController.ConfirmSetupIntentResult.Failed(
-                        IllegalStateException("No setupIntentClientSecret in Configuration")
+                        IllegalStateException("No payment method available. Call present() first.")
                     )
                 )
                 return@launch
             }
 
-            val pmResult = interactor.performCreatePaymentMethodForConfirmation()
-            pmResult.fold(
-                onSuccess = { paymentMethod ->
-                    paymentLauncher.confirm(
-                        ConfirmSetupIntentParams.create(
-                            paymentMethodId = paymentMethod.id,
-                            clientSecret = setupIntentClientSecret,
-                        )
-                    )
-                },
-                onFailure = { error ->
-                    interactor.emitConfirmSetupIntentResult(
-                        LinkController.ConfirmSetupIntentResult.Failed(error)
-                    )
-                }
+            paymentLauncher.confirm(
+                ConfirmSetupIntentParams.create(
+                    paymentMethodId = paymentMethod.id,
+                    clientSecret = clientSecret,
+                )
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -118,7 +118,9 @@ internal class LinkControllerInteractor @Inject constructor(
     init {
         coroutineScope.launch {
             _presentSelectionSucceededFlow.collect {
-                val presentResult = performCreatePaymentMethod(apiKey = null).fold(
+                val pmResult = performCreatePaymentMethod(apiKey = null)
+                updateState { it.copy(createdPaymentMethod = pmResult.getOrNull()) }
+                val presentResult = pmResult.fold(
                     onSuccess = { pm -> LinkController.PresentResult.Completed(pm) },
                     onFailure = { error -> LinkController.PresentResult.Failed(error) }
                 )
@@ -137,8 +139,8 @@ internal class LinkControllerInteractor @Inject constructor(
         MutableSharedFlow<LinkController.ConfirmSetupIntentResult>(extraBufferCapacity = 1)
     val confirmSetupIntentResultFlow = _confirmSetupIntentResultFlow.asSharedFlow()
 
-    internal val setupIntentClientSecret: String?
-        get() = _state.value.setupIntentClientSecret
+    internal val lastCreatedPaymentMethod: PaymentMethod?
+        get() = _state.value.createdPaymentMethod
 
     val paymentMethodMetadata: PaymentMethodMetadata?
         get() = _state.value.paymentMethodMetadata
@@ -194,7 +196,6 @@ internal class LinkControllerInteractor @Inject constructor(
                         it.copy(
                             linkComponent = component,
                             paymentMethodMetadata = paymentMethodMetadata,
-                            setupIntentClientSecret = config.setupIntentClientSecret,
                         )
                     }
                     savedStateHandle[LINK_CONFIGURED_KEY] = true
@@ -590,12 +591,6 @@ internal class LinkControllerInteractor @Inject constructor(
         )
     }
 
-    internal suspend fun performCreatePaymentMethodForConfirmation(): Result<PaymentMethod> {
-        val result = performCreatePaymentMethod(apiKey = null)
-        updateState { it.copy(createdPaymentMethod = result.getOrNull()) }
-        return result
-    }
-
     internal fun onSetupIntentConfirmationResult(result: InternalPaymentResult) {
         val confirmResult = when (result) {
             is InternalPaymentResult.Completed -> {
@@ -794,7 +789,6 @@ internal class LinkControllerInteractor @Inject constructor(
     internal data class State(
         val linkComponent: LinkComponent? = null,
         val paymentMethodMetadata: PaymentMethodMetadata? = null,
-        val setupIntentClientSecret: String? = null,
         val emailInput: String? = null,
         val selectedPaymentMethod: LinkPaymentMethod? = null,
         val createdPaymentMethod: PaymentMethod? = null,

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -203,5 +204,17 @@ internal class LinkControllerCoordinatorTest {
         presentResultFlow.emit(result)
 
         assertThat(presentResults).containsExactly(result)
+    }
+
+    @Test
+    fun `confirmSetupIntent() emits Failed when no payment method is available`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.STARTED)
+        val coordinator = createCoordinator()
+
+        coordinator.confirmSetupIntent("seti_test_secret")
+
+        val captor = argumentCaptor<LinkController.ConfirmSetupIntentResult>()
+        verify(viewModel).emitConfirmSetupIntentResult(captor.capture())
+        assertThat(captor.firstValue).isInstanceOf(LinkController.ConfirmSetupIntentResult.Failed::class.java)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -1367,6 +1367,30 @@ class LinkControllerInteractorTest {
     }
 
     @Test
+    fun `onLinkActivityResult() with present flow Completed stores createdPaymentMethod in state`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+
+        interactor.presentFull(FakeActivityResultLauncher())
+
+        val expectedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        linkAccountManager.createPaymentMethodResult = Result.success(expectedPaymentMethod)
+
+        interactor.presentResultFlow.test {
+            interactor.onLinkActivityResult(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                    selectedPayment = createTestPaymentMethod(),
+                    shippingAddress = null,
+                )
+            )
+            awaitItem() // wait for PresentResult
+        }
+
+        assertThat(interactor.lastCreatedPaymentMethod).isEqualTo(expectedPaymentMethod)
+    }
+
+    @Test
     fun `onLinkActivityResult() with present flow Failed emits PresentResult Failed`() = runTest {
         val interactor = createInteractor()
         configure(interactor)


### PR DESCRIPTION
# Summary

Updates the LinkController's LinkControllerPreview API shape to separate the setup intent confirmation step from the payment method selection step. This is done by adding a new API confirmSetupIntent that can be called to confirm the last selected payment method.

```kt
/**
    * Confirm a SetupIntent using the payment method from the most recent successful [present] call.
    *
    * This uses the payment method already created during the [present] flow to confirm the
    * provided SetupIntent. Requires that [present] has completed successfully first; otherwise
    * the result is [ConfirmSetupIntentResult.Failed].
    *
    * The result will be communicated through the [ConfirmSetupIntentCallback] provided
    * during presenter creation.
    *
    * @param clientSecret The client secret of the SetupIntent to confirm.
    */
fun confirmSetupIntent(clientSecret: String)
```

# Motivation

[Fixes some payments related errors.](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-214)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified


