### PR TITLE
Refactor embedded content tests to share a helper state factory.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
@@ -55,11 +55,9 @@ internal class DefaultEmbeddedContentHelperStateHolderTest {
         setup = {
             set(
                 EmbeddedContentHelperStateHolder.STATE_KEY_EMBEDDED_CONTENT,
-                EmbeddedContentHelperStateHolder.State(
-                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                EmbeddedContentHelperStateFactory.create(
                     appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
                     embeddedViewDisplaysMandateText = false,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -73,11 +73,8 @@ internal class DefaultEmbeddedContentHelperTest {
 
     @Test
     fun `initializing embeddedContentHelper with paymentMethodMetadata emits correct initial event`() = testScenario(
-        initialState = EmbeddedContentHelperStateHolder.State(
-            PaymentMethodMetadataFactory.create(),
-            Embedded(Embedded.RowStyle.FloatingButton.default),
-            embeddedViewDisplaysMandateText = true,
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        initialState = EmbeddedContentHelperStateFactory.create(
+            appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
         )
     ) {
         embeddedContentHelper.embeddedContent.test {
@@ -95,12 +92,7 @@ internal class DefaultEmbeddedContentHelperTest {
 
     @Test
     fun `presentPaymentOptions reports error when launcher is null`() = testScenario(
-        initialState = EmbeddedContentHelperStateHolder.State(
-            PaymentMethodMetadataFactory.create(),
-            Embedded(Embedded.RowStyle.FlatWithRadio.default),
-            embeddedViewDisplaysMandateText = true,
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        )
+        initialState = EmbeddedContentHelperStateFactory.create()
     ) {
         embeddedContentHelper.presentPaymentOptions()
         assertThat(errorReporter.getLoggedErrors()).containsExactly(
@@ -115,10 +107,8 @@ internal class DefaultEmbeddedContentHelperTest {
         val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         testScenario(
-            initialState = EmbeddedContentHelperStateHolder.State(
-                paymentMethodMetadata,
-                Embedded(Embedded.RowStyle.FlatWithRadio.default),
-                embeddedViewDisplaysMandateText = true,
+            initialState = EmbeddedContentHelperStateFactory.create(
+                paymentMethodMetadata = paymentMethodMetadata,
                 configuration = configuration,
             ),
             setup = {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateFactory.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+
+internal object EmbeddedContentHelperStateFactory {
+    fun create(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        appearance: Embedded = Embedded(Embedded.RowStyle.FlatWithRadio.default),
+        embeddedViewDisplaysMandateText: Boolean = true,
+        configuration: EmbeddedPaymentElement.Configuration =
+            EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+    ): EmbeddedContentHelperStateHolder.State = EmbeddedContentHelperStateHolder.State(
+        paymentMethodMetadata = paymentMethodMetadata,
+        appearance = appearance,
+        embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+        configuration = configuration,
+    )
+}


### PR DESCRIPTION
# Summary
Refactored test setup for embedded content helper tests by introducing an `EmbeddedContentHelperStateFactory` to avoid duplication and streamline test state creation.

# Motivation
Reduce test code duplication and improve maintainability by centralizing test state construction logic.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog