### PR TITLE
Add NFC scanning dimensions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.analytics.experiment
 
+import com.stripe.android.common.nfcscan.analytics.NfcScanningExperimentDimensions
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.ExperimentAssignment
@@ -105,12 +106,14 @@ internal sealed class LoggableExperiment(
     data class OcsMobileNfcScanningFeatureHoldback(
         val experimentsData: ElementsSession.ExperimentsData,
         override val group: String,
+        val canUseNfcScanner: Boolean,
         val metadata: PaymentMethodMetadata,
         val mode: EventReporter.Mode,
     ) : LoggableExperiment(
         arbId = experimentsData.arbId,
         experiment = ExperimentAssignment.OCS_MOBILE_NFC_SCANNING_FEATURE_HOLDBACK,
         group = group,
-        dimensions = CommonElementsDimensions.getDimensions(metadata, mode),
+        dimensions = CommonElementsDimensions.getDimensions(metadata, mode) +
+            NfcScanningExperimentDimensions.getDimensions(canUseNfcScanner, metadata),
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
@@ -25,22 +25,24 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
             return false
         }
 
+        val canUseNfcScanner = isDeviceSecureForNfc.get() &&
+            nfcHardwareDelegate.isAvailable()
+
         val variant = metadata.experimentsData?.experimentAssignments[
             ExperimentAssignment.OCS_MOBILE_NFC_SCANNING_FEATURE_HOLDBACK
         ]
 
-        logExposureIfNeeded(variant, metadata)
+        logExposureIfNeeded(variant, metadata, canUseNfcScanner)
 
         val canUseNfcScanning = variant == "treatment" || variant == null
 
-        return canUseNfcScanning &&
-            isDeviceSecureForNfc.get() &&
-            nfcHardwareDelegate.isAvailable()
+        return canUseNfcScanning && canUseNfcScanner
     }
 
     private fun logExposureIfNeeded(
         variant: String?,
         metadata: PaymentMethodMetadata,
+        canUseNfcScanner: Boolean,
     ) {
         if (variant == null) {
             return
@@ -52,6 +54,7 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
             group = variant,
             metadata = metadata,
             mode = mode,
+            canUseNfcScanner = canUseNfcScanner,
         )
 
         eventReporter.onExperimentExposure(exposure)

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensions.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal object NfcScanningExperimentDimensions {
+    fun getDimensions(
+        canUseNfcScanner: Boolean,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): Map<String, String> {
+        val billingDetailsConfig = paymentMethodMetadata.billingDetailsCollectionConfiguration
+
+        val billingDetailsCollection = when (billingDetailsConfig.address) {
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> "min"
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> "none"
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> "full"
+        }
+
+        val hasDefaultBillingDetails = paymentMethodMetadata.defaultBillingDetails != null
+
+        val requiresContactInfoCollection = billingDetailsConfig.collectsName ||
+            billingDetailsConfig.collectsPhone ||
+            billingDetailsConfig.collectsEmail
+
+        return mapOf(
+            "can_use_nfc_scanning" to canUseNfcScanner.toString(),
+            "has_default_billing_details" to hasDefaultBillingDetails.toString(),
+            "billing_address_collection" to billingDetailsCollection,
+            "requires_contact_info_collection" to requiresContactInfoCollection.toString(),
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensions.kt
@@ -16,7 +16,7 @@ internal object NfcScanningExperimentDimensions {
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> "full"
         }
 
-        val hasDefaultBillingDetails = paymentMethodMetadata.defaultBillingDetails != null
+        val hasDefaultBillingDetails = paymentMethodMetadata.defaultBillingDetails?.isFilledOut() == true
 
         val requiresContactInfoCollection = billingDetailsConfig.collectsName ||
             billingDetailsConfig.collectsPhone ||

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.common.nfcscan.hardware.FakeNfcHardwareDelegate
 import com.stripe.android.common.nfcscan.security.FakeIsDeviceSecureForNfc
+import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.ExperimentAssignment
@@ -121,6 +122,8 @@ internal class IsNfcScanningAvailableTest {
             as LoggableExperiment.OcsMobileNfcScanningFeatureHoldback
         assertThat(exposure.group).isEqualTo("treatment")
         assertThat(exposure.experiment).isEqualTo(ExperimentAssignment.OCS_MOBILE_NFC_SCANNING_FEATURE_HOLDBACK)
+        assertThat(exposure.canUseNfcScanner).isTrue()
+        assertThat(exposure.dimensions).containsEntry("can_use_nfc_scanning", "true")
         eventReporter.experimentExposureCalls.expectNoEvents()
     }
 
@@ -138,6 +141,57 @@ internal class IsNfcScanningAvailableTest {
         val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
             as LoggableExperiment.OcsMobileNfcScanningFeatureHoldback
         assertThat(exposure.group).isEqualTo("control")
+        assertThat(exposure.canUseNfcScanner).isTrue()
+        assertThat(exposure.dimensions).containsEntry("can_use_nfc_scanning", "true")
+        eventReporter.experimentExposureCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `logs canUseNfcScanner as false when device is not secure`() = runTest {
+        val eventReporter = FakeEventReporter()
+        val isNfcScanningAvailable = createIsNfcScanningAvailable(
+            eventReporter = eventReporter,
+            isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = false),
+        )
+
+        isNfcScanningAvailable.get(
+            metadata = createMetadata(
+                isNfcScanningEnabled = true,
+                experimentVariant = "treatment",
+            )
+        )
+
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+        assertThat(exposure).isInstanceOf<LoggableExperiment.OcsMobileNfcScanningFeatureHoldback>()
+        val featureHoldback = exposure as LoggableExperiment.OcsMobileNfcScanningFeatureHoldback
+
+        assertThat(featureHoldback.canUseNfcScanner).isFalse()
+        assertThat(featureHoldback.dimensions).containsEntry("can_use_nfc_scanning", "false")
+
+        eventReporter.experimentExposureCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `logs canUseNfcScanner as false when NFC hardware is unavailable`() = runTest {
+        val eventReporter = FakeEventReporter()
+        val isNfcScanningAvailable = createIsNfcScanningAvailable(
+            eventReporter = eventReporter,
+            nfcHardwareDelegate = FakeNfcHardwareDelegate(result = false),
+        )
+
+        isNfcScanningAvailable.get(
+            metadata = createMetadata(
+                isNfcScanningEnabled = true,
+                experimentVariant = "control",
+            )
+        )
+
+        val exposure = eventReporter.experimentExposureCalls.awaitItem().experiment
+        assertThat(exposure).isInstanceOf<LoggableExperiment.OcsMobileNfcScanningFeatureHoldback>()
+        val featureHoldback = exposure as LoggableExperiment.OcsMobileNfcScanningFeatureHoldback
+
+        assertThat(featureHoldback.canUseNfcScanner).isFalse()
+        assertThat(featureHoldback.dimensions).containsEntry("can_use_nfc_scanning", "false")
         eventReporter.experimentExposureCalls.expectNoEvents()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensionsTest.kt
@@ -1,0 +1,138 @@
+package com.stripe.android.common.nfcscan.analytics
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Test
+
+internal class NfcScanningExperimentDimensionsTest {
+    @Test
+    fun `can_use_nfc_scanning dimension reflects availability`() {
+        val metadata = PaymentMethodMetadataFactory.create()
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = metadata,
+            )
+        ).containsEntry("can_use_nfc_scanning", "true")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = false,
+                paymentMethodMetadata = metadata,
+            )
+        ).containsEntry("can_use_nfc_scanning", "false")
+    }
+
+    @Test
+    fun `has_default_billing_details dimension reflects default billing details presence`() {
+        val metadataWithDefaults = PaymentMethodMetadataFactory.create(
+            defaultBillingDetails = PaymentSheet.BillingDetails(name = "Jane Doe"),
+        )
+        val metadataWithoutDefaults = metadataWithDefaults.copy(defaultBillingDetails = null)
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = metadataWithDefaults,
+            )
+        ).containsEntry("has_default_billing_details", "true")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = metadataWithoutDefaults,
+            )
+        ).containsEntry("has_default_billing_details", "false")
+    }
+
+    @Test
+    fun `billing_address_collection dimension maps address collection mode`() {
+        val automaticMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            ),
+        )
+        val neverMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+            ),
+        )
+        val fullMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            ),
+        )
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = automaticMetadata,
+            )
+        ).containsEntry("billing_address_collection", "min")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = neverMetadata,
+            )
+        ).containsEntry("billing_address_collection", "none")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = fullMetadata,
+            )
+        ).containsEntry("billing_address_collection", "full")
+    }
+
+    @Test
+    fun `requires_contact_info_collection dimension reflects contact field collection`() {
+        val noContactCollectionMetadata = PaymentMethodMetadataFactory.create()
+
+        val nameCollectionMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            ),
+        )
+        val phoneCollectionMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            ),
+        )
+        val emailCollectionMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            ),
+        )
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = noContactCollectionMetadata,
+            )
+        ).containsEntry("requires_contact_info_collection", "false")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = nameCollectionMetadata,
+            )
+        ).containsEntry("requires_contact_info_collection", "true")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = phoneCollectionMetadata,
+            )
+        ).containsEntry("requires_contact_info_collection", "true")
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = emailCollectionMetadata,
+            )
+        ).containsEntry("requires_contact_info_collection", "true")
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/NfcScanningExperimentDimensionsTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 internal class NfcScanningExperimentDimensionsTest {
     @Test
-    fun `can_use_nfc_scanning dimension reflects availability`() {
+    fun `can_use_nfc_scanning is true when NFC scanner is available`() {
         val metadata = PaymentMethodMetadataFactory.create()
 
         assertThat(
@@ -16,6 +16,11 @@ internal class NfcScanningExperimentDimensionsTest {
                 paymentMethodMetadata = metadata,
             )
         ).containsEntry("can_use_nfc_scanning", "true")
+    }
+
+    @Test
+    fun `can_use_nfc_scanning is false when NFC scanner is unavailable`() {
+        val metadata = PaymentMethodMetadataFactory.create()
 
         assertThat(
             NfcScanningExperimentDimensions.getDimensions(
@@ -26,11 +31,10 @@ internal class NfcScanningExperimentDimensionsTest {
     }
 
     @Test
-    fun `has_default_billing_details dimension reflects default billing details presence`() {
+    fun `has_default_billing_details is true when default billing details is available`() {
         val metadataWithDefaults = PaymentMethodMetadataFactory.create(
             defaultBillingDetails = PaymentSheet.BillingDetails(name = "Jane Doe"),
         )
-        val metadataWithoutDefaults = metadataWithDefaults.copy(defaultBillingDetails = null)
 
         assertThat(
             NfcScanningExperimentDimensions.getDimensions(
@@ -38,6 +42,13 @@ internal class NfcScanningExperimentDimensionsTest {
                 paymentMethodMetadata = metadataWithDefaults,
             )
         ).containsEntry("has_default_billing_details", "true")
+    }
+
+    @Test
+    fun `has_default_billing_details is false when default billing details is empty`() {
+        val metadataWithoutDefaults = PaymentMethodMetadataFactory.create(
+            defaultBillingDetails = PaymentSheet.BillingDetails()
+        )
 
         assertThat(
             NfcScanningExperimentDimensions.getDimensions(
@@ -48,18 +59,52 @@ internal class NfcScanningExperimentDimensionsTest {
     }
 
     @Test
-    fun `billing_address_collection dimension maps address collection mode`() {
+    fun `has_default_billing_details is false when default billing details is null`() {
+        val metadataWithoutDefaults = PaymentMethodMetadataFactory.create().copy(defaultBillingDetails = null)
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = metadataWithoutDefaults,
+            )
+        ).containsEntry("has_default_billing_details", "false")
+    }
+
+    @Test
+    fun `billing_address_collection is 'min' when address collection is 'Automatic'`() {
         val automaticMetadata = PaymentMethodMetadataFactory.create(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
             ),
         )
-        val neverMetadata = PaymentMethodMetadataFactory.create(
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = automaticMetadata,
+            )
+        ).containsEntry("billing_address_collection", "min")
+    }
+
+    @Test
+    fun `billing_address_collection is 'none' when address collection is 'Never'`() {
+        val automaticMetadata = PaymentMethodMetadataFactory.create(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
             ),
         )
-        val fullMetadata = PaymentMethodMetadataFactory.create(
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = automaticMetadata,
+            )
+        ).containsEntry("billing_address_collection", "none")
+    }
+
+    @Test
+    fun `billing_address_collection is 'full' when address collection is 'Full'`() {
+        val automaticMetadata = PaymentMethodMetadataFactory.create(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             ),
@@ -70,38 +115,46 @@ internal class NfcScanningExperimentDimensionsTest {
                 canUseNfcScanner = true,
                 paymentMethodMetadata = automaticMetadata,
             )
-        ).containsEntry("billing_address_collection", "min")
-
-        assertThat(
-            NfcScanningExperimentDimensions.getDimensions(
-                canUseNfcScanner = true,
-                paymentMethodMetadata = neverMetadata,
-            )
-        ).containsEntry("billing_address_collection", "none")
-
-        assertThat(
-            NfcScanningExperimentDimensions.getDimensions(
-                canUseNfcScanner = true,
-                paymentMethodMetadata = fullMetadata,
-            )
         ).containsEntry("billing_address_collection", "full")
     }
 
     @Test
-    fun `requires_contact_info_collection dimension reflects contact field collection`() {
-        val noContactCollectionMetadata = PaymentMethodMetadataFactory.create()
+    fun `requires_contact_info_collection is false when none of contact fields are always`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            ),
+        )
 
-        val nameCollectionMetadata = PaymentMethodMetadataFactory.create(
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = paymentMethodMetadata,
+            )
+        ).containsEntry("requires_contact_info_collection", "false")
+    }
+
+    @Test
+    fun `requires_contact_info_collection is true when name field is always collected`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             ),
         )
