### PR TITLE
Thread automatic-tax billing fields into saved-card edit flow (MOBILESDK-4696)

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -23,6 +23,7 @@
     <ID>LargeClass:CustomerSheetViewModel.kt:CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt:CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultConfirmationHandlerTest.kt:DefaultConfirmationHandlerTest</ID>
+    <ID>LargeClass:DefaultEditCardDetailsInteractorTest.kt:DefaultEditCardDetailsInteractorTest</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt:DefaultEventReporterTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt:DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentElementLoaderTest.kt:DefaultPaymentElementLoaderTest</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -601,6 +601,8 @@ internal class CustomerSheetViewModel(
                         )
                     },
                     autocompleteAddressInteractorFactory = null,
+                    // CustomerSheet has no automatic tax / checkout session concept.
+                    requiresBillingAddressForAutomaticTax = false,
                 ),
                 isLiveMode = isLiveMode,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
@@ -144,6 +144,7 @@ internal fun UpdateCardScreenBodyPreview() {
                     billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(),
                     requiresModification = true,
                     autocompleteAddressInteractorFactory = null,
+                    requiresBillingAddressForAutomaticTax = false,
                 ),
                 state = UpdateCardScreenState(
                     paymentDetailsId = "card_id_1234",

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -227,6 +227,8 @@ internal class UpdateCardScreenViewModel @Inject constructor(
             // already be complete on first render. The user can submit without modifying.
             requiresModification = state.value.isBillingDetailsUpdateFlow.not(),
             autocompleteAddressInteractorFactory = null,
+            // Link's update card flow has no Checkout Session automatic tax concept.
+            requiresBillingAddressForAutomaticTax = false,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -85,6 +85,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 embeddedNavigatorProvider.get().performAction(EmbeddedNavigator.Action.Back)
             },
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = paymentMethodMetadata.requiresBillingAddressForAutomaticTax,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -412,6 +412,8 @@ internal class SavedPaymentMethodMutator(
                                 ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
                             autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+                            requiresBillingAddressForAutomaticTax =
+                                paymentMethodMetadata?.requiresBillingAddressForAutomaticTax ?: false,
                         )
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -28,6 +28,7 @@ internal class BillingDetailsForm(
     private val collectPhone: Boolean,
     allowedBillingCountries: Set<String>,
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    requiresBillingAddressForAutomaticTax: Boolean,
 ) {
     val nameElement: SimpleTextElement? = if (nameCollection == NameCollection.OutsideBillingDetailsForm) {
         SimpleTextElement(
@@ -57,6 +58,7 @@ internal class BillingDetailsForm(
         rawValuesMap = rawAddressValues(billingDetails),
         autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         shouldHideCountryOnNoAddressCollection = false,
+        requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
     )
 
     val addressSectionElement = SectionElement.wrap(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -175,6 +175,7 @@ internal interface EditCardDetailsInteractor {
             onBrandChoiceChanged: CardBrandCallback,
             onCardUpdateParamsChanged: CardUpdateParamsCallback,
             autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+            requiresBillingAddressForAutomaticTax: Boolean,
         ): EditCardDetailsInteractor
     }
 }
@@ -191,6 +192,7 @@ internal class DefaultEditCardDetailsInteractor(
     private val onBrandChoiceChanged: CardBrandCallback,
     private val onCardUpdateParamsChanged: CardUpdateParamsCallback,
     private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    private val requiresBillingAddressForAutomaticTax: Boolean,
 ) : EditCardDetailsInteractor {
     private val cardDetailsEntry = MutableStateFlow(
         value = cardEditConfiguration?.buildDefaultCardEntry()
@@ -366,6 +368,7 @@ internal class DefaultEditCardDetailsInteractor(
             collectPhone = billingDetailsCollectionConfiguration.collectsPhone,
             allowedBillingCountries = billingDetailsCollectionConfiguration.allowedBillingCountries,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
     }
 
@@ -400,6 +403,7 @@ internal class DefaultEditCardDetailsInteractor(
             onBrandChoiceChanged: CardBrandCallback,
             onCardUpdateParamsChanged: CardUpdateParamsCallback,
             autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+            requiresBillingAddressForAutomaticTax: Boolean,
         ): EditCardDetailsInteractor {
             return DefaultEditCardDetailsInteractor(
                 payload = payload,
@@ -410,6 +414,7 @@ internal class DefaultEditCardDetailsInteractor(
                 onCardUpdateParamsChanged = onCardUpdateParamsChanged,
                 requiresModification = requiresModification,
                 autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -134,6 +134,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     val editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
         .Factory(),
     private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    private val requiresBillingAddressForAutomaticTax: Boolean,
 ) : UpdatePaymentMethodInteractor {
     private val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val error = MutableStateFlow(getInitialError())
@@ -215,6 +216,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
             ),
             requiresModification = true,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
     }
 
@@ -244,6 +246,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
             ),
             requiresModification = true,
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -370,6 +370,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             isDefaultPaymentMethod = false,
             onUpdateSuccess = {},
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = false,
         ),
         modifier = Modifier
     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -402,6 +402,7 @@ internal class CustomerSheetScreenshotTest {
                 removeMessage = null,
                 onUpdateSuccess = {},
                 autocompleteAddressInteractorFactory = null,
+                requiresBillingAddressForAutomaticTax = false,
             ).also { closeInteractorRule.track(it) },
             isLiveMode = true,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenshotTest.kt
@@ -52,6 +52,7 @@ internal class UpdateCardScreenshotTest(
                         onBrandChoiceChanged = {},
                         onCardUpdateParamsChanged = {},
                         autocompleteAddressInteractorFactory = null,
+                        requiresBillingAddressForAutomaticTax = false,
                     ).apply {
                         if (testCase.validate) {
                             handleViewAction(EditCardDetailsInteractor.ViewAction.Validate)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
@@ -117,6 +117,7 @@ internal class BillingDetailsFormTest {
             collectPhone = false,
             allowedBillingCountries = allowedCountries,
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = false,
         )
         block(form)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
@@ -86,6 +86,7 @@ internal class BillingDetailsFormUITest {
             collectPhone = false,
             allowedBillingCountries = emptySet(),
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = false,
         )
         composeRule.setContent {
             BillingDetailsFormUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
@@ -410,6 +410,7 @@ internal class CardDetailsEditUITest {
                 onCardUpdateParamsChanged = {},
                 requiresModification = true,
                 autocompleteAddressInteractorFactory = null,
+                requiresBillingAddressForAutomaticTax = false,
             )
         composeRule.setContent {
             CardDetailsEditUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -693,19 +693,11 @@ internal class DefaultEditCardDetailsInteractorTest {
     }
 
     @Test
-    fun whenRequiresBillingAddressForAutomaticTaxIsTrueForCaThenOnlyPostalCodeIsRequired() = runTest {
+    fun whenRequiresBillingAddressForAutomaticTaxIsTrueForInThenOnlyPostalCodeIsRequired() = runTest {
+        // IN is deliberately chosen over CA/US: it is NOT in the AVS postal-code list, so postal
+        // code is only ever shown via the automatic-tax path. That isolates the tax logic from AVS.
         val handler = handler(
-            billingDetails = PaymentMethod.BillingDetails(
-                address = Address(
-                    line1 = "1234 Main Street",
-                    city = "Toronto",
-                    country = "CA",
-                    postalCode = "M5H 2N2",
-                ),
-                email = "jenny.rosen@example.com",
-                name = "Jenny Rosen",
-                phone = "123-456-7890",
-            ),
+            billingDetails = inBillingDetails(),
             addressCollectionMode = AddressCollectionMode.Automatic,
             requiresBillingAddressForAutomaticTax = true,
         )
@@ -717,8 +709,33 @@ internal class DefaultEditCardDetailsInteractorTest {
             billingDetailsForm.hiddenElements.test {
                 val hiddenIdentifiers = awaitItem()
 
-                // CA only needs postal code in addition to country; line1/city/state stay hidden.
+                // IN only needs postal code in addition to country; line1/city/state stay hidden.
                 assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.PostalCode)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line1)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.City)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.State)
+            }
+        }
+    }
+
+    @Test
+    fun whenRequiresBillingAddressForAutomaticTaxIsFalseForInThenPostalCodeIsHidden() = runTest {
+        // Without the flag IN falls back to AVS, which does not include IN, so postal code is hidden.
+        // This is the half of the pair that CA could not prove (CA is in AVS, so it shows postal either way).
+        val handler = handler(
+            billingDetails = inBillingDetails(),
+            addressCollectionMode = AddressCollectionMode.Automatic,
+            requiresBillingAddressForAutomaticTax = false,
+        )
+
+        handler.state.test {
+            val state = awaitItem()
+            val billingDetailsForm = requireNotNull(state.billingDetailsForm)
+
+            billingDetailsForm.hiddenElements.test {
+                val hiddenIdentifiers = awaitItem()
+
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.PostalCode)
                 assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line1)
                 assertThat(hiddenIdentifiers).contains(IdentifierSpec.City)
                 assertThat(hiddenIdentifiers).contains(IdentifierSpec.State)
@@ -764,6 +781,18 @@ internal class DefaultEditCardDetailsInteractorTest {
             assertThat(validatingBillingForm.addressSectionElement.controller.validationMessage.value).isNotNull()
         }
     }
+
+    private fun inBillingDetails() = PaymentMethod.BillingDetails(
+        address = Address(
+            line1 = "1 MG Road",
+            city = "Bengaluru",
+            country = "IN",
+            postalCode = "560001",
+        ),
+        email = "jenny.rosen@example.com",
+        name = "Jenny Rosen",
+        phone = "123-456-7890",
+    )
 
     private val EditCardDetailsInteractor.uiState
         get() = this.state.value

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -16,6 +17,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -644,6 +646,87 @@ internal class DefaultEditCardDetailsInteractorTest {
     }
 
     @Test
+    fun whenRequiresBillingAddressForAutomaticTaxIsTrueThenAutomaticTaxFieldsAreNotHidden() = runTest {
+        // BILLING_DETAILS defaults to a US address, so the US automatic-tax fields apply.
+        val handler = handler(
+            addressCollectionMode = AddressCollectionMode.Automatic,
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        handler.state.test {
+            val state = awaitItem()
+            val billingDetailsForm = requireNotNull(state.billingDetailsForm)
+
+            billingDetailsForm.hiddenElements.test {
+                val hiddenIdentifiers = awaitItem()
+
+                assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.Line1)
+                assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.City)
+                assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.State)
+                assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.PostalCode)
+            }
+        }
+    }
+
+    @Test
+    fun whenRequiresBillingAddressForAutomaticTaxIsFalseThenAutomaticTaxFieldsAreHidden() = runTest {
+        // BILLING_DETAILS defaults to a US address; without the flag, only postal code
+        // stays visible (AVS), matching today's non-tax behavior.
+        val handler = handler(
+            addressCollectionMode = AddressCollectionMode.Automatic,
+            requiresBillingAddressForAutomaticTax = false,
+        )
+
+        handler.state.test {
+            val state = awaitItem()
+            val billingDetailsForm = requireNotNull(state.billingDetailsForm)
+
+            billingDetailsForm.hiddenElements.test {
+                val hiddenIdentifiers = awaitItem()
+
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line1)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.City)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.State)
+                assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.PostalCode)
+            }
+        }
+    }
+
+    @Test
+    fun whenRequiresBillingAddressForAutomaticTaxIsTrueForCaThenOnlyPostalCodeIsRequired() = runTest {
+        val handler = handler(
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(
+                    line1 = "1234 Main Street",
+                    city = "Toronto",
+                    country = "CA",
+                    postalCode = "M5H 2N2",
+                ),
+                email = "jenny.rosen@example.com",
+                name = "Jenny Rosen",
+                phone = "123-456-7890",
+            ),
+            addressCollectionMode = AddressCollectionMode.Automatic,
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        handler.state.test {
+            val state = awaitItem()
+            val billingDetailsForm = requireNotNull(state.billingDetailsForm)
+
+            billingDetailsForm.hiddenElements.test {
+                val hiddenIdentifiers = awaitItem()
+
+                // CA only needs postal code in addition to country; line1/city/state stay hidden.
+                assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.PostalCode)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line1)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.City)
+                assertThat(hiddenIdentifiers).contains(IdentifierSpec.State)
+            }
+        }
+    }
+
+    @Test
     fun whenValidateIsCalled_shouldSetAllFieldsToValidationState() = runTest {
         val handler = handler(
             billingDetails = null,
@@ -699,7 +782,8 @@ internal class DefaultEditCardDetailsInteractorTest {
         billingDetails: PaymentMethod.BillingDetails? = PaymentMethodFixtures.BILLING_DETAILS,
         requiresModification: Boolean = true,
         onBrandChoiceChanged: (CardBrand) -> Unit = {},
-        onCardUpdateParamsChanged: (CardUpdateParams?) -> Unit = {}
+        onCardUpdateParamsChanged: (CardUpdateParams?) -> Unit = {},
+        requiresBillingAddressForAutomaticTax: Boolean = false,
     ): EditCardDetailsInteractor {
         return DefaultEditCardDetailsInteractor.Factory().create(
             coroutineScope = TestScope(testDispatcher),
@@ -718,6 +802,7 @@ internal class DefaultEditCardDetailsInteractorTest {
             onBrandChoiceChanged = onBrandChoiceChanged,
             onCardUpdateParamsChanged = onCardUpdateParamsChanged,
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -757,6 +757,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             .Factory(),
         onBrandChoiceSelected: (CardBrand) -> Unit = {},
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
+        requiresBillingAddressForAutomaticTax: Boolean = false,
         testBlock: suspend TestParams.() -> Unit
     ) {
         val onUpdateSuccessTurbine = Turbine<Unit>()
@@ -781,6 +782,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             removeMessage = null,
             allowedBillingCountries = allowedBillingCountries,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
         cleanupRule.track(interactor)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -706,6 +706,18 @@ class DefaultUpdatePaymentMethodInteractorTest {
     }
 
     @Test
+    fun editCardDetailsInteractorFactory_forwardsRequiresBillingAddressForAutomaticTax() {
+        val fakeEditCardFactory = FakeEditCardDetailsInteractorFactory()
+        runScenario(
+            editCardDetailsInteractorFactory = fakeEditCardFactory,
+            requiresBillingAddressForAutomaticTax = true,
+        ) {
+            interactor.editCardDetailsInteractor
+            assertThat(fakeEditCardFactory.requiresBillingAddressForAutomaticTax).isTrue()
+        }
+    }
+
+    @Test
     fun editCardDetailsInteractorFactory_forwardsAutocompleteAddressInteractorFactory() {
         val fakeEditCardFactory = FakeEditCardDetailsInteractorFactory()
         val fakeAutocompleteFactory = AutocompleteAddressInteractor.Factory {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
@@ -14,6 +14,9 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
     var autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null
         private set
 
+    var requiresBillingAddressForAutomaticTax: Boolean? = null
+        private set
+
     override fun create(
         coroutineScope: CoroutineScope,
         cardEditConfiguration: CardEditConfiguration?,
@@ -23,10 +26,12 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
         onBrandChoiceChanged: CardBrandCallback,
         onCardUpdateParamsChanged: CardUpdateParamsCallback,
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+        requiresBillingAddressForAutomaticTax: Boolean,
     ): EditCardDetailsInteractor {
         this.onCardUpdateParamsChanged = onCardUpdateParamsChanged
         this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
         this.autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory
+        this.requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax
         return FakeEditCardDetailsInteractor(
             payload = payload,
             shouldShowCardBrandDropdown = cardEditConfiguration?.isCbcModifiable ?: false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -44,6 +44,7 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val canChangeCbc: Boolean = true,
     private val editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
         .Factory(),
+    private val requiresBillingAddressForAutomaticTax: Boolean = false,
 ) : UpdatePaymentMethodInteractor {
     val closeCalls = Turbine<Unit>()
 
@@ -76,6 +77,7 @@ internal class FakeUpdatePaymentMethodInteractor(
             onBrandChoiceChanged = {},
             onCardUpdateParamsChanged = {},
             autocompleteAddressInteractorFactory = null,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
     }
 


### PR DESCRIPTION
# Summary
Wires the `requiresBillingAddressForAutomaticTax` flag (added in #13470) into the saved-card **edit** flow's billing address form, so editing a saved card in a Checkout Session using automatic tax with the billing address as the tax source shows the same tax-required fields as the initial card entry form.

The flag now threads through `EditCardDetailsInteractor.Factory` → `DefaultEditCardDetailsInteractor` → `BillingDetailsForm` → `CardBillingAddressElement`'s `Automatic` collection mode, mirroring the wiring #13470 already did for the entry-side form. `UpdatePaymentMethodInteractor` forwards `PaymentMethodMetadata.requiresBillingAddressForAutomaticTax` from `SavedPaymentMethodMutator` (PaymentSheet) and `EmbeddedUpdateScreenInteractorFactory` (embedded manage screen). CustomerSheet and Link's update-card flow explicitly pass `false`, since neither has a Checkout Session / automatic-tax concept.

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-4696

This is EwCS parity for the saved-card edit flow: web (Stripe.js/EwCS) already applies the same automatic-tax-driven billing field requirements when editing a saved payment method, not just when adding a new one. #13470 wired the flag into the initial card entry form only; this PR closes the gap for the edit flow so behavior is consistent across both entry points.

This surface is pre-GA/preview: Checkout Session's `CheckoutSessionPreview` API is not yet generally available, and wallets (Google Pay) and Link are already disabled in this mode (see #13470's investigation), so this change is scoped purely to card billing address fields in the edit UI.

# Testing
- [ ] Manually verified

- `DefaultEditCardDetailsInteractorTest` — new coverage exercising `requiresBillingAddressForAutomaticTax` threading through to the built `BillingDetailsForm`.
- Existing `BillingDetailsFormTest` / `BillingDetailsFormUITest` / `CardDetailsEditUITest` / `DefaultUpdatePaymentMethodInteractorTest` updated for the new constructor parameter.
- Verified locally: `:paymentsheet:testDebugUnitTest` (changed test classes), `:paymentsheet:apiCheck`, `:paymentsheet:detekt` all pass (all touched types are `internal`, no public API change).

# Screenshots
N/A — no visual changes; this only changes which fields are shown in an existing form, consistent with #13470.

# Changelog
No CHANGELOG entry — internal, pre-GA/preview surface with no publicly-visible API change (matches precedent in #13470).

# Related
- MOBILESDK-4696 (this PR)
- MOBILESDK-4667 / #13470 (merged) — initial entry-flow wiring this PR extends to the edit flow
- MOBILESDK-4699 — iOS sibling ticket, not yet implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)