### PR TITLE
[ECE] Use Link brand from Link account when consumer is logged in

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
@@ -6,6 +6,7 @@ import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.effectiveLinkBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -31,7 +32,7 @@ internal sealed interface ExpressButton {
                         paymentDetails = linkAccount?.displayablePaymentDetails,
                     ),
                     theme = PaymentSheet.ButtonThemes.LinkButtonTheme.DEFAULT,
-                    linkBrand = paymentMethodMetadata.linkBrand,
+                    linkBrand = paymentMethodMetadata.effectiveLinkBrand(linkAccount),
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout.ece
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.TestFactory
+import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
@@ -27,6 +28,23 @@ internal class ExpressButtonTest {
         )
 
         assertThat(button.linkBrand).isEqualTo(LinkBrand.Onelink)
+    }
+
+    @Test
+    fun `Link create uses link brand from account when logged in`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkBrand = LinkBrand.Onelink,
+        )
+        val linkAccount = LinkAccount(
+            consumerSession = TestFactory.CONSUMER_SESSION.copy(linkBrand = LinkBrand.Link)
+        )
+
+        val button = ExpressButton.Link.create(
+            paymentMethodMetadata = paymentMethodMetadata,
+            linkAccountInfo = LinkAccountUpdate.Value(linkAccount),
+        )
+
+        assertThat(button.linkBrand).isEqualTo(LinkBrand.Link)
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
[ECE] Use Link brand from Link account when consumer is logged in

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Show correct Link brand for logged in consumer

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
