### PR TITLE
Refactor to pass EmbeddedPaymentElement.Configuration directly.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -30,7 +30,7 @@ internal interface EmbeddedSheetLauncher {
     fun launchForm(
         code: String,
         paymentMethodMetadata: PaymentMethodMetadata,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
         customerState: CustomerState?,
         promotion: PaymentMethodMessagePromotion?,
     )
@@ -39,14 +39,14 @@ internal interface EmbeddedSheetLauncher {
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
         selection: PaymentSelection?,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
     )
 
     fun launchPaymentOptions(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState?,
         selection: PaymentSelection?,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
     )
 }
 
@@ -158,7 +158,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     override fun launchForm(
         code: String,
         paymentMethodMetadata: PaymentMethodMetadata,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
         customerState: CustomerState?,
         promotion: PaymentMethodMessagePromotion?,
     ) {
@@ -167,7 +167,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
             CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
         }
-        if (embeddedConfirmationState == null) {
+        if (configuration == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
             )
@@ -181,7 +181,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             ?: selectionHolder.getPreviousNewSelection(code)
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
-            configuration = embeddedConfirmationState.configuration,
+            configuration = configuration,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = currentSelection,
@@ -196,14 +196,14 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
         selection: PaymentSelection?,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
     ) {
         val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
         if (checkoutSession != null) {
             CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
             CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
         }
-        if (embeddedConfirmationState == null) {
+        if (configuration == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
             )
@@ -213,7 +213,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         sheetStateHolder.sheetIsOpen = true
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
-            configuration = embeddedConfirmationState.configuration,
+            configuration = configuration,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
@@ -228,14 +228,14 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState?,
         selection: PaymentSelection?,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
     ) {
         val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
         if (checkoutSession != null) {
             CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
             CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
         }
-        if (embeddedConfirmationState == null) {
+        if (configuration == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
             )
@@ -245,7 +245,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         sheetStateHolder.sheetIsOpen = true
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
-            configuration = embeddedConfirmationState.configuration,
+            configuration = configuration,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -33,7 +33,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
     private val customerStateHolder: CustomerStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
-    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     private val errorReporter: ErrorReporter,
 ) : EmbeddedContentHelper {
 
@@ -97,7 +96,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             paymentMethodMetadata = state.paymentMethodMetadata,
             customerState = customerStateHolder.customer.value,
             selection = selectionHolder.selection.value,
-            embeddedConfirmationState = confirmationStateHolder.state,
+            configuration = state.configuration,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateHolder.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.embedded.content
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +18,7 @@ internal interface EmbeddedContentHelperStateHolder {
         paymentMethodMetadata: PaymentMethodMetadata,
         appearance: Embedded,
         embeddedViewDisplaysMandateText: Boolean,
+        configuration: EmbeddedPaymentElement.Configuration,
     )
 
     fun clearEmbeddedContent()
@@ -26,6 +28,7 @@ internal interface EmbeddedContentHelperStateHolder {
         val paymentMethodMetadata: PaymentMethodMetadata,
         val appearance: Embedded,
         val embeddedViewDisplaysMandateText: Boolean,
+        val configuration: EmbeddedPaymentElement.Configuration,
     ) : Parcelable
 
     companion object {
@@ -49,12 +52,14 @@ internal class DefaultEmbeddedContentHelperStateHolder @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         appearance: Embedded,
         embeddedViewDisplaysMandateText: Boolean,
+        configuration: EmbeddedPaymentElement.Configuration,
     ) {
         eventReporter.onShowNewPaymentOptions()
         val state = EmbeddedContentHelperStateHolder.State(
             paymentMethodMetadata = paymentMethodMetadata,
             appearance = appearance,
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+            configuration = configuration,
         )
         savedStateHandle[EmbeddedContentHelperStateHolder.STATE_KEY_EMBEDDED_CONTENT] = state
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
@@ -46,7 +46,7 @@ internal class EmbeddedContentSavedPaymentMethodMutatorFactory @Inject construct
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateHolder.state,
+                    configuration = confirmationStateHolder.state?.configuration,
                 )
             },
             isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -93,14 +93,14 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
-                    embeddedConfirmationState = confirmationStateHolder.state,
+                    configuration = confirmationStateHolder.state?.configuration,
                 )
             },
             transitionToFormScreen = { code ->
                 sheetLauncherHolder.sheetLauncher?.launchForm(
                     code = code,
                     paymentMethodMetadata = paymentMethodMetadata,
-                    embeddedConfirmationState = confirmationStateHolder.state,
+                    configuration = confirmationStateHolder.state?.configuration,
                     customerState = customerStateHolder.customer.value,
                     promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
                         code = code,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -55,6 +55,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
             paymentMethodMetadata = state.confirmationState.paymentMethodMetadata,
             appearance = state.confirmationState.configuration.appearance.embeddedAppearance,
             embeddedViewDisplaysMandateText = state.confirmationState.configuration.embeddedViewDisplaysMandateText,
+            configuration = state.confirmationState.configuration,
         )
         confirmationHandler.bootstrap(state.confirmationState.paymentMethodMetadata)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedSheetLauncher.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentelement.embedded
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
-import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
@@ -11,7 +11,7 @@ internal class FakeEmbeddedSheetLauncher : EmbeddedSheetLauncher {
     override fun launchForm(
         code: String,
         paymentMethodMetadata: PaymentMethodMetadata,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
         customerState: CustomerState?,
         promotion: PaymentMethodMessagePromotion?,
     ) {
@@ -22,7 +22,7 @@ internal class FakeEmbeddedSheetLauncher : EmbeddedSheetLauncher {
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
         selection: PaymentSelection?,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
     ) {
         error("Not expected.")
     }
@@ -31,7 +31,7 @@ internal class FakeEmbeddedSheetLauncher : EmbeddedSheetLauncher {
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState?,
         selection: PaymentSelection?,
-        embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+        configuration: EmbeddedPaymentElement.Configuration?,
     ) {
         error("Not expected.")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -17,15 +18,18 @@ internal class DefaultEmbeddedContentHelperStateHolderTest {
             assertThat(awaitItem()).isNull()
             val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
             val appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default)
+            val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
             stateHolder.dataLoaded(
                 paymentMethodMetadata = paymentMethodMetadata,
                 appearance = appearance,
                 embeddedViewDisplaysMandateText = true,
+                configuration = configuration,
             )
             val state = awaitItem()
             assertThat(state?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
             assertThat(state?.appearance).isEqualTo(appearance)
             assertThat(state?.embeddedViewDisplaysMandateText).isTrue()
+            assertThat(state?.configuration).isEqualTo(configuration)
         }
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
@@ -36,6 +40,7 @@ internal class DefaultEmbeddedContentHelperStateHolderTest {
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
             embeddedViewDisplaysMandateText = true,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         )
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
         assertThat(stateHolder.state.value).isNotNull()
@@ -54,6 +59,7 @@ internal class DefaultEmbeddedContentHelperStateHolderTest {
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
                     appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
                     embeddedViewDisplaysMandateText = false,
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
@@ -49,7 +50,12 @@ internal class DefaultEmbeddedContentHelperTest {
             .isNull()
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default)
-        stateHolder.dataLoaded(paymentMethodMetadata, appearance, embeddedViewDisplaysMandateText = true)
+        stateHolder.dataLoaded(
+            paymentMethodMetadata,
+            appearance,
+            embeddedViewDisplaysMandateText = true,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        )
         val state = savedStateHandle.get<EmbeddedContentHelperStateHolder.State?>(STATE_KEY_EMBEDDED_CONTENT)
         assertThat(state?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
         assertThat(state?.appearance).isEqualTo(appearance)
@@ -64,6 +70,7 @@ internal class DefaultEmbeddedContentHelperTest {
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
         }
@@ -78,6 +85,7 @@ internal class DefaultEmbeddedContentHelperTest {
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
         }
@@ -92,6 +100,7 @@ internal class DefaultEmbeddedContentHelperTest {
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
             stateHolder.clearEmbeddedContent()
@@ -108,6 +117,7 @@ internal class DefaultEmbeddedContentHelperTest {
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
             stateHolder.clearEmbeddedContent()
@@ -125,6 +135,7 @@ internal class DefaultEmbeddedContentHelperTest {
                     PaymentMethodMetadataFactory.create(),
                     Embedded(Embedded.RowStyle.FloatingButton.default),
                     embeddedViewDisplaysMandateText = true,
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 )
             )
         }
@@ -151,6 +162,7 @@ internal class DefaultEmbeddedContentHelperTest {
                     PaymentMethodMetadataFactory.create(),
                     Embedded(Embedded.RowStyle.FlatWithRadio.default),
                     embeddedViewDisplaysMandateText = true,
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 )
             )
         }
@@ -166,6 +178,7 @@ internal class DefaultEmbeddedContentHelperTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = createCustomerState()
         val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         testScenario(
             setup = {
                 set(
@@ -174,6 +187,7 @@ internal class DefaultEmbeddedContentHelperTest {
                         paymentMethodMetadata,
                         Embedded(Embedded.RowStyle.FlatWithRadio.default),
                         embeddedViewDisplaysMandateText = true,
+                        configuration = configuration,
                     )
                 )
                 set(CustomerStateHolder.SAVED_CUSTOMER, customerState)
@@ -189,7 +203,7 @@ internal class DefaultEmbeddedContentHelperTest {
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = customerState,
                     selection = selection,
-                    embeddedConfirmationState = null,
+                    configuration = configuration,
                 )
             )
             assertThat(errorReporter.getLoggedErrors()).isEmpty()
@@ -296,7 +310,6 @@ internal class DefaultEmbeddedContentHelperTest {
             internalRowSelectionCallback = { null },
             customerStateHolder = customerStateHolder,
             selectionHolder = selectionHolder,
-            confirmationStateHolder = confirmationStateHolder,
             errorReporter = errorReporter,
         )
         Scenario(
@@ -317,7 +330,7 @@ internal class DefaultEmbeddedContentHelperTest {
         override fun launchForm(
             code: String,
             paymentMethodMetadata: PaymentMethodMetadata,
-            embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+            configuration: EmbeddedPaymentElement.Configuration?,
             customerState: CustomerState?,
             promotion: PaymentMethodMessagePromotion?,
         ) = error("Not expected.")
@@ -326,21 +339,21 @@ internal class DefaultEmbeddedContentHelperTest {
             paymentMethodMetadata: PaymentMethodMetadata,
             customerState: CustomerState,
             selection: PaymentSelection?,
-            embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+            configuration: EmbeddedPaymentElement.Configuration?,
         ) = error("Not expected.")
 
         override fun launchPaymentOptions(
             paymentMethodMetadata: PaymentMethodMetadata,
             customerState: CustomerState?,
             selection: PaymentSelection?,
-            embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+            configuration: EmbeddedPaymentElement.Configuration?,
         ) {
             launchPaymentOptionsCalls.add(
                 LaunchPaymentOptionsCall(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = customerState,
                     selection = selection,
-                    embeddedConfirmationState = embeddedConfirmationState,
+                    configuration = configuration,
                 )
             )
         }
@@ -349,7 +362,7 @@ internal class DefaultEmbeddedContentHelperTest {
             val paymentMethodMetadata: PaymentMethodMetadata,
             val customerState: CustomerState?,
             val selection: PaymentSelection?,
-            val embeddedConfirmationState: EmbeddedConfirmationStateHolder.State?,
+            val configuration: EmbeddedPaymentElement.Configuration?,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -100,7 +100,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
             customerState = customerState,
             promotion = promotion,
         )
@@ -119,7 +119,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
             customerState = createCustomerState(),
             promotion = null,
         )
@@ -137,7 +137,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
             customerState = createCustomerState(),
             promotion = null,
         )
@@ -154,7 +154,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
             customerState = createCustomerState(),
             promotion = null,
         )
@@ -171,7 +171,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
             customerState = createCustomerState(),
             promotion = null,
         )
@@ -187,7 +187,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = null,
+            configuration = null,
             customerState = createCustomerState(),
             promotion = null,
         )
@@ -208,7 +208,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetLauncher.launchForm(
             code = code,
             paymentMethodMetadata = paymentMethodMetadata,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
             customerState = createCustomerState(),
             promotion = null,
         )
@@ -401,7 +401,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentMethodMetadata = paymentMethodMetadata,
             customerState = customerState,
             selection = PaymentSelection.GooglePay,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
 
@@ -419,7 +419,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentMethodMetadata = paymentMethodMetadata,
             customerState = customerState,
             selection = PaymentSelection.GooglePay,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
         )
     }
 
@@ -569,7 +569,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             sheetLauncher.launchForm(
                 code = "card",
                 paymentMethodMetadata = paymentMethodMetadata,
-                embeddedConfirmationState = state,
+                configuration = state.configuration,
                 customerState = createCustomerState(),
                 promotion = null,
             )
@@ -604,7 +604,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 paymentMethodMetadata = paymentMethodMetadata,
                 customerState = customerState,
                 selection = PaymentSelection.GooglePay,
-                embeddedConfirmationState = state,
+                configuration = state.configuration,
             )
         }.exceptionOrNull()
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
@@ -635,7 +635,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentMethodMetadata = paymentMethodMetadata,
             customerState = customerState,
             selection = selection,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
 
@@ -651,7 +651,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentMethodMetadata = paymentMethodMetadata,
             customerState = null,
             selection = null,
-            embeddedConfirmationState = null,
+            configuration = null,
         )
         val loggedErrors = errorReporter.getLoggedErrors()
         assertThat(loggedErrors.size).isEqualTo(1)
@@ -669,7 +669,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentMethodMetadata = paymentMethodMetadata,
             customerState = null,
             selection = null,
-            embeddedConfirmationState = state,
+            configuration = state.configuration,
         )
     }
 
@@ -860,7 +860,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             sheetLauncher.launchForm(
                 code = code,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-                embeddedConfirmationState = EmbeddedConfirmationStateFixtures.defaultState(),
+                configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
                 customerState = null,
                 promotion = null,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
@@ -69,6 +70,7 @@ internal class EmbeddedContentUiTest {
                     PaymentMethodMetadataFactory.create(),
                     Embedded(Embedded.RowStyle.FlatWithRadio.default),
                     embeddedViewDisplaysMandateText = true,
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 )
                 val content = awaitItem()
                 assertThat(content).isNotNull()
@@ -92,6 +94,7 @@ internal class EmbeddedContentUiTest {
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             val content = awaitItem()
             assertThat(content).isNotNull()
@@ -115,6 +118,7 @@ internal class EmbeddedContentUiTest {
                 PaymentMethodMetadataFactory.create(),
                 Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
                 embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             val content = awaitItem()
             assertThat(content).isNotNull()
@@ -229,7 +233,6 @@ internal class EmbeddedContentUiTest {
                 internalRowSelectionCallback = { internalRowSelectionCallback },
                 customerStateHolder = customerStateHolder,
                 selectionHolder = selectionHolder,
-                confirmationStateHolder = confirmationStateHolder,
                 errorReporter = errorReporter,
             )
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelperStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelperStateHolder.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.embedded.content
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,12 +22,14 @@ internal class FakeEmbeddedContentHelperStateHolder(
         paymentMethodMetadata: PaymentMethodMetadata,
         appearance: Embedded,
         embeddedViewDisplaysMandateText: Boolean,
+        configuration: EmbeddedPaymentElement.Configuration,
     ) {
         _dataLoadedTurbine.add(
             EmbeddedContentHelperStateHolder.State(
                 paymentMethodMetadata = paymentMethodMetadata,
                 appearance = appearance,
                 embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+                configuration = configuration,
             )
         )
     }


### PR DESCRIPTION
# Summary
Refactor code to pass EmbeddedPaymentElement.Configuration directly to EmbeddedSheetLauncher and related classes instead of passing EmbeddedConfirmationStateHolder.State.

# Motivation
This change reduces unnecessary coupling and improves clarity in how configuration is accessed for embedded payment flows, simplifying the interfaces and making the data flow more explicit.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- No user-facing changes; internal API refactor only. -->