### PR TITLE
Expose selected payment option display data in CheckoutSession.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.checkout.CheckoutSession
-import com.stripe.android.checkout.PaymentElement
+import com.stripe.android.checkout.PaymentOptionDisplayData
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
 import com.stripe.android.uicore.format.CurrencyFormatter
@@ -81,7 +81,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                 },
                 bottomBarContent = {
                     val configured = status as? CheckoutControllerExampleViewModel.Status.Configured
-//                    PaymentOptionRow(configured?.paymentOption)
+                    PaymentOptionRow(configured?.checkoutSession?.paymentOptionDisplayData)
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(
                         onClick = { paymentElement.presentPaymentOptions() },
@@ -131,7 +131,7 @@ private fun ErrorContent(message: String) {
 }
 
 @Composable
-private fun PaymentOptionRow(paymentOption: PaymentElement.PaymentOptionDisplayData?) {
+private fun PaymentOptionRow(paymentOption: PaymentOptionDisplayData?) {
     if (paymentOption != null) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -44,7 +44,13 @@ internal data class CheckoutControllerState(
     override val shippingAddress: Address.State? get() = collectedDetails.shippingAddress
     override val billingAddress: Address.State? get() = collectedDetails.billingAddress
 
-    fun asCheckoutSession(): CheckoutSession {
-        return checkoutSessionResponse.asCheckoutSession(flagImages)
+    fun asCheckoutSession(paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory): CheckoutSession {
+        return checkoutSessionResponse.asCheckoutSession(
+            flagImages = flagImages,
+            paymentOptionDisplayData = paymentOptionFactory.create(
+                selection = paymentSelection,
+                paymentMethodMetadata = paymentMethodMetadata,
+            ),
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -26,6 +26,7 @@ import javax.inject.Singleton
 internal class CheckoutControllerStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val errorReporter: ErrorReporter,
+    private val paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory,
 ) : EmbeddedSelectionHolder {
     var state: CheckoutControllerState?
         get() = savedStateHandle[STATE_KEY]
@@ -37,7 +38,7 @@ internal class CheckoutControllerStateHolder @Inject constructor(
         savedStateHandle.getStateFlow(STATE_KEY, null)
 
     val checkoutSession: StateFlow<CheckoutSession?> =
-        stateFlow.mapAsStateFlow { it?.asCheckoutSession() }
+        stateFlow.mapAsStateFlow { it?.asCheckoutSession(paymentOptionFactory) }
 
     override val selection: StateFlow<PaymentSelection?> =
         stateFlow.mapAsStateFlow { it?.paymentSelection }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.checkout
+
+import android.content.Context
+import androidx.compose.ui.text.AnnotatedString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.content.NullUiDefinitionFactoryHelper
+import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.darkThemeIconUrl
+import com.stripe.android.paymentsheet.model.drawableResourceId
+import com.stripe.android.paymentsheet.model.drawableResourceIdNight
+import com.stripe.android.paymentsheet.model.label
+import com.stripe.android.paymentsheet.model.lightThemeIconUrl
+import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun interface CheckoutPaymentOptionDisplayDataFactory {
+    fun create(
+        selection: PaymentSelection?,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): PaymentOptionDisplayData?
+}
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutPaymentOptionDisplayDataFactory @Inject constructor(
+    private val iconLoader: PaymentSelection.IconLoader,
+    private val cardArtDrawableLoader: PaymentOptionCardArtDrawableLoader,
+    private val context: Context,
+) : CheckoutPaymentOptionDisplayDataFactory {
+    override fun create(
+        selection: PaymentSelection?,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): PaymentOptionDisplayData? {
+        if (selection == null) {
+            return null
+        }
+
+        val mandate = when (selection) {
+            is PaymentSelection.New -> {
+                paymentMethodMetadata.formElementsForCode(
+                    code = selection.paymentMethodType,
+                    uiDefinitionFactoryArgumentsFactory = NullUiDefinitionFactoryHelper.nullEmbeddedUiDefinitionFactory
+                )?.firstNotNullOfOrNull { it.mandateText }
+            }
+            is PaymentSelection.Saved -> selection.mandateTextFromPaymentMethodMetadata(paymentMethodMetadata)
+            is PaymentSelection.CustomPaymentMethod,
+            is PaymentSelection.ExternalPaymentMethod,
+            is PaymentSelection.GooglePay,
+            is PaymentSelection.Link -> null
+        }
+
+        return PaymentOptionDisplayData(
+            imageLoader = {
+                cardArtDrawableLoader.load(selection) ?: iconLoader.load(
+                    drawableResourceId = selection.drawableResourceId,
+                    drawableResourceIdNight = selection.drawableResourceIdNight,
+                    lightThemeIconUrl = selection.lightThemeIconUrl,
+                    darkThemeIconUrl = selection.darkThemeIconUrl,
+                )
+            },
+            label = selection.label(paymentMethodMetadata.linkBrand).resolve(context),
+            paymentMethodType = selection.paymentMethodType,
+            mandateText = if (mandate == null) null else AnnotatedString(mandate.resolve(context)),
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -51,6 +51,10 @@ class CheckoutSession internal constructor(
      * Available shipping options for this checkout session.
      */
     val shippingOptions: List<ShippingRate>,
+    /**
+     * The customer's currently selected payment option, or `null` if none has been selected yet.
+     */
+    val paymentOptionDisplayData: PaymentOptionDisplayData?,
     internal val currencySelectorOptions: CurrencySelectorOptions?,
 ) {
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
@@ -30,13 +30,14 @@ internal data class InternalState(
         )
 
     fun asCheckoutSession(): CheckoutSession {
-        return checkoutSessionResponse.asCheckoutSession(flagImages)
+        return checkoutSessionResponse.asCheckoutSession(flagImages, paymentOptionDisplayData = null)
     }
 }
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutSessionResponse.asCheckoutSession(
     flagImages: Map<String, Bitmap>?,
+    paymentOptionDisplayData: PaymentOptionDisplayData?,
 ): CheckoutSession {
     return CheckoutSession(
         id = id,
@@ -48,6 +49,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         totalSummary = totalSummary?.asTotalSummary(),
         lineItems = lineItems.map { it.asLineItem() },
         shippingOptions = shippingOptions.map { it.asShippingRate() },
+        paymentOptionDisplayData = paymentOptionDisplayData,
         currencySelectorOptions = CurrencySelectorOptionsFactory.create(
             adaptivePricingInfo = adaptivePricingInfo,
             flagImages = flagImages,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -1,16 +1,9 @@
 package com.stripe.android.checkout
 
-import android.graphics.drawable.Drawable
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.text.AnnotatedString
-import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.image.rememberDrawablePainter
-import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -56,25 +49,5 @@ class PaymentElement @Inject internal constructor() {
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
         )
-    }
-
-    @Poko
-    @CheckoutSessionPreview
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    class PaymentOptionDisplayData internal constructor(
-        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val imageLoader: suspend () -> Drawable,
-        val label: String,
-        val billingDetails: PaymentSheet.BillingDetails?,
-        val paymentMethodType: String,
-        val mandateText: AnnotatedString?,
-    ) {
-        private val iconDrawable: Drawable by lazy {
-            DelegateDrawable(imageLoader)
-        }
-
-        val iconPainter: Painter
-            @Composable
-            get() = rememberDrawablePainter(iconDrawable)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentOptionDisplayData.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentOptionDisplayData.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.checkout
+
+import android.graphics.drawable.Drawable
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.text.AnnotatedString
+import com.stripe.android.common.ui.DelegateDrawable
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.uicore.image.rememberDrawablePainter
+import dev.drewhamilton.poko.Poko
+
+@Poko
+@CheckoutSessionPreview
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class PaymentOptionDisplayData internal constructor(
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    val imageLoader: suspend () -> Drawable,
+    /**
+     * A user facing string representing the payment method; e.g. "Google Pay" or "···· 4242" for a card.
+     */
+    val label: String,
+    /**
+     * A string representation of the customer's desired payment method:
+     * - If this is a Stripe payment method, see
+     *      https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
+     * - If this is an external payment method, see
+     *      https://docs.stripe.com/payments/mobile/external-payment-methods?platform=android
+     *      for possible values.
+     * - If this is Google Pay, the value is "google_pay".
+     */
+    val paymentMethodType: String,
+    /**
+     * If you set [CheckoutController.Configuration.embeddedViewDisplaysMandateText] to `false`, this text must be
+     * displayed to the customer near your "Buy" button to comply with regulations.
+     */
+    val mandateText: AnnotatedString?,
+) {
+    private val iconDrawable: Drawable by lazy {
+        DelegateDrawable(imageLoader)
+    }
+
+    /**
+     * An image representing a payment method; e.g. the Google Pay logo or a VISA logo.
+     */
+    val iconPainter: Painter
+        @Composable
+        get() = rememberDrawablePainter(iconDrawable)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -3,11 +3,15 @@
 package com.stripe.android.checkout.injection
 
 import android.app.Application
+import android.content.Context
+import android.content.res.Resources
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.CheckoutPaymentOptionDisplayDataFactory
+import com.stripe.android.checkout.DefaultCheckoutPaymentOptionDisplayDataFactory
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.common.nfcscan.NfcScanningAvailabilityModule
 import com.stripe.android.common.taptoadd.TapToAddConnectionModule
@@ -186,6 +190,11 @@ internal interface CheckoutControllerModule {
     @Binds
     fun bindsEmbeddedSelectionHolder(impl: CheckoutControllerStateHolder): EmbeddedSelectionHolder
 
+    @Binds
+    fun bindsCheckoutPaymentOptionDisplayDataFactory(
+        impl: DefaultCheckoutPaymentOptionDisplayDataFactory
+    ): CheckoutPaymentOptionDisplayDataFactory
+
     companion object {
         private const val CALLBACK_IDENTIFIER_KEY = "CheckoutController_CallbackIdentifier"
 
@@ -213,6 +222,11 @@ internal interface CheckoutControllerModule {
         @Provides
         fun provideDurationProvider(): DurationProvider {
             return DefaultDurationProvider.instance
+        }
+
+        @Provides
+        fun provideResources(context: Context): Resources {
+            return context.resources
         }
 
         @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -2,13 +2,16 @@ package com.stripe.android.checkout
 
 import android.graphics.Bitmap
 import android.os.Bundle
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
 
 @OptIn(CheckoutSessionPreview::class)
 internal object CheckoutControllerStateFactory {
@@ -40,6 +43,19 @@ internal object CheckoutControllerStateFactory {
             paymentSelection = paymentSelection,
             temporarySelection = temporarySelection,
             previousNewSelections = previousNewSelections,
+        )
+    }
+
+    fun createStateHolder(
+        savedStateHandle: SavedStateHandle,
+        errorReporter: ErrorReporter = FakeErrorReporter(),
+        paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory =
+            CheckoutPaymentOptionDisplayDataFactory { _, _ -> null },
+    ): CheckoutControllerStateHolder {
+        return CheckoutControllerStateHolder(
+            savedStateHandle = savedStateHandle,
+            errorReporter = errorReporter,
+            paymentOptionFactory = paymentOptionFactory,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -29,6 +29,28 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
+    fun `checkoutSession projects the paymentOption the factory builds from the committed state`() {
+        val expectedOption = PaymentOptionDisplayData(
+            imageLoader = { error("not needed for this test") },
+            label = "Google Pay",
+            paymentMethodType = "google_pay",
+            mandateText = null,
+        )
+        var capturedSelection: PaymentSelection? = null
+        val factory = CheckoutPaymentOptionDisplayDataFactory { selection, _ ->
+            capturedSelection = selection
+            expectedOption
+        }
+
+        testScenario(paymentOptionFactory = factory) {
+            stateHolder.state = committedState(paymentSelection = PaymentSelection.GooglePay)
+
+            assertThat(stateHolder.checkoutSession.value?.paymentOptionDisplayData).isSameInstanceAs(expectedOption)
+            assertThat(capturedSelection).isEqualTo(PaymentSelection.GooglePay)
+        }
+    }
+
+    @Test
     fun `setSelection updates paymentSelection on the state and emits`() = testScenario {
         stateHolder.state = committedState()
 
@@ -128,6 +150,7 @@ internal class CheckoutControllerStateHolderTest {
         val stateHolder = CheckoutControllerStateHolder(
             savedStateHandle = SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restored)),
             errorReporter = FakeErrorReporter(),
+            paymentOptionFactory = { _, _ -> null },
         )
 
         assertThat(stateHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
@@ -155,11 +178,13 @@ internal class CheckoutControllerStateHolderTest {
     )
 
     private fun testScenario(
+        paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory =
+            CheckoutPaymentOptionDisplayDataFactory { _, _ -> null },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val errorReporter = FakeErrorReporter()
         Scenario(
-            stateHolder = CheckoutControllerStateHolder(SavedStateHandle(), errorReporter),
+            stateHolder = CheckoutControllerStateHolder(SavedStateHandle(), errorReporter, paymentOptionFactory),
             errorReporter = errorReporter,
         ).block()
         errorReporter.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CleanupTestRule
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -223,7 +222,7 @@ internal class CheckoutControllerTest {
         val savedStateHandle = SavedStateHandle()
         val controller = createController(savedStateHandle)
         assertThat(controller.checkoutSession.value).isNull()
-        assertThat(CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state).isNull()
+        assertThat(CheckoutControllerStateFactory.createStateHolder(savedStateHandle).state).isNull()
     }
 
     @Test
@@ -248,7 +247,7 @@ internal class CheckoutControllerTest {
 
         // A fresh state holder over the same SavedStateHandle simulates the controller being
         // rebuilt after process death: the committed state is read back from persisted storage.
-        val state = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state
+        val state = CheckoutControllerStateFactory.createStateHolder(savedStateHandle).state
         assertThat(state).isNotNull()
         assertThat(state!!.embeddedConfiguration.merchantDisplayName)
             .isEqualTo(expectedMerchantDisplayName)
@@ -985,7 +984,7 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         val committedState: CheckoutControllerState?
-            get() = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state
+            get() = CheckoutControllerStateFactory.createStateHolder(savedStateHandle).state
     }
 
     // Configures a controller from a fresh init, then hands it to [block] alongside the shared
@@ -1042,12 +1041,12 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         fun committedState(): CheckoutControllerState =
-            requireNotNull(CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()).state)
+            requireNotNull(CheckoutControllerStateFactory.createStateHolder(savedStateHandle).state)
 
         // Simulates a presented payment flow by flipping the committed state's integrationLaunched
         // flag, which the mutation guard reads back through the same SavedStateHandle.
         fun markIntegrationLaunched() {
-            val stateHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter())
+            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
             stateHolder.state = committedState().copy(integrationLaunched = true)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
@@ -192,7 +191,7 @@ internal class CheckoutStateLoaderTest {
                 savedStateHandle = savedStateHandle,
                 formHelperFactory = EmbeddedFormHelperFactory(
                     linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-                    embeddedSelectionHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter()),
+                    embeddedSelectionHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle),
                     cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                     savedStateHandle = savedStateHandle,
                 ),
@@ -355,7 +354,7 @@ internal class CheckoutStateLoaderTest {
             ),
         )
         val savedStateHandle = SavedStateHandle()
-        val stateHolder = CheckoutControllerStateHolder(savedStateHandle, FakeErrorReporter())
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         val recordingChooser = RecordingSelectionChooser(chosenSelection)
         val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
         val loader = CheckoutStateLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
@@ -1,0 +1,125 @@
+package com.stripe.android.checkout
+
+import android.content.Context
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.FakeStripeImageLoader
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultCheckoutPaymentOptionFactoryTest {
+    @Test
+    fun `create returns null when there is no selection`() = runScenario {
+        assertThat(factory.create(selection = null, paymentMethodMetadata = metadata)).isNull()
+    }
+
+    @Test
+    fun `create maps a Google Pay selection`() = runScenario {
+        val option = factory.create(selection = PaymentSelection.GooglePay, paymentMethodMetadata = metadata)
+
+        assertThat(option).isNotNull()
+        assertThat(option?.paymentMethodType).isEqualTo("google_pay")
+        assertThat(option?.label).isEqualTo("Google Pay")
+        assertThat(option?.mandateText).isNull()
+    }
+
+    @Test
+    fun `create maps a new card selection`() = runScenario {
+        val option = factory.create(
+            selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(option).isNotNull()
+        assertThat(option?.paymentMethodType).isEqualTo("card")
+        assertThat(option?.label).contains("4242")
+    }
+
+    @Test
+    fun `create attaches mandate text for a new card that requires setup`() = runScenario(
+        // A SetupIntent forces the card form to require a mandate, unlike the default PaymentIntent metadata.
+        metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_SUCCEEDED.copy(paymentMethodTypes = listOf("card")),
+        ),
+    ) {
+        val option = factory.create(
+            selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(option?.mandateText).isNotNull()
+    }
+
+    @Test
+    fun `create does not attach mandate text for a saved card`() = runScenario {
+        val option = factory.create(
+            selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(option).isNotNull()
+        assertThat(option?.paymentMethodType).isEqualTo("card")
+        assertThat(option?.mandateText).isNull()
+    }
+
+    @Test
+    fun `imageLoader returns the card art when the card art loader provides one`() = runScenario(
+        cardArt = ColorDrawable(),
+    ) {
+        // Card art is only ever loaded for saved payment methods.
+        val option = factory.create(
+            selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(option?.imageLoader?.invoke()).isSameInstanceAs(cardArt)
+    }
+
+    @Test
+    fun `imageLoader falls back to the icon loader when there is no card art`() = runScenario {
+        val option = factory.create(
+            selection = PaymentSelection.GooglePay,
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(option?.imageLoader?.invoke()).isNotNull()
+    }
+
+    private fun runScenario(
+        metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        cardArt: Drawable? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        Scenario(
+            factory = DefaultCheckoutPaymentOptionDisplayDataFactory(
+                iconLoader = PaymentSelection.IconLoader(
+                    resources = context.resources,
+                    imageLoader = FakeStripeImageLoader(),
+                ),
+                cardArtDrawableLoader = { cardArt },
+                context = context,
+            ),
+            metadata = metadata,
+            cardArt = cardArt,
+        ).block()
+    }
+
+    private class Scenario(
+        val factory: DefaultCheckoutPaymentOptionDisplayDataFactory,
+        val metadata: PaymentMethodMetadata,
+        val cardArt: Drawable?,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -157,6 +157,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
         val stateHolder = CheckoutControllerStateHolder(
             savedStateHandle = savedStateHandle,
             errorReporter = FakeErrorReporter(),
+            paymentOptionFactory = { _, _ -> null },
         )
         stateHolder.state = CheckoutControllerStateFactory.create(
             paymentMethodMetadata = paymentMethodMetadata,


### PR DESCRIPTION
# Summary
Expose information about the currently selected payment option through the `CheckoutSession` API, via a new `paymentOptionDisplayData` property.

# Motivation
Makes it easier for integrators using the Embedded Checkout API to access and display information about the customer's selected payment method, such as its icon, label, and potential mandate text, outside of Stripe UI components.

# Testing
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

