### PR TITLE
Filter tax-insufficient saved payment methods (MOBILESDK-4697)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/validation/BillingDetailsValidation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/validation/BillingDetailsValidation.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.common.validation
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.ui.core.elements.automaticTaxRequiredFields
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+/**
+ * Does this saved payment method's billing address have what Stripe Tax needs to compute
+ * automatic tax for its country? See automaticTaxRequiredFields for the per-country field set.
+ */
+internal fun PaymentMethod.hasSufficientBillingDetailsForAutomaticTax(): Boolean {
+    val address = billingDetails?.address ?: return false
+    // Saved-PM billing details come from the API and are not guaranteed uppercase, unlike the
+    // CountryConfig-sourced value the CardBillingAddressElement form passes. Uppercase before the
+    // map lookup; do not "simplify" this away.
+    val country = address.country?.uppercase()
+    if (country.isNullOrBlank()) return false
+
+    return automaticTaxRequiredFields(country).all { field ->
+        when (field) {
+            IdentifierSpec.Line1 -> !address.line1.isNullOrBlank()
+            IdentifierSpec.City -> !address.city.isNullOrBlank()
+            IdentifierSpec.State -> !address.state.isNullOrBlank()
+            IdentifierSpec.PostalCode -> !address.postalCode.isNullOrBlank()
+            // additionalAutomaticTaxFieldsByCountry only emits the four specs above today. If that
+            // map ever adds another (e.g. Line2), add its case here — else it silently over-filters.
+            else -> false
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/validation/BillingDetailsValidation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/validation/BillingDetailsValidation.kt
@@ -11,7 +11,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal fun PaymentMethod.hasSufficientBillingDetailsForAutomaticTax(): Boolean {
     val address = billingDetails?.address ?: return false
     // Saved-PM billing details come from the API and are not guaranteed uppercase, unlike the
-    // CountryConfig-sourced value the CardBillingAddressElement form passes. Uppercase before the
+    // CountryConfig-sourced value the billing-address form passes. Uppercase before the
     // map lookup; do not "simplify" this away.
     val country = address.country?.uppercase()
     if (country.isNullOrBlank()) return false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -70,6 +70,7 @@ internal class CreateCustomerState @Inject constructor(
                         cardFundingFilter = metadata.cardFundingFilter,
                         remoteDefaultPaymentMethodId = state.defaultPaymentMethodId,
                         localSavedSelection = savedSelection,
+                        requiresBillingAddressForAutomaticTax = metadata.requiresBillingAddressForAutomaticTax,
                     )
                 )
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.common.validation.hasSufficientBillingDetailsForAutomaticTax
 import com.stripe.android.common.validation.isSupportedWithBillingConfig
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
@@ -26,6 +27,7 @@ internal interface PaymentMethodFilter {
         val cardBrandFilter: CardBrandFilter,
         val cardFundingFilter: CardFundingFilter,
         val localSavedSelection: Deferred<SavedSelection>,
+        val requiresBillingAddressForAutomaticTax: Boolean,
     )
 }
 
@@ -45,7 +47,11 @@ internal class DefaultPaymentMethodFilter @Inject constructor() : PaymentMethodF
             } ?: true
             params.cardBrandFilter.isAccepted(paymentMethod) &&
                 fundingAccepted &&
-                paymentMethod.isSupportedWithBillingConfig(params.billingDetailsCollectionConfiguration)
+                paymentMethod.isSupportedWithBillingConfig(params.billingDetailsCollectionConfiguration) &&
+                (
+                    !params.requiresBillingAddressForAutomaticTax ||
+                        paymentMethod.hasSufficientBillingDetailsForAutomaticTax()
+                    )
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
@@ -48,6 +48,9 @@ internal class DefaultPaymentMethodFilter @Inject constructor() : PaymentMethodF
             params.cardBrandFilter.isAccepted(paymentMethod) &&
                 fundingAccepted &&
                 paymentMethod.isSupportedWithBillingConfig(params.billingDetailsCollectionConfiguration) &&
+                // Intentionally applies to every saved PM type, not just cards: pay-server's
+                // confirm-time tax guard (finalize_payment_taxes) is not payment-method-type gated,
+                // so any SPM whose billing address can't resolve a tax location 400s at confirm.
                 (
                     !params.requiresBillingAddressForAutomaticTax ||
                         paymentMethod.hasSufficientBillingDetailsForAutomaticTax()

--- a/paymentsheet/src/test/java/com/stripe/android/common/validation/BillingDetailsValidationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/validation/BillingDetailsValidationTest.kt
@@ -1,0 +1,72 @@
+package com.stripe.android.common.validation
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.testing.PaymentMethodFactory
+import kotlin.test.Test
+
+class BillingDetailsValidationTest {
+
+    private fun card(
+        line1: String? = "123 Main St",
+        city: String? = "San Francisco",
+        state: String? = "CA",
+        postalCode: String? = "94111",
+        country: String? = "US",
+        hasAddress: Boolean = true,
+    ): PaymentMethod = PaymentMethodFactory.card(id = "pm_test").copy(
+        billingDetails = PaymentMethod.BillingDetails(
+            address = if (hasAddress) {
+                Address(
+                    line1 = line1,
+                    city = city,
+                    state = state,
+                    postalCode = postalCode,
+                    country = country,
+                )
+            } else {
+                null
+            },
+        ),
+    )
+
+    @Test
+    fun `null address is insufficient`() {
+        assertThat(card(hasAddress = false).hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+    }
+
+    @Test
+    fun `missing country is insufficient`() {
+        assertThat(card(country = null).hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+    }
+
+    @Test
+    fun `country with no additional tax requirement needs only the country`() {
+        val pm = card(country = "FR", line1 = null, city = null, state = null, postalCode = null)
+        assertThat(pm.hasSufficientBillingDetailsForAutomaticTax()).isTrue()
+    }
+
+    @Test
+    fun `CA GB IN require postal code only`() {
+        assertThat(card(country = "CA", postalCode = null).hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+        assertThat(card(country = "CA", postalCode = "K1A0B1").hasSufficientBillingDetailsForAutomaticTax()).isTrue()
+        assertThat(card(country = "GB", postalCode = null).hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+        assertThat(card(country = "IN", postalCode = null).hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+    }
+
+    @Test
+    fun `PR requires line1, city, and postal code but not state`() {
+        val missingCity = card(country = "PR", city = null)
+        assertThat(missingCity.hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+
+        val completeWithoutState = card(country = "PR", state = null)
+        assertThat(completeWithoutState.hasSufficientBillingDetailsForAutomaticTax()).isTrue()
+    }
+
+    @Test
+    fun `US requires line1, city, state, and postal code`() {
+        assertThat(card(country = "US", state = null).hasSufficientBillingDetailsForAutomaticTax()).isFalse()
+        assertThat(card(country = "US").hasSufficientBillingDetailsForAutomaticTax()).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
@@ -192,6 +192,34 @@ internal class CreateCustomerStateTest {
 
             val filterCall = filterCalls.awaitItem()
             assertThat(filterCall.paymentMethods).isEqualTo(cards)
+            // Default metadata does not require a billing address for automatic tax.
+            assertThat(filterCall.params.requiresBillingAddressForAutomaticTax).isFalse()
+        }
+    }
+
+    @Test
+    fun `Threads requiresBillingAddressForAutomaticTax into the filter params`() = runScenario {
+        val cards = PaymentMethodFactory.cards(3)
+
+        FakePaymentMethodFilter.test(filteredPaymentMethods = cards) {
+            createCustomerState(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                elementsSession = DEFAULT_ELEMENTS_SESSION.copy(
+                    customer = createElementsSessionCustomer(paymentMethods = cards),
+                ),
+                metadata = PaymentMethodMetadataFactory.create(
+                    checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                        automaticTaxEnabled = true,
+                        taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                    ),
+                )
+                    .copy(customerMetadata = CUSTOMER_SESSION_METADATA),
+                savedSelection = CompletableDeferred(SavedSelection.None),
+                paymentMethodFilter = paymentMethodFilter,
+            )
+
+            val filterCall = filterCalls.awaitItem()
+            assertThat(filterCall.params.requiresBillingAddressForAutomaticTax).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
@@ -190,6 +190,86 @@ class DefaultPaymentMethodFilterTest {
         assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
     }
 
+    private fun usCard(id: String, state: String?): PaymentMethod = PaymentMethodFactory.card(id = id).update(
+        last4 = "1000",
+        addCbcNetworks = false,
+        brand = CardBrand.Visa,
+    ).copy(
+        billingDetails = PaymentMethod.BillingDetails(
+            address = Address(
+                line1 = "123 Main St",
+                city = "San Francisco",
+                state = state,
+                postalCode = "94111",
+                country = "US",
+            ),
+        ),
+    )
+
+    @Test
+    fun `Drops SPM lacking automatic-tax-required fields when automatic tax requires a billing address`() = runTest {
+        val complete = usCard(id = "pm_complete", state = "CA")
+        val incomplete = usCard(id = "pm_incomplete", state = null)
+
+        val observed = filter(
+            paymentMethods = listOf(complete, incomplete),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(observed).containsExactly(complete)
+    }
+
+    @Test
+    fun `Does not filter by automatic-tax fields when automatic tax does not require a billing address`() = runTest {
+        val complete = usCard(id = "pm_complete", state = "CA")
+        val incomplete = usCard(id = "pm_incomplete", state = null)
+
+        val observed = filter(
+            paymentMethods = listOf(complete, incomplete),
+            requiresBillingAddressForAutomaticTax = false,
+        )
+
+        assertThat(observed).containsExactly(complete, incomplete)
+    }
+
+    @Test
+    fun `Keeps a country-only-sufficient SPM when automatic tax requires a billing address`() = runTest {
+        // FR has no additional automatic-tax fields, so country alone is sufficient. Proves the
+        // clause does not over-drop valid cards.
+        val frCard = PaymentMethodFactory.card(id = "pm_fr").update(
+            last4 = "1000",
+            addCbcNetworks = false,
+            brand = CardBrand.Visa,
+        ).copy(
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(country = "FR"),
+            ),
+        )
+
+        val observed = filter(
+            paymentMethods = listOf(frCard),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(observed).containsExactly(frCard)
+    }
+
+    @Test
+    fun `Drops SPM with null billing address when automatic tax requires a billing address`() = runTest {
+        val noAddress = PaymentMethodFactory.card(id = "pm_no_addr").update(
+            last4 = "1000",
+            addCbcNetworks = false,
+            brand = CardBrand.Visa,
+        ).copy(billingDetails = PaymentMethod.BillingDetails(address = null))
+
+        val observed = filter(
+            paymentMethods = listOf(noAddress),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(observed).isEmpty()
+    }
+
     private suspend fun filter(
         paymentMethods: List<PaymentMethod>,
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
@@ -197,6 +277,7 @@ class DefaultPaymentMethodFilterTest {
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
         remoteDefaultPaymentMethodId: String? = null,
         localSavedSelection: SavedSelection = SavedSelection.None,
+        requiresBillingAddressForAutomaticTax: Boolean = false,
         cardBrandFilter: PaymentSheetCardBrandFilter = PaymentSheetCardBrandFilter(
             cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.all(),
         ),
@@ -222,6 +303,7 @@ class DefaultPaymentMethodFilterTest {
                 localSavedSelection = CompletableDeferred(localSavedSelection),
                 cardBrandFilter = cardBrandFilter,
                 cardFundingFilter = cardFundingFilter,
+                requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
@@ -270,6 +270,62 @@ class DefaultPaymentMethodFilterTest {
         assertThat(observed).isEmpty()
     }
 
+    @Test
+    fun `Applies automatic-tax filter to non-card SPMs too`() = runTest {
+        // pay-server's confirm-time tax guard is not payment-method-type gated, so a bank-account
+        // SPM with an insufficient tax address 400s at confirm just like a card; the filter must
+        // drop it as well. Guards against a future card-only regression.
+        val completeBank = PaymentMethodFactory.usBankAccount().copy(
+            id = "pm_bank_complete",
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(
+                    line1 = "1 Market St",
+                    city = "San Francisco",
+                    state = "CA",
+                    postalCode = "94111",
+                    country = "US",
+                ),
+            ),
+        )
+        val incompleteBank = PaymentMethodFactory.usBankAccount().copy(
+            id = "pm_bank_incomplete",
+            billingDetails = PaymentMethod.BillingDetails(
+                // Missing line1 and state for a US address.
+                address = Address(city = "San Francisco", postalCode = "94111", country = "US"),
+            ),
+        )
+
+        val observed = filter(
+            paymentMethods = listOf(completeBank, incompleteBank),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(observed).containsExactly(completeBank)
+    }
+
+    @Test
+    fun `Applies per-country automatic-tax fields at the filter boundary`() = runTest {
+        // CA requires only a postal code (not the US line1/city/state set), proving the per-country
+        // lookup is consulted at the filter boundary rather than hardcoding US behavior.
+        val caComplete = PaymentMethodFactory.card(id = "pm_ca_complete").update(
+            last4 = "1000",
+            addCbcNetworks = false,
+            brand = CardBrand.Visa,
+        ).copy(billingDetails = PaymentMethod.BillingDetails(address = Address(postalCode = "K1A0B1", country = "CA")))
+        val caMissingPostal = PaymentMethodFactory.card(id = "pm_ca_missing").update(
+            last4 = "1000",
+            addCbcNetworks = false,
+            brand = CardBrand.Visa,
+        ).copy(billingDetails = PaymentMethod.BillingDetails(address = Address(country = "CA")))
+
+        val observed = filter(
+            paymentMethods = listOf(caComplete, caMissingPostal),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(observed).containsExactly(caComplete)
+    }
+
     private suspend fun filter(
         paymentMethods: List<PaymentMethod>,
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =


### PR DESCRIPTION
# Summary
On the Checkout Session path, when automatic tax uses billing as its tax address source, filter out saved payment methods whose billing address lacks the country-specific fields Stripe Tax needs. This prevents offering a saved payment method that would hard-fail at confirm.

This PR is stacked after the new-payment-method work in #13713 and #13718. It reuses the shared country requirements from #13717 without mixing saved-payment-method behavior into MOBILESDK-4667.

# Motivation
Verified against pay-server: `FinalizePaymentTaxes` recomputes tax from the selected payment method billing address at confirm and raises `checkout_automatic_tax_confirmation_failure` (subscription mode: `billing_automatic_tax_unrecognized_customer_location`), HTTP 400, on any non-`complete` tax status. There is no silent zero-tax path. That confirm guard is not payment-method-type gated, so the filter intentionally applies to all saved-payment-method types.

Email does not need client-side sufficiency validation; the backend handles it. This change validates only the billing address required to compute tax for the payment method country.

Implementation:
- Add `PaymentMethod.hasSufficientBillingDetailsForAutomaticTax()` using the shared country requirements from #13717.
- Consult it in `DefaultPaymentMethodFilter` for every saved payment-method type.
- Thread the Checkout Session-only requirement from `PaymentMethodMetadata` through `CustomerState` into `FilterParams`; other PaymentSheet integrations remain no-ops.

Saved-card billing-details editing remains separate and standalone in #13506.

JIRA: [MOBILESDK-4697](https://jira.corp.stripe.com/browse/MOBILESDK-4697). iOS sibling: MOBILESDK-4698.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Targeted unit tests passed:
- `BillingDetailsValidationTest`: country-specific address sufficiency.
- `DefaultPaymentMethodFilterTest`: gating, null/incomplete addresses, country boundaries, and non-card saved methods.
- `CreateCustomerStateTest`: propagation of the automatic-tax billing-address requirement.

The focused PaymentSheet unit-test set, `:paymentsheet:detekt`, and `:paymentsheet:apiCheck` passed.

# Screenshots
N/A - no new UI surface; this removes unusable saved payment methods from the list.

# Changelog
N/A - Checkout Session is behind `@CheckoutSessionPreview`; the implementation is internal/library-group restricted.
