### PR TITLE
Refactor DefaultEmbeddedContentHelper to depend on StateFlow state.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -23,7 +23,7 @@ internal interface EmbeddedContentHelper {
 @Singleton
 internal class DefaultEmbeddedContentHelper @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val stateHolder: EmbeddedContentHelperStateHolder,
+    private val state: StateFlow<EmbeddedContentHelperStateHolder.State?>,
     private val verticalLayoutInteractorFactory: EmbeddedPaymentMethodVerticalLayoutInteractorFactory,
     private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
     private val embeddedWalletsHelper: EmbeddedWalletsHelper,
@@ -38,7 +38,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
 
     init {
         coroutineScope.launch {
-            stateHolder.state.collect { state ->
+            state.collect { state ->
                 _embeddedContent.value = if (state == null) {
                     null
                 } else {
@@ -61,7 +61,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     }
 
     override fun presentPaymentOptions() {
-        val state = stateHolder.state.value
+        val state = state.value
         if (state == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -249,6 +249,13 @@ internal interface EmbeddedPaymentElementViewModelModule {
         }
 
         @Provides
+        fun provideEmbeddedContentState(
+            stateHolder: EmbeddedContentHelperStateHolder,
+        ): StateFlow<EmbeddedContentHelperStateHolder.State?> {
+            return stateHolder.state
+        }
+
+        @Provides
         fun providesConfirmationStateSupplier(
             confirmationStateHolder: EmbeddedConfirmationStateHolder,
         ): () -> EmbeddedConfirmationStateHolder.State? {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder.Companion.STATE_KEY_EMBEDDED_CONTENT
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
@@ -32,6 +31,7 @@ import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -42,68 +42,43 @@ internal class DefaultEmbeddedContentHelperTest {
     val coroutineTestRule = CoroutineTestRule()
 
     @Test
-    fun `dataLoaded updates savedStateHandle with paymentMethodMetadata`() = testScenario {
-        assertThat(savedStateHandle.get<PaymentMethodMetadata?>(STATE_KEY_EMBEDDED_CONTENT))
-            .isNull()
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default)
-        stateHolder.dataLoaded(
-            paymentMethodMetadata,
-            appearance,
-            embeddedViewDisplaysMandateText = true,
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        )
-        val state = savedStateHandle.get<EmbeddedContentHelperStateHolder.State?>(STATE_KEY_EMBEDDED_CONTENT)
-        assertThat(state?.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
-        assertThat(state?.appearance).isEqualTo(appearance)
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
-    }
-
-    @Test
-    fun `dataLoaded emits embeddedContent event`() = testScenario {
+    fun `embeddedContent is populated when state is set`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
+            state.value = EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
         }
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
-    fun `embeddedContent emits null when clearEmbeddedContent is called`() = testScenario {
+    fun `embeddedContent emits null when state is set to null`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
+            state.value = EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
-            stateHolder.clearEmbeddedContent()
+            state.value = null
             assertThat(awaitItem()).isNull()
         }
-        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
     fun `initializing embeddedContentHelper with paymentMethodMetadata emits correct initial event`() = testScenario(
-        setup = {
-            set(
-                STATE_KEY_EMBEDDED_CONTENT,
-                EmbeddedContentHelperStateHolder.State(
-                    PaymentMethodMetadataFactory.create(),
-                    Embedded(Embedded.RowStyle.FloatingButton.default),
-                    embeddedViewDisplaysMandateText = true,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-                )
-            )
-        }
+        initialState = EmbeddedContentHelperStateHolder.State(
+            PaymentMethodMetadataFactory.create(),
+            Embedded(Embedded.RowStyle.FloatingButton.default),
+            embeddedViewDisplaysMandateText = true,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        )
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNotNull()
@@ -120,17 +95,12 @@ internal class DefaultEmbeddedContentHelperTest {
 
     @Test
     fun `presentPaymentOptions reports error when launcher is null`() = testScenario(
-        setup = {
-            set(
-                STATE_KEY_EMBEDDED_CONTENT,
-                EmbeddedContentHelperStateHolder.State(
-                    PaymentMethodMetadataFactory.create(),
-                    Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                    embeddedViewDisplaysMandateText = true,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-                )
-            )
-        }
+        initialState = EmbeddedContentHelperStateHolder.State(
+            PaymentMethodMetadataFactory.create(),
+            Embedded(Embedded.RowStyle.FlatWithRadio.default),
+            embeddedViewDisplaysMandateText = true,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        )
     ) {
         embeddedContentHelper.presentPaymentOptions()
         assertThat(errorReporter.getLoggedErrors()).containsExactly(
@@ -145,16 +115,13 @@ internal class DefaultEmbeddedContentHelperTest {
         val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         testScenario(
+            initialState = EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata,
+                Embedded(Embedded.RowStyle.FlatWithRadio.default),
+                embeddedViewDisplaysMandateText = true,
+                configuration = configuration,
+            ),
             setup = {
-                set(
-                    STATE_KEY_EMBEDDED_CONTENT,
-                    EmbeddedContentHelperStateHolder.State(
-                        paymentMethodMetadata,
-                        Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                        embeddedViewDisplaysMandateText = true,
-                        configuration = configuration,
-                    )
-                )
                 set(CustomerStateHolder.SAVED_CUSTOMER, customerState)
                 set(DefaultEmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY, selection)
             }
@@ -177,16 +144,15 @@ internal class DefaultEmbeddedContentHelperTest {
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
-        val stateHolder: EmbeddedContentHelperStateHolder,
+        val state: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
         val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
-        val savedStateHandle: SavedStateHandle,
-        val eventReporter: FakeEventReporter,
         val errorReporter: FakeErrorReporter,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
     @Suppress("LongMethod")
     private fun testScenario(
+        initialState: EmbeddedContentHelperStateHolder.State? = null,
         setup: SavedStateHandle.() -> Unit = {},
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
@@ -217,10 +183,7 @@ internal class DefaultEmbeddedContentHelperTest {
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
 
-        val stateHolder = DefaultEmbeddedContentHelperStateHolder(
-            savedStateHandle = savedStateHandle,
-            eventReporter = eventReporter,
-        )
+        val state = MutableStateFlow(initialState)
         val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
@@ -247,7 +210,7 @@ internal class DefaultEmbeddedContentHelperTest {
 
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
             coroutineScope = backgroundScope,
-            state = stateHolder.state,
+            state = state,
             verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
             sheetLauncherHolder = sheetLauncherHolder,
             embeddedWalletsHelper = { stateFlowOf(null) },
@@ -258,10 +221,8 @@ internal class DefaultEmbeddedContentHelperTest {
         )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
-            stateHolder = stateHolder,
+            state = state,
             sheetLauncherHolder = sheetLauncherHolder,
-            savedStateHandle = savedStateHandle,
-            eventReporter = eventReporter,
             errorReporter = errorReporter,
         ).block()
         confirmationHandler.validate()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -247,7 +247,7 @@ internal class DefaultEmbeddedContentHelperTest {
 
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
             coroutineScope = backgroundScope,
-            stateHolder = stateHolder,
+            state = stateHolder.state,
             verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
             sheetLauncherHolder = sheetLauncherHolder,
             embeddedWalletsHelper = { stateFlowOf(null) },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -63,9 +64,9 @@ internal class EmbeddedContentUiTest {
         runScenario(internalRowSelectionCallback = {}) {
             embeddedContentHelper.embeddedContent.test {
                 assertThat(awaitItem()).isNull()
-                stateHolder.dataLoaded(
-                    PaymentMethodMetadataFactory.create(),
-                    Embedded(Embedded.RowStyle.FlatWithRadio.default),
+                state.value = EmbeddedContentHelperStateHolder.State(
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                    appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
                     embeddedViewDisplaysMandateText = true,
                     configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 )
@@ -87,9 +88,9 @@ internal class EmbeddedContentUiTest {
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
+            state.value = EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
                 embeddedViewDisplaysMandateText = true,
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
@@ -111,9 +112,9 @@ internal class EmbeddedContentUiTest {
     ) {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
-            stateHolder.dataLoaded(
-                PaymentMethodMetadataFactory.create(),
-                Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
+            state.value = EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                appearance = Embedded(Embedded.RowStyle.FlatWithDisclosure.default),
                 embeddedViewDisplaysMandateText = true,
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
@@ -133,7 +134,7 @@ internal class EmbeddedContentUiTest {
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
-        val stateHolder: EmbeddedContentHelperStateHolder,
+        val state: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
@@ -171,10 +172,7 @@ internal class EmbeddedContentUiTest {
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
 
-        val stateHolder = DefaultEmbeddedContentHelperStateHolder(
-            savedStateHandle = savedStateHandle,
-            eventReporter = eventReporter,
-        )
+        val state = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(null)
         val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
@@ -202,7 +200,7 @@ internal class EmbeddedContentUiTest {
         val embeddedContentHelper =
             DefaultEmbeddedContentHelper(
                 coroutineScope = viewModelScope,
-                state = stateHolder.state,
+                state = state,
                 verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
                 sheetLauncherHolder = sheetLauncherHolder,
                 embeddedWalletsHelper = { stateFlowOf(null) },
@@ -213,7 +211,7 @@ internal class EmbeddedContentUiTest {
             )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
-            stateHolder = stateHolder,
+            state = state,
         ).block()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -202,7 +202,7 @@ internal class EmbeddedContentUiTest {
         val embeddedContentHelper =
             DefaultEmbeddedContentHelper(
                 coroutineScope = viewModelScope,
-                stateHolder = stateHolder,
+                state = stateHolder.state,
                 verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
                 sheetLauncherHolder = sheetLauncherHolder,
                 embeddedWalletsHelper = { stateFlowOf(null) },


### PR DESCRIPTION
# Summary
Refactored `DefaultEmbeddedContentHelper` to depend directly on a `StateFlow<EmbeddedContentHelperStateHolder.State?>` rather than the full `EmbeddedContentHelperStateHolder`. Updated construction and dependency injection accordingly, and modified affected tests.

# Motivation
This change clarifies the dependencies for `DefaultEmbeddedContentHelper`, improves testability, and aligns with best practices for exposing only the necessary state rather than entire holders or components.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
