### PR TITLE
Add haptic feedback on a successful or failed NFC scan

### DIFF
--- a/paymentsheet/src/main/AndroidManifest.xml
+++ b/paymentsheet/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application>
         <activity

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
@@ -1,14 +1,20 @@
 package com.stripe.android.common.nfcscan
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
 import com.stripe.android.common.nfcscan.ui.NfcScanningScreen
 import com.stripe.android.common.nfcscan.ui.NfcScanningTheme
 import com.stripe.android.uicore.utils.collectAsState
@@ -37,8 +43,11 @@ internal class NfcScanningActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            viewModel.result.collectLatest { result ->
-                finishWithResult(result)
+            viewModel.event.collectLatest { event ->
+                when (event) {
+                    is NfcScanningEvent.CloseWithResult -> finishWithResult(event.result)
+                    is NfcScanningEvent.TriggerHapticFeedback -> triggerHapticFeedback(event.type)
+                }
             }
         }
 
@@ -56,6 +65,8 @@ internal class NfcScanningActivity : AppCompatActivity() {
         setContent {
             NfcScanningTheme {
                 val viewState by viewModel.viewState.collectAsState()
+
+                LaunchedEffect(Unit) { }
 
                 NfcScanningScreen(
                     state = viewState,
@@ -77,6 +88,39 @@ internal class NfcScanningActivity : AppCompatActivity() {
         }
     }
 
+    private fun triggerHapticFeedback(type: HapticFeedbackType) {
+        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager = getSystemService(VIBRATOR_MANAGER_SERVICE) as? VibratorManager
+            vibratorManager?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            getSystemService(VIBRATOR_SERVICE) as? Vibrator
+        }
+
+        if (vibrator == null) {
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val effect = when (type) {
+                HapticFeedbackType.Success -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
+                HapticFeedbackType.Failed -> {
+                    VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
+                }
+            }
+
+            vibrator.vibrate(effect)
+        } else {
+            val pattern = when (type) {
+                HapticFeedbackType.Success -> LEGACY_SUCCESS_HAPTIC_VIBRATION
+                HapticFeedbackType.Failed -> LEGACY_FAILED_HAPTIC_VIBRATION
+            }
+
+            @Suppress("DEPRECATION")
+            vibrator.vibrate(pattern, VIBRATOR_REPEAT)
+        }
+    }
+
     private fun finishWithResult(result: NfcScanningContract.Result) {
         setResult(
             RESULT_OK,
@@ -88,5 +132,12 @@ internal class NfcScanningActivity : AppCompatActivity() {
     override fun finish() {
         super.finish()
         fadeOut()
+    }
+
+    private companion object {
+        const val VIBRATOR_REPEAT = -1
+
+        val LEGACY_SUCCESS_HAPTIC_VIBRATION = longArrayOf(0, 50)
+        val LEGACY_FAILED_HAPTIC_VIBRATION = longArrayOf(0, 80, 100, 80)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
@@ -1,20 +1,14 @@
 package com.stripe.android.common.nfcscan
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
 import com.stripe.android.common.nfcscan.ui.NfcScanningScreen
 import com.stripe.android.common.nfcscan.ui.NfcScanningTheme
 import com.stripe.android.uicore.utils.collectAsState
@@ -46,7 +40,9 @@ internal class NfcScanningActivity : AppCompatActivity() {
             viewModel.event.collectLatest { event ->
                 when (event) {
                     is NfcScanningEvent.CloseWithResult -> finishWithResult(event.result)
-                    is NfcScanningEvent.TriggerHapticFeedback -> triggerHapticFeedback(event.type)
+                    is NfcScanningEvent.TriggerHapticFeedback -> {
+                        NfcScanningHapticFeedback.trigger(this@NfcScanningActivity, event.type)
+                    }
                 }
             }
         }
@@ -86,39 +82,6 @@ internal class NfcScanningActivity : AppCompatActivity() {
         }
     }
 
-    private fun triggerHapticFeedback(type: HapticFeedbackType) {
-        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val vibratorManager = getSystemService(VIBRATOR_MANAGER_SERVICE) as? VibratorManager
-            vibratorManager?.defaultVibrator
-        } else {
-            @Suppress("DEPRECATION")
-            getSystemService(VIBRATOR_SERVICE) as? Vibrator
-        }
-
-        if (vibrator == null) {
-            return
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val effect = when (type) {
-                HapticFeedbackType.Success -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
-                HapticFeedbackType.Failed -> {
-                    VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
-                }
-            }
-
-            vibrator.vibrate(effect)
-        } else {
-            val pattern = when (type) {
-                HapticFeedbackType.Success -> LEGACY_SUCCESS_HAPTIC_VIBRATION
-                HapticFeedbackType.Failed -> LEGACY_FAILED_HAPTIC_VIBRATION
-            }
-
-            @Suppress("DEPRECATION")
-            vibrator.vibrate(pattern, VIBRATOR_REPEAT)
-        }
-    }
-
     private fun finishWithResult(result: NfcScanningContract.Result) {
         setResult(
             RESULT_OK,
@@ -130,12 +93,5 @@ internal class NfcScanningActivity : AppCompatActivity() {
     override fun finish() {
         super.finish()
         fadeOut()
-    }
-
-    private companion object {
-        const val VIBRATOR_REPEAT = -1
-
-        val LEGACY_SUCCESS_HAPTIC_VIBRATION = longArrayOf(0, 50)
-        val LEGACY_FAILED_HAPTIC_VIBRATION = longArrayOf(0, 80, 100, 80)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
@@ -66,8 +66,6 @@ internal class NfcScanningActivity : AppCompatActivity() {
             NfcScanningTheme {
                 val viewState by viewModel.viewState.collectAsState()
 
-                LaunchedEffect(Unit) { }
-
                 NfcScanningScreen(
                     state = viewState,
                     viewActionHandler = viewModel::handleViewAction,

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningEvent.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.common.nfcscan
+
+import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
+
+internal sealed interface NfcScanningEvent {
+    data class TriggerHapticFeedback(val type: HapticFeedbackType) : NfcScanningEvent
+    data class CloseWithResult(val result: NfcScanningContract.Result) : NfcScanningEvent
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningHapticFeedback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningHapticFeedback.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.common.nfcscan
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
+
+internal object NfcScanningHapticFeedback {
+    fun trigger(
+        context: Context,
+        type: HapticFeedbackType,
+    ) {
+        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager
+            vibratorManager?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+
+        if (vibrator == null) {
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val effect = when (type) {
+                HapticFeedbackType.Success -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
+                HapticFeedbackType.Failed -> VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK)
+            }
+
+            vibrator.vibrate(effect)
+        } else {
+            val pattern = when (type) {
+                HapticFeedbackType.Success -> LEGACY_SUCCESS_HAPTIC_VIBRATION
+                HapticFeedbackType.Failed -> LEGACY_FAILED_HAPTIC_VIBRATION
+            }
+
+            @Suppress("DEPRECATION")
+            vibrator.vibrate(pattern, VIBRATOR_REPEAT)
+        }
+    }
+
+    private const val VIBRATOR_REPEAT = -1
+
+    private val LEGACY_SUCCESS_HAPTIC_VIBRATION = longArrayOf(0, 50)
+    private val LEGACY_FAILED_HAPTIC_VIBRATION = longArrayOf(0, 80, 100, 80)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
@@ -9,6 +9,7 @@ import com.stripe.android.common.nfcscan.analytics.NfcScanningEventReporter
 import com.stripe.android.common.nfcscan.scanner.NfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.ScannedCardData
 import com.stripe.android.common.nfcscan.tapzone.TapZoneResolver
+import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
 import com.stripe.android.common.nfcscan.ui.NfcScanningStatus
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.requireApplication
@@ -31,8 +32,8 @@ internal class NfcScanningViewModel @Inject constructor(
 ) : ViewModel() {
     private val tapZone = tapZoneResolver.get()
 
-    private val _result = MutableSharedFlow<NfcScanningContract.Result>()
-    val result = _result.asSharedFlow()
+    private val _event = MutableSharedFlow<NfcScanningEvent>()
+    val event = _event.asSharedFlow()
 
     private val _viewState = MutableStateFlow(
         NfcScanningViewState(
@@ -62,6 +63,8 @@ internal class NfcScanningViewModel @Inject constructor(
                         eventReporter.onNfcScanAttemptStarted()
                     }
                     is NfcCardScanner.State.Failed -> {
+                        _event.emit(NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Failed))
+
                         val error = state.error
 
                         _viewState.emit(
@@ -74,6 +77,8 @@ internal class NfcScanningViewModel @Inject constructor(
                         eventReporter.onNfcScanAttemptFailed(errorCode = error.code)
                     }
                     is NfcCardScanner.State.Complete -> {
+                        _event.emit(NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Success))
+
                         _viewState.emit(
                             NfcScanningViewState(
                                 tapZone = tapZone,
@@ -99,7 +104,7 @@ internal class NfcScanningViewModel @Inject constructor(
             is NfcScanningViewAction.Close -> {
                 viewModelScope.launch {
                     eventReporter.onNfcScanCancelled()
-                    _result.emit(NfcScanningContract.Result.Canceled)
+                    _event.emit(NfcScanningEvent.CloseWithResult(NfcScanningContract.Result.Canceled))
                 }
             }
             is NfcScanningViewAction.SuccessShown -> {
@@ -110,11 +115,13 @@ internal class NfcScanningViewModel @Inject constructor(
                 eventReporter.onNfcScanSucceeded()
                 viewModelScope.launch {
                     pendingValidCardData?.let { cardData ->
-                        _result.emit(
-                            NfcScanningContract.Result.Complete(
-                                cardNumber = cardData.cardNumber,
-                                expirationYear = cardData.expirationYear,
-                                expirationMonth = cardData.expirationMonth,
+                        _event.emit(
+                            NfcScanningEvent.CloseWithResult(
+                                NfcScanningContract.Result.Complete(
+                                    cardNumber = cardData.cardNumber,
+                                    expirationYear = cardData.expirationYear,
+                                    expirationMonth = cardData.expirationMonth,
+                                )
                             )
                         )
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/ui/HapticFeedbackType.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/ui/HapticFeedbackType.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.common.nfcscan.ui
+
+internal enum class HapticFeedbackType {
+    Success,
+    Failed
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Looper
+import android.os.VibrationEffect
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
@@ -13,6 +14,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.NfcScanningActivityTestHelpers.configureNfc
+import com.stripe.android.common.nfcscan.NfcScanningActivityTestHelpers.getShadowVibrator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.createComposeCleanupRule
@@ -92,11 +94,13 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
-    fun `successful card scan returns complete result`() = test {
+    fun `successful card scan perform haptic feedback & returns complete result`() = test {
         NfcScanningActivityTestHelpers.completeSuccessfulScan(
             scenario = this,
             responses = NfcScanningActivityTestFixtures.successResponses(),
         )
+
+        assertThat(context.getShadowVibrator().effectId).isEqualTo(VibrationEffect.EFFECT_CLICK)
 
         waitForActivityFinish()
 
@@ -110,12 +114,14 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
-    fun `declined card shows error and keeps activity open`() = test {
+    fun `declined card shows error, performs haptic feedback, and keeps activity open`() = test {
         NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
             scenario = this,
             responses = NfcScanningActivityTestFixtures.declinedCardResponses(),
             errorText = context.getString(R.string.stripe_nfc_scan_error_declined_card),
         )
+
+        assertThat(context.getShadowVibrator().effectId).isEqualTo(VibrationEffect.EFFECT_HEAVY_CLICK)
 
         assertThat(isActivityDestroyed()).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.nfc.NfcAdapter
 import android.nfc.tech.IsoDep
 import android.os.Looper
+import android.os.Vibrator
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -18,6 +19,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mockStatic
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowNfcAdapter
+import org.robolectric.shadows.ShadowVibrator
 
 internal object NfcScanningActivityTestHelpers {
     private const val UI_TIMEOUT_MS = 5_000L
@@ -110,6 +112,12 @@ internal object NfcScanningActivityTestHelpers {
             resultCode = activityScenario.result.resultCode,
             intent = activityScenario.result.resultData,
         )
+    }
+
+    fun Context.getShadowVibrator(): ShadowVibrator {
+        @Suppress("DEPRECATION")
+        val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        return shadowOf(vibrator)
     }
 
     fun configureNfc(context: Context) {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningHapticFeedbackTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningHapticFeedbackTest.kt
@@ -1,0 +1,160 @@
+package com.stripe.android.common.nfcscan
+
+import android.content.Context
+import android.os.Build
+import android.os.Looper
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+internal class NfcScanningHapticFeedbackTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `success uses legacy vibration pattern on API 28`() {
+        val spiedContext = spy(context)
+
+        triggerHapticFeedback(HapticFeedbackType.Success, spiedContext)
+
+        spiedContext.verifyVibratorServiceUsed()
+
+        assertThat(shadowVibrator.pattern).isEqualTo(LEGACY_SUCCESS_HAPTIC_VIBRATION)
+        assertThat(shadowVibrator.repeat).isEqualTo(VIBRATOR_REPEAT)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `failure uses legacy vibration pattern on API 28`() {
+        val spiedContext = spy(context)
+
+        triggerHapticFeedback(HapticFeedbackType.Failed, spiedContext)
+
+        spiedContext.verifyVibratorServiceUsed()
+
+        assertThat(shadowVibrator.pattern).isEqualTo(LEGACY_FAILED_HAPTIC_VIBRATION)
+        assertThat(shadowVibrator.repeat).isEqualTo(VIBRATOR_REPEAT)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `success uses vibrator service click effect on API 29`() {
+        val spiedContext = spy(context)
+
+        triggerHapticFeedback(HapticFeedbackType.Success, spiedContext)
+
+        spiedContext.verifyVibratorServiceUsed()
+
+        assertThat(shadowVibrator.effectId).isEqualTo(VibrationEffect.EFFECT_CLICK)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `failure uses vibrator service heavy click effect on API 29`() {
+        val spiedContext = spy(context)
+
+        triggerHapticFeedback(HapticFeedbackType.Failed, spiedContext)
+
+        spiedContext.verifyVibratorServiceUsed()
+
+        assertThat(shadowVibrator.effectId).isEqualTo(VibrationEffect.EFFECT_HEAVY_CLICK)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun `success uses vibrator manager click effect on API 31`() {
+        val vibrator = mock<Vibrator>()
+        val spiedContext = contextWithVibratorManager(vibrator)
+
+        triggerHapticFeedback(HapticFeedbackType.Success, spiedContext)
+
+        spiedContext.verifyVibratorManagerServiceUsed()
+
+        verifyVibrationEffect(vibrator, VibrationEffect.EFFECT_CLICK)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun `failure uses vibrator manager heavy click effect on API 31`() {
+        val vibrator = mock<Vibrator>()
+        val spiedContext = contextWithVibratorManager(vibrator)
+
+        triggerHapticFeedback(HapticFeedbackType.Failed, spiedContext)
+
+        spiedContext.verifyVibratorManagerServiceUsed()
+
+        verifyVibrationEffect(vibrator, VibrationEffect.EFFECT_HEAVY_CLICK)
+    }
+
+    private fun triggerHapticFeedback(
+        type: HapticFeedbackType,
+        triggerContext: Context = context,
+    ) {
+        NfcScanningHapticFeedback.trigger(triggerContext, type)
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun Context.verifyVibratorServiceUsed() {
+        @Suppress("DEPRECATION")
+        verify(this).getSystemService(Context.VIBRATOR_SERVICE)
+        verify(this, never()).getSystemService(Context.VIBRATOR_MANAGER_SERVICE)
+    }
+
+    private fun Context.verifyVibratorManagerServiceUsed() {
+        @Suppress("DEPRECATION")
+        verify(this, never()).getSystemService(Context.VIBRATOR_SERVICE)
+        verify(this).getSystemService(Context.VIBRATOR_MANAGER_SERVICE)
+    }
+
+    private fun verifyVibrationEffect(
+        vibrator: Vibrator,
+        expectedEffectId: Int,
+    ) {
+        val vibrationEffectCaptor = argumentCaptor<VibrationEffect>()
+
+        verify(vibrator).vibrate(vibrationEffectCaptor.capture())
+
+        assertThat(vibrationEffectCaptor.firstValue)
+            .isEqualTo(VibrationEffect.createPredefined(expectedEffectId))
+    }
+
+    private fun contextWithVibratorManager(vibrator: Vibrator): Context {
+        val vibratorManager = mock<VibratorManager> {
+            on { defaultVibrator } doReturn vibrator
+        }
+
+        return spy(context) {
+            on { getSystemService(Context.VIBRATOR_MANAGER_SERVICE) } doReturn vibratorManager
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private val realVibrator: Vibrator
+        get() = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+
+    @Suppress("DEPRECATION")
+    private val shadowVibrator
+        get() = shadowOf(realVibrator)
+
+    private companion object {
+        const val VIBRATOR_REPEAT = -1
+
+        val LEGACY_SUCCESS_HAPTIC_VIBRATION = longArrayOf(0, 50)
+        val LEGACY_FAILED_HAPTIC_VIBRATION = longArrayOf(0, 80, 100, 80)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -10,8 +10,10 @@ import com.stripe.android.common.nfcscan.scanner.NfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.ScannedCardData
 import com.stripe.android.common.nfcscan.tapzone.FakeTapZoneResolver
 import com.stripe.android.common.nfcscan.tapzone.TapZone
+import com.stripe.android.common.nfcscan.ui.HapticFeedbackType
 import com.stripe.android.common.nfcscan.ui.NfcScanningStatus
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CleanupTestRule
@@ -53,10 +55,16 @@ internal class NfcScanningViewModelTest {
 
     @Test
     fun `handleViewAction Close emits Canceled result`() = runScenario {
-        viewModel.result.test {
+        viewModel.event.test {
             viewModel.handleViewAction(NfcScanningViewAction.Close)
 
-            assertThat(awaitItem()).isEqualTo(NfcScanningContract.Result.Canceled)
+            val event = awaitItem()
+
+            assertThat(event).isInstanceOf<NfcScanningEvent.CloseWithResult>()
+
+            val resultEvent = event as NfcScanningEvent.CloseWithResult
+
+            assertThat(resultEvent.result).isEqualTo(NfcScanningContract.Result.Canceled)
         }
 
         assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem()).isNotNull()
@@ -163,7 +171,7 @@ internal class NfcScanningViewModelTest {
 
     @Test
     fun `card scanner Complete state emits Complete result after success animation`() = runScenario {
-        viewModel.result.test {
+        viewModel.event.test {
             scannerState.emit(
                 NfcCardScanner.State.Complete(
                     ScannedCardData(
@@ -174,11 +182,19 @@ internal class NfcScanningViewModelTest {
                 ),
             )
 
-            expectNoEvents()
+            assertThat(awaitItem()).isEqualTo(
+                NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Success),
+            )
 
             viewModel.handleViewAction(NfcScanningViewAction.SuccessShown)
 
-            assertThat(awaitItem()).isEqualTo(
+            val event = awaitItem()
+
+            assertThat(event).isInstanceOf<NfcScanningEvent.CloseWithResult>()
+
+            val resultEvent = event as NfcScanningEvent.CloseWithResult
+
+            assertThat(resultEvent.result).isEqualTo(
                 NfcScanningContract.Result.Complete(
                     cardNumber = "4242424242424242",
                     expirationMonth = 12,
@@ -189,6 +205,47 @@ internal class NfcScanningViewModelTest {
 
         assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
         assertThat(fakeEventReporter.onNfcScanSucceededCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `card scanner failed emits failed haptic feedback event`() = runScenario {
+        viewModel.event.test {
+            scannerState.emit(
+                NfcCardScanner.State.Failed(
+                    error = NfcCardScanner.Error(
+                        code = "expiredCard",
+                        userMessage = R.string.stripe_nfc_expired_error.resolvableString,
+                    ),
+                ),
+            )
+
+            assertThat(awaitItem()).isEqualTo(
+                NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Failed),
+            )
+        }
+
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("expiredCard")
+    }
+
+    @Test
+    fun `card scanner complete emits success haptic feedback event`() = runScenario {
+        viewModel.event.test {
+            scannerState.emit(
+                NfcCardScanner.State.Complete(
+                    ScannedCardData(
+                        cardNumber = "4242424242424242",
+                        expirationMonth = 12,
+                        expirationYear = 2030,
+                    ),
+                ),
+            )
+
+            assertThat(awaitItem()).isEqualTo(
+                NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Success),
+            )
+        }
+
+        assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Add haptic feedback through the `Vibrator` system service to trigger a vibration when a successful or failed NFC scan occurs.

# Motivation
Better indications of a successful or failed NFC scan.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified