### PR TITLE
Keep card pill when opening and closing `FlowController` & Embedded form.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
@@ -46,11 +46,17 @@ sealed class PaymentMethodExtraParams(
     data class Card(
         val setAsDefault: Boolean? = null,
         val phoneNumberCountry: String? = null,
+        val fromValidatedScan: Boolean? = null,
     ) : PaymentMethodExtraParams(PaymentMethod.Type.Card) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
-                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
+                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString(),
+                PARAM_VALIDATED_SCAN to fromValidatedScan?.toString()
             )
+        }
+
+        internal companion object {
+            const val PARAM_VALIDATED_SCAN = "validated_scan"
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodExtraParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodExtraParamsTest.kt
@@ -18,4 +18,26 @@ class PaymentMethodExtraParamsTest {
             )
         )
     }
+
+    @Test
+    fun createFromCardWithValidatedScan() {
+        assertThat(PaymentMethodExtraParams.Card(fromValidatedScan = true).toParamMap()).isEqualTo(
+            mapOf(
+                "card" to mapOf(
+                    "validated_scan" to "true"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun createFromCardWithoutValidatedScan() {
+        assertThat(PaymentMethodExtraParams.Card(fromValidatedScan = false).toParamMap()).isEqualTo(
+            mapOf(
+                "card" to mapOf(
+                    "validated_scan" to "false"
+                )
+            )
+        )
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -148,6 +148,7 @@ class FieldValuesToParamsMapConverter {
                     setAsDefault =
                     fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean(),
                     phoneNumberCountry = fieldValuePairsForExtras[IdentifierSpec.PhoneNumberCountry]?.value,
+                    fromValidatedScan = fieldValuePairsForExtras[IdentifierSpec.CardValidatedScan]?.value?.toBoolean(),
                 )
                 PaymentMethod.Type.Link.code -> PaymentMethodExtraParams.Link(
                     setAsDefault =

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -51,7 +51,20 @@ internal class CardDetailsController(
     dateConfig: TextFieldConfig = DateConfig(),
     private val validationMessageComparator: FieldValidationMessageComparator = DefaultFieldValidationMessageComparator
 ) : SectionFieldValidationController, SectionFieldComposable {
-    val cardPillElement = MutableStateFlow<CardPillElement?>(null)
+    private val initialCardNumber = initialValues[IdentifierSpec.CardNumber]
+
+    val cardPillElement = MutableStateFlow(
+        if (initialValues[IdentifierSpec.CardValidatedScan].toBoolean() && initialCardNumber != null) {
+            CardPillElement(
+                controller = CardPillController(
+                    cardNumber = initialCardNumber,
+                    onDismissPill = ::dismissCardPill,
+                )
+            )
+        } else {
+            null
+        }
+    )
 
     val nameElement = if (collectName) {
         SimpleTextElement(
@@ -77,7 +90,7 @@ internal class CardDetailsController(
             cardAccountRangeRepository = cardAccountRangeRepositoryFactory.create(),
             uiContext = uiContext,
             workContext = workContext,
-            initialValue = initialValues[IdentifierSpec.CardNumber],
+            initialValue = initialCardNumber,
             cardBrandChoiceConfig = when (cbcEligibility) {
                 is CardBrandChoiceEligibility.Eligible -> CardBrandChoiceConfig.Eligible(
                     preferredBrands = cbcEligibility.preferredNetworks,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -107,6 +107,14 @@ internal class CardDetailsElement(
                     IdentifierSpec.CardExpYear to getExpiryYearFormFieldEntry(it)
                 }
             )
+
+            add(
+                controller.cardPillElement.mapAsStateFlow { element ->
+                    val hasCardPill = element != null
+
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry(hasCardPill.toString(), true)
+                }
+            )
         }
         return combineAsStateFlow(flows) { it.toList() }
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -483,6 +483,52 @@ class FieldValuesToParamsMapConverterTest {
     }
 
     @Test
+    fun `transformToPaymentMethodExtraParams returns correct params for Card with validated scan`() {
+        val paymentMethodExtraParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodExtraParams(
+                mapOf(
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry(
+                        "true",
+                        true
+                    ),
+                ),
+                PaymentMethod.Type.Card.code,
+            )
+
+        assertThat(paymentMethodExtraParams).isNotNull()
+        assertThat(paymentMethodExtraParams?.toParamMap()).isEqualTo(
+            mapOf(
+                "card" to mapOf(
+                    "validated_scan" to "true"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `transformToPaymentMethodExtraParams returns correct params for Card with np validated scan`() {
+        val paymentMethodExtraParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodExtraParams(
+                mapOf(
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry(
+                        "false",
+                        true
+                    ),
+                ),
+                PaymentMethod.Type.Card.code,
+            )
+
+        assertThat(paymentMethodExtraParams).isNotNull()
+        assertThat(paymentMethodExtraParams?.toParamMap()).isEqualTo(
+            mapOf(
+                "card" to mapOf(
+                    "validated_scan" to "false"
+                )
+            )
+        )
+    }
+
+    @Test
     fun `allowRedisplay is set to UNSPECIFIED in param map`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -220,6 +220,79 @@ class CardDetailsControllerTest {
     }
 
     @Test
+    fun `When initialized with validated scan and card number, card pill is shown`() = runTest {
+        val cardController = cardDetailsController(
+            initialValues = mapOf(
+                IdentifierSpec.CardNumber to "4242424242424242",
+                IdentifierSpec.CardValidatedScan to "true",
+                IdentifierSpec.CardExpMonth to "06",
+                IdentifierSpec.CardExpYear to "2030",
+            )
+        )
+
+        idleLooper()
+
+        cardController.fields.test {
+            val fields = awaitItem()
+
+            assertThat(fields).hasSize(2)
+
+            assertThat(fields[0]).isInstanceOf<CardPillElement>()
+            assertThat(fields[1]).isSameInstanceAs(cardController.cvcElement)
+
+            ensureAllEventsConsumed()
+        }
+
+        assertThat(cardController.cardPillElement.value).isNotNull()
+    }
+
+    @Test
+    fun `When initialized with validated scan but no card number, card pill is not shown`() = runTest {
+        val cardController = cardDetailsController(
+            initialValues = mapOf(
+                IdentifierSpec.CardValidatedScan to "true",
+            )
+        )
+        idleLooper()
+
+        cardController.fields.test {
+            val fields = awaitItem()
+
+            assertThat(fields).hasSize(2)
+
+            assertThat(fields[0]).isSameInstanceAs(cardController.numberElement)
+            assertThat(fields[1]).isInstanceOf(RowElement::class.java)
+
+            ensureAllEventsConsumed()
+        }
+
+        assertThat(cardController.cardPillElement.value).isNull()
+    }
+
+    @Test
+    fun `When initialized with validated scan false, card pill is not shown`() = runTest {
+        val cardController = cardDetailsController(
+            initialValues = mapOf(
+                IdentifierSpec.CardNumber to "4242424242424242",
+                IdentifierSpec.CardValidatedScan to "false",
+            )
+        )
+        idleLooper()
+
+        cardController.fields.test {
+            val fields = awaitItem()
+
+            assertThat(fields).hasSize(2)
+            assertThat(fields[0]).isSameInstanceAs(cardController.numberElement)
+            assertThat(fields[1]).isInstanceOf(RowElement::class.java)
+
+            ensureAllEventsConsumed()
+        }
+
+        assertThat(cardController.cardPillElement.value).isNull()
+    }
+
+    @Test
     fun `When validated scanned card, card data is applied and fields have card pill & cvc`() = runTest {
         val cardController = cardDetailsController()
         idleLooper()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -59,7 +59,8 @@ class CardDetailsElementTest {
                     IdentifierSpec.CardCvc to FormFieldEntry("321", true),
                     IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -87,7 +88,8 @@ class CardDetailsElementTest {
                     IdentifierSpec.CardCvc to FormFieldEntry("321", true),
                     IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("12", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -124,7 +126,8 @@ class CardDetailsElementTest {
                     IdentifierSpec.CardCvc to FormFieldEntry("321", true),
                     IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -166,7 +169,8 @@ class CardDetailsElementTest {
                     IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
                     IdentifierSpec.PreferredCardBrand to FormFieldEntry(null, true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -215,7 +219,8 @@ class CardDetailsElementTest {
                     IdentifierSpec.PreferredCardBrand to FormFieldEntry("cartes_bancaires", true),
                     IdentifierSpec.CardBrand to FormFieldEntry("cartes_bancaires", true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -257,7 +262,8 @@ class CardDetailsElementTest {
                     IdentifierSpec.PreferredCardBrand to FormFieldEntry("cartes_bancaires", true),
                     IdentifierSpec.CardBrand to FormFieldEntry("cartes_bancaires", true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -293,9 +299,109 @@ class CardDetailsElementTest {
                     IdentifierSpec.CardCvc to FormFieldEntry("", false),
                     IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
                     IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
+        }
+    }
+
+    @Test
+    fun `test form field values include validated scan when initialized with card pill`() = runTest {
+        val cardDetailsElement = CardDetailsElement(
+            IdentifierSpec.Generic("card_details"),
+            cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            initialValues = mapOf(
+                IdentifierSpec.CardNumber to "4242424242424242",
+                IdentifierSpec.CardValidatedScan to "true",
+                IdentifierSpec.CardExpMonth to "06",
+                IdentifierSpec.CardExpYear to "2030",
+            ),
+        )
+
+        cardDetailsElement.getFormFieldValueFlow().test {
+            assertThat(awaitItem()).containsExactlyElementsIn(
+                listOf(
+                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
+                    IdentifierSpec.CardCvc to FormFieldEntry("", false),
+                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+                    IdentifierSpec.CardExpMonth to FormFieldEntry("06", true),
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("true", true),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `test form field values include validated scan when validated card is scanned`() = runTest {
+        val repositoryFactory = DefaultCardAccountRangeRepositoryFactory(context)
+        val cardController = CardDetailsController(
+            cardAccountRangeRepositoryFactory = repositoryFactory,
+            initialValues = emptyMap(),
+            uiContext = testDispatcher,
+            workContext = testDispatcher,
+        )
+
+        val cardDetailsElement = CardDetailsElement(
+            IdentifierSpec.Generic("card_details"),
+            cardAccountRangeRepositoryFactory = repositoryFactory,
+            initialValues = emptyMap(),
+            controller = cardController,
+        )
+
+        cardController.onScannedCard(
+            ScannedCardDetails.Validated(
+                cardNumber = "4242424242424242",
+                expirationMonth = 6,
+                expirationYear = 2030,
+            )
+        )
+
+        cardDetailsElement.getFormFieldValueFlow().test {
+            assertThat(awaitItem()).containsExactlyElementsIn(
+                listOf(
+                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
+                    IdentifierSpec.CardCvc to FormFieldEntry("", false),
+                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+                    IdentifierSpec.CardExpMonth to FormFieldEntry("06", true),
+                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+                    IdentifierSpec.CardValidatedScan to FormFieldEntry("true", true),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `test form field values clear validated scan when card pill is dismissed`() = runTest {
+        val initialValues = mapOf(
+            IdentifierSpec.CardNumber to "4242424242424242",
+            IdentifierSpec.CardValidatedScan to "true",
+            IdentifierSpec.CardExpMonth to "06",
+            IdentifierSpec.CardExpYear to "2030",
+        )
+        val repositoryFactory = DefaultCardAccountRangeRepositoryFactory(context)
+        val cardController = CardDetailsController(
+            cardAccountRangeRepositoryFactory = repositoryFactory,
+            initialValues = initialValues,
+            uiContext = testDispatcher,
+            workContext = testDispatcher,
+        )
+        val cardDetailsElement = CardDetailsElement(
+            IdentifierSpec.Generic("card_details"),
+            cardAccountRangeRepositoryFactory = repositoryFactory,
+            initialValues = initialValues,
+            controller = cardController,
+        )
+
+        cardDetailsElement.getFormFieldValueFlow().test {
+            assertThat(awaitItem())
+                .contains(IdentifierSpec.CardValidatedScan to FormFieldEntry("true", true))
+
+            cardController.cardPillElement.value = null
+
+            assertThat(awaitItem())
+                .contains(IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),)
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -114,6 +114,12 @@ data class IdentifierSpec(
             destination = ParameterDestination.Local.Extras
         )
 
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val CardValidatedScan = IdentifierSpec(
+            "card[validated_scan]",
+            destination = ParameterDestination.Local.Extras
+        )
+
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
         fun get(value: String) = when (value) {
             CardBrand.v1 -> CardBrand


### PR DESCRIPTION
# Summary
Keep card pill when opening and closing `FlowController` & Embedded form by adding a `PaymentMethodExtraParams` signifying that the card came from a validated scan. This signal will repopulate the card pill in the card form.

# Motivation
Better UX experience

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/d47e2b13-9446-4e94-890d-f1e07867cc06