### PR TITLE
Get Google Pay country from CheckoutSession instead of from client side config

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -60,8 +60,9 @@ internal class CheckoutStateLoader @Inject constructor(
                     .asPaymentSheet()
             )
             .googlePay(
-                // TODO: pass the merchantCountry from the checkoutSession into asPaymentSheet
-                googlePay = configuration.googlePayConfiguration?.asPaymentSheet()
+                googlePay = configuration.googlePayConfiguration?.asPaymentSheet(
+                    merchantCountry = response.merchantCountry
+                )
             )
             .build()
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -60,6 +60,7 @@ internal class CheckoutStateLoader @Inject constructor(
                     .asPaymentSheet()
             )
             .googlePay(
+                // TODO: pass the merchantCountry from the checkoutSession into asPaymentSheet
                 googlePay = configuration.googlePayConfiguration?.asPaymentSheet()
             )
             .build()

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -60,9 +60,9 @@ internal class CheckoutStateLoader @Inject constructor(
                     .asPaymentSheet()
             )
             .googlePay(
-                googlePay = configuration.googlePayConfiguration?.asPaymentSheet(
-                    merchantCountry = response.merchantCountry
-                )
+                googlePay = response.merchantCountry?.let { merchantCountry ->
+                    configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)
+                }
             )
             .build()
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfiguration.kt
@@ -11,15 +11,11 @@ import kotlinx.parcelize.Parcelize
  * @param environment The Google Pay environment to use. See
  * [Google's documentation](https://developers.google.com/android/reference/com/google/android/gms/wallet/Wallet.WalletOptions#environment)
  * for more information.
- * @param countryCode The two-letter ISO 3166 code of the country of your business, e.g. "US".
- * See your account's country value [here](https://dashboard.stripe.com/settings/account).
  */
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GooglePayConfiguration(
     private val environment: Environment,
-    // TODO: remove countryCode
-    private val countryCode: String,
 ) {
     private var label: String? = null
     private var buttonType: ButtonType = ButtonType.Pay
@@ -56,8 +52,6 @@ class GooglePayConfiguration(
     @Parcelize
     internal data class State(
         val environment: Environment,
-        // TODO: remove countryCode
-        val countryCode: String,
         val label: String?,
         val buttonType: ButtonType,
         val additionalEnabledNetworks: List<String>,
@@ -65,7 +59,6 @@ class GooglePayConfiguration(
 
     internal fun build(): State = State(
         environment = environment,
-        countryCode = countryCode,
         label = label,
         buttonType = buttonType,
         additionalEnabledNetworks = additionalEnabledNetworks.toList(),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfiguration.kt
@@ -18,6 +18,7 @@ import kotlinx.parcelize.Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GooglePayConfiguration(
     private val environment: Environment,
+    // TODO: remove countryCode
     private val countryCode: String,
 ) {
     private var label: String? = null
@@ -55,6 +56,7 @@ class GooglePayConfiguration(
     @Parcelize
     internal data class State(
         val environment: Environment,
+        // TODO: remove countryCode
         val countryCode: String,
         val label: String?,
         val buttonType: ButtonType,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationMapper.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 
+// TODO: add merchantCountry as a param and use that value for countryCode instead of the one from GooglePayConfiguration.State
 @OptIn(CheckoutSessionPreview::class)
 internal fun GooglePayConfiguration.State.asPaymentSheet(): PaymentSheet.GooglePayConfiguration =
     PaymentSheet.GooglePayConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationMapper.kt
@@ -5,16 +5,14 @@ import com.stripe.android.paymentsheet.PaymentSheet
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun GooglePayConfiguration.State.asPaymentSheet(
-    merchantCountry: String?,
-): PaymentSheet.GooglePayConfiguration? = merchantCountry?.let { countryCode ->
-    PaymentSheet.GooglePayConfiguration(
-        environment = environment.asPaymentSheet(),
-        countryCode = countryCode,
-        label = label,
-        buttonType = buttonType.asPaymentSheet(),
-        additionalEnabledNetworks = additionalEnabledNetworks,
-    )
-}
+    merchantCountry: String,
+): PaymentSheet.GooglePayConfiguration = PaymentSheet.GooglePayConfiguration(
+    environment = environment.asPaymentSheet(),
+    countryCode = merchantCountry,
+    label = label,
+    buttonType = buttonType.asPaymentSheet(),
+    additionalEnabledNetworks = additionalEnabledNetworks,
+)
 
 @OptIn(CheckoutSessionPreview::class)
 private fun GooglePayConfiguration.Environment.asPaymentSheet():

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationMapper.kt
@@ -3,9 +3,10 @@ package com.stripe.android.checkout
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 
-// TODO: add merchantCountry as a param and use that value for countryCode instead of the one from GooglePayConfiguration.State
 @OptIn(CheckoutSessionPreview::class)
-internal fun GooglePayConfiguration.State.asPaymentSheet(): PaymentSheet.GooglePayConfiguration =
+internal fun GooglePayConfiguration.State.asPaymentSheet(
+    merchantCountry: String?,
+): PaymentSheet.GooglePayConfiguration? = merchantCountry?.let { countryCode ->
     PaymentSheet.GooglePayConfiguration(
         environment = environment.asPaymentSheet(),
         countryCode = countryCode,
@@ -13,6 +14,7 @@ internal fun GooglePayConfiguration.State.asPaymentSheet(): PaymentSheet.GoogleP
         buttonType = buttonType.asPaymentSheet(),
         additionalEnabledNetworks = additionalEnabledNetworks,
     )
+}
 
 @OptIn(CheckoutSessionPreview::class)
 private fun GooglePayConfiguration.Environment.asPaymentSheet():

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -30,6 +30,7 @@ internal data class CheckoutSessionResponse(
     val taxAddressSource: TaxAddressSource?,
     val allowedShippingCountries: List<String>?,
     val requiresBillingAddress: Boolean,
+    val merchantCountry: String?,
 ) : StripeModel {
 
     val shouldDisableWalletsForAutomaticTaxBilling: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -37,9 +37,10 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         require(uiMode == UI_MODE_CUSTOM) {
             "Expected ui_mode to be \"$UI_MODE_CUSTOM\" but was \"$uiMode\""
         }
-        // TODO: make account_settings and country fields string consts like we otherwise use as params.
-        val accountSettings = json.optJSONObject("account_settings")
-        val merchantCountry = accountSettings?.optString("country")
+        val accountSettings = json.optJSONObject(FIELD_ACCOUNT_SETTINGS)
+        val merchantCountry = accountSettings?.let {
+            StripeJsonUtils.optCountryCode(it, FIELD_ACCOUNT_SETTINGS_COUNTRY)
+        }
         val mode = parseMode(json.optString(FIELD_MODE))
         val status = parseStatus(json.optString(FIELD_STATUS))
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
@@ -110,7 +111,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
-            // TODO: add merchant country field which is equal to merchantCountry
+            merchantCountry = merchantCountry,
         )
     }
 
@@ -530,6 +531,8 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     }
 
     private const val FIELD_SESSION_ID = "session_id"
+    private const val FIELD_ACCOUNT_SETTINGS = "account_settings"
+    private const val FIELD_ACCOUNT_SETTINGS_COUNTRY = "country"
     private const val FIELD_UI_MODE = "ui_mode"
     private const val UI_MODE_CUSTOM = "custom"
     private const val FIELD_MODE = "mode"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -37,6 +37,9 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         require(uiMode == UI_MODE_CUSTOM) {
             "Expected ui_mode to be \"$UI_MODE_CUSTOM\" but was \"$uiMode\""
         }
+        // TODO: make account_settings and country fields string consts like we otherwise use as params.
+        val accountSettings = json.optJSONObject("account_settings")
+        val merchantCountry = accountSettings?.optString("country")
         val mode = parseMode(json.optString(FIELD_MODE))
         val status = parseStatus(json.optString(FIELD_STATUS))
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
@@ -107,6 +110,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
+            // TODO: add merchant country field which is equal to merchantCountry
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -135,6 +135,24 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `loadInitial leaves googlePayConfiguration null when checkout session country is missing`() = runScenario {
+        val configuration = CheckoutController.Configuration()
+            .googlePayConfiguration(
+                GooglePayConfiguration(
+                    GooglePayConfiguration.Environment.Production,
+                )
+            )
+            .build()
+
+        loader.loadInitial(
+            configuration = configuration,
+            checkoutSessionResponse = response(merchantCountry = null),
+        )
+
+        assertThat(stateHolder.state?.embeddedConfiguration?.googlePay).isNull()
+    }
+
+    @Test
     fun `loadInitial upgrades Automatic to Full when the session requires a billing address`() =
         runScenario {
             val configuration = CheckoutController.Configuration()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -107,12 +107,11 @@ internal class CheckoutStateLoaderTest {
         }
 
     @Test
-    fun `loadInitial propagates googlePayConfiguration from the checkout configuration`() = runScenario {
+    fun `loadInitial uses the checkout session country for googlePayConfiguration`() = runScenario {
         val configuration = CheckoutController.Configuration()
             .googlePayConfiguration(
                 GooglePayConfiguration(
                     GooglePayConfiguration.Environment.Production,
-                    "CA",
                 )
                     .label("Total")
                     .buttonType(GooglePayConfiguration.ButtonType.Checkout)
@@ -120,12 +119,15 @@ internal class CheckoutStateLoaderTest {
             )
             .build()
 
-        loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+        loader.loadInitial(
+            configuration = configuration,
+            checkoutSessionResponse = response(merchantCountry = "GB"),
+        )
 
         val actual = requireNotNull(stateHolder.state?.embeddedConfiguration?.googlePay)
         assertThat(actual.environment)
             .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Production)
-        assertThat(actual.countryCode).isEqualTo("CA")
+        assertThat(actual.countryCode).isEqualTo("GB")
         assertThat(actual.label).isEqualTo("Total")
         assertThat(actual.buttonType)
             .isEqualTo(PaymentSheet.GooglePayConfiguration.ButtonType.Checkout)
@@ -290,7 +292,9 @@ internal class CheckoutStateLoaderTest {
 
     private fun defaultConfiguration() = CheckoutController.Configuration().build()
 
-    private fun response() = CheckoutSessionResponseFactory.create()
+    private fun response(
+        merchantCountry: String? = "US",
+    ) = CheckoutSessionResponseFactory.create(merchantCountry = merchantCountry)
 
     private fun bdcc(
         address: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/GooglePayConfigurationMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/GooglePayConfigurationMapperTest.kt
@@ -10,11 +10,9 @@ internal class GooglePayConfigurationMapperTest {
 
     @Test
     fun `default owned config maps to PaymentSheet defaults`() {
-        val mapped = requireNotNull(
-            GooglePayConfiguration(
-                GooglePayConfiguration.Environment.Test,
-            ).build().asPaymentSheet(merchantCountry = "US")
-        )
+        val mapped = GooglePayConfiguration(
+            GooglePayConfiguration.Environment.Test,
+        ).build().asPaymentSheet(merchantCountry = "US")
 
         assertThat(mapped.environment).isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Test)
         assertThat(mapped.countryCode).isEqualTo("US")
@@ -23,16 +21,14 @@ internal class GooglePayConfigurationMapperTest {
 
     @Test
     fun `all fields map 1 to 1`() {
-        val mapped = requireNotNull(
-            GooglePayConfiguration(
-                GooglePayConfiguration.Environment.Production,
-            )
-                .label("Total")
-                .buttonType(GooglePayConfiguration.ButtonType.Checkout)
-                .additionalEnabledNetworks(listOf("INTERAC"))
-                .build()
-                .asPaymentSheet(merchantCountry = "CA")
+        val mapped = GooglePayConfiguration(
+            GooglePayConfiguration.Environment.Production,
         )
+            .label("Total")
+            .buttonType(GooglePayConfiguration.ButtonType.Checkout)
+            .additionalEnabledNetworks(listOf("INTERAC"))
+            .build()
+            .asPaymentSheet(merchantCountry = "CA")
 
         assertThat(mapped.environment)
             .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Production)
@@ -44,25 +40,14 @@ internal class GooglePayConfigurationMapperTest {
     }
 
     @Test
-    fun `returns null when merchant country is not available`() {
-        val mapped = GooglePayConfiguration(
-            GooglePayConfiguration.Environment.Test,
-        ).build().asPaymentSheet(merchantCountry = null)
-
-        assertThat(mapped).isNull()
-    }
-
-    @Test
     fun `every button type maps to the matching PaymentSheet value`() {
         GooglePayConfiguration.ButtonType.entries.forEach { buttonType ->
-            val mapped = requireNotNull(
-                GooglePayConfiguration(
-                    GooglePayConfiguration.Environment.Test,
-                )
-                    .buttonType(buttonType)
-                    .build()
-                    .asPaymentSheet(merchantCountry = "US")
+            val mapped = GooglePayConfiguration(
+                GooglePayConfiguration.Environment.Test,
             )
+                .buttonType(buttonType)
+                .build()
+                .asPaymentSheet(merchantCountry = "US")
 
             assertThat(mapped.buttonType.name).isEqualTo(buttonType.name)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/GooglePayConfigurationMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/GooglePayConfigurationMapperTest.kt
@@ -10,10 +10,11 @@ internal class GooglePayConfigurationMapperTest {
 
     @Test
     fun `default owned config maps to PaymentSheet defaults`() {
-        val mapped = GooglePayConfiguration(
-            GooglePayConfiguration.Environment.Test,
-            "US",
-        ).build().asPaymentSheet()
+        val mapped = requireNotNull(
+            GooglePayConfiguration(
+                GooglePayConfiguration.Environment.Test,
+            ).build().asPaymentSheet(merchantCountry = "US")
+        )
 
         assertThat(mapped.environment).isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Test)
         assertThat(mapped.countryCode).isEqualTo("US")
@@ -22,15 +23,16 @@ internal class GooglePayConfigurationMapperTest {
 
     @Test
     fun `all fields map 1 to 1`() {
-        val mapped = GooglePayConfiguration(
-            GooglePayConfiguration.Environment.Production,
-            "CA",
+        val mapped = requireNotNull(
+            GooglePayConfiguration(
+                GooglePayConfiguration.Environment.Production,
+            )
+                .label("Total")
+                .buttonType(GooglePayConfiguration.ButtonType.Checkout)
+                .additionalEnabledNetworks(listOf("INTERAC"))
+                .build()
+                .asPaymentSheet(merchantCountry = "CA")
         )
-            .label("Total")
-            .buttonType(GooglePayConfiguration.ButtonType.Checkout)
-            .additionalEnabledNetworks(listOf("INTERAC"))
-            .build()
-            .asPaymentSheet()
 
         assertThat(mapped.environment)
             .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Production)
@@ -42,15 +44,25 @@ internal class GooglePayConfigurationMapperTest {
     }
 
     @Test
+    fun `returns null when merchant country is not available`() {
+        val mapped = GooglePayConfiguration(
+            GooglePayConfiguration.Environment.Test,
+        ).build().asPaymentSheet(merchantCountry = null)
+
+        assertThat(mapped).isNull()
+    }
+
+    @Test
     fun `every button type maps to the matching PaymentSheet value`() {
         GooglePayConfiguration.ButtonType.entries.forEach { buttonType ->
-            val mapped = GooglePayConfiguration(
-                GooglePayConfiguration.Environment.Test,
-                "US",
+            val mapped = requireNotNull(
+                GooglePayConfiguration(
+                    GooglePayConfiguration.Environment.Test,
+                )
+                    .buttonType(buttonType)
+                    .build()
+                    .asPaymentSheet(merchantCountry = "US")
             )
-                .buttonType(buttonType)
-                .build()
-                .asPaymentSheet()
 
             assertThat(mapped.buttonType.name).isEqualTo(buttonType.name)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/GooglePayConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/GooglePayConfigurationTest.kt
@@ -11,11 +11,9 @@ internal class GooglePayConfigurationTest {
     fun `configuration defaults optional values`() {
         val state = GooglePayConfiguration(
             GooglePayConfiguration.Environment.Test,
-            "US"
         ).build()
 
         assertThat(state.environment).isEqualTo(GooglePayConfiguration.Environment.Test)
-        assertThat(state.countryCode).isEqualTo("US")
         assertThat(state.label).isNull()
         assertThat(state.buttonType).isEqualTo(GooglePayConfiguration.ButtonType.Pay)
         assertThat(state.additionalEnabledNetworks).isEmpty()
@@ -25,7 +23,6 @@ internal class GooglePayConfigurationTest {
     fun `configuration builds requested values`() {
         val state = GooglePayConfiguration(
             GooglePayConfiguration.Environment.Production,
-            "CA",
         )
             .label("Total")
             .buttonType(GooglePayConfiguration.ButtonType.Checkout)
@@ -33,7 +30,6 @@ internal class GooglePayConfigurationTest {
             .build()
 
         assertThat(state.environment).isEqualTo(GooglePayConfiguration.Environment.Production)
-        assertThat(state.countryCode).isEqualTo("CA")
         assertThat(state.label).isEqualTo("Total")
         assertThat(state.buttonType).isEqualTo(GooglePayConfiguration.ButtonType.Checkout)
         assertThat(state.additionalEnabledNetworks).containsExactly("INTERAC")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -29,6 +29,7 @@ internal object CheckoutSessionResponseFactory {
         taxAddressSource: CheckoutSessionResponse.TaxAddressSource? = null,
         allowedShippingCountries: List<String>? = null,
         requiresBillingAddress: Boolean = false,
+        merchantCountry: String? = "US",
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -52,6 +53,7 @@ internal object CheckoutSessionResponseFactory {
             taxAddressSource = taxAddressSource,
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
+            merchantCountry = merchantCountry,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -762,6 +762,25 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
+    fun `parse merchant country from account settings`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "ui_mode": "custom",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 },
+                "account_settings": { "country": "GB" }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser.parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.merchantCountry).isEqualTo("GB")
+    }
+
+    @Test
     fun `customerEmail is null when customer_email is JSON null`() {
         val json = JSONObject(
             """


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Get Google Pay country from CheckoutSession instead of from client side config

Merchant country should always be available on the response, but we need to handle it being nullable for safety

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Ease for integration + consistency

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified