### PR TITLE
Add ComposeCleanupRule to fix lint issue.

### DIFF
--- a/stripe-ui-core/src/test/java/com/stripe/android/testing/ComposeCleanupRule.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/testing/ComposeCleanupRule.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.testing
+
+import junit.framework.Assert.assertFalse
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import kotlin.coroutines.CoroutineContext
+
+/*
+ * This rule is a workaround for https://github.com/robolectric/robolectric/issues/7055. It will cleanup any remaining
+ * resources from Jetpack Compose after completing a test. Ideally, this is handled by Robolectric. If Robolectric
+ * does handle cleanup in a new version, this rule should be removed.
+ *
+ * See https://github.com/robolectric/robolectric/issues/7055#issuecomment-1482789098 for explanation on the issue
+ * that is occurring.
+ *
+ * Pulled from: https://github.com/robolectric/robolectric/issues/7055#issuecomment-1551119229
+ */
+private class ComposeCleanupRule : TestWatcher() {
+    override fun starting(description: Description?) {
+        val clazz = javaClass.classLoader!!.loadClass("androidx.compose.ui.platform.AndroidUiDispatcher")
+        val combinedContextClass = javaClass.classLoader!!.loadClass("kotlin.coroutines.CombinedContext")
+        val companionClazz = clazz.getDeclaredField("Companion").get(clazz)
+        val combinedContext = companionClazz.javaClass.getDeclaredMethod("getMain")
+            .invoke(companionClazz) as CoroutineContext
+
+        val androidUiDispatcher = combinedContextClass.getDeclaredField("element")
+            .apply { isAccessible = true }
+            .get(combinedContext)
+            .let { clazz.cast(it) }
+
+        var scheduledFrameDispatch = clazz.getDeclaredField("scheduledFrameDispatch")
+            .apply { isAccessible = true }
+            .getBoolean(androidUiDispatcher)
+        var scheduledTrampolineDispatch = clazz.getDeclaredField("scheduledTrampolineDispatch")
+            .apply { isAccessible = true }
+            .getBoolean(androidUiDispatcher)
+
+        val dispatchCallback = clazz.getDeclaredField("dispatchCallback")
+            .apply { isAccessible = true }
+            .get(androidUiDispatcher) as Runnable
+
+        if (scheduledFrameDispatch || scheduledTrampolineDispatch) {
+            dispatchCallback.run()
+            scheduledFrameDispatch = clazz.getDeclaredField("scheduledFrameDispatch")
+                .apply { isAccessible = true }
+                .getBoolean(androidUiDispatcher)
+            scheduledTrampolineDispatch = clazz.getDeclaredField("scheduledTrampolineDispatch")
+                .apply { isAccessible = true }
+                .getBoolean(androidUiDispatcher)
+        }
+
+        assertFalse(scheduledFrameDispatch)
+        assertFalse(scheduledTrampolineDispatch)
+
+        super.finished(description)
+    }
+}
+
+fun createComposeCleanupRule(): TestWatcher = ComposeCleanupRule()

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUITest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUITest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.pressKey
+import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,6 +25,9 @@ import org.robolectric.annotation.Config
 class OTPElementUITest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     @Test
     fun `single digit advances focus`() {


### PR DESCRIPTION
# Summary
Added a ComposeCleanupRule and applied it to OTPElementUITest to fix lint issue.