### PR TITLE
Refactor CurrencySelector appearance types and expand appearance test coverage.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -617,7 +617,37 @@ class Checkout private constructor(
             isEnabled = !isLoading,
             showCurrencyCode = showCurrencyCode,
             errorMessage = errorMessage?.resolve(),
-            appearance = appearanceState,
+            appearance = appearanceState.toElementAppearanceState(),
         )
     }
 }
+
+/**
+ * Maps [Checkout]'s public [Checkout.CurrencySelectorContentAppearance.State] onto the
+ * [CurrencySelectorElement.Appearance.State] consumed by [CurrencySelectorToggle]. The two carry the
+ * same fields; [Checkout] keeps its own appearance type while the shared toggle speaks the element's.
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun Checkout.CurrencySelectorContentAppearance.State.toElementAppearanceState():
+    CurrencySelectorElement.Appearance.State = CurrencySelectorElement.Appearance.State(
+    contentVerticalPaddingDp = contentVerticalPaddingDp,
+    cornerRadiusDp = cornerRadiusDp,
+    borderWidthDp = borderWidthDp,
+    borderColor = borderColor,
+    background = background,
+    selectedBackground = selectedBackground,
+    textColor = textColor,
+    selectedTextColor = selectedTextColor,
+    textSecondaryColor = textSecondaryColor,
+    dangerColor = dangerColor,
+    fontResId = fontResId,
+    sizeScaleFactor = sizeScaleFactor,
+    labelContent = when (labelContent) {
+        Checkout.CurrencySelectorContentAppearance.LabelContent.AUTOMATIC ->
+            CurrencySelectorElement.Appearance.LabelContent.AUTOMATIC
+        Checkout.CurrencySelectorContentAppearance.LabelContent.CURRENCY_CODE ->
+            CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE
+        Checkout.CurrencySelectorContentAppearance.LabelContent.AMOUNT ->
+            CurrencySelectorElement.Appearance.LabelContent.AMOUNT
+    },
+)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
@@ -21,21 +21,22 @@ import javax.inject.Inject
 class CurrencySelectorElement @Inject internal constructor(
     private val checkoutController: CheckoutController,
     private val viewModelFactory: CurrencySelectorViewModel.Factory,
+    private val stateHolder: CheckoutControllerStateHolder,
 ) {
     private val viewModelKey = "CurrencySelectorViewModel:${System.identityHashCode(checkoutController)}"
 
     @Composable
     fun Content() {
-        val appearanceState = Checkout.CurrencySelectorContentAppearance().build()
         val viewModel: CurrencySelectorViewModel = viewModel(
             key = viewModelKey,
             factory = viewModelFactory,
         )
+        val state by stateHolder.stateFlow.collectAsState()
+        val appearanceState = state?.configuration?.currencySelectorElementConfiguration?.appearance ?: return
         val isLoading by checkoutController.isLoading.collectAsState()
         val checkoutSession by checkoutController.checkoutSession.collectAsState()
         val currencySelectorOptions = checkoutSession?.currencySelectorOptions ?: return
-        val showCurrencyCode =
-            appearanceState.labelContent == Checkout.CurrencySelectorContentAppearance.LabelContent.CURRENCY_CODE
+        val showCurrencyCode = appearanceState.labelContent == Appearance.LabelContent.CURRENCY_CODE
         val errorMessage by viewModel.errorMessage.collectAsState()
         CurrencySelectorToggle(
             options = currencySelectorOptions,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggle.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
-import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CurrencySelectorElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import androidx.compose.ui.R as ComposeR
 import com.stripe.android.uicore.R as StripeUiCoreR
@@ -92,7 +92,7 @@ internal fun CurrencySelectorToggle(
     isEnabled: Boolean,
     showCurrencyCode: Boolean,
     errorMessage: String? = null,
-    appearance: Checkout.CurrencySelectorContentAppearance.State,
+    appearance: CurrencySelectorElement.Appearance.State,
     modifier: Modifier = Modifier,
 ) {
     val shape = appearance.cornerRadiusDp?.let { RoundedCornerShape(it.dp) }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorElementAppearanceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorElementAppearanceTest.kt
@@ -1,0 +1,212 @@
+package com.stripe.android.checkout
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+@OptIn(CheckoutSessionPreview::class)
+class CurrencySelectorElementAppearanceTest {
+
+    @Test
+    fun `default build produces expected defaults`() {
+        val state = CurrencySelectorElement.Appearance().build()
+
+        assertThat(state.contentVerticalPaddingDp).isEqualTo(4f)
+        assertThat(state.cornerRadiusDp).isNull()
+        assertThat(state.borderWidthDp).isNull()
+        assertThat(state.borderColor).isNull()
+        assertThat(state.background).isNull()
+        assertThat(state.selectedBackground).isNull()
+        assertThat(state.textColor).isNull()
+        assertThat(state.selectedTextColor).isNull()
+        assertThat(state.textSecondaryColor).isNull()
+        assertThat(state.dangerColor).isNull()
+        assertThat(state.fontResId).isNull()
+        assertThat(state.sizeScaleFactor).isEqualTo(1.0f)
+        assertThat(state.labelContent)
+            .isEqualTo(CurrencySelectorElement.Appearance.LabelContent.AUTOMATIC)
+    }
+
+    @Test
+    fun `all properties can be set via builder`() {
+        val state = CurrencySelectorElement.Appearance()
+            .contentVerticalPaddingDp(12f)
+            .cornerRadiusDp(8f)
+            .borderWidthDp(2f)
+            .borderColor(Color.Red)
+            .background(Color.Blue)
+            .selectedBackground(Color.Green)
+            .textColor(Color.White)
+            .selectedTextColor(Color.Black)
+            .textSecondaryColor(Color.Gray)
+            .dangerColor(Color.Magenta)
+            .fontResId(123)
+            .sizeScaleFactor(1.5f)
+            .labelContent(CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE)
+            .build()
+
+        assertThat(state.contentVerticalPaddingDp).isEqualTo(12f)
+        assertThat(state.cornerRadiusDp).isEqualTo(8f)
+        assertThat(state.borderWidthDp).isEqualTo(2f)
+        assertThat(state.borderColor).isEqualTo(Color.Red.toArgb())
+        assertThat(state.background).isEqualTo(Color.Blue.toArgb())
+        assertThat(state.selectedBackground).isEqualTo(Color.Green.toArgb())
+        assertThat(state.textColor).isEqualTo(Color.White.toArgb())
+        assertThat(state.selectedTextColor).isEqualTo(Color.Black.toArgb())
+        assertThat(state.textSecondaryColor).isEqualTo(Color.Gray.toArgb())
+        assertThat(state.dangerColor).isEqualTo(Color.Magenta.toArgb())
+        assertThat(state.fontResId).isEqualTo(123)
+        assertThat(state.sizeScaleFactor).isEqualTo(1.5f)
+        assertThat(state.labelContent)
+            .isEqualTo(CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE)
+    }
+
+    @Test
+    fun `textSecondaryColor alpha is clamped to 0_5 minimum`() {
+        val state = CurrencySelectorElement.Appearance()
+            .textSecondaryColor(Color.Red.copy(alpha = 0.2f))
+            .build()
+
+        val resultColor = Color(state.textSecondaryColor!!)
+        assertThat(resultColor.alpha).isWithin(0.01f).of(0.5f)
+        assertThat(resultColor.red).isWithin(0.01f).of(1.0f)
+    }
+
+    @Test
+    fun `textSecondaryColor alpha above 0_5 is preserved`() {
+        val state = CurrencySelectorElement.Appearance()
+            .textSecondaryColor(Color.Red.copy(alpha = 0.8f))
+            .build()
+
+        val resultColor = Color(state.textSecondaryColor!!)
+        assertThat(resultColor.alpha).isWithin(0.01f).of(0.8f)
+    }
+
+    @Test
+    fun `textSecondaryColor alpha exactly 0_5 is preserved`() {
+        val state = CurrencySelectorElement.Appearance()
+            .textSecondaryColor(Color.Red.copy(alpha = 0.5f))
+            .build()
+
+        val resultColor = Color(state.textSecondaryColor!!)
+        assertThat(resultColor.alpha).isWithin(0.01f).of(0.5f)
+    }
+
+    @Test
+    fun `sizeScaleFactor of zero throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .sizeScaleFactor(0f)
+        }
+    }
+
+    @Test
+    fun `sizeScaleFactor of negative value throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .sizeScaleFactor(-1f)
+        }
+    }
+
+    @Test
+    fun `sizeScaleFactor of infinite value throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .sizeScaleFactor(Float.POSITIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun `negative contentVerticalPaddingDp throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .contentVerticalPaddingDp(-1f)
+        }
+    }
+
+    @Test
+    fun `infinite contentVerticalPaddingDp throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .contentVerticalPaddingDp(Float.POSITIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun `negative cornerRadiusDp throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .cornerRadiusDp(-1f)
+        }
+    }
+
+    @Test
+    fun `infinite cornerRadiusDp throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .cornerRadiusDp(Float.POSITIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun `negative borderWidthDp throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .borderWidthDp(-1f)
+        }
+    }
+
+    @Test
+    fun `infinite borderWidthDp throws`() {
+        assertFailsWith<IllegalArgumentException> {
+            CurrencySelectorElement.Appearance()
+                .borderWidthDp(Float.POSITIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun `builder methods are chainable`() {
+        val appearance = CurrencySelectorElement.Appearance()
+            .contentVerticalPaddingDp(10f)
+            .cornerRadiusDp(20f)
+            .borderWidthDp(1f)
+
+        val state = appearance.build()
+        assertThat(state.contentVerticalPaddingDp).isEqualTo(10f)
+        assertThat(state.cornerRadiusDp).isEqualTo(20f)
+        assertThat(state.borderWidthDp).isEqualTo(1f)
+    }
+
+    @Test
+    fun `fontResId null clears font`() {
+        val state = CurrencySelectorElement.Appearance()
+            .fontResId(123)
+            .fontResId(null)
+            .build()
+
+        assertThat(state.fontResId).isNull()
+    }
+
+    @Test
+    fun `configuration default build uses default appearance`() {
+        val state = CurrencySelectorElement.Configuration().build()
+
+        assertThat(state.appearance).isEqualTo(CurrencySelectorElement.Appearance().build())
+    }
+
+    @Test
+    fun `configuration carries the supplied appearance`() {
+        val appearance = CurrencySelectorElement.Appearance()
+            .labelContent(CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE)
+            .cornerRadiusDp(8f)
+
+        val state = CurrencySelectorElement.Configuration()
+            .appearance(appearance)
+            .build()
+
+        assertThat(state.appearance).isEqualTo(appearance.build())
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorElementContentUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorElementContentUITest.kt
@@ -80,6 +80,46 @@ internal class CurrencySelectorElementContentUITest {
     }
 
     @Test
+    fun currencySelectorConfiguredWithCurrencyCodeLabel_displaysCurrencyCodes() = runScenario(
+        configuration = CheckoutController.Configuration().currencySelectorElement(
+            CurrencySelectorElement.Configuration().appearance(
+                CurrencySelectorElement.Appearance()
+                    .labelContent(CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE)
+            )
+        ),
+    ) {
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertContentDescriptionContains("USD")
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertContentDescriptionContains("EUR")
+    }
+
+    @Test
+    fun reconfiguringWithCurrencyCodeAfterComposition_updatesRenderedLabels() = runScenario {
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertContentDescriptionContains("50.99")
+
+        enqueueCheckoutInit()
+        runBlocking {
+            controller.configure(
+                DEFAULT_CLIENT_SECRET,
+                CheckoutController.Configuration().currencySelectorElement(
+                    CurrencySelectorElement.Configuration().appearance(
+                        CurrencySelectorElement.Appearance()
+                            .labelContent(CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE)
+                    )
+                ),
+            ).getOrThrow()
+        }
+
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}USD")
+            .assertContentDescriptionContains("USD")
+        composeRule.onNodeWithTag("${TEST_TAG_CURRENCY_OPTION_PREFIX}EUR")
+            .assertContentDescriptionContains("EUR")
+    }
+
+    @Test
     fun clickingSelectedOption_doesNotTriggerNetworkRequest() = runScenario {
         // EUR is the selected option. Clicking it is a no-op.
         // If it triggered a network request, NetworkRule teardown would fail
@@ -119,16 +159,10 @@ internal class CurrencySelectorElementContentUITest {
     private fun runScenario(
         fixture: String = FIXTURE_WITH_ADAPTIVE_PRICING,
         setContent: Boolean = true,
+        configuration: CheckoutController.Configuration = CheckoutController.Configuration(),
         block: Scenario.() -> Unit,
     ) {
-        networkRule.checkoutInit { response ->
-            // The loader requires a billing email (sourced from customer_email) and Link is disabled
-            // so the loader doesn't fire an unrelated consumer session lookup.
-            response.testBodyFromFile(fixture) { json ->
-                json.put("customer_email", "checkout@example.com")
-                json.getJSONObject("elements_session").remove("link_settings")
-            }
-        }
+        enqueueCheckoutInit(fixture)
 
         val controller = destroyControllerRule.track(
             CheckoutController.Builder(
@@ -137,7 +171,7 @@ internal class CurrencySelectorElementContentUITest {
             ).build()
         )
 
-        runBlocking { controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow() }
+        runBlocking { controller.configure(DEFAULT_CLIENT_SECRET, configuration).getOrThrow() }
 
         val element = controller.createPresenter(composeRule.activity).currencySelectorElement()
         if (setContent) {
@@ -147,6 +181,17 @@ internal class CurrencySelectorElementContentUITest {
         }
 
         Scenario(controller = controller).block()
+    }
+
+    private fun enqueueCheckoutInit(fixture: String = FIXTURE_WITH_ADAPTIVE_PRICING) {
+        networkRule.checkoutInit { response ->
+            // The loader requires a billing email (sourced from customer_email) and Link is disabled
+            // so the loader doesn't fire an unrelated consumer session lookup.
+            response.testBodyFromFile(fixture) { json ->
+                json.put("customer_email", "checkout@example.com")
+                json.getJSONObject("elements_session").remove("link_settings")
+            }
+        }
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleAppearanceScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleAppearanceScreenshotTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CurrencySelectorElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -31,7 +31,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testCustomColors() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .selectedBackground(Color(0xFF6200EE))
             .background(Color(0xFFE8DEF8))
             .selectedTextColor(Color.White)
@@ -54,7 +54,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testCustomDimensions() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .contentVerticalPaddingDp(12f)
             .cornerRadiusDp(8f)
             .borderWidthDp(1f)
@@ -73,7 +73,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testLargeSizeScaleFactor() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .sizeScaleFactor(1.4f)
             .contentVerticalPaddingDp(8f)
             .build()
@@ -91,7 +91,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testSmallSizeScaleFactor() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .sizeScaleFactor(0.8f)
             .contentVerticalPaddingDp(2f)
             .build()
@@ -109,7 +109,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testCustomDangerColor() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .dangerColor(Color(0xFFB3261E))
             .build()
 
@@ -127,7 +127,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testNoBorder() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .borderWidthDp(0f)
             .build()
 
@@ -144,7 +144,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testSquareCorners() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .cornerRadiusDp(0f)
             .borderWidthDp(1f)
             .build()
@@ -162,7 +162,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testCustomTextSecondaryColor() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .textSecondaryColor(Color(0xFF006B5E))
             .build()
 
@@ -179,7 +179,7 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testSecondOptionSelectedWithCustomColors() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
+        val appearance = CurrencySelectorElement.Appearance()
             .selectedBackground(Color(0xFF006B5E))
             .selectedTextColor(Color.White)
             .background(Color(0xFFD0F5EE))
@@ -199,8 +199,8 @@ internal class CurrencySelectorToggleAppearanceScreenshotTest {
 
     @Test
     fun testLabelContentCurrencyCode() {
-        val appearance = Checkout.CurrencySelectorContentAppearance()
-            .labelContent(Checkout.CurrencySelectorContentAppearance.LabelContent.CURRENCY_CODE)
+        val appearance = CurrencySelectorElement.Appearance()
+            .labelContent(CurrencySelectorElement.Appearance.LabelContent.CURRENCY_CODE)
             .build()
 
         paparazziRule.snapshot {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleScreenshotTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.verticalmode
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CurrencySelectorElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -23,7 +23,7 @@ internal class CurrencySelectorToggleScreenshotTest {
         boxModifier = Modifier.padding(all = 16.dp),
     )
 
-    private val defaultAppearance = Checkout.CurrencySelectorContentAppearance().build()
+    private val defaultAppearance = CurrencySelectorElement.Appearance().build()
 
     private val options = CurrencySelectorOptions(
         first = CurrencyOption(code = "USD", formattedAmount = "$50.99", flag = FlagContent.Emoji("🇺🇸")),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/CurrencySelectorToggleUITest.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CurrencySelectorElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.createComposeCleanupRule
 import kotlinx.coroutines.test.runTest
@@ -174,7 +174,7 @@ internal class CurrencySelectorToggleUITest {
                 isEnabled = isEnabled,
                 showCurrencyCode = showCurrencyCode,
                 errorMessage = errorMessage,
-                appearance = Checkout.CurrencySelectorContentAppearance().build(),
+                appearance = CurrencySelectorElement.Appearance().build(),
             )
         }
 


### PR DESCRIPTION
# Summary
Refactored CurrencySelector appearance from using Checkout-specific types to a shared CurrencySelectorElement.Appearance type, clarified mapping between types, and expanded test coverage for appearance configuration. Updated usages, tests, and screenshots to use the new type.

# Motivation
Simplify and standardize styling of the CurrencySelector element across the codebase, removing ambiguity between similar appearance types and making appearance configuration easier to use and test. Improved testability and reliability by adding dedicated unit and UI tests.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