-        val phoneCollectionMetadata = PaymentMethodMetadataFactory.create(
-            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            ),
-        )
-        val emailCollectionMetadata = PaymentMethodMetadataFactory.create(
+
+        assertThat(
+            NfcScanningExperimentDimensions.getDimensions(
+                canUseNfcScanner = true,
+                paymentMethodMetadata = paymentMethodMetadata,
+            )
+        ).containsEntry("requires_contact_info_collection", "true")
+    }
+
+    @Test
+    fun `requires_contact_info_collection is true when email field is always collected`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             ),
@@ -110,28 +163,23 @@ internal class NfcScanningExperimentDimensionsTest {
         assertThat(
             NfcScanningExperimentDimensions.getDimensions(
                 canUseNfcScanner = true,
-                paymentMethodMetadata = noContactCollectionMetadata,
-            )
-        ).containsEntry("requires_contact_info_collection", "false")
-
-        assertThat(
-            NfcScanningExperimentDimensions.getDimensions(
-                canUseNfcScanner = true,
-                paymentMethodMetadata = nameCollectionMetadata,
+                paymentMethodMetadata = paymentMethodMetadata,
             )
         ).containsEntry("requires_contact_info_collection", "true")
+    }
+
+    @Test
+    fun `requires_contact_info_collection is true when phone field is always collected`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            ),
+        )
 
         assertThat(
             NfcScanningExperimentDimensions.getDimensions(
                 canUseNfcScanner = true,
-                paymentMethodMetadata = phoneCollectionMetadata,
-            )
-        ).containsEntry("requires_contact_info_collection", "true")
-
-        assertThat(
-            NfcScanningExperimentDimensions.getDimensions(
-                canUseNfcScanner = true,
-                paymentMethodMetadata = emailCollectionMetadata,
+                paymentMethodMetadata = paymentMethodMetadata,
             )
         ).containsEntry("requires_contact_info_collection", "true")
     }


### PR DESCRIPTION
# Summary
Add NFC scanning dimensions to better indicate what settings merchants have enabled that could affect overall conversion rate of the NFC scanning feature.

# Motivation
Better visibility into NFC scanning conversion rates.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified