### PR TITLE
Refactor EmbeddedContentHelper state management to separate StateHolder class.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -1,101 +1,41 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import android.os.Parcelable
-import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.ViewModelScope
-import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.link.verification.NoOpLinkInlineInteractor
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentelement.AnalyticEventCallback
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.FormHelper.FormType
-import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
-import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
-import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
-import com.stripe.android.paymentsheet.state.WalletsState
-import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
-import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
-import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
-import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import com.stripe.android.uicore.utils.combineAsStateFlow
-import com.stripe.android.uicore.utils.mapAsStateFlow
-import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 internal interface EmbeddedContentHelper {
     val embeddedContent: StateFlow<EmbeddedContent?>
     val walletButtonsContent: StateFlow<WalletButtonsContent?>
 
-    fun dataLoaded(
-        paymentMethodMetadata: PaymentMethodMetadata,
-        appearance: Embedded,
-        embeddedViewDisplaysMandateText: Boolean,
-    )
-
-    fun clearEmbeddedContent()
-
-    fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher)
-
-    fun clearSheetLauncher()
-
     fun presentPaymentOptions()
 }
 
-@OptIn(ExperimentalAnalyticEventCallbackApi::class)
 @Singleton
 internal class DefaultEmbeddedContentHelper @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val savedStateHandle: SavedStateHandle,
-    private val eventReporter: EventReporter,
-    private val errorReporter: ErrorReporter,
-    @IOContext private val workContext: CoroutineContext,
-    @UIContext private val uiContext: CoroutineContext,
-    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
-    private val selectionHolder: EmbeddedSelectionHolder,
-    private val embeddedLinkHelper: EmbeddedLinkHelper,
-    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
-    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
-    private val analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
+    private val stateHolder: EmbeddedContentHelperStateHolder,
+    private val verticalLayoutInteractorFactory: EmbeddedPaymentMethodVerticalLayoutInteractorFactory,
+    private val walletButtonsInteractorFactory: EmbeddedWalletButtonsInteractorFactory,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
     private val embeddedWalletsHelper: EmbeddedWalletsHelper,
+    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
     private val customerStateHolder: CustomerStateHolder,
-    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
-    private val confirmationHandler: ConfirmationHandler,
+    private val selectionHolder: EmbeddedSelectionHolder,
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
-    private val linkPaymentLauncher: LinkPaymentLauncher,
-    private val linkAccountHolder: LinkAccountHolder,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
+    private val errorReporter: ErrorReporter,
 ) : EmbeddedContentHelper {
-
-    private val state: StateFlow<State?> = savedStateHandle.getStateFlow(
-        key = STATE_KEY_EMBEDDED_CONTENT,
-        initialValue = null
-    )
 
     private val _embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
     override val embeddedContent: StateFlow<EmbeddedContent?> = _embeddedContent.asStateFlow()
@@ -103,18 +43,15 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     private val _walletButtonsContent = MutableStateFlow<WalletButtonsContent?>(null)
     override val walletButtonsContent: StateFlow<WalletButtonsContent?> = _walletButtonsContent.asStateFlow()
 
-    private var sheetLauncher: EmbeddedSheetLauncher? = null
-
     init {
         coroutineScope.launch {
-            state.collect { state ->
+            stateHolder.state.collect { state ->
                 _embeddedContent.value = if (state == null) {
                     null
                 } else {
                     val isImmediateAction = internalRowSelectionCallback.get() != null
                     EmbeddedContent(
-                        interactor = createInteractor(
-                            coroutineScope = coroutineScope,
+                        interactor = verticalLayoutInteractorFactory.create(
                             paymentMethodMetadata = state.paymentMethodMetadata,
                             walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
                             isImmediateAction = isImmediateAction,
@@ -129,54 +66,27 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
         }
 
         coroutineScope.launch {
-            state.collect { state ->
+            stateHolder.state.collect { state ->
                 _walletButtonsContent.value = if (state == null) {
                     null
                 } else {
                     WalletButtonsContent(
-                        interactor = createWalletButtonsInteractor(
-                            coroutineScope = coroutineScope,
-                        ),
+                        interactor = walletButtonsInteractorFactory.create(),
                     )
                 }
             }
         }
     }
 
-    override fun dataLoaded(
-        paymentMethodMetadata: PaymentMethodMetadata,
-        appearance: Embedded,
-        embeddedViewDisplaysMandateText: Boolean,
-    ) {
-        eventReporter.onShowNewPaymentOptions()
-        savedStateHandle[STATE_KEY_EMBEDDED_CONTENT] = State(
-            paymentMethodMetadata = paymentMethodMetadata,
-            appearance = appearance,
-            embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
-        )
-    }
-
-    override fun clearEmbeddedContent() {
-        savedStateHandle[STATE_KEY_EMBEDDED_CONTENT] = null
-    }
-
-    override fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher) {
-        this.sheetLauncher = sheetLauncher
-    }
-
-    override fun clearSheetLauncher() {
-        sheetLauncher = null
-    }
-
     override fun presentPaymentOptions() {
-        val state = state.value
+        val state = stateHolder.state.value
         if (state == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED
             )
             return
         }
-        val launcher = sheetLauncher
+        val launcher = sheetLauncherHolder.sheetLauncher
         if (launcher == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER
@@ -189,176 +99,5 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             selection = selectionHolder.selection.value,
             embeddedConfirmationState = confirmationStateHolder.state,
         )
-    }
-
-    private fun createWalletButtonsInteractor(
-        coroutineScope: CoroutineScope,
-    ): WalletButtonsInteractor {
-        return DefaultWalletButtonsInteractor.create(
-            embeddedLinkHelper = embeddedLinkHelper,
-            confirmationStateHolder = confirmationStateHolder,
-            confirmationHandler = confirmationHandler,
-            coroutineScope = coroutineScope,
-            errorReporter = errorReporter,
-            eventReporter = eventReporter,
-            linkPaymentLauncher = linkPaymentLauncher,
-            linkAccountHolder = linkAccountHolder,
-            linkInlineInteractor = NoOpLinkInlineInteractor(),
-            analyticsCallbackProvider = analyticsCallbackProvider,
-        )
-    }
-
-    private fun createInteractor(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        walletsState: StateFlow<WalletsState?>,
-        isImmediateAction: Boolean,
-        embeddedViewDisplaysMandateText: Boolean,
-    ): PaymentMethodVerticalLayoutInteractor {
-        val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
-            incentive = paymentMethodMetadata.paymentMethodIncentive,
-        )
-        val formHelper = embeddedFormHelperFactory.create(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = eventReporter,
-            // Card scan auto-launch is only relevant in the form, not the list (as the form helper is used in here).
-            automaticallyLaunchedCardScanFormDataHelper = null,
-            tapToAddHelper = null,
-            selectionUpdater = {
-                setSelection(it)
-                invokeRowSelectionCallback()
-            },
-            // Not important for determining formType so set to default value
-            setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-        )
-        val savedPaymentMethodMutator = createSavedPaymentMethodMutator(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            customerStateHolder = customerStateHolder,
-        )
-
-        return DefaultPaymentMethodVerticalLayoutInteractor(
-            paymentMethodMetadata = paymentMethodMetadata,
-            processing = combineAsStateFlow(
-                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
-                confirmationStateHolder.stateFlow.mapAsStateFlow { it != null },
-            ) { confirmationStateValid, configurationStateValid ->
-                confirmationStateValid && configurationStateValid
-            },
-            temporarySelection = selectionHolder.temporarySelection,
-            selection = selectionHolder.selection,
-            paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
-            formTypeForCode = { code ->
-                formHelper.formTypeForCode(code)
-            },
-            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
-            transitionToManageScreen = {
-                sheetLauncher?.launchManage(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = requireNotNull(customerStateHolder.customer.value),
-                    selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateHolder.state,
-                )
-            },
-            transitionToFormScreen = { code ->
-                sheetLauncher?.launchForm(
-                    code = code,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    embeddedConfirmationState = confirmationStateHolder.state,
-                    customerState = customerStateHolder.customer.value,
-                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
-                        code = code,
-                        metadata = paymentMethodMetadata
-                    )
-                )
-            },
-            paymentMethods = customerStateHolder.paymentMethods,
-            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
-            canRemove = customerStateHolder.canRemove,
-            canUpdateCardExpiryAndBillingDetails = customerStateHolder.canUpdateCardExpiryAndBillingDetails,
-            canChangeCbc = customerStateHolder.canChangeCbc,
-            walletsState = walletsState,
-            updateSelection = { updatedSelection, requiresConfirmation ->
-                setSelection(updatedSelection)
-            },
-            isCurrentScreen = stateFlowOf(true),
-            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
-            reportFormShown = eventReporter::onPaymentMethodFormShown,
-            onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
-            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
-                val isConfirmFlow = confirmationStateHolder.state?.configuration?.formSheetAction ==
-                    EmbeddedPaymentElement.FormSheetAction.Confirm
-                if (isConfirmFlow) {
-                    val requiresFormScreen = paymentMethodCode != null &&
-                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
-                    !requiresFormScreen
-                } else {
-                    true
-                }
-            },
-            invokeRowSelectionCallback = ::invokeRowSelectionCallback,
-            displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
-            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
-                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
-                    visiblePaymentMethods = visiblePaymentMethods,
-                    hiddenPaymentMethods = hiddenPaymentMethods,
-                    walletsState = walletsState.value,
-                    isVerticalLayout = true,
-                )
-            },
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-        )
-    }
-
-    private fun createSavedPaymentMethodMutator(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        customerStateHolder: CustomerStateHolder,
-    ): SavedPaymentMethodMutator {
-        return SavedPaymentMethodMutator(
-            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
-            eventReporter = eventReporter,
-            coroutineScope = coroutineScope,
-            workContext = workContext,
-            uiContext = uiContext,
-            savedPaymentMethodRepository = savedPaymentMethodRepository,
-            selection = selectionHolder.selection,
-            setSelection = ::setSelection,
-            customerStateHolder = customerStateHolder,
-            prePaymentMethodRemoveActions = {},
-            postPaymentMethodRemoveActions = {},
-            onUpdatePaymentMethod = { _, _, _, _, _ ->
-                sheetLauncher?.launchManage(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = requireNotNull(customerStateHolder.customer.value),
-                    selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateHolder.state,
-                )
-            },
-            isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
-            isNotPaymentFlow = false,
-            accountLinkBrandFlow = linkAccountHolder.linkAccountInfo.mapAsStateFlow { it.account?.linkBrand },
-        )
-    }
-
-    private fun invokeRowSelectionCallback() {
-        rowSelectionImmediateActionHandler.invoke()
-    }
-
-    private fun setSelection(paymentSelection: PaymentSelection?) {
-        selectionHolder.setSelection(paymentSelection)
-    }
-
-    @Parcelize
-    class State(
-        val paymentMethodMetadata: PaymentMethodMetadata,
-        val appearance: Embedded,
-        val embeddedViewDisplaysMandateText: Boolean,
-    ) : Parcelable
-
-    companion object {
-        const val STATE_KEY_EMBEDDED_CONTENT = "STATE_KEY_EMBEDDED_CONTENT"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateHolder.kt
@@ -1,0 +1,65 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal interface EmbeddedContentHelperStateHolder {
+    val state: StateFlow<State?>
+
+    fun dataLoaded(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        appearance: Embedded,
+        embeddedViewDisplaysMandateText: Boolean,
+    )
+
+    fun clearEmbeddedContent()
+
+    @Parcelize
+    class State(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val appearance: Embedded,
+        val embeddedViewDisplaysMandateText: Boolean,
+    ) : Parcelable
+
+    companion object {
+        const val STATE_KEY_EMBEDDED_CONTENT = "STATE_KEY_EMBEDDED_CONTENT"
+    }
+}
+
+@Singleton
+internal class DefaultEmbeddedContentHelperStateHolder @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val eventReporter: EventReporter,
+) : EmbeddedContentHelperStateHolder {
+
+    override val state: StateFlow<EmbeddedContentHelperStateHolder.State?> =
+        savedStateHandle.getStateFlow(
+            key = EmbeddedContentHelperStateHolder.STATE_KEY_EMBEDDED_CONTENT,
+            initialValue = null,
+        )
+
+    override fun dataLoaded(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        appearance: Embedded,
+        embeddedViewDisplaysMandateText: Boolean,
+    ) {
+        eventReporter.onShowNewPaymentOptions()
+        val state = EmbeddedContentHelperStateHolder.State(
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
+            embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+        )
+        savedStateHandle[EmbeddedContentHelperStateHolder.STATE_KEY_EMBEDDED_CONTENT] = state
+    }
+
+    override fun clearEmbeddedContent() {
+        savedStateHandle[EmbeddedContentHelperStateHolder.STATE_KEY_EMBEDDED_CONTENT] = null
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.UIContext
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+internal class EmbeddedContentSavedPaymentMethodMutatorFactory @Inject constructor(
+    private val eventReporter: EventReporter,
+    @IOContext private val workContext: CoroutineContext,
+    @UIContext private val uiContext: CoroutineContext,
+    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    private val linkAccountHolder: LinkAccountHolder,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+) {
+    fun create(paymentMethodMetadata: PaymentMethodMetadata): SavedPaymentMethodMutator {
+        return SavedPaymentMethodMutator(
+            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
+            eventReporter = eventReporter,
+            coroutineScope = coroutineScope,
+            workContext = workContext,
+            uiContext = uiContext,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
+            selection = selectionHolder.selection,
+            setSelection = selectionHolder::setSelection,
+            customerStateHolder = customerStateHolder,
+            prePaymentMethodRemoveActions = {},
+            postPaymentMethodRemoveActions = {},
+            onUpdatePaymentMethod = { _, _, _, _, _ ->
+                sheetLauncherHolder.sheetLauncher?.launchManage(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    customerState = requireNotNull(customerStateHolder.customer.value),
+                    selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = confirmationStateHolder.state,
+                )
+            },
+            isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
+            isNotPaymentFlow = false,
+            accountLinkBrandFlow = linkAccountHolder.linkAccountInfo.mapAsStateFlow { it.account?.linkBrand },
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializer.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @EmbeddedPaymentElementScope
 internal class EmbeddedPaymentElementInitializer @Inject constructor(
     private val sheetLauncher: EmbeddedSheetLauncher,
-    private val contentHelper: EmbeddedContentHelper,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
     private val lifecycleOwner: LifecycleOwner,
     private val savedStateHandle: SavedStateHandle,
     private val eventReporter: EventReporter,
@@ -30,13 +30,13 @@ internal class EmbeddedPaymentElementInitializer @Inject constructor(
             previouslySentDeepLinkEvent = true
         }
 
-        contentHelper.setSheetLauncher(sheetLauncher)
+        sheetLauncherHolder.sheetLauncher = sheetLauncher
 
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     PaymentElementCallbackReferences.remove(paymentElementCallbackIdentifier)
-                    contentHelper.clearSheetLauncher()
+                    sheetLauncherHolder.sheetLauncher = null
                 }
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -173,6 +173,21 @@ internal interface EmbeddedPaymentElementViewModelModule {
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
 
     @Binds
+    fun bindsEmbeddedContentHelperStateHolder(
+        stateHolder: DefaultEmbeddedContentHelperStateHolder
+    ): EmbeddedContentHelperStateHolder
+
+    @Binds
+    fun bindsEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
+        factory: DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory
+    ): EmbeddedPaymentMethodVerticalLayoutInteractorFactory
+
+    @Binds
+    fun bindsEmbeddedWalletButtonsInteractorFactory(
+        factory: DefaultEmbeddedWalletButtonsInteractorFactory
+    ): EmbeddedWalletButtonsInteractorFactory
+
+    @Binds
     fun bindsEmbeddedRowSelectionImmediateActionHandler(
         handler: DefaultEmbeddedRowSelectionImmediateActionHandler
     ): EmbeddedRowSelectionImmediateActionHandler

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -1,0 +1,148 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.FormHelper.FormType
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
+import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+internal fun interface EmbeddedPaymentMethodVerticalLayoutInteractorFactory {
+    fun create(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        walletsState: StateFlow<WalletsState?>,
+        isImmediateAction: Boolean,
+        embeddedViewDisplaysMandateText: Boolean,
+    ): PaymentMethodVerticalLayoutInteractor
+}
+
+internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inject constructor(
+    private val eventReporter: EventReporter,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    private val confirmationHandler: ConfirmationHandler,
+    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+    private val savedPaymentMethodMutatorFactory: EmbeddedContentSavedPaymentMethodMutatorFactory,
+) : EmbeddedPaymentMethodVerticalLayoutInteractorFactory {
+
+    @Suppress("LongMethod")
+    override fun create(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        walletsState: StateFlow<WalletsState?>,
+        isImmediateAction: Boolean,
+        embeddedViewDisplaysMandateText: Boolean,
+    ): PaymentMethodVerticalLayoutInteractor {
+        val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
+            incentive = paymentMethodMetadata.paymentMethodIncentive,
+        )
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = coroutineScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            // Card scan auto-launch is only relevant in the form, not the list (as the form helper is used in here).
+            automaticallyLaunchedCardScanFormDataHelper = null,
+            tapToAddHelper = null,
+            selectionUpdater = {
+                selectionHolder.setSelection(it)
+                rowSelectionImmediateActionHandler.invoke()
+            },
+            // Not important for determining formType so set to default value
+            setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+        )
+        val savedPaymentMethodMutator = savedPaymentMethodMutatorFactory.create(paymentMethodMetadata)
+
+        return DefaultPaymentMethodVerticalLayoutInteractor(
+            paymentMethodMetadata = paymentMethodMetadata,
+            processing = combineAsStateFlow(
+                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
+                confirmationStateHolder.stateFlow.mapAsStateFlow { it != null },
+            ) { confirmationStateValid, configurationStateValid ->
+                confirmationStateValid && configurationStateValid
+            },
+            temporarySelection = selectionHolder.temporarySelection,
+            selection = selectionHolder.selection,
+            paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
+            formTypeForCode = { code ->
+                formHelper.formTypeForCode(code)
+            },
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            transitionToManageScreen = {
+                sheetLauncherHolder.sheetLauncher?.launchManage(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    customerState = requireNotNull(customerStateHolder.customer.value),
+                    selection = selectionHolder.selection.value,
+                    embeddedConfirmationState = confirmationStateHolder.state,
+                )
+            },
+            transitionToFormScreen = { code ->
+                sheetLauncherHolder.sheetLauncher?.launchForm(
+                    code = code,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    embeddedConfirmationState = confirmationStateHolder.state,
+                    customerState = customerStateHolder.customer.value,
+                    promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
+                        code = code,
+                        metadata = paymentMethodMetadata
+                    )
+                )
+            },
+            paymentMethods = customerStateHolder.paymentMethods,
+            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
+            canRemove = customerStateHolder.canRemove,
+            canUpdateCardExpiryAndBillingDetails = customerStateHolder.canUpdateCardExpiryAndBillingDetails,
+            canChangeCbc = customerStateHolder.canChangeCbc,
+            walletsState = walletsState,
+            updateSelection = { updatedSelection, _ ->
+                selectionHolder.setSelection(updatedSelection)
+            },
+            isCurrentScreen = stateFlowOf(true),
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportFormShown = eventReporter::onPaymentMethodFormShown,
+            onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
+            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
+                val isConfirmFlow = confirmationStateHolder.state?.configuration?.formSheetAction ==
+                    EmbeddedPaymentElement.FormSheetAction.Confirm
+                if (isConfirmFlow) {
+                    val requiresFormScreen = paymentMethodCode != null &&
+                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
+                    !requiresFormScreen
+                } else {
+                    true
+                }
+            },
+            invokeRowSelectionCallback = rowSelectionImmediateActionHandler::invoke,
+            displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = walletsState.value,
+                    isVerticalLayout = true,
+                )
+            },
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSheetLauncherHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSheetLauncherHolder.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class EmbeddedSheetLauncherHolder @Inject constructor() {
+    var sheetLauncher: EmbeddedSheetLauncher? = null
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -17,7 +17,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
-    private val embeddedContentHelper: EmbeddedContentHelper,
+    private val contentStateHolder: EmbeddedContentHelperStateHolder,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
     private val confirmationHandler: ConfirmationHandler
 ) : EmbeddedStateHelper {
@@ -51,7 +51,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
         customerStateHolder.setCustomerState(state.customer)
         selectionHolder.setPreviousNewSelections(state.previousNewSelections)
         selectionHolder.setSelection(state.confirmationState.selection)
-        embeddedContentHelper.dataLoaded(
+        contentStateHolder.dataLoaded(
             paymentMethodMetadata = state.confirmationState.paymentMethodMetadata,
             appearance = state.confirmationState.configuration.appearance.embeddedAppearance,
             embeddedViewDisplaysMandateText = state.confirmationState.configuration.embeddedViewDisplaysMandateText,
@@ -78,7 +78,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     }
 
     private fun clearState() {
-        embeddedContentHelper.clearEmbeddedContent()
+        contentStateHolder.clearEmbeddedContent()
         confirmationStateHolder.state = null
         selectionHolder.setSelection(null)
         selectionHolder.previousNewSelections.clear()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletButtonsInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletButtonsInteractorFactory.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.verification.NoOpLinkInlineInteractor
+import com.stripe.android.paymentelement.AnalyticEventCallback
+import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
+import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal fun interface EmbeddedWalletButtonsInteractorFactory {
+    fun create(): WalletButtonsInteractor
+}
+
+@OptIn(ExperimentalAnalyticEventCallbackApi::class)
+internal class DefaultEmbeddedWalletButtonsInteractorFactory @Inject constructor(
+    private val embeddedLinkHelper: EmbeddedLinkHelper,
+    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    private val confirmationHandler: ConfirmationHandler,
+    private val errorReporter: ErrorReporter,
+    private val eventReporter: EventReporter,
+    private val linkPaymentLauncher: LinkPaymentLauncher,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val analyticsCallbackProvider: Provider<AnalyticEventCallback?>,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+) : EmbeddedWalletButtonsInteractorFactory {
+
+    override fun create(): WalletButtonsInteractor {
+        return DefaultWalletButtonsInteractor.create(
+            embeddedLinkHelper = embeddedLinkHelper,
+            confirmationStateHolder = confirmationStateHolder,
+            confirmationHandler = confirmationHandler,
+            coroutineScope = coroutineScope,
+            errorReporter = errorReporter,
+            eventReporter = eventReporter,
+            linkPaymentLauncher = linkPaymentLauncher,
+            linkAccountHolder = linkAccountHolder,
+            linkInlineInteractor = NoOpLinkInlineInteractor(),
+            analyticsCallbackProvider = analyticsCallbackProvider,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class DefaultEmbeddedContentHelperStateHolderTest {
+    @Test
+    fun `dataLoaded stores state and reports onShowNewPaymentOptions`() = testScenario {
+        stateHolder.state.test {
+            assertThat(awaitItem()).isNull()
+            val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+            val appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default)
+            stateHolder.dataLoaded(
+                paymentMethodMetadata = paymentMethodMetadata,
+                appearance = appearance,
+                embeddedViewDisplaysMandateText = true,
+            )
+            val state = awaitItem()
+            assertThat(state?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
+            assertThat(state?.appearance).isEqualTo(appearance)
+            assertThat(state?.embeddedViewDisplaysMandateText).isTrue()
+        }
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `clearEmbeddedContent resets state to null`() = testScenario {
+        stateHolder.dataLoaded(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
+            embeddedViewDisplaysMandateText = true,
+        )
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(stateHolder.state.value).isNotNull()
+
+        stateHolder.clearEmbeddedContent()
+
+        assertThat(stateHolder.state.value).isNull()
+    }
+
+    @Test
+    fun `initial state is restored from savedStateHandle`() = testScenario(
+        setup = {
+            set(
+                EmbeddedContentHelperStateHolder.STATE_KEY_EMBEDDED_CONTENT,
+                EmbeddedContentHelperStateHolder.State(
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                    appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
+                    embeddedViewDisplaysMandateText = false,
+                )
+            )
+        }
+    ) {
+        assertThat(stateHolder.state.value).isNotNull()
+    }
+
+    private class Scenario(
+        val stateHolder: EmbeddedContentHelperStateHolder,
+        val eventReporter: FakeEventReporter,
+    )
+
+    private fun testScenario(
+        setup: SavedStateHandle.() -> Unit = {},
+        block: suspend Scenario.() -> Unit,
+    ) = runTest(UnconfinedTestDispatcher()) {
+        val savedStateHandle = SavedStateHandle().apply { setup() }
+        val eventReporter = FakeEventReporter()
+        val stateHolder = DefaultEmbeddedContentHelperStateHolder(
+            savedStateHandle = savedStateHandle,
+            eventReporter = eventReporter,
+        )
+        Scenario(
+            stateHolder = stateHolder,
+            eventReporter = eventReporter,
+        ).block()
+        eventReporter.validate()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper.Companion.STATE_KEY_EMBEDDED_CONTENT
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder.Companion.STATE_KEY_EMBEDDED_CONTENT
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
@@ -49,8 +49,8 @@ internal class DefaultEmbeddedContentHelperTest {
             .isNull()
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default)
-        embeddedContentHelper.dataLoaded(paymentMethodMetadata, appearance, embeddedViewDisplaysMandateText = true)
-        val state = savedStateHandle.get<DefaultEmbeddedContentHelper.State?>(STATE_KEY_EMBEDDED_CONTENT)
+        stateHolder.dataLoaded(paymentMethodMetadata, appearance, embeddedViewDisplaysMandateText = true)
+        val state = savedStateHandle.get<EmbeddedContentHelperStateHolder.State?>(STATE_KEY_EMBEDDED_CONTENT)
         assertThat(state?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
         assertThat(state?.appearance).isEqualTo(appearance)
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
@@ -60,7 +60,7 @@ internal class DefaultEmbeddedContentHelperTest {
     fun `dataLoaded emits embeddedContent event`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
+            stateHolder.dataLoaded(
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
@@ -74,7 +74,7 @@ internal class DefaultEmbeddedContentHelperTest {
     fun `dataLoaded emits walletButtonsContent event`() = testScenario {
         embeddedContentHelper.walletButtonsContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
+            stateHolder.dataLoaded(
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
@@ -88,13 +88,13 @@ internal class DefaultEmbeddedContentHelperTest {
     fun `embeddedContent emits null when clearEmbeddedContent is called`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
+            stateHolder.dataLoaded(
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
             )
             assertThat(awaitItem()).isNotNull()
-            embeddedContentHelper.clearEmbeddedContent()
+            stateHolder.clearEmbeddedContent()
             assertThat(awaitItem()).isNull()
         }
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
@@ -104,13 +104,13 @@ internal class DefaultEmbeddedContentHelperTest {
     fun `walletButtonsContent emits null when clearEmbeddedContent is called`() = testScenario {
         embeddedContentHelper.walletButtonsContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
+            stateHolder.dataLoaded(
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
             )
             assertThat(awaitItem()).isNotNull()
-            embeddedContentHelper.clearEmbeddedContent()
+            stateHolder.clearEmbeddedContent()
             assertThat(awaitItem()).isNull()
         }
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
@@ -121,7 +121,7 @@ internal class DefaultEmbeddedContentHelperTest {
         setup = {
             set(
                 STATE_KEY_EMBEDDED_CONTENT,
-                DefaultEmbeddedContentHelper.State(
+                EmbeddedContentHelperStateHolder.State(
                     PaymentMethodMetadataFactory.create(),
                     Embedded(Embedded.RowStyle.FloatingButton.default),
                     embeddedViewDisplaysMandateText = true,
@@ -147,7 +147,7 @@ internal class DefaultEmbeddedContentHelperTest {
         setup = {
             set(
                 STATE_KEY_EMBEDDED_CONTENT,
-                DefaultEmbeddedContentHelper.State(
+                EmbeddedContentHelperStateHolder.State(
                     PaymentMethodMetadataFactory.create(),
                     Embedded(Embedded.RowStyle.FlatWithRadio.default),
                     embeddedViewDisplaysMandateText = true,
@@ -170,7 +170,7 @@ internal class DefaultEmbeddedContentHelperTest {
             setup = {
                 set(
                     STATE_KEY_EMBEDDED_CONTENT,
-                    DefaultEmbeddedContentHelper.State(
+                    EmbeddedContentHelperStateHolder.State(
                         paymentMethodMetadata,
                         Embedded(Embedded.RowStyle.FlatWithRadio.default),
                         embeddedViewDisplaysMandateText = true,
@@ -181,7 +181,7 @@ internal class DefaultEmbeddedContentHelperTest {
             }
         ) {
             val fakeLauncher = RecordingEmbeddedSheetLauncher()
-            embeddedContentHelper.setSheetLauncher(fakeLauncher)
+            sheetLauncherHolder.sheetLauncher = fakeLauncher
             embeddedContentHelper.presentPaymentOptions()
 
             assertThat(fakeLauncher.launchPaymentOptionsCalls.single()).isEqualTo(
@@ -198,12 +198,15 @@ internal class DefaultEmbeddedContentHelperTest {
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
+        val stateHolder: EmbeddedContentHelperStateHolder,
+        val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
         val savedStateHandle: SavedStateHandle,
         val eventReporter: FakeEventReporter,
         val errorReporter: FakeErrorReporter,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
+    @Suppress("LongMethod")
     private fun testScenario(
         setup: SavedStateHandle.() -> Unit = {},
         block: suspend Scenario.() -> Unit,
@@ -224,42 +227,82 @@ internal class DefaultEmbeddedContentHelperTest {
             coroutineScope = backgroundScope,
             internalRowSelectionCallback = { null }
         )
-
-        val embeddedContentHelper = DefaultEmbeddedContentHelper(
-            coroutineScope = backgroundScope,
+        val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(
+                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
+            ),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        )
+        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+            savedStateHandle = savedStateHandle,
+            selectionHolder = selectionHolder,
+            coroutineScope = backgroundScope,
+        )
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
+
+        val stateHolder = DefaultEmbeddedContentHelperStateHolder(
+            savedStateHandle = savedStateHandle,
+            eventReporter = eventReporter,
+        )
+        val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
             uiContext = Dispatchers.Unconfined,
             savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
             selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            confirmationStateHolder = confirmationStateHolder,
+            linkAccountHolder = linkAccountHolder,
+            coroutineScope = backgroundScope,
+            sheetLauncherHolder = sheetLauncherHolder,
+        )
+        val verticalLayoutInteractorFactory = DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
+            eventReporter = eventReporter,
+            embeddedFormHelperFactory = embeddedFormHelperFactory,
+            confirmationHandler = confirmationHandler,
+            confirmationStateHolder = confirmationStateHolder,
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            rowSelectionImmediateActionHandler = immediateActionHandler,
+            coroutineScope = backgroundScope,
+            sheetLauncherHolder = sheetLauncherHolder,
+            savedPaymentMethodMutatorFactory = savedPaymentMethodMutatorFactory,
+        )
+        val walletButtonsInteractorFactory = DefaultEmbeddedWalletButtonsInteractorFactory(
             embeddedLinkHelper = object : EmbeddedLinkHelper {
                 override val linkEmail: StateFlow<String?> = stateFlowOf(null)
             },
-            embeddedWalletsHelper = { stateFlowOf(null) },
-            customerStateHolder = DefaultCustomerStateHolder(
-                savedStateHandle = savedStateHandle,
-                selection = selectionHolder.selection,
-                customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
-                paymentMethodMetadataFlow = stateFlowOf(null),
-            ),
-            embeddedFormHelperFactory = embeddedFormHelperFactory,
+            confirmationStateHolder = confirmationStateHolder,
             confirmationHandler = confirmationHandler,
-            confirmationStateHolder = EmbeddedConfirmationStateHolder(
-                savedStateHandle = savedStateHandle,
-                selectionHolder = selectionHolder,
-                coroutineScope = backgroundScope,
-            ),
-            rowSelectionImmediateActionHandler = immediateActionHandler,
             errorReporter = errorReporter,
-            internalRowSelectionCallback = { null },
+            eventReporter = eventReporter,
             linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
+            linkAccountHolder = linkAccountHolder,
             analyticsCallbackProvider = { AnalyticEventCallbackRule() },
-            linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
-            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+            coroutineScope = backgroundScope,
+        )
+
+        val embeddedContentHelper = DefaultEmbeddedContentHelper(
+            coroutineScope = backgroundScope,
+            stateHolder = stateHolder,
+            verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
+            walletButtonsInteractorFactory = walletButtonsInteractorFactory,
+            sheetLauncherHolder = sheetLauncherHolder,
+            embeddedWalletsHelper = { stateFlowOf(null) },
+            internalRowSelectionCallback = { null },
+            customerStateHolder = customerStateHolder,
+            selectionHolder = selectionHolder,
+            confirmationStateHolder = confirmationStateHolder,
+            errorReporter = errorReporter,
         )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
+            stateHolder = stateHolder,
+            sheetLauncherHolder = sheetLauncherHolder,
             savedStateHandle = savedStateHandle,
             eventReporter = eventReporter,
             errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -44,7 +44,7 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem().appearance)
+        assertThat(contentStateHolder.dataLoadedTurbine.awaitItem().appearance)
             .isEqualTo(Embedded(Embedded.RowStyle.FlatWithRadio.default))
     }
 
@@ -73,7 +73,7 @@ internal class DefaultEmbeddedStateHelperTest {
 
         // Reset appearance
         PaymentSheet.Appearance().parseAppearance()
-        embeddedContentHelper.dataLoadedTurbine.awaitItem()
+        contentStateHolder.dataLoadedTurbine.awaitItem()
     }
 
     @Test
@@ -93,7 +93,7 @@ internal class DefaultEmbeddedStateHelperTest {
         assertThat(confirmationStateHolder.state).isNotNull()
         assertThat(customerStateHolder.customer.value).isEqualTo(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
         assertThat(selectionHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        assertThat(contentStateHolder.dataLoadedTurbine.awaitItem()).isNotNull()
 
         stateHelper.state = null
 
@@ -102,7 +102,7 @@ internal class DefaultEmbeddedStateHelperTest {
         assertThat(customerStateHolder.customer.value).isNull()
         assertThat(selectionHolder.selection.value).isNull()
         assertThat(selectionHolder.previousNewSelections.isEmpty).isTrue()
-        assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
+        assertThat(contentStateHolder.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
@@ -117,7 +117,7 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        assertThat(contentStateHolder.dataLoadedTurbine.awaitItem()).isNotNull()
     }
 
     @Test
@@ -136,7 +136,7 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        assertThat(contentStateHolder.dataLoadedTurbine.awaitItem()).isNotNull()
     }
 
     @Test
@@ -156,7 +156,7 @@ internal class DefaultEmbeddedStateHelperTest {
         }
 
         confirmationHandler.bootstrapTurbine.awaitItem()
-        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+        assertThat(contentStateHolder.dataLoadedTurbine.awaitItem()).isNotNull()
     }
 
     @Test
@@ -200,7 +200,7 @@ internal class DefaultEmbeddedStateHelperTest {
     fun `confirmation handler is bootstrapped when state is set`() = testScenario {
         setState()
         assertThat(confirmationHandler.bootstrapTurbine.awaitItem().paymentMethodMetadata).isNotNull()
-        embeddedContentHelper.dataLoadedTurbine.awaitItem()
+        contentStateHolder.dataLoadedTurbine.awaitItem()
     }
 
     private fun testScenario(
@@ -222,13 +222,13 @@ internal class DefaultEmbeddedStateHelperTest {
             selectionHolder = selectionHolder,
             coroutineScope = backgroundScope,
         )
-        val embeddedContentHelper = FakeEmbeddedContentHelper()
+        val contentStateHolder = FakeEmbeddedContentHelperStateHolder()
         val confirmationHandler = FakeConfirmationHandler()
         val stateHelper = DefaultEmbeddedStateHelper(
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             confirmationStateHolder = confirmationStateHolder,
-            embeddedContentHelper = embeddedContentHelper,
+            contentStateHolder = contentStateHolder,
             internalRowSelectionCallback = { rowSelectionCallback },
             confirmationHandler = confirmationHandler,
         )
@@ -237,12 +237,12 @@ internal class DefaultEmbeddedStateHelperTest {
             confirmationStateHolder = confirmationStateHolder,
             customerStateHolder = customerStateHolder,
             selectionHolder = selectionHolder,
-            embeddedContentHelper = embeddedContentHelper,
+            contentStateHolder = contentStateHolder,
             stateHelper = stateHelper,
             confirmationHandler = confirmationHandler,
         ).block()
 
-        embeddedContentHelper.validate()
+        contentStateHolder.validate()
         confirmationHandler.validate()
     }
 
@@ -250,7 +250,7 @@ internal class DefaultEmbeddedStateHelperTest {
         val confirmationStateHolder: EmbeddedConfirmationStateHolder,
         val customerStateHolder: CustomerStateHolder,
         val selectionHolder: EmbeddedSelectionHolder,
-        val embeddedContentHelper: FakeEmbeddedContentHelper,
+        val contentStateHolder: FakeEmbeddedContentHelperStateHolder,
         val stateHelper: EmbeddedStateHelper,
         val confirmationHandler: FakeConfirmationHandler,
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -65,7 +65,7 @@ internal class EmbeddedContentUiTest {
         runScenario(internalRowSelectionCallback = {}) {
             embeddedContentHelper.embeddedContent.test {
                 assertThat(awaitItem()).isNull()
-                embeddedContentHelper.dataLoaded(
+                stateHolder.dataLoaded(
                     PaymentMethodMetadataFactory.create(),
                     Embedded(Embedded.RowStyle.FlatWithRadio.default),
                     embeddedViewDisplaysMandateText = true,
@@ -88,7 +88,7 @@ internal class EmbeddedContentUiTest {
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
+            stateHolder.dataLoaded(
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
@@ -111,7 +111,7 @@ internal class EmbeddedContentUiTest {
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            embeddedContentHelper.dataLoaded(
+            stateHolder.dataLoaded(
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
                 embeddedViewDisplaysMandateText = true,
@@ -132,9 +132,11 @@ internal class EmbeddedContentUiTest {
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
+        val stateHolder: EmbeddedContentHelperStateHolder,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
+    @Suppress("LongMethod")
     private fun runScenario(
         internalRowSelectionCallback: InternalRowSelectionCallback? = null,
         block: suspend Scenario.() -> Unit,
@@ -151,50 +153,88 @@ internal class EmbeddedContentUiTest {
         val confirmationHandler = FakeConfirmationHandler()
         val eventReporter = FakeEventReporter()
         val errorReporter = FakeErrorReporter()
+        val viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined))
         val immediateActionHandler =
             DefaultEmbeddedRowSelectionImmediateActionHandler(
                 coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                 internalRowSelectionCallback = { null }
             )
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(
+                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
+            ),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        )
+        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+            savedStateHandle = savedStateHandle,
+            selectionHolder = selectionHolder,
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
+        )
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
+
+        val stateHolder = DefaultEmbeddedContentHelperStateHolder(
+            savedStateHandle = savedStateHandle,
+            eventReporter = eventReporter,
+        )
+        val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
+            eventReporter = eventReporter,
+            workContext = Dispatchers.Unconfined,
+            uiContext = Dispatchers.Unconfined,
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            confirmationStateHolder = confirmationStateHolder,
+            linkAccountHolder = linkAccountHolder,
+            coroutineScope = viewModelScope,
+            sheetLauncherHolder = sheetLauncherHolder,
+        )
+        val verticalLayoutInteractorFactory = DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
+            eventReporter = eventReporter,
+            embeddedFormHelperFactory = embeddedFormHelperFactory,
+            confirmationHandler = confirmationHandler,
+            confirmationStateHolder = confirmationStateHolder,
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            rowSelectionImmediateActionHandler = immediateActionHandler,
+            coroutineScope = viewModelScope,
+            sheetLauncherHolder = sheetLauncherHolder,
+            savedPaymentMethodMutatorFactory = savedPaymentMethodMutatorFactory,
+        )
+        val walletButtonsInteractorFactory = DefaultEmbeddedWalletButtonsInteractorFactory(
+            embeddedLinkHelper = object : EmbeddedLinkHelper {
+                override val linkEmail: StateFlow<String?> = stateFlowOf(null)
+            },
+            confirmationStateHolder = confirmationStateHolder,
+            confirmationHandler = confirmationHandler,
+            errorReporter = errorReporter,
+            eventReporter = eventReporter,
+            linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
+            linkAccountHolder = linkAccountHolder,
+            analyticsCallbackProvider = { AnalyticEventCallbackRule() },
+            coroutineScope = viewModelScope,
+        )
 
         val embeddedContentHelper =
             DefaultEmbeddedContentHelper(
-                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
-                savedStateHandle = savedStateHandle,
-                eventReporter = eventReporter,
-                workContext = Dispatchers.Unconfined,
-                uiContext = Dispatchers.Unconfined,
-                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
-                selectionHolder = selectionHolder,
-                embeddedLinkHelper = object : EmbeddedLinkHelper {
-                    override val linkEmail: StateFlow<String?> = stateFlowOf(null)
-                },
+                coroutineScope = viewModelScope,
+                stateHolder = stateHolder,
+                verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
+                walletButtonsInteractorFactory = walletButtonsInteractorFactory,
+                sheetLauncherHolder = sheetLauncherHolder,
                 embeddedWalletsHelper = { stateFlowOf(null) },
-                customerStateHolder = DefaultCustomerStateHolder(
-                    savedStateHandle = savedStateHandle,
-                    selection = selectionHolder.selection,
-                    customerMetadata = stateFlowOf(
-                        PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
-                    ),
-                    paymentMethodMetadataFlow = stateFlowOf(null),
-                ),
-                embeddedFormHelperFactory = embeddedFormHelperFactory,
-                confirmationHandler = confirmationHandler,
-                confirmationStateHolder = EmbeddedConfirmationStateHolder(
-                    savedStateHandle = savedStateHandle,
-                    selectionHolder = selectionHolder,
-                    coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
-                ),
-                rowSelectionImmediateActionHandler = immediateActionHandler,
-                errorReporter = errorReporter,
                 internalRowSelectionCallback = { internalRowSelectionCallback },
-                linkPaymentLauncher = RecordingLinkPaymentLauncher.noOp(),
-                analyticsCallbackProvider = { AnalyticEventCallbackRule() },
-                linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
+                customerStateHolder = customerStateHolder,
+                selectionHolder = selectionHolder,
+                confirmationStateHolder = confirmationStateHolder,
+                errorReporter = errorReporter,
             )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
+            stateHolder = stateHolder,
         ).block()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializerTest.kt
@@ -19,11 +19,11 @@ internal class EmbeddedPaymentElementInitializerTest {
 
     @Test
     fun `initialize init and clear sheetLauncher`() = testScenario {
-        assertThat(contentHelper.testSheetLauncher).isNull()
+        assertThat(sheetLauncherHolder.sheetLauncher).isNull()
         initializer.initialize(true)
-        assertThat(contentHelper.testSheetLauncher).isNotNull()
+        assertThat(sheetLauncherHolder.sheetLauncher).isNotNull()
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-        assertThat(contentHelper.testSheetLauncher).isNull()
+        assertThat(sheetLauncherHolder.sheetLauncher).isNull()
     }
 
     @Test
@@ -79,11 +79,11 @@ internal class EmbeddedPaymentElementInitializerTest {
         paymentElementCallbackIdentifier: String = PAYMENT_ELEMENT_CALLBACK_TEST_IDENTIFIER,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val contentHelper = FakeEmbeddedContentHelper()
+        val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
         val eventReporter = FakeEventReporter()
         val initializer = EmbeddedPaymentElementInitializer(
             sheetLauncher = FakeEmbeddedSheetLauncher(),
-            contentHelper = contentHelper,
+            sheetLauncherHolder = sheetLauncherHolder,
             lifecycleOwner = lifecycleOwner,
             savedStateHandle = SavedStateHandle(),
             eventReporter = eventReporter,
@@ -91,7 +91,7 @@ internal class EmbeddedPaymentElementInitializerTest {
         )
         Scenario(
             initializer = initializer,
-            contentHelper = contentHelper,
+            sheetLauncherHolder = sheetLauncherHolder,
             lifecycleOwner = lifecycleOwner,
             eventReporter = eventReporter,
         ).block()
@@ -100,7 +100,7 @@ internal class EmbeddedPaymentElementInitializerTest {
 
     private class Scenario(
         val initializer: EmbeddedPaymentElementInitializer,
-        val contentHelper: FakeEmbeddedContentHelper,
+        val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
         val lifecycleOwner: TestLifecycleOwner,
         val eventReporter: FakeEventReporter,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelper.kt
@@ -1,9 +1,5 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import app.cash.turbine.ReceiveTurbine
-import app.cash.turbine.Turbine
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,43 +8,5 @@ internal class FakeEmbeddedContentHelper(
     override val embeddedContent: MutableStateFlow<EmbeddedContent?> = MutableStateFlow(null),
     override val walletButtonsContent: StateFlow<WalletButtonsContent?> = MutableStateFlow(null),
 ) : EmbeddedContentHelper {
-    private val _dataLoadedTurbine = Turbine<DefaultEmbeddedContentHelper.State>()
-    val dataLoadedTurbine: ReceiveTurbine<DefaultEmbeddedContentHelper.State> = _dataLoadedTurbine
-    private val _clearEmbeddedContentTurbine = Turbine<Unit>()
-    val clearEmbeddedContentTurbine: ReceiveTurbine<Unit> = _clearEmbeddedContentTurbine
-
-    var testSheetLauncher: EmbeddedSheetLauncher? = null
-
-    override fun dataLoaded(
-        paymentMethodMetadata: PaymentMethodMetadata,
-        appearance: Embedded,
-        embeddedViewDisplaysMandateText: Boolean,
-    ) {
-        _dataLoadedTurbine.add(
-            DefaultEmbeddedContentHelper.State(
-                paymentMethodMetadata = paymentMethodMetadata,
-                appearance = appearance,
-                embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
-            )
-        )
-    }
-
-    override fun clearEmbeddedContent() {
-        _clearEmbeddedContentTurbine.add(Unit)
-    }
-
-    override fun setSheetLauncher(sheetLauncher: EmbeddedSheetLauncher) {
-        this.testSheetLauncher = sheetLauncher
-    }
-
-    override fun clearSheetLauncher() {
-        testSheetLauncher = null
-    }
-
     override fun presentPaymentOptions() = Unit
-
-    fun validate() {
-        dataLoadedTurbine.ensureAllEventsConsumed()
-        clearEmbeddedContentTurbine.ensureAllEventsConsumed()
-    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelperStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelperStateHolder.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal class FakeEmbeddedContentHelperStateHolder(
+    _state: MutableStateFlow<EmbeddedContentHelperStateHolder.State?> = MutableStateFlow(null),
+) : EmbeddedContentHelperStateHolder {
+    override val state: StateFlow<EmbeddedContentHelperStateHolder.State?> = _state
+
+    private val _dataLoadedTurbine = Turbine<EmbeddedContentHelperStateHolder.State>()
+    val dataLoadedTurbine: ReceiveTurbine<EmbeddedContentHelperStateHolder.State> = _dataLoadedTurbine
+    private val _clearEmbeddedContentTurbine = Turbine<Unit>()
+    val clearEmbeddedContentTurbine: ReceiveTurbine<Unit> = _clearEmbeddedContentTurbine
+
+    override fun dataLoaded(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        appearance: Embedded,
+        embeddedViewDisplaysMandateText: Boolean,
+    ) {
+        _dataLoadedTurbine.add(
+            EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = paymentMethodMetadata,
+                appearance = appearance,
+                embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+            )
+        )
+    }
+
+    override fun clearEmbeddedContent() {
+        _clearEmbeddedContentTurbine.add(Unit)
+    }
+
+    fun validate() {
+        dataLoadedTurbine.ensureAllEventsConsumed()
+        clearEmbeddedContentTurbine.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary
Refactored the internal implementation of EmbeddedContentHelper by moving state management into a dedicated EmbeddedContentHelperStateHolder class for improved modularity and clarity. Extracted factories for PaymentMethodVerticalLayoutInteractor and WalletButtonsInteractor, updated related tests, and cleaned up dependencies and approach to sheet launcher management.

# Motivation
The EmbeddedContentHelper had too many responsibilities related to persisting and managing state, making it harder to maintain and extend. Moving state management to a separate class improves separation of concerns and makes it easier to test and evolve the logic. This also standardizes the factory approach for core interactors.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
