### PR TITLE
Update GooglePay ExpressButton to use GooglePayConfiguration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -58,6 +58,7 @@ internal data class CheckoutControllerState(
             availableExpressButtonTypes = availableExpressButtonTypesFactory.create(
                 paymentMethodMetadata = paymentMethodMetadata,
                 expressCheckoutElementConfiguration = configuration.expressCheckoutElementConfiguration,
+                googlePayConfiguration = configuration.googlePayConfiguration,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.checkout
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.checkout.ece.ExpressButtonType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
 import dev.drewhamilton.poko.Poko
@@ -57,7 +57,7 @@ class CheckoutSession internal constructor(
      */
     val paymentOptionDisplayData: PaymentOptionDisplayData?,
     internal val currencySelectorOptions: CurrencySelectorOptions?,
-    internal val availableExpressButtonTypes: List<WalletType>,
+    internal val availableExpressButtonTypes: List<ExpressButtonType>,
 ) {
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/GooglePayConfigurationKtx.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.model.GooglePayButtonType
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun GooglePayConfiguration.ButtonType.asGooglePayButtonType(): GooglePayButtonType {
+    return when (this) {
+        GooglePayConfiguration.ButtonType.Buy -> GooglePayButtonType.Buy
+        GooglePayConfiguration.ButtonType.Book -> GooglePayButtonType.Book
+        GooglePayConfiguration.ButtonType.Checkout -> GooglePayButtonType.Checkout
+        GooglePayConfiguration.ButtonType.Donate -> GooglePayButtonType.Donate
+        GooglePayConfiguration.ButtonType.Order -> GooglePayButtonType.Order
+        GooglePayConfiguration.ButtonType.Pay -> GooglePayButtonType.Pay
+        GooglePayConfiguration.ButtonType.Subscribe -> GooglePayButtonType.Subscribe
+        GooglePayConfiguration.ButtonType.Plain -> GooglePayButtonType.Plain
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import android.graphics.Bitmap
 import android.os.Parcelable
+import com.stripe.android.checkout.ece.ExpressButtonType
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -43,7 +44,7 @@ internal data class InternalState(
 internal fun CheckoutSessionResponse.asCheckoutSession(
     flagImages: Map<String, Bitmap>?,
     paymentOptionDisplayData: PaymentOptionDisplayData?,
-    availableExpressButtonTypes: List<WalletType>,
+    availableExpressButtonTypes: List<ExpressButtonType>,
 ): CheckoutSession {
     return CheckoutSession(
         id = id,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/InternalState.kt
@@ -3,7 +3,6 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Parcelable
 import com.stripe.android.checkout.ece.ExpressButtonType
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/AvailableExpressButtonTypesFactory.kt
@@ -2,6 +2,7 @@
 package com.stripe.android.checkout.ece
 
 import com.stripe.android.checkout.ExpressCheckoutElement
+import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -11,22 +12,28 @@ internal fun interface AvailableExpressButtonTypesFactory {
     fun create(
         paymentMethodMetadata: PaymentMethodMetadata,
         expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State,
-    ): List<WalletType>
+        googlePayConfiguration: GooglePayConfiguration.State?,
+    ): List<ExpressButtonType>
 }
 
 internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constructor() :
     AvailableExpressButtonTypesFactory {
     override fun create(
         paymentMethodMetadata: PaymentMethodMetadata,
-        expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State
-    ): List<WalletType> {
+        expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State,
+        googlePayConfiguration: GooglePayConfiguration.State?,
+    ): List<ExpressButtonType> {
         return paymentMethodMetadata.availableWallets.mapNotNull { walletType ->
             when (walletType) {
-                WalletType.GooglePay -> WalletType.GooglePay.takeIf {
-                    expressCheckoutElementConfiguration.googlePayVisibility !=
-                        ExpressCheckoutElement.Configuration.GooglePayVisibility.Never
+                WalletType.GooglePay -> googlePayConfiguration?.let {
+                    ExpressButtonType.GooglePay(
+                        googlePayConfiguration = it,
+                    ).takeIf {
+                        expressCheckoutElementConfiguration.googlePayVisibility !=
+                            ExpressCheckoutElement.Configuration.GooglePayVisibility.Never
+                    }
                 }
-                WalletType.Link -> WalletType.Link.takeIf {
+                WalletType.Link -> ExpressButtonType.Link.takeIf {
                     expressCheckoutElementConfiguration.linkVisibility !=
                         ExpressCheckoutElement.Configuration.LinkVisibility.Never
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
@@ -57,7 +57,7 @@ internal sealed interface ExpressButton {
                 googlePayConfiguration: GooglePayConfiguration.State,
             ): GooglePay {
                 return GooglePay(
-                    allowCreditCards = paymentMethodMetadata.cardFundingFilter.isAccepted(CardFunding.Credit),
+                    allowCreditCards = true,
                     googlePayButtonType = googlePayConfiguration.buttonType.asGooglePayButtonType(),
                     cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
                     cardFundingFilter = paymentMethodMetadata.cardFundingFilter,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
@@ -1,12 +1,17 @@
+@file:OptIn(CheckoutSessionPreview::class)
 package com.stripe.android.checkout.ece
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.checkout.GooglePayConfiguration
+import com.stripe.android.checkout.asGooglePayButtonType
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.CardFunding
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 
@@ -48,15 +53,16 @@ internal sealed interface ExpressButton {
         companion object {
             fun create(
                 paymentMethodMetadata: PaymentMethodMetadata,
+                googlePayConfiguration: GooglePayConfiguration.State,
             ): GooglePay {
                 return GooglePay(
-                    allowCreditCards = true,
-                    googlePayButtonType = GooglePayButtonType.Pay,
+                    allowCreditCards = paymentMethodMetadata.cardFundingFilter.isAccepted(CardFunding.Credit),
+                    googlePayButtonType = googlePayConfiguration.buttonType.asGooglePayButtonType(),
                     cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
                     cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
                     billingAddressParameters = paymentMethodMetadata.billingDetailsCollectionConfiguration
                         .toBillingAddressParameters(),
-                    additionalEnabledNetworks = emptyList(),
+                    additionalEnabledNetworks = googlePayConfiguration.additionalEnabledNetworks,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
@@ -10,7 +10,6 @@ import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.effectiveLinkBrand
-import com.stripe.android.model.CardFunding
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButtonType.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButtonType.kt
@@ -9,5 +9,5 @@ internal sealed class ExpressButtonType {
     data object Link : ExpressButtonType()
     data class GooglePay(
         val googlePayConfiguration: GooglePayConfiguration.State,
-    ): ExpressButtonType()
+    ) : ExpressButtonType()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButtonType.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButtonType.kt
@@ -1,0 +1,13 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout.ece
+
+import com.stripe.android.checkout.GooglePayConfiguration
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+
+internal sealed class ExpressButtonType {
+    data object Link : ExpressButtonType()
+    data class GooglePay(
+        val googlePayConfiguration: GooglePayConfiguration.State,
+    ): ExpressButtonType()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
@@ -9,7 +9,6 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import kotlin.collections.emptyList
-import kotlin.math.exp
 
 internal interface ExpressCheckoutElementInteractor {
     val state: StateFlow<State>

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
@@ -4,7 +4,6 @@ package com.stripe.android.checkout.ece
 
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
@@ -10,6 +10,7 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import kotlin.collections.emptyList
+import kotlin.math.exp
 
 internal interface ExpressCheckoutElementInteractor {
     val state: StateFlow<State>
@@ -34,14 +35,15 @@ internal class DefaultExpressCheckoutElementInteractor @Inject constructor(
         }
 
         ExpressCheckoutElementInteractor.State(
-            expressButtons = checkoutSession.availableExpressButtonTypes.map { walletType ->
-                when (walletType) {
-                    WalletType.Link -> ExpressButton.Link.create(
+            expressButtons = checkoutSession.availableExpressButtonTypes.map { expressButtonType ->
+                when (expressButtonType) {
+                    ExpressButtonType.Link -> ExpressButton.Link.create(
                         paymentMethodMetadata = state.paymentMethodMetadata,
                         linkAccountInfo = linkAccountInfo,
                     )
-                    WalletType.GooglePay -> ExpressButton.GooglePay.create(
+                    is ExpressButtonType.GooglePay -> ExpressButton.GooglePay.create(
                         paymentMethodMetadata = state.paymentMethodMetadata,
+                        googlePayConfiguration = expressButtonType.googlePayConfiguration,
                     )
                 }
             },

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout.ece
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.ExpressCheckoutElement
+import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -10,18 +11,28 @@ import org.junit.Test
 
 class DefaultAvailableExpressButtonTypesFactoryTest {
     @Test
-    fun `create keeps only wallets returned by metadata`() {
+    fun `create keeps only express button types returned by metadata`() {
         val availableExpressButtonTypes = create(
             availableWallets = listOf(WalletType.GooglePay),
         )
 
         assertThat(availableExpressButtonTypes).containsExactly(
-            WalletType.GooglePay
+            ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
         )
     }
 
     @Test
-    fun `create filters out wallets disabled by configuration`() {
+    fun `create filters out google pay when configuration is missing`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.GooglePay),
+            googlePayConfiguration = null,
+        )
+
+        assertThat(availableExpressButtonTypes).isEmpty()
+    }
+
+    @Test
+    fun `create filters out buttons disabled by configuration`() {
         val availableExpressButtonTypes = create(
             availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
             configuration = ExpressCheckoutElement.Configuration()
@@ -29,31 +40,39 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
         )
 
         assertThat(availableExpressButtonTypes).containsExactly(
-            WalletType.GooglePay
+            ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
         )
     }
 
     @Test
-    fun `create returns all available wallets`() {
+    fun `create returns all available express button types`() {
         val availableExpressButtonTypes = create(
             availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
         )
 
         assertThat(availableExpressButtonTypes).containsExactly(
-            WalletType.Link,
-            WalletType.GooglePay,
+            ExpressButtonType.Link,
+            ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
         )
     }
 
     private fun create(
         availableWallets: List<WalletType>,
         configuration: ExpressCheckoutElement.Configuration = ExpressCheckoutElement.Configuration(),
-    ): List<WalletType> {
+        googlePayConfiguration: GooglePayConfiguration.State? = TEST_GOOGLE_PAY_CONFIGURATION,
+    ): List<ExpressButtonType> {
         return DefaultAvailableExpressButtonTypesFactory().create(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 availableWallets = availableWallets,
             ),
             expressCheckoutElementConfiguration = configuration.build(),
+            googlePayConfiguration = googlePayConfiguration,
         )
+    }
+
+    private companion object {
+        val TEST_GOOGLE_PAY_CONFIGURATION = GooglePayConfiguration(
+            GooglePayConfiguration.Environment.Test,
+        ).build()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.ExpressCheckoutElement
+import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
@@ -36,6 +37,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
 
     @Test
     fun `state contains provided express buttons`() {
+        val googlePayConfiguration = createGooglePayConfiguration()
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             availableWallets = listOf(
                 WalletType.Link,
@@ -44,6 +46,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
         )
         val interactor = createInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
+            googlePayConfiguration = googlePayConfiguration,
         )
 
         assertThat(interactor.state.value.expressButtons).containsExactly(
@@ -52,7 +55,8 @@ internal class DefaultExpressCheckoutElementInteractorTest {
                 linkAccountInfo = LinkAccountUpdate.Value(null),
             ),
             ExpressButton.GooglePay.create(
-                paymentMethodMetadata,
+                paymentMethodMetadata = paymentMethodMetadata,
+                googlePayConfiguration = googlePayConfiguration
             ),
         )
     }
@@ -113,22 +117,32 @@ internal class DefaultExpressCheckoutElementInteractorTest {
     }
 
     @Test
-    fun `state reflects available wallets from checkoutSession`() {
+    fun `state reflects available express button types from checkoutSession`() {
+        val googlePayConfiguration = createGooglePayConfiguration(
+            buttonType = GooglePayConfiguration.ButtonType.Checkout,
+            additionalEnabledNetworks = listOf("INTERAC"),
+        )
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             availableWallets = listOf(
                 WalletType.Link,
                 WalletType.GooglePay,
             )
         )
-        val availableWallets = listOf(WalletType.GooglePay)
+        val availableExpressButtonTypes = listOf(
+            ExpressButtonType.GooglePay(
+                googlePayConfiguration = googlePayConfiguration,
+            )
+        )
         val interactor = createInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
-            availableWallets = availableWallets,
+            googlePayConfiguration = googlePayConfiguration,
+            availableExpressButtonTypes = availableExpressButtonTypes,
         )
 
         assertThat(interactor.state.value.expressButtons).containsExactly(
             ExpressButton.GooglePay.create(
-                paymentMethodMetadata,
+                paymentMethodMetadata = paymentMethodMetadata,
+                googlePayConfiguration = googlePayConfiguration,
             ),
         )
     }
@@ -136,8 +150,14 @@ internal class DefaultExpressCheckoutElementInteractorTest {
     private fun createInteractor(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         configuration: ExpressCheckoutElement.Configuration = ExpressCheckoutElement.Configuration(),
+        googlePayConfiguration: GooglePayConfiguration.State = createGooglePayConfiguration(),
         linkAccountHolder: LinkAccountHolder = LinkAccountHolder(SavedStateHandle()),
-        availableWallets: List<WalletType> = paymentMethodMetadata.availableWallets,
+        availableExpressButtonTypes: List<ExpressButtonType> = paymentMethodMetadata.availableWallets.map {
+            when (it) {
+                WalletType.Link -> ExpressButtonType.Link
+                WalletType.GooglePay -> ExpressButtonType.GooglePay(googlePayConfiguration)
+            }
+        },
     ): DefaultExpressCheckoutElementInteractor {
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateHolder(
@@ -145,7 +165,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
             errorReporter = FakeErrorReporter(),
             paymentOptionFactory = { _, _ -> null },
             availableExpressButtonTypesFactory = FakeAvailableExpressButtonTypesFactory(
-                availableWallets = availableWallets,
+                availableExpressButtonTypes = availableExpressButtonTypes,
             ),
         )
         stateHolder.state = CheckoutControllerStateFactory.create(
@@ -159,5 +179,17 @@ internal class DefaultExpressCheckoutElementInteractorTest {
             linkAccountHolder = linkAccountHolder,
             stateHolder = stateHolder,
         )
+    }
+
+    private fun createGooglePayConfiguration(
+        buttonType: GooglePayConfiguration.ButtonType = GooglePayConfiguration.ButtonType.Pay,
+        additionalEnabledNetworks: List<String> = emptyList(),
+    ): GooglePayConfiguration.State {
+        return GooglePayConfiguration(
+            GooglePayConfiguration.Environment.Test,
+        )
+            .buttonType(buttonType)
+            .additionalEnabledNetworks(additionalEnabledNetworks)
+            .build()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
@@ -1,15 +1,21 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
 package com.stripe.android.checkout.ece
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.state.LinkState
 import org.junit.Test
 
@@ -80,10 +86,34 @@ internal class ExpressButtonTest {
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
         )
 
-        val button = ExpressButton.GooglePay.create(paymentMethodMetadata)
+        val button = createGooglePayExpressButton(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
 
         assertThat(button.billingAddressParameters)
             .isEqualTo(billingDetailsCollectionConfiguration.toBillingAddressParameters())
+    }
+
+    @Test
+    fun `GooglePay create uses button type from google pay configuration`() {
+        val button = createGooglePayExpressButton(
+            googlePayConfiguration = createGooglePayConfiguration(
+                buttonType = GooglePayConfiguration.ButtonType.Checkout,
+            ),
+        )
+
+        assertThat(button.googlePayButtonType).isEqualTo(GooglePayButtonType.Checkout)
+    }
+
+    @Test
+    fun `GooglePay create uses additional enabled networks from google pay configuration`() {
+        val button = createGooglePayExpressButton(
+            googlePayConfiguration = createGooglePayConfiguration(
+                additionalEnabledNetworks = listOf("INTERAC"),
+            ),
+        )
+
+        assertThat(button.additionalEnabledNetworks).containsExactly("INTERAC")
     }
 
     @Test
@@ -97,7 +127,9 @@ internal class ExpressButtonTest {
             cardBrandFilter = cardBrandFilter,
         )
 
-        val button = ExpressButton.GooglePay.create(paymentMethodMetadata)
+        val button = createGooglePayExpressButton(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
 
         assertThat(button.cardBrandFilter).isSameInstanceAs(cardBrandFilter)
     }
@@ -111,8 +143,47 @@ internal class ExpressButtonTest {
             cardFundingFilter = cardFundingFilter,
         )
 
-        val button = ExpressButton.GooglePay.create(paymentMethodMetadata)
+        val button = createGooglePayExpressButton(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
 
         assertThat(button.cardFundingFilter).isSameInstanceAs(cardFundingFilter)
+    }
+
+    @Test
+    fun `GooglePay create disallows credit cards when funding filter excludes credit`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            cardFundingFilter = PaymentSheetCardFundingFilter(
+                allowedCardFundingTypes = listOf(PaymentSheet.CardFundingType.Debit),
+            ),
+        )
+
+        val button = createGooglePayExpressButton(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+
+        assertThat(button.allowCreditCards).isFalse()
+    }
+
+    private fun createGooglePayExpressButton(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        googlePayConfiguration: GooglePayConfiguration.State = createGooglePayConfiguration()
+    ): ExpressButton.GooglePay {
+         return ExpressButton.GooglePay.create(
+             paymentMethodMetadata = paymentMethodMetadata,
+             googlePayConfiguration = googlePayConfiguration
+         )
+    }
+
+    private fun createGooglePayConfiguration(
+        buttonType: GooglePayConfiguration.ButtonType = GooglePayConfiguration.ButtonType.Pay,
+        additionalEnabledNetworks: List<String> = emptyList(),
+    ): GooglePayConfiguration.State {
+        return GooglePayConfiguration(
+            GooglePayConfiguration.Environment.Test,
+        )
+            .buttonType(buttonType)
+            .additionalEnabledNetworks(additionalEnabledNetworks)
+            .build()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
@@ -168,21 +168,6 @@ internal class ExpressButtonTest {
         assertThat(button.cardFundingFilter).isSameInstanceAs(cardFundingFilter)
     }
 
-    @Test
-    fun `GooglePay create disallows credit cards when funding filter excludes credit`() {
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            cardFundingFilter = PaymentSheetCardFundingFilter(
-                allowedCardFundingTypes = listOf(PaymentSheet.CardFundingType.Debit),
-            ),
-        )
-
-        val button = createGooglePayExpressButton(
-            paymentMethodMetadata = paymentMethodMetadata,
-        )
-
-        assertThat(button.allowCreditCards).isFalse()
-    }
-
     private fun createGooglePayExpressButton(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         googlePayConfiguration: GooglePayConfiguration.State = createGooglePayConfiguration()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractorStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractorStateFactory.kt
@@ -1,7 +1,11 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
 package com.stripe.android.checkout.ece
 
+import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 
 internal object ExpressCheckoutElementInteractorStateFactory {
     private val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -16,6 +20,9 @@ internal object ExpressCheckoutElementInteractorStateFactory {
             ),
             ExpressButton.GooglePay.create(
                 paymentMethodMetadata = paymentMethodMetadata,
+                googlePayConfiguration = GooglePayConfiguration(
+                    GooglePayConfiguration.Environment.Test,
+                ).build(),
             ),
         ),
     ): ExpressCheckoutElementInteractor.State {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/FakeAvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/FakeAvailableExpressButtonTypesFactory.kt
@@ -2,18 +2,25 @@
 package com.stripe.android.checkout.ece
 
 import com.stripe.android.checkout.ExpressCheckoutElement
+import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 
 internal class FakeAvailableExpressButtonTypesFactory(
-    private val availableWallets: List<WalletType> = listOf(WalletType.GooglePay),
+    private val availableExpressButtonTypes: List<ExpressButtonType> = listOf(
+        ExpressButtonType.GooglePay(
+            googlePayConfiguration = GooglePayConfiguration(
+                GooglePayConfiguration.Environment.Test,
+            ).build(),
+        ),
+    ),
 ) : AvailableExpressButtonTypesFactory {
 
     override fun create(
         paymentMethodMetadata: PaymentMethodMetadata,
-        expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State
-    ): List<WalletType> {
-        return availableWallets
+        expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State,
+        googlePayConfiguration: GooglePayConfiguration.State?,
+    ): List<ExpressButtonType> {
+        return availableExpressButtonTypes
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update GooglePay ExpressButton to use GooglePayConfiguration

In order to enable this, we need a GooglePayConfiguration.State when creating the GooglePay ExpressButton. The GooglePayConfiguration should never be null if google pay is returned from PaymentMethodMetadata as an available wallet. But in order to have a non-null copy of GooglePayConfiguration, I threaded it through a new ExpressButtonType type.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Add functionality to google pay button / show correct values

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified
