### PR TITLE
Pass configuration directly to EmbeddedPaymentMethodVerticalLayoutInteractorFactory.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -46,6 +46,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                     EmbeddedContent(
                         interactor = verticalLayoutInteractorFactory.create(
                             paymentMethodMetadata = state.paymentMethodMetadata,
+                            configuration = state.configuration,
                             walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
                             isImmediateAction = isImmediateAction,
                             embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
@@ -23,12 +24,14 @@ internal class EmbeddedContentSavedPaymentMethodMutatorFactory @Inject construct
     private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
-    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     private val linkAccountHolder: LinkAccountHolder,
     @ViewModelScope private val coroutineScope: CoroutineScope,
     private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
 ) {
-    fun create(paymentMethodMetadata: PaymentMethodMetadata): SavedPaymentMethodMutator {
+    fun create(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        configuration: EmbeddedPaymentElement.Configuration,
+    ): SavedPaymentMethodMutator {
         return SavedPaymentMethodMutator(
             paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
             eventReporter = eventReporter,
@@ -46,7 +49,7 @@ internal class EmbeddedContentSavedPaymentMethodMutatorFactory @Inject construct
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
-                    configuration = confirmationStateHolder.state?.configuration,
+                    configuration = configuration,
                 )
             },
             isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -26,6 +26,7 @@ import javax.inject.Inject
 internal fun interface EmbeddedPaymentMethodVerticalLayoutInteractorFactory {
     fun create(
         paymentMethodMetadata: PaymentMethodMetadata,
+        configuration: EmbeddedPaymentElement.Configuration,
         walletsState: StateFlow<WalletsState?>,
         isImmediateAction: Boolean,
         embeddedViewDisplaysMandateText: Boolean,
@@ -49,6 +50,7 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
     @Suppress("LongMethod")
     override fun create(
         paymentMethodMetadata: PaymentMethodMetadata,
+        configuration: EmbeddedPaymentElement.Configuration,
         walletsState: StateFlow<WalletsState?>,
         isImmediateAction: Boolean,
         embeddedViewDisplaysMandateText: Boolean,
@@ -93,14 +95,14 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
-                    configuration = confirmationStateHolder.state?.configuration,
+                    configuration = configuration,
                 )
             },
             transitionToFormScreen = { code ->
                 sheetLauncherHolder.sheetLauncher?.launchForm(
                     code = code,
                     paymentMethodMetadata = paymentMethodMetadata,
-                    configuration = confirmationStateHolder.state?.configuration,
+                    configuration = configuration,
                     customerState = customerStateHolder.customer.value,
                     promotion = paymentMethodMessagePromotionsHelper.getPromotionIfAvailableForCode(
                         code = code,
@@ -122,7 +124,7 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
             reportFormShown = eventReporter::onPaymentMethodFormShown,
             onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
             shouldUpdateVerticalModeSelection = { paymentMethodCode ->
-                val isConfirmFlow = confirmationStateHolder.state?.configuration?.formSheetAction ==
+                val isConfirmFlow = configuration.formSheetAction ==
                     EmbeddedPaymentElement.FormSheetAction.Confirm
                 if (isConfirmFlow) {
                     val requiresFormScreen = paymentMethodCode != null &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -16,7 +16,6 @@ import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVertical
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
@@ -37,7 +36,6 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
     private val eventReporter: EventReporter,
     private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
     private val confirmationHandler: ConfirmationHandler,
-    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
@@ -73,16 +71,14 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
         )
-        val savedPaymentMethodMutator = savedPaymentMethodMutatorFactory.create(paymentMethodMetadata)
+        val savedPaymentMethodMutator = savedPaymentMethodMutatorFactory.create(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = configuration,
+        )
 
         return DefaultPaymentMethodVerticalLayoutInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
-            processing = combineAsStateFlow(
-                confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
-                confirmationStateHolder.stateFlow.mapAsStateFlow { it != null },
-            ) { confirmationStateValid, configurationStateValid ->
-                confirmationStateValid && configurationStateValid
-            },
+            processing = confirmationHandler.state.mapAsStateFlow { it is ConfirmationHandler.State.Confirming },
             temporarySelection = selectionHolder.temporarySelection,
             selection = selectionHolder.selection,
             paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -214,11 +214,6 @@ internal class DefaultEmbeddedContentHelperTest {
             ),
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
-        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
-            savedStateHandle = savedStateHandle,
-            selectionHolder = selectionHolder,
-            coroutineScope = backgroundScope,
-        )
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
 
@@ -233,7 +228,6 @@ internal class DefaultEmbeddedContentHelperTest {
             savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
-            confirmationStateHolder = confirmationStateHolder,
             linkAccountHolder = linkAccountHolder,
             coroutineScope = backgroundScope,
             sheetLauncherHolder = sheetLauncherHolder,
@@ -242,7 +236,6 @@ internal class DefaultEmbeddedContentHelperTest {
             eventReporter = eventReporter,
             embeddedFormHelperFactory = embeddedFormHelperFactory,
             confirmationHandler = confirmationHandler,
-            confirmationStateHolder = confirmationStateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -168,11 +168,6 @@ internal class EmbeddedContentUiTest {
             ),
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
-        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
-            savedStateHandle = savedStateHandle,
-            selectionHolder = selectionHolder,
-            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
-        )
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
 
@@ -187,7 +182,6 @@ internal class EmbeddedContentUiTest {
             savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
-            confirmationStateHolder = confirmationStateHolder,
             linkAccountHolder = linkAccountHolder,
             coroutineScope = viewModelScope,
             sheetLauncherHolder = sheetLauncherHolder,
@@ -196,7 +190,6 @@ internal class EmbeddedContentUiTest {
             eventReporter = eventReporter,
             embeddedFormHelperFactory = embeddedFormHelperFactory,
             confirmationHandler = confirmationHandler,
-            confirmationStateHolder = confirmationStateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),


### PR DESCRIPTION
# Summary
Passes the EmbeddedPaymentElement.Configuration object directly through to the EmbeddedPaymentMethodVerticalLayoutInteractorFactory and its usages, instead of accessing it from confirmation state.

# Motivation
Ensures the correct configuration is always available in the factory, preventing potential dependency issues and improving code clarity by removing reliance on confirmationStateHolder in the factory.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog