### PR TITLE
Match Google Pay `Pay` button label exactly

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -140,6 +140,7 @@ internal class Selectors(
 
     val googlePayCheckoutButton = UiAutomatorText(
         "Pay",
+        labelMatchesExactly = true,
         className = "android.widget.Button",
         device = device
     )


### PR DESCRIPTION
# Summary
Match Google Pay `Pay` button label exactly to prevent other buttons with `Pay` text from matching.

# Motivation
Observed in https://github.com/stripe/stripe-android/pull/13526 that sometimes there are text buttons with a `Pay` substring that match before the primary pay button.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified