### PR TITLE
Standalone Link Controller logout fix

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ComposeExtensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ComposeExtensions.kt
@@ -14,11 +14,12 @@ import com.stripe.android.uicore.utils.extractActivity
  */
 @Composable
 internal inline fun <reified T : ViewModel> linkViewModel(
+    key: String? = null,
     factory: (NativeLinkComponent) -> ViewModelProvider.Factory
 ): T {
     val component = parentActivity().viewModel?.activityRetainedComponent
         ?: throw IllegalStateException("no viewmodel in parent activity")
-    return viewModel<T>(factory = factory(component))
+    return viewModel<T>(key = key, factory = factory(component))
 }
 
 /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -45,7 +45,6 @@ import com.stripe.android.uicore.navigation.NavBackStackEntryUpdate
 import com.stripe.android.uicore.navigation.NavigationManager
 import com.stripe.android.uicore.navigation.PopUpToBehavior
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -54,7 +53,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -169,7 +167,7 @@ internal class LinkActivityViewModel @Inject constructor(
     @OptIn(DelicateCoroutinesApi::class)
     private fun handleLogoutClicked() {
         val shouldDismiss = when (val mode = linkLaunchMode) {
-            is LinkLaunchMode.PaymentMethodSelection -> mode.shouldShowSecondaryCta
+            is LinkLaunchMode.PaymentMethodSelection -> mode.canContinueWithoutLink
             else -> true
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -166,15 +166,18 @@ internal class LinkActivityViewModel @Inject constructor(
 
     @OptIn(DelicateCoroutinesApi::class)
     private fun handleLogoutClicked() {
-        val shouldDismiss = when (val mode = linkLaunchMode) {
-            is LinkLaunchMode.PaymentMethodSelection -> mode.canContinueWithoutLink
-            else -> true
+        val shouldDismiss = when (linkLaunchMode) {
+            is LinkLaunchMode.Authentication,
+            is LinkLaunchMode.Authorization,
+            is LinkLaunchMode.Confirmation,
+            LinkLaunchMode.Full -> true
+            is LinkLaunchMode.PaymentMethodSelection -> linkLaunchMode.canContinueWithoutLink
         }
 
+        GlobalScope.launch {
+            linkAccountManager.logOut()
+        }
         if (shouldDismiss) {
-            GlobalScope.launch {
-                linkAccountManager.logOut()
-            }
             dismissWithResult(
                 LinkActivityResult.Canceled(
                     reason = LinkActivityResult.Canceled.Reason.LoggedOut,
@@ -185,9 +188,8 @@ internal class LinkActivityViewModel @Inject constructor(
             savedStateHandle[SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO] = false
             navigate(LinkScreen.SignUp, clearStack = true)
             viewModelScope.launch {
-                linkAccountManager.logOut()
-            }
-            viewModelScope.launch {
+                // Wait for the Wallet exit animation to finish. Clearing earlier triggers NoLinkAccountFoundException
+                // from the Wallet composable's null-check while it's still in composition.
                 delay(LINK_DEFAULT_ANIMATION_DELAY_MILLIS)
                 linkAccountHolder.set(LinkAccountUpdate.Value(null, LoggedOut))
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -45,6 +45,7 @@ import com.stripe.android.uicore.navigation.NavBackStackEntryUpdate
 import com.stripe.android.uicore.navigation.NavigationManager
 import com.stripe.android.uicore.navigation.PopUpToBehavior
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -167,16 +168,32 @@ internal class LinkActivityViewModel @Inject constructor(
 
     @OptIn(DelicateCoroutinesApi::class)
     private fun handleLogoutClicked() {
-        GlobalScope.launch {
-            linkAccountManager.logOut()
+        val shouldDismiss = when (val mode = linkLaunchMode) {
+            is LinkLaunchMode.PaymentMethodSelection -> mode.shouldShowSecondaryCta
+            else -> true
         }
 
-        dismissWithResult(
-            LinkActivityResult.Canceled(
-                reason = LinkActivityResult.Canceled.Reason.LoggedOut,
-                linkAccountUpdate = LinkAccountUpdate.Value(null, LoggedOut)
+        if (shouldDismiss) {
+            GlobalScope.launch {
+                linkAccountManager.logOut()
+            }
+            dismissWithResult(
+                LinkActivityResult.Canceled(
+                    reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                    linkAccountUpdate = LinkAccountUpdate.Value(null, LoggedOut)
+                )
             )
-        )
+        } else {
+            savedStateHandle[SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO] = false
+            navigate(LinkScreen.SignUp, clearStack = true)
+            viewModelScope.launch {
+                linkAccountManager.logOut()
+            }
+            viewModelScope.launch {
+                delay(LINK_DEFAULT_ANIMATION_DELAY_MILLIS)
+                linkAccountHolder.set(LinkAccountUpdate.Value(null, LoggedOut))
+            }
+        }
     }
 
     fun onNavEntryChanged(entry: NavBackStackEntryUpdate) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -229,7 +229,7 @@ internal class LinkControllerInteractor @Inject constructor(
                     selectedPayment = state.selectedPaymentMethod?.details,
                     paymentMethodFilters = paymentMethodTypes?.toFilters(),
                     sharePaymentDetailsImmediatelyAfterCreation = false,
-                    shouldShowSecondaryCta = false,
+                    canContinueWithoutLink = false,
                 )
             }
         )
@@ -261,7 +261,7 @@ internal class LinkControllerInteractor @Inject constructor(
                     selectedPayment = state.selectedPaymentMethod?.details,
                     paymentMethodFilters = config.supportedPaymentMethodTypes?.toFilters(),
                     sharePaymentDetailsImmediatelyAfterCreation = false,
-                    shouldShowSecondaryCta = false,
+                    canContinueWithoutLink = false,
                 )
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -28,7 +28,7 @@ internal sealed interface LinkLaunchMode : Parcelable {
         /**
          * Whether or not a secondary CTA to pay another way should be shown.
          */
-        val shouldShowSecondaryCta: Boolean = true,
+        val canContinueWithoutLink: Boolean = true,
     ) : LinkLaunchMode
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationBody.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationBody.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link.ui.verification
 
 import android.content.Context
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationBody.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationBody.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.ui.verification
 
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -34,7 +34,7 @@ internal fun VerificationDialog(
     onDismissClicked: () -> Unit,
     dismissWithResult: (LinkActivityResult) -> Unit
 ) {
-    val viewModel = linkViewModel<VerificationViewModel> { parentComponent ->
+    val viewModel = linkViewModel<VerificationViewModel>(key = linkAccount.clientSecret) { parentComponent ->
         VerificationViewModel.factory(
             parentComponent = parentComponent,
             linkAccount = linkAccount,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -659,7 +659,7 @@ private fun StripeIntent.secondaryButtonLabel(linkLaunchMode: LinkLaunchMode): R
             is SetupIntent -> R.string.stripe_wallet_continue_another_way.resolvableString
         }
         is LinkLaunchMode.PaymentMethodSelection -> {
-            if (linkLaunchMode.shouldShowSecondaryCta) {
+            if (linkLaunchMode.canContinueWithoutLink) {
                 R.string.stripe_wallet_continue_another_way.resolvableString
             } else {
                 null

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -731,7 +731,7 @@ internal class LinkActivityViewModelTest {
             linkAccountManager = linkAccountManager,
             linkLaunchMode = LinkLaunchMode.PaymentMethodSelection(
                 selectedPayment = null,
-                shouldShowSecondaryCta = true,
+                canContinueWithoutLink = true,
             ),
         )
 
@@ -761,7 +761,7 @@ internal class LinkActivityViewModelTest {
             linkAccountHolder = linkAccountHolder,
             linkLaunchMode = LinkLaunchMode.PaymentMethodSelection(
                 selectedPayment = null,
-                shouldShowSecondaryCta = false,
+                canContinueWithoutLink = false,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -725,6 +725,68 @@ internal class LinkActivityViewModelTest {
     }
 
     @Test
+    fun `logout action should dismiss when shouldShowSecondaryCta is true`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val viewModel = createViewModel(
+            linkAccountManager = linkAccountManager,
+            linkLaunchMode = LinkLaunchMode.PaymentMethodSelection(
+                selectedPayment = null,
+                shouldShowSecondaryCta = true,
+            ),
+        )
+
+        viewModel.result.test {
+            viewModel.handleViewAction(LinkAction.LogoutClicked)
+
+            linkAccountManager.awaitLogoutCall()
+            assertThat(awaitItem()).isEqualTo(
+                LinkActivityResult.Canceled(
+                    reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                    linkAccountUpdate = LinkAccountUpdate.Value(null, LoggedOut)
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `logout action should navigate to signup when shouldShowSecondaryCta is false`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val navigationManager = TestNavigationManager()
+        val savedStateHandle = SavedStateHandle()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val viewModel = createViewModel(
+            linkAccountManager = linkAccountManager,
+            navigationManager = navigationManager,
+            savedStateHandle = savedStateHandle,
+            linkAccountHolder = linkAccountHolder,
+            linkLaunchMode = LinkLaunchMode.PaymentMethodSelection(
+                selectedPayment = null,
+                shouldShowSecondaryCta = false,
+            ),
+        )
+
+        viewModel.result.test {
+            viewModel.handleViewAction(LinkAction.LogoutClicked)
+
+            linkAccountManager.awaitLogoutCall()
+            expectNoEvents()
+        }
+
+        assertThat(savedStateHandle.get<Boolean>(SignUpViewModel.USE_LINK_CONFIGURATION_CUSTOMER_INFO)).isFalse()
+
+        navigationManager.assertNavigatedTo(
+            route = LinkScreen.SignUp.route,
+            popUpTo = PopUpToBehavior.Start,
+        )
+
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertThat(linkAccountHolder.linkAccountInfo.value).isEqualTo(
+            LinkAccountUpdate.Value(null, LoggedOut)
+        )
+    }
+
+    @Test
     fun `change email should navigate to email route and update savedStateHandle`() {
         val navigationManager = TestNavigationManager()
         val savedStateHandle = SavedStateHandle()

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -725,7 +725,7 @@ internal class LinkActivityViewModelTest {
     }
 
     @Test
-    fun `logout action should dismiss when shouldShowSecondaryCta is true`() = runTest {
+    fun `logout action should dismiss when canContinueWithoutLink is true`() = runTest {
         val linkAccountManager = FakeLinkAccountManager()
         val viewModel = createViewModel(
             linkAccountManager = linkAccountManager,
@@ -749,7 +749,7 @@ internal class LinkActivityViewModelTest {
     }
 
     @Test
-    fun `logout action should navigate to signup when shouldShowSecondaryCta is false`() = runTest {
+    fun `logout action should navigate to signup when canContinueWithoutLink is false`() = runTest {
         val linkAccountManager = FakeLinkAccountManager()
         val navigationManager = TestNavigationManager()
         val savedStateHandle = SavedStateHandle()

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -474,7 +474,7 @@ class LinkControllerInteractorTest {
                 LinkLaunchMode.PaymentMethodSelection(
                     selectedPayment = null,
                     sharePaymentDetailsImmediatelyAfterCreation = false,
-                    shouldShowSecondaryCta = false,
+                    canContinueWithoutLink = false,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -981,11 +981,11 @@ class WalletViewModelTest {
     fun `secondaryButtonLabel is present based on shouldShowSecondaryCta`() = runTest(dispatcher) {
         val launchMode = LinkLaunchMode.PaymentMethodSelection(
             selectedPayment = null,
-            shouldShowSecondaryCta = true
+            canContinueWithoutLink = true
         )
         listOf(
             launchMode to resolvableString(R.string.stripe_wallet_continue_another_way),
-            launchMode.copy(shouldShowSecondaryCta = false) to null,
+            launchMode.copy(canContinueWithoutLink = false) to null,
         ).forEach { (mode, expected) ->
             assertThat(createViewModel(linkLaunchMode = mode).uiState.value.secondaryButtonLabel)
                 .isEqualTo(expected)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Updates Link Standalone logout behavior of returning to the login screen rather than dismissing the flow entirely. When the Link wallet is presented via MPE, logging out returns back to MPE, but in this integration there is no MPE to return to. This fixes that.

This integration is captured by `PaymentMethodSelection.shouldShowSecondaryCta == false`, but that name wasn't really accurate. I renamed it to `canContinueWithoutLink`. Also added a key to `linkViewModel` so ViewModels can be instantiated when key changes.


# Motivation
https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-212


# Testing
Before:
<video src="https://github.com/user-attachments/assets/b4055a39-32ba-456f-bf26-8fa57615811e"/>

After:
<video src="https://github.com/user-attachments/assets/4350c65a-e192-497f-b79c-d02db16c9514"/>

MPE (unchanged):
<video src="https://github.com/user-attachments/assets/77496d4d-ac07-49fc-932a-6e8b2884f1e9"/>
# Changelog
n/a