### PR TITLE
Add param names to CheckoutControllerStateHolder constructor in test

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -187,9 +187,9 @@ internal class CheckoutControllerStateHolderTest {
         val errorReporter = FakeErrorReporter()
         Scenario(
             stateHolder = CheckoutControllerStateHolder(
-                SavedStateHandle(),
-                errorReporter,
-                paymentOptionFactory,
+                savedStateHandle = SavedStateHandle(),
+                errorReporter = errorReporter,
+                paymentOptionFactory = paymentOptionFactory,
                 availableExpressButtonTypesFactory = FakeAvailableExpressButtonTypesFactory(),
             ),
             errorReporter = errorReporter,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add param names to CheckoutControllerStateHolder constructor in test

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/13520#discussion_r3617352978

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified