### PR TITLE
Wire StripeHostedPlacesClientProxy into DI and ViewModels

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -37,7 +37,7 @@ interface PlacesClientProxy {
         placeId: String
     ): Result<FetchPlaceResponse>
 
-    fun resetSession() {}
+    fun resetSession()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
@@ -172,6 +172,8 @@ internal class DefaultPlacesClientProxy(
 }
 
 internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : PlacesClientProxy {
+    override fun resetSession() = Unit
+
     override suspend fun findAutocompletePredictions(
         query: String?,
         country: String,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -37,6 +37,8 @@ interface PlacesClientProxy {
         placeId: String
     ): Result<FetchPlaceResponse>
 
+    fun resetSession() {}
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         @Volatile
@@ -90,7 +92,11 @@ internal class DefaultPlacesClientProxy(
     private val client: PlacesClient,
     private val errorReporter: ErrorReporter
 ) : PlacesClientProxy {
-    private val token = AutocompleteSessionToken.newInstance()
+    private var token = AutocompleteSessionToken.newInstance()
+
+    override fun resetSession() {
+        token = AutocompleteSessionToken.newInstance()
+    }
 
     override suspend fun findAutocompletePredictions(
         query: String?,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -18,7 +18,6 @@ import com.stripe.android.model.Address
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
@@ -37,12 +36,11 @@ interface PlacesClientProxy {
     ): Result<FindAutocompletePredictionsResponse>
 
     suspend fun fetchPlace(
-        placeId: String
-    ): Result<FetchPlaceResponse>
+        placeId: String,
+        locale: Locale,
+    ): Result<Address>
 
     fun resetSession()
-
-    fun transformToAddress(locale: Locale): Address
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
@@ -100,12 +98,8 @@ internal class DefaultPlacesClientProxy(
     @Volatile
     private var token = AutocompleteSessionToken.newInstance()
 
-    @Volatile
-    private var lastFetchedResponse: FetchPlaceResponse? = null
-
     override fun resetSession() {
         token = AutocompleteSessionToken.newInstance()
-        lastFetchedResponse = null
     }
 
     override suspend fun findAutocompletePredictions(
@@ -147,8 +141,9 @@ internal class DefaultPlacesClientProxy(
     }
 
     override suspend fun fetchPlace(
-        placeId: String
-    ): Result<FetchPlaceResponse> {
+        placeId: String,
+        locale: Locale,
+    ): Result<Address> {
         return try {
             val response = client.fetchPlace(
                 FetchPlaceRequest.newInstance(
@@ -159,19 +154,16 @@ internal class DefaultPlacesClientProxy(
                 )
             ).await()
             errorReporter.report(ErrorReporter.SuccessEvent.PLACES_FETCH_PLACE_SUCCESS)
-            val fetchPlaceResponse = FetchPlaceResponse(
-                Place(
-                    response.place.addressComponents?.asList()?.map {
-                        AddressComponent(
-                            shortName = it.shortName,
-                            longName = it.name,
-                            types = it.types
-                        )
-                    }
-                )
+            val place = Place(
+                response.place.addressComponents?.asList()?.map {
+                    AddressComponent(
+                        shortName = it.shortName,
+                        longName = it.name,
+                        types = it.types
+                    )
+                }
             )
-            lastFetchedResponse = fetchPlaceResponse
-            Result.success(fetchPlaceResponse)
+            Result.success(place.transformGoogleToStripeAddress(locale))
         } catch (e: Exception) {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.PLACES_FETCH_PLACE_ERROR, StripeException.create(e))
             Result.failure(
@@ -179,16 +171,10 @@ internal class DefaultPlacesClientProxy(
             )
         }
     }
-
-    override fun transformToAddress(locale: Locale): Address {
-        return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
-    }
 }
 
 internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : PlacesClientProxy {
     override fun resetSession() = Unit
-
-    override fun transformToAddress(locale: Locale): Address = Address()
 
     override suspend fun findAutocompletePredictions(
         query: String?,
@@ -205,7 +191,7 @@ internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : 
         return Result.failure(exception)
     }
 
-    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
+    override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
         val exception = IllegalStateException(
             "Missing Google Places dependency, please add it to your apps build.gradle"
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -14,15 +14,18 @@ import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRe
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.stripe.android.BuildConfig
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.model.Address
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import com.stripe.android.uicore.elements.DefaultIsPlacesAvailable
 import com.stripe.android.uicore.elements.IsPlacesAvailable
 import kotlinx.coroutines.tasks.await
+import java.util.Locale
 import com.google.android.libraries.places.R as PlacesR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -38,6 +41,8 @@ interface PlacesClientProxy {
     ): Result<FetchPlaceResponse>
 
     fun resetSession()
+
+    fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
@@ -92,6 +97,7 @@ internal class DefaultPlacesClientProxy(
     private val client: PlacesClient,
     private val errorReporter: ErrorReporter
 ) : PlacesClientProxy {
+    @Volatile
     private var token = AutocompleteSessionToken.newInstance()
 
     override fun resetSession() {
@@ -169,10 +175,18 @@ internal class DefaultPlacesClientProxy(
             )
         }
     }
+
+    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+        return response.place.transformGoogleToStripeAddress(locale)
+    }
 }
 
 internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : PlacesClientProxy {
     override fun resetSession() = Unit
+
+    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+        return response.place.transformGoogleToStripeAddress(locale)
+    }
 
     override suspend fun findAutocompletePredictions(
         query: String?,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -42,7 +42,7 @@ interface PlacesClientProxy {
 
     fun resetSession()
 
-    fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address
+    fun transformToAddress(locale: Locale): Address
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
@@ -100,8 +100,12 @@ internal class DefaultPlacesClientProxy(
     @Volatile
     private var token = AutocompleteSessionToken.newInstance()
 
+    @Volatile
+    private var lastFetchedResponse: FetchPlaceResponse? = null
+
     override fun resetSession() {
         token = AutocompleteSessionToken.newInstance()
+        lastFetchedResponse = null
     }
 
     override suspend fun findAutocompletePredictions(
@@ -155,19 +159,19 @@ internal class DefaultPlacesClientProxy(
                 )
             ).await()
             errorReporter.report(ErrorReporter.SuccessEvent.PLACES_FETCH_PLACE_SUCCESS)
-            Result.success(
-                FetchPlaceResponse(
-                    Place(
-                        response.place.addressComponents?.asList()?.map {
-                            AddressComponent(
-                                shortName = it.shortName,
-                                longName = it.name,
-                                types = it.types
-                            )
-                        }
-                    )
+            val fetchPlaceResponse = FetchPlaceResponse(
+                Place(
+                    response.place.addressComponents?.asList()?.map {
+                        AddressComponent(
+                            shortName = it.shortName,
+                            longName = it.name,
+                            types = it.types
+                        )
+                    }
                 )
             )
+            lastFetchedResponse = fetchPlaceResponse
+            Result.success(fetchPlaceResponse)
         } catch (e: Exception) {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.PLACES_FETCH_PLACE_ERROR, StripeException.create(e))
             Result.failure(
@@ -176,17 +180,15 @@ internal class DefaultPlacesClientProxy(
         }
     }
 
-    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
-        return response.place.transformGoogleToStripeAddress(locale)
+    override fun transformToAddress(locale: Locale): Address {
+        return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
     }
 }
 
 internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : PlacesClientProxy {
     override fun resetSession() = Unit
 
-    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
-        return response.place.transformGoogleToStripeAddress(locale)
-    }
+    override fun transformToAddress(locale: Locale): Address = Address()
 
     override suspend fun findAutocompletePredictions(
         query: String?,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -3,12 +3,6 @@ package com.stripe.android.ui.core.elements.autocomplete.model
 import androidx.annotation.RestrictTo
 import java.util.Locale
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val STRIPE_HOSTED_JAPANESE_LINE1 = "stripe_hosted_japanese_line1"
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val STRIPE_HOSTED_JAPANESE_LINE2 = "stripe_hosted_japanese_line2"
-
 internal data class AddressLine1(
     var streetNumber: String? = null,
     var route: String? = null,
@@ -179,19 +173,11 @@ fun Place.transformGoogleToStripeAddress(
 ): com.stripe.android.model.Address {
     var address = Address()
     val addressLine1 = AddressLine1()
-    var hostedJapaneseLine1: String? = null
-    var hostedJapaneseLine2: String? = null
 
     addressComponents?.forEach { field ->
         val types = field.types
 
         when {
-            types.contains(STRIPE_HOSTED_JAPANESE_LINE1) -> {
-                hostedJapaneseLine1 = field.longName
-            }
-            types.contains(STRIPE_HOSTED_JAPANESE_LINE2) -> {
-                hostedJapaneseLine2 = field.longName
-            }
             types.contains(Place.Type.STREET_NUMBER.value) -> {
                 addressLine1.streetNumber = field.longName
             }
@@ -253,12 +239,8 @@ fun Place.transformGoogleToStripeAddress(
         }
     }
 
-    val isHostedJapaneseAddress = address.country == Locale.JAPAN.country && hostedJapaneseLine1 != null
-    address.addressLine1 = hostedJapaneseLine1 ?: composeAddressLine1(locale, addressLine1, address)
+    address.addressLine1 = composeAddressLine1(locale, addressLine1, address)
     address = address.modifyStripeAddressByCountry(this)
-    if (isHostedJapaneseAddress) {
-        address.addressLine2 = hostedJapaneseLine2
-    }
 
     return com.stripe.android.model.Address.Builder()
         .setLine1(address.addressLine1)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -3,8 +3,11 @@ package com.stripe.android.ui.core.elements.autocomplete.model
 import androidx.annotation.RestrictTo
 import java.util.Locale
 
-private const val STRIPE_HOSTED_JAPANESE_LINE1 = "stripe_hosted_japanese_line1"
-private const val STRIPE_HOSTED_JAPANESE_LINE2 = "stripe_hosted_japanese_line2"
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val STRIPE_HOSTED_JAPANESE_LINE1 = "stripe_hosted_japanese_line1"
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val STRIPE_HOSTED_JAPANESE_LINE2 = "stripe_hosted_japanese_line2"
 
 internal data class AddressLine1(
     var streetNumber: String? = null,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -3,6 +3,9 @@ package com.stripe.android.ui.core.elements.autocomplete.model
 import androidx.annotation.RestrictTo
 import java.util.Locale
 
+private const val STRIPE_HOSTED_JAPANESE_LINE1 = "stripe_hosted_japanese_line1"
+private const val STRIPE_HOSTED_JAPANESE_LINE2 = "stripe_hosted_japanese_line2"
+
 internal data class AddressLine1(
     var streetNumber: String? = null,
     var route: String? = null,
@@ -173,11 +176,19 @@ fun Place.transformGoogleToStripeAddress(
 ): com.stripe.android.model.Address {
     var address = Address()
     val addressLine1 = AddressLine1()
+    var hostedJapaneseLine1: String? = null
+    var hostedJapaneseLine2: String? = null
 
     addressComponents?.forEach { field ->
         val types = field.types
 
         when {
+            types.contains(STRIPE_HOSTED_JAPANESE_LINE1) -> {
+                hostedJapaneseLine1 = field.longName
+            }
+            types.contains(STRIPE_HOSTED_JAPANESE_LINE2) -> {
+                hostedJapaneseLine2 = field.longName
+            }
             types.contains(Place.Type.STREET_NUMBER.value) -> {
                 addressLine1.streetNumber = field.longName
             }
@@ -239,8 +250,12 @@ fun Place.transformGoogleToStripeAddress(
         }
     }
 
-    address.addressLine1 = composeAddressLine1(locale, addressLine1, address)
+    val isHostedJapaneseAddress = address.country == Locale.JAPAN.country && hostedJapaneseLine1 != null
+    address.addressLine1 = hostedJapaneseLine1 ?: composeAddressLine1(locale, addressLine1, address)
     address = address.modifyStripeAddressByCountry(this)
+    if (isHostedJapaneseAddress) {
+        address.addressLine2 = hostedJapaneseLine2
+    }
 
     return com.stripe.android.model.Address.Builder()
         .setLine1(address.addressLine1)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
@@ -169,12 +169,13 @@ class PlacesClientProxyTest {
             )
 
             val place = proxy.fetchPlace(
-                "placeId"
+                placeId = "placeId",
+                locale = java.util.Locale.getDefault(),
             )
 
             runCurrent()
 
-            assertThat(place.getOrNull()?.place)
+            assertThat(place.getOrNull())
                 .isNotNull()
         }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/utils/ExpiryDateContentDescriptionFormatterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/utils/ExpiryDateContentDescriptionFormatterTest.kt
@@ -7,7 +7,10 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.elements.formatExpirationDateForAccessibility
 import com.stripe.android.uicore.R
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ExpiryDateContentDescriptionFormatterTest {
 
     @Test

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -12,11 +12,9 @@ import com.stripe.android.paymentsheet.utils.PlacesClientProxyTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
-import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -145,46 +143,13 @@ class PaymentSheetAddressAutocompleteTest {
     private fun enqueuePlaceFetch() {
         placesClientProxyTestRule.enqueueFetchPlaceResponse(
             Result.success(
-                FetchPlaceResponse(
-                    place = Place(
-                        listOf(
-                            AddressComponent(
-                                shortName = "123",
-                                longName = "123",
-                                types = listOf(Place.Type.STREET_NUMBER.value)
-                            ),
-                            AddressComponent(
-                                shortName = "Main Street",
-                                longName = "Main Street",
-                                types = listOf(Place.Type.ROUTE.value)
-                            ),
-                            AddressComponent(
-                                shortName = "Unit #123",
-                                longName = "Unit #123",
-                                types = listOf(Place.Type.PREMISE.value)
-                            ),
-                            AddressComponent(
-                                shortName = "South SF",
-                                longName = "South San Francisco",
-                                types = listOf(Place.Type.LOCALITY.value)
-                            ),
-                            AddressComponent(
-                                shortName = "CA",
-                                longName = "California",
-                                types = listOf(Place.Type.ADMINISTRATIVE_AREA_LEVEL_1.value)
-                            ),
-                            AddressComponent(
-                                shortName = "US",
-                                longName = "United States",
-                                types = listOf(Place.Type.COUNTRY.value)
-                            ),
-                            AddressComponent(
-                                shortName = "94111",
-                                longName = "94111",
-                                types = listOf(Place.Type.POSTAL_CODE.value)
-                            )
-                        )
-                    )
+                Address(
+                    line1 = "123 Main Street",
+                    line2 = "Unit #123",
+                    city = "South San Francisco",
+                    state = "CA",
+                    country = "US",
+                    postalCode = "94111",
                 )
             )
         )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
@@ -18,6 +19,8 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
+import java.util.Locale
 import com.stripe.android.uicore.DefaultStripeTheme
 import org.junit.Rule
 import org.junit.Test
@@ -90,6 +93,10 @@ class AutocompleteScreenTest {
         private val addressComponents: List<AddressComponent> = listOf()
     ) : PlacesClientProxy {
         override fun resetSession() = Unit
+
+        override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+            return response.place.transformGoogleToStripeAddress(locale)
+        }
 
         override suspend fun findAutocompletePredictions(
             query: String?,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -92,10 +92,12 @@ class AutocompleteScreenTest {
         private val predictions: List<AutocompletePrediction> = listOf(),
         private val addressComponents: List<AddressComponent> = listOf()
     ) : PlacesClientProxy {
+        private var lastFetchedResponse: FetchPlaceResponse? = null
+
         override fun resetSession() = Unit
 
-        override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
-            return response.place.transformGoogleToStripeAddress(locale)
+        override fun transformToAddress(locale: Locale): Address {
+            return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
         }
 
         override suspend fun findAutocompletePredictions(
@@ -109,11 +111,9 @@ class AutocompleteScreenTest {
         }
 
         override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-            return Result.success(
-                FetchPlaceResponse(
-                    Place(addressComponents)
-                )
-            )
+            val response = FetchPlaceResponse(Place(addressComponents))
+            lastFetchedResponse = response
+            return Result.success(response)
         }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -14,14 +14,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
-import java.util.Locale
 import com.stripe.android.uicore.DefaultStripeTheme
+import java.util.Locale
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -90,15 +86,9 @@ class AutocompleteScreenTest {
 
     private class FakeGooglePlacesClient(
         private val predictions: List<AutocompletePrediction> = listOf(),
-        private val addressComponents: List<AddressComponent> = listOf()
+        private val fetchResult: Address = Address(),
     ) : PlacesClientProxy {
-        private var lastFetchedResponse: FetchPlaceResponse? = null
-
         override fun resetSession() = Unit
-
-        override fun transformToAddress(locale: Locale): Address {
-            return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
-        }
 
         override suspend fun findAutocompletePredictions(
             query: String?,
@@ -110,10 +100,8 @@ class AutocompleteScreenTest {
             )
         }
 
-        override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-            val response = FetchPlaceResponse(Place(addressComponents))
-            lastFetchedResponse = response
-            return Result.success(response)
+        override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
+            return Result.success(fetchResult)
         }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -89,6 +89,8 @@ class AutocompleteScreenTest {
         private val predictions: List<AutocompletePrediction> = listOf(),
         private val addressComponents: List<AddressComponent> = listOf()
     ) : PlacesClientProxy {
+        override fun resetSession() = Unit
+
         override suspend fun findAutocompletePredictions(
             query: String?,
             country: String,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
@@ -2,9 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import java.util.Locale
 import kotlinx.coroutines.channels.Channel
 import org.junit.rules.TestWatcher
@@ -13,7 +11,7 @@ import org.junit.runner.Description
 class PlacesClientProxyTestRule : TestWatcher() {
     private val findAutocompletePredictionsResponseChannel =
         Channel<Result<FindAutocompletePredictionsResponse>>(capacity = 1)
-    private val fetchPlaceResponseChannel = Channel<Result<FetchPlaceResponse>>(capacity = 1)
+    private val fetchPlaceResponseChannel = Channel<Result<Address>>(capacity = 1)
 
     override fun starting(description: Description?) {
         super.starting(description)
@@ -35,22 +33,16 @@ class PlacesClientProxyTestRule : TestWatcher() {
     }
 
     fun enqueueFetchPlaceResponse(
-        response: Result<FetchPlaceResponse>
+        response: Result<Address>
     ) {
         fetchPlaceResponseChannel.trySend(response)
     }
 
     private class FakePlacesClientProxy(
         private val findAutocompletePredictionsResponseChannel: Channel<Result<FindAutocompletePredictionsResponse>>,
-        private val fetchPlaceResponseChannel: Channel<Result<FetchPlaceResponse>>,
+        private val fetchPlaceResponseChannel: Channel<Result<Address>>,
     ) : PlacesClientProxy {
-        private var lastFetchedResponse: FetchPlaceResponse? = null
-
         override fun resetSession() = Unit
-
-        override fun transformToAddress(locale: Locale): Address {
-            return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
-        }
 
         override suspend fun findAutocompletePredictions(
             query: String?,
@@ -60,10 +52,8 @@ class PlacesClientProxyTestRule : TestWatcher() {
             return findAutocompletePredictionsResponseChannel.receive()
         }
 
-        override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-            return fetchPlaceResponseChannel.receive().also { result ->
-                result.onSuccess { lastFetchedResponse = it }
-            }
+        override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
+            return fetchPlaceResponseChannel.receive()
         }
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
@@ -41,6 +41,8 @@ class PlacesClientProxyTestRule : TestWatcher() {
         private val findAutocompletePredictionsResponseChannel: Channel<Result<FindAutocompletePredictionsResponse>>,
         private val fetchPlaceResponseChannel: Channel<Result<FetchPlaceResponse>>,
     ) : PlacesClientProxy {
+        override fun resetSession() = Unit
+
         override suspend fun findAutocompletePredictions(
             query: String?,
             country: String,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
@@ -44,10 +44,12 @@ class PlacesClientProxyTestRule : TestWatcher() {
         private val findAutocompletePredictionsResponseChannel: Channel<Result<FindAutocompletePredictionsResponse>>,
         private val fetchPlaceResponseChannel: Channel<Result<FetchPlaceResponse>>,
     ) : PlacesClientProxy {
+        private var lastFetchedResponse: FetchPlaceResponse? = null
+
         override fun resetSession() = Unit
 
-        override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
-            return response.place.transformGoogleToStripeAddress(locale)
+        override fun transformToAddress(locale: Locale): Address {
+            return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
         }
 
         override suspend fun findAutocompletePredictions(
@@ -59,7 +61,9 @@ class PlacesClientProxyTestRule : TestWatcher() {
         }
 
         override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-            return fetchPlaceResponseChannel.receive()
+            return fetchPlaceResponseChannel.receive().also { result ->
+                result.onSuccess { lastFetchedResponse = it }
+            }
         }
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PlacesClientProxyTestRule.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.utils
 
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
+import java.util.Locale
 import kotlinx.coroutines.channels.Channel
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
@@ -42,6 +45,10 @@ class PlacesClientProxyTestRule : TestWatcher() {
         private val fetchPlaceResponseChannel: Channel<Result<FetchPlaceResponse>>,
     ) : PlacesClientProxy {
         override fun resetSession() = Unit
+
+        override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+            return response.place.transformGoogleToStripeAddress(locale)
+        }
 
         override suspend fun findAutocompletePredictions(
             query: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -212,6 +212,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                             FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
                                     ),
                                     placesClient = null,
+                                    stripeAutocompleteRepository = null,
                                     coroutineScope = null,
                                     shouldUseAutocompleteProxyEndpointsProvider = { false },
                                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -87,7 +87,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     @ViewModelScope customViewModelScope: CoroutineScope,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
     placesClient: PlacesClientProxy?,
-    stripeAutocompleteRepository: StripeAutocompleteRepository?,
+    stripeAutocompleteRepository: StripeAutocompleteRepository,
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -35,6 +35,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -86,6 +87,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     @ViewModelScope customViewModelScope: CoroutineScope,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
     placesClient: PlacesClientProxy?,
+    stripeAutocompleteRepository: StripeAutocompleteRepository?,
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,
@@ -99,6 +101,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
     placesClient = placesClient,
+    stripeAutocompleteRepository = stripeAutocompleteRepository,
 ) {
 
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -108,7 +108,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     @ViewModelScope customViewModelScope: CoroutineScope,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
     placesClient: PlacesClientProxy?,
-    stripeAutocompleteRepository: StripeAutocompleteRepository?,
+    stripeAutocompleteRepository: StripeAutocompleteRepository,
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -43,6 +43,7 @@ import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfi
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
@@ -107,6 +108,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     @ViewModelScope customViewModelScope: CoroutineScope,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
     placesClient: PlacesClientProxy?,
+    stripeAutocompleteRepository: StripeAutocompleteRepository?,
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,
@@ -120,6 +122,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     customerStateHolderFactory = customerStateHolderFactory,
     customViewModelScope = customViewModelScope,
     placesClient = placesClient,
+    stripeAutocompleteRepository = stripeAutocompleteRepository,
 ) {
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -86,6 +86,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
+@Suppress("LargeClass")
 @Singleton
 internal class PaymentSheetViewModel @Inject internal constructor(
     internal val args: PaymentSheetContract.Args,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -28,6 +28,7 @@ internal object AddressElementActivityContract :
     @Parcelize
     data class Args internal constructor(
         internal val publishableKey: String,
+        internal val stripeAccountId: String?,
         internal val config: AddressLauncher.Configuration?,
     ) : ActivityStarter.Args {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -28,7 +28,6 @@ internal object AddressElementActivityContract :
     @Parcelize
     data class Args internal constructor(
         internal val publishableKey: String,
-        internal val stripeAccountId: String?,
         internal val config: AddressLauncher.Configuration?,
     ) : ActivityStarter.Args {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -85,34 +85,8 @@ class AddressLauncher internal constructor(
         publishableKey: String,
         configuration: Configuration = Configuration()
     ) {
-        launchAddressElement(
-            publishableKey = publishableKey,
-            stripeAccountId = null,
-            configuration = configuration,
-        )
-    }
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun present(
-        publishableKey: String,
-        stripeAccountId: String?,
-        configuration: Configuration,
-    ) {
-        launchAddressElement(
-            publishableKey = publishableKey,
-            stripeAccountId = stripeAccountId,
-            configuration = configuration,
-        )
-    }
-
-    private fun launchAddressElement(
-        publishableKey: String,
-        stripeAccountId: String?,
-        configuration: Configuration,
-    ) {
         val args = AddressElementActivityContract.Args(
             publishableKey = publishableKey,
-            stripeAccountId = stripeAccountId,
             config = configuration,
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -85,9 +85,35 @@ class AddressLauncher internal constructor(
         publishableKey: String,
         configuration: Configuration = Configuration()
     ) {
+        launchAddressElement(
+            publishableKey = publishableKey,
+            stripeAccountId = null,
+            configuration = configuration,
+        )
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun present(
+        publishableKey: String,
+        stripeAccountId: String?,
+        configuration: Configuration,
+    ) {
+        launchAddressElement(
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
+            configuration = configuration,
+        )
+    }
+
+    private fun launchAddressElement(
+        publishableKey: String,
+        stripeAccountId: String?,
+        configuration: Configuration,
+    ) {
         val args = AddressElementActivityContract.Args(
-            publishableKey,
-            configuration,
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
+            config = configuration,
         )
 
         val options = ActivityOptionsCompat.makeCustomAnimation(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -117,7 +117,7 @@ internal class AutocompleteViewModel @Inject constructor(
                 onSuccess = {
                     _loading.value = false
                     val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-                    val address = placesClient.transformToAddress(it, locale)
+                    val address = placesClient.transformToAddress(locale)
 
                     _event.emit(
                         Event.GoBack(
@@ -137,6 +137,7 @@ internal class AutocompleteViewModel @Inject constructor(
                     _event.emit(Event.GoBack(address = null))
                 }
             )
+            placesClient?.resetSession()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -112,31 +112,33 @@ internal class AutocompleteViewModel @Inject constructor(
         viewModelScope.launch {
             _loading.value = true
             val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-            placesClient?.fetchPlace(
-                placeId = prediction.placeId,
-                locale = locale,
-            )?.fold(
-                onSuccess = { address ->
-                    _loading.value = false
-                    _event.emit(
-                        Event.GoBack(
-                            address = PaymentSheet.Address(
-                                city = address.city,
-                                country = address.country,
-                                line1 = address.line1,
-                                line2 = address.line2,
-                                postalCode = address.postalCode,
-                                state = address.state
+            try {
+                placesClient?.fetchPlace(
+                    placeId = prediction.placeId,
+                    locale = locale,
+                )?.fold(
+                    onSuccess = { address ->
+                        _event.emit(
+                            Event.GoBack(
+                                address = PaymentSheet.Address(
+                                    city = address.city,
+                                    country = address.country,
+                                    line1 = address.line1,
+                                    line2 = address.line2,
+                                    postalCode = address.postalCode,
+                                    state = address.state
+                                )
                             )
                         )
-                    )
-                },
-                onFailure = {
-                    _loading.value = false
-                    _event.emit(Event.GoBack(address = null))
-                }
-            )
-            placesClient?.resetSession()
+                    },
+                    onFailure = {
+                        _event.emit(Event.GoBack(address = null))
+                    }
+                )
+            } finally {
+                _loading.value = false
+                placesClient?.resetSession()
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -111,14 +111,13 @@ internal class AutocompleteViewModel @Inject constructor(
     fun selectPrediction(prediction: AutocompletePrediction) {
         viewModelScope.launch {
             _loading.value = true
+            val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
             placesClient?.fetchPlace(
-                placeId = prediction.placeId
+                placeId = prediction.placeId,
+                locale = locale,
             )?.fold(
-                onSuccess = {
+                onSuccess = { address ->
                     _loading.value = false
-                    val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-                    val address = placesClient.transformToAddress(locale)
-
                     _event.emit(
                         Event.GoBack(
                             address = PaymentSheet.Address(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcompone
 import com.stripe.android.paymentsheet.injection.DaggerAutocompleteViewModelFactoryComponent
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -118,7 +117,7 @@ internal class AutocompleteViewModel @Inject constructor(
                 onSuccess = {
                     _loading.value = false
                     val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-                    val address = it.place.transformGoogleToStripeAddress(locale)
+                    val address = placesClient.transformToAddress(it, locale)
 
                     _event.emit(
                         Event.GoBack(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/DefaultStripeAutocompleteRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/DefaultStripeAutocompleteRepository.kt
@@ -9,16 +9,12 @@ internal class DefaultStripeAutocompleteRepository(
     private val stripeNetworkClient: StripeNetworkClient,
     private val apiRequestFactory: ApiRequest.Factory,
     private val publishableKeyProvider: () -> String,
-    private val stripeAccountIdProvider: () -> String?
 ) : StripeAutocompleteRepository {
 
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
     private val requestOptions: ApiRequest.Options
-        get() = ApiRequest.Options(
-            apiKey = publishableKeyProvider(),
-            stripeAccount = stripeAccountIdProvider(),
-        )
+        get() = ApiRequest.Options(apiKey = publishableKeyProvider())
 
     override suspend fun findAutocompletePredictions(
         query: String,
@@ -49,14 +45,18 @@ internal class DefaultStripeAutocompleteRepository(
 
     override suspend fun fetchPlaceDetails(
         placeId: String,
-        sessionToken: String
+        sessionToken: String,
+        locale: String?
     ): Result<PlaceDetailsResult> {
-        val params = mapOf(
-            "place_id" to placeId,
-            "session_token" to sessionToken,
-            "client_type" to "mobile",
-            "source" to "google",
-        )
+        val params = buildMap<String, Any> {
+            put("place_id", placeId)
+            put("session_token", sessionToken)
+            put("client_type", "mobile")
+            put("source", "google")
+            if (locale != null) {
+                put("locale", locale)
+            }
+        }
         return executeRequestWithResultParser(
             stripeNetworkClient = stripeNetworkClient,
             stripeErrorJsonParser = stripeErrorJsonParser,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.addresselement
 
 import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -68,16 +67,16 @@ internal class InlineAutocompleteController(
             val result = placesClient.fetchPlace(predictionId)
             ensureActive()
             result.fold(
-                onSuccess = { handleFetchPlaceSuccess(it) },
+                onSuccess = { handleFetchPlaceSuccess() },
                 onFailure = { handleFailure() }
             )
             placesClient.resetSession()
         }
     }
 
-    private fun handleFetchPlaceSuccess(response: FetchPlaceResponse) {
+    private fun handleFetchPlaceSuccess() {
         val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-        val address = placesClient.transformToAddress(response, locale)
+        val address = placesClient.transformToAddress(locale)
         lastPredictionLine1 = address.line1
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         eventListenerProvider()?.invoke(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -4,7 +4,6 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.CoroutineScope
@@ -67,18 +66,18 @@ internal class InlineAutocompleteController(
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
             val result = placesClient.fetchPlace(predictionId)
-            placesClient.resetSession()
             ensureActive()
             result.fold(
-                onSuccess = ::handleFetchPlaceSuccess,
+                onSuccess = { handleFetchPlaceSuccess(it) },
                 onFailure = { handleFailure() }
             )
+            placesClient.resetSession()
         }
     }
 
     private fun handleFetchPlaceSuccess(response: FetchPlaceResponse) {
         val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-        val address = response.place.transformGoogleToStripeAddress(locale)
+        val address = placesClient.transformToAddress(response, locale)
         lastPredictionLine1 = address.line1
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         eventListenerProvider()?.invoke(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import androidx.appcompat.app.AppCompatDelegate
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
@@ -64,19 +65,18 @@ internal class InlineAutocompleteController(
     fun onPredictionSelected(predictionId: String) {
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
-            val result = placesClient.fetchPlace(predictionId)
+            val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+            val result = placesClient.fetchPlace(predictionId, locale)
             ensureActive()
             result.fold(
-                onSuccess = { handleFetchPlaceSuccess() },
+                onSuccess = { handleFetchPlaceSuccess(it) },
                 onFailure = { handleFailure() }
             )
             placesClient.resetSession()
         }
     }
 
-    private fun handleFetchPlaceSuccess() {
-        val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-        val address = placesClient.transformToAddress(locale)
+    private fun handleFetchPlaceSuccess(address: Address) {
         lastPredictionLine1 = address.line1
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         eventListenerProvider()?.invoke(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -67,12 +67,15 @@ internal class InlineAutocompleteController(
         selectionJob = coroutineScope.launch {
             val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
             val result = placesClient.fetchPlace(predictionId, locale)
-            ensureActive()
-            result.fold(
-                onSuccess = { handleFetchPlaceSuccess(it) },
-                onFailure = { handleFailure() }
-            )
-            placesClient.resetSession()
+            try {
+                ensureActive()
+                result.fold(
+                    onSuccess = { handleFetchPlaceSuccess(it) },
+                    onFailure = { handleFailure() }
+                )
+            } finally {
+                placesClient.resetSession()
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -67,16 +67,11 @@ internal class InlineAutocompleteController(
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
             val result = placesClient.fetchPlace(predictionId)
+            placesClient.resetSession()
             ensureActive()
             result.fold(
-                onSuccess = { response ->
-                    placesClient.resetSession()
-                    handleFetchPlaceSuccess(response)
-                },
-                onFailure = {
-                    placesClient.resetSession()
-                    handleFailure()
-                }
+                onSuccess = ::handleFetchPlaceSuccess,
+                onFailure = { handleFailure() }
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -10,6 +10,8 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -64,9 +66,17 @@ internal class InlineAutocompleteController(
     fun onPredictionSelected(predictionId: String) {
         selectionJob?.cancel()
         selectionJob = coroutineScope.launch {
-            placesClient.fetchPlace(predictionId).fold(
-                onSuccess = ::handleFetchPlaceSuccess,
-                onFailure = { handleFailure() }
+            val result = placesClient.fetchPlace(predictionId)
+            ensureActive()
+            result.fold(
+                onSuccess = { response ->
+                    placesClient.resetSession()
+                    handleFetchPlaceSuccess(response)
+                },
+                onFailure = {
+                    placesClient.resetSession()
+                    handleFailure()
+                }
             )
         }
     }
@@ -116,6 +126,7 @@ internal class InlineAutocompleteController(
             country = country,
             limit = AutocompleteViewModel.MAX_DISPLAYED_RESULTS,
         )
+        currentCoroutineContext().ensureActive()
         result.fold(
             onSuccess = { handleFindPredictionsSuccess(query, it) },
             onFailure = { handleFailure() }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.injection.AddressElementViewModelModule
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
@@ -19,12 +20,14 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Provider
 
 internal class InputAddressViewModel @Inject constructor(
     val args: AddressElementActivityContract.Args,
     val navigator: AddressElementNavigator,
     private val eventReporter: AddressLauncherEventReporter,
+    @Named(AddressElementViewModelModule.INLINE_PLACES_CLIENT)
     private val placesClient: PlacesClientProxy?,
 ) : ViewModel(), AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -45,6 +45,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private val launcher: AutocompleteLauncher,
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
         private val placesClient: PlacesClientProxy?,
+        private val stripeAutocompleteRepository: StripeAutocompleteRepository?,
         private val coroutineScope: CoroutineScope?,
         private val shouldUseAutocompleteProxyEndpointsProvider: () -> Boolean,
     ) : AutocompleteAddressInteractor.Factory {
@@ -52,10 +53,14 @@ internal class PaymentElementAutocompleteAddressInteractor(
 
         override fun create(): AutocompleteAddressInteractor {
             val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
-            val resolvedClient = if (useStripeHosted) {
-                StripeHostedPlacesClientProxy()
-            } else {
-                placesClient
+            val resolvedClient = when {
+                useStripeHosted && stripeAutocompleteRepository != null ->
+                    StripeHostedPlacesClientProxy(
+                        repository = stripeAutocompleteRepository,
+                        googleApiKey = autocompleteConfig.googlePlacesApiKey,
+                    )
+                !useStripeHosted -> placesClient
+                else -> null
             }
             if (resolvedClient != null && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 activeInlineInteractor?.dispose()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -54,13 +54,10 @@ internal class PaymentElementAutocompleteAddressInteractor(
         override fun create(): AutocompleteAddressInteractor {
             if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
-                val resolvedClient = when {
-                    useStripeHosted && stripeAutocompleteRepository != null ->
-                        StripeHostedPlacesClientProxy(
-                            repository = stripeAutocompleteRepository,
-                        )
-                    !useStripeHosted -> placesClient
-                    else -> null
+                val resolvedClient = if (useStripeHosted) {
+                    stripeAutocompleteRepository?.let { StripeHostedPlacesClientProxy(repository = it) }
+                } else {
+                    placesClient
                 }
                 if (resolvedClient != null) {
                     activeInlineInteractor?.dispose()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -58,7 +58,6 @@ internal class PaymentElementAutocompleteAddressInteractor(
                     useStripeHosted && stripeAutocompleteRepository != null ->
                         StripeHostedPlacesClientProxy(
                             repository = stripeAutocompleteRepository,
-                            googleApiKey = autocompleteConfig.googlePlacesApiKey,
                         )
                     !useStripeHosted -> placesClient
                     else -> null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -52,31 +52,36 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
         override fun create(): AutocompleteAddressInteractor {
-            val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
-            val resolvedClient = when {
-                useStripeHosted && stripeAutocompleteRepository != null ->
-                    StripeHostedPlacesClientProxy(
-                        repository = stripeAutocompleteRepository,
-                        googleApiKey = autocompleteConfig.googlePlacesApiKey,
-                    )
-                !useStripeHosted -> placesClient
-                else -> null
+            if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
+                val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
+                val resolvedClient = when {
+                    useStripeHosted && stripeAutocompleteRepository != null ->
+                        StripeHostedPlacesClientProxy(
+                            repository = stripeAutocompleteRepository,
+                            googleApiKey = autocompleteConfig.googlePlacesApiKey,
+                        )
+                    !useStripeHosted -> placesClient
+                    else -> null
+                }
+                if (resolvedClient != null) {
+                    activeInlineInteractor?.dispose()
+                    return BillingInlineAutocompleteAddressInteractor(
+                        placesClient = resolvedClient,
+                        autocompleteConfig = AutocompleteAddressInteractor.Config(
+                            googlePlacesApiKey = autocompleteConfig.googlePlacesApiKey,
+                            autocompleteCountries = autocompleteConfig.autocompleteCountries,
+                            isPlacesAvailable = autocompleteConfig.isPlacesAvailable,
+                            isInlineAutocompleteEnabled = autocompleteConfig.isInlineAutocompleteEnabled,
+                            shouldUseStripeHostedAutocomplete = useStripeHosted ||
+                                autocompleteConfig.shouldUseStripeHostedAutocomplete,
+                        ),
+                        coroutineScope = coroutineScope,
+                    ).also { activeInlineInteractor = it }
+                }
             }
-            if (resolvedClient != null && coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
-                activeInlineInteractor?.dispose()
-                return BillingInlineAutocompleteAddressInteractor(
-                    placesClient = resolvedClient,
-                    autocompleteConfig = AutocompleteAddressInteractor.Config(
-                        googlePlacesApiKey = autocompleteConfig.googlePlacesApiKey,
-                        autocompleteCountries = autocompleteConfig.autocompleteCountries,
-                        isPlacesAvailable = autocompleteConfig.isPlacesAvailable,
-                        isInlineAutocompleteEnabled = autocompleteConfig.isInlineAutocompleteEnabled,
-                        shouldUseStripeHostedAutocomplete = useStripeHosted ||
-                            autocompleteConfig.shouldUseStripeHostedAutocomplete,
-                    ),
-                    coroutineScope = coroutineScope,
-                ).also { activeInlineInteractor = it }
-            }
+
+            activeInlineInteractor?.dispose()
+            activeInlineInteractor = null
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,
                 autocompleteConfig = autocompleteConfig,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepository.kt
@@ -10,6 +10,7 @@ internal interface StripeAutocompleteRepository {
 
     suspend fun fetchPlaceDetails(
         placeId: String,
-        sessionToken: String
+        sessionToken: String,
+        locale: String?
     ): Result<PlaceDetailsResult>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -74,7 +74,7 @@ internal class StripeHostedPlacesClientProxy(
         }
     }
 
-    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+    override fun transformToAddress(locale: Locale): Address {
         val address = synchronized(lock) { lastResolvedAddress }
         return Address(
             line1 = address?.line1,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -73,7 +73,15 @@ internal class StripeHostedPlacesClientProxy(
             placeId = placeId,
             sessionToken = token,
             locale = locale.toLanguageTag(),
-        ).map { result ->
+        ).also { result ->
+            result.onSuccess { details ->
+                synchronized(lock) {
+                    predictionCache[placeId]?.let { existing ->
+                        predictionCache[placeId] = existing.copy(address = details.address)
+                    }
+                }
+            }
+        }.map { result ->
             Address(
                 line1 = result.address?.line1,
                 line2 = result.address?.line2,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -15,7 +15,6 @@ import java.util.UUID
 
 internal class StripeHostedPlacesClientProxy(
     private val repository: StripeAutocompleteRepository,
-    private val googleApiKey: String?,
 ) : PlacesClientProxy {
     private val lock = Any()
     private var sessionToken: String = newSessionToken()
@@ -41,7 +40,6 @@ internal class StripeHostedPlacesClientProxy(
             country = country,
             sessionToken = token,
             locale = locale.toLanguageTag(),
-            googleApiKey = googleApiKey,
         ).map { result ->
             val limitedPredictions = result.predictions.take(limit)
             synchronized(lock) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -2,14 +2,12 @@ package com.stripe.android.paymentsheet.addresselement
 
 import android.text.SpannableString
 import androidx.appcompat.app.AppCompatDelegate
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
-import com.stripe.android.ui.core.elements.autocomplete.model.STRIPE_HOSTED_JAPANESE_LINE1
-import com.stripe.android.ui.core.elements.autocomplete.model.STRIPE_HOSTED_JAPANESE_LINE2
 import java.util.Locale
 import java.util.UUID
 
@@ -19,11 +17,13 @@ internal class StripeHostedPlacesClientProxy(
     private val lock = Any()
     private var sessionToken: String = newSessionToken()
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
+    private var lastResolvedAddress: StripeProxyAddress? = null
 
     override fun resetSession() {
         synchronized(lock) {
             sessionToken = newSessionToken()
             predictionCache.clear()
+            lastResolvedAddress = null
         }
     }
 
@@ -43,7 +43,6 @@ internal class StripeHostedPlacesClientProxy(
         ).map { result ->
             val limitedPredictions = result.predictions.take(limit)
             synchronized(lock) {
-                predictionCache.clear()
                 limitedPredictions.forEach { predictionCache[it.placeId] = it }
             }
             FindAutocompletePredictionsResponse(
@@ -63,45 +62,28 @@ internal class StripeHostedPlacesClientProxy(
             predictionCache[placeId] to sessionToken
         }
         if (cached?.address != null) {
-            return Result.success(cached.address.toFetchPlaceResponse())
+            synchronized(lock) { lastResolvedAddress = cached.address }
+            return Result.success(FetchPlaceResponse(Place(addressComponents = null)))
         }
         return repository.fetchPlaceDetails(
             placeId = placeId,
             sessionToken = token,
         ).map { result ->
-            result.address.toFetchPlaceResponse()
+            synchronized(lock) { lastResolvedAddress = result.address }
+            FetchPlaceResponse(Place(addressComponents = null))
         }
     }
 
-    private fun StripeProxyAddress.toFetchPlaceResponse(): FetchPlaceResponse {
-        val isJapaneseAddress = country == Locale.JAPAN.country
-        val components = buildList {
-            line1?.let { line1 ->
-                add(
-                    AddressComponent(
-                        shortName = line1,
-                        longName = line1,
-                        types = listOf(if (isJapaneseAddress) STRIPE_HOSTED_JAPANESE_LINE1 else "route"),
-                    )
-                )
-            }
-            line2?.let { line2 ->
-                add(
-                    AddressComponent(
-                        shortName = line2,
-                        longName = line2,
-                        types = listOf(if (isJapaneseAddress) STRIPE_HOSTED_JAPANESE_LINE2 else "premise"),
-                    )
-                )
-            }
-            city?.let { add(AddressComponent(shortName = it, longName = it, types = listOf("locality"))) }
-            state?.let {
-                add(AddressComponent(shortName = it, longName = it, types = listOf("administrative_area_level_1")))
-            }
-            postalCode?.let { add(AddressComponent(shortName = it, longName = it, types = listOf("postal_code"))) }
-            country?.let { add(AddressComponent(shortName = it, longName = it, types = listOf("country"))) }
-        }
-        return FetchPlaceResponse(Place(addressComponents = components))
+    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+        val address = synchronized(lock) { lastResolvedAddress }
+        return Address(
+            line1 = address?.line1,
+            line2 = address?.line2,
+            city = address?.city,
+            state = address?.state,
+            postalCode = address?.postalCode,
+            country = address?.country,
+        )
     }
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -8,22 +8,24 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.ui.core.elements.autocomplete.model.STRIPE_HOSTED_JAPANESE_LINE1
+import com.stripe.android.ui.core.elements.autocomplete.model.STRIPE_HOSTED_JAPANESE_LINE2
 import java.util.Locale
 import java.util.UUID
-
-private const val STRIPE_HOSTED_JAPANESE_LINE1 = "stripe_hosted_japanese_line1"
-private const val STRIPE_HOSTED_JAPANESE_LINE2 = "stripe_hosted_japanese_line2"
 
 internal class StripeHostedPlacesClientProxy(
     private val repository: StripeAutocompleteRepository,
     private val googleApiKey: String?,
 ) : PlacesClientProxy {
+    private val lock = Any()
     private var sessionToken: String = newSessionToken()
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
 
     override fun resetSession() {
-        sessionToken = newSessionToken()
-        predictionCache.clear()
+        synchronized(lock) {
+            sessionToken = newSessionToken()
+            predictionCache.clear()
+        }
     }
 
     override suspend fun findAutocompletePredictions(
@@ -33,16 +35,19 @@ internal class StripeHostedPlacesClientProxy(
     ): Result<FindAutocompletePredictionsResponse> {
         val q = query ?: return Result.success(FindAutocompletePredictionsResponse(emptyList()))
         val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+        val token = synchronized(lock) { sessionToken }
         return repository.findAutocompletePredictions(
             query = q,
             country = country,
-            sessionToken = sessionToken,
+            sessionToken = token,
             locale = locale.toLanguageTag(),
             googleApiKey = googleApiKey,
         ).map { result ->
             val limitedPredictions = result.predictions.take(limit)
-            predictionCache.clear()
-            limitedPredictions.forEach { predictionCache[it.placeId] = it }
+            synchronized(lock) {
+                predictionCache.clear()
+                limitedPredictions.forEach { predictionCache[it.placeId] = it }
+            }
             FindAutocompletePredictionsResponse(
                 autocompletePredictions = limitedPredictions.map { suggestion ->
                     AutocompletePrediction(
@@ -56,13 +61,15 @@ internal class StripeHostedPlacesClientProxy(
     }
 
     override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-        val cached = predictionCache[placeId]
+        val (cached, token) = synchronized(lock) {
+            predictionCache[placeId] to sessionToken
+        }
         if (cached?.address != null) {
             return Result.success(cached.address.toFetchPlaceResponse())
         }
         return repository.fetchPlaceDetails(
             placeId = placeId,
-            sessionToken = sessionToken,
+            sessionToken = token,
         ).map { result ->
             result.address.toFetchPlaceResponse()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -1,23 +1,105 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import android.text.SpannableString
+import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
+import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import java.util.Locale
+import java.util.UUID
 
-internal class StripeHostedPlacesClientProxy : PlacesClientProxy {
+private const val STRIPE_HOSTED_JAPANESE_LINE1 = "stripe_hosted_japanese_line1"
+private const val STRIPE_HOSTED_JAPANESE_LINE2 = "stripe_hosted_japanese_line2"
+
+internal class StripeHostedPlacesClientProxy(
+    private val repository: StripeAutocompleteRepository,
+    private val googleApiKey: String?,
+) : PlacesClientProxy {
+    private var sessionToken: String = newSessionToken()
+    private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
+
+    override fun resetSession() {
+        sessionToken = newSessionToken()
+        predictionCache.clear()
+    }
+
     override suspend fun findAutocompletePredictions(
         query: String?,
         country: String,
-        limit: Int
+        limit: Int,
     ): Result<FindAutocompletePredictionsResponse> {
-        return Result.failure(
-            NotImplementedError("Stripe-hosted autocomplete not yet implemented")
-        )
+        val q = query ?: return Result.success(FindAutocompletePredictionsResponse(emptyList()))
+        val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+        return repository.findAutocompletePredictions(
+            query = q,
+            country = country,
+            sessionToken = sessionToken,
+            locale = locale.toLanguageTag(),
+            googleApiKey = googleApiKey,
+        ).map { result ->
+            val limitedPredictions = result.predictions.take(limit)
+            predictionCache.clear()
+            limitedPredictions.forEach { predictionCache[it.placeId] = it }
+            FindAutocompletePredictionsResponse(
+                autocompletePredictions = limitedPredictions.map { suggestion ->
+                    AutocompletePrediction(
+                        primaryText = SpannableString(suggestion.primaryText),
+                        secondaryText = SpannableString(suggestion.secondaryText),
+                        placeId = suggestion.placeId,
+                    )
+                }
+            )
+        }
     }
 
     override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-        return Result.failure(
-            NotImplementedError("Stripe-hosted place details not yet implemented")
-        )
+        val cached = predictionCache[placeId]
+        if (cached?.address != null) {
+            return Result.success(cached.address.toFetchPlaceResponse())
+        }
+        return repository.fetchPlaceDetails(
+            placeId = placeId,
+            sessionToken = sessionToken,
+        ).map { result ->
+            result.address.toFetchPlaceResponse()
+        }
+    }
+
+    private fun StripeProxyAddress.toFetchPlaceResponse(): FetchPlaceResponse {
+        val isJapaneseAddress = country == Locale.JAPAN.country
+        val components = buildList {
+            line1?.let { line1 ->
+                add(
+                    AddressComponent(
+                        shortName = line1,
+                        longName = line1,
+                        types = listOf(if (isJapaneseAddress) STRIPE_HOSTED_JAPANESE_LINE1 else "route"),
+                    )
+                )
+            }
+            line2?.let { line2 ->
+                add(
+                    AddressComponent(
+                        shortName = line2,
+                        longName = line2,
+                        types = listOf(if (isJapaneseAddress) STRIPE_HOSTED_JAPANESE_LINE2 else "premise"),
+                    )
+                )
+            }
+            city?.let { add(AddressComponent(shortName = it, longName = it, types = listOf("locality"))) }
+            state?.let {
+                add(AddressComponent(shortName = it, longName = it, types = listOf("administrative_area_level_1")))
+            }
+            postalCode?.let { add(AddressComponent(shortName = it, longName = it, types = listOf("postal_code"))) }
+            country?.let { add(AddressComponent(shortName = it, longName = it, types = listOf("country"))) }
+        }
+        return FetchPlaceResponse(Place(addressComponents = components))
+    }
+
+    private companion object {
+        fun newSessionToken(): String = UUID.randomUUID().toString()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -5,9 +5,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import java.util.Locale
 import java.util.UUID
 
@@ -17,13 +15,11 @@ internal class StripeHostedPlacesClientProxy(
     private val lock = Any()
     private var sessionToken: String = newSessionToken()
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
-    private var lastResolvedAddress: StripeProxyAddress? = null
 
     override fun resetSession() {
         synchronized(lock) {
             sessionToken = newSessionToken()
             predictionCache.clear()
-            lastResolvedAddress = null
         }
     }
 
@@ -57,33 +53,36 @@ internal class StripeHostedPlacesClientProxy(
         }
     }
 
-    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
+    override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
         val (cached, token) = synchronized(lock) {
             predictionCache[placeId] to sessionToken
         }
         if (cached?.address != null) {
-            synchronized(lock) { lastResolvedAddress = cached.address }
-            return Result.success(FetchPlaceResponse(Place(addressComponents = null)))
+            return Result.success(
+                Address(
+                    line1 = cached.address.line1,
+                    line2 = cached.address.line2,
+                    city = cached.address.city,
+                    state = cached.address.state,
+                    postalCode = cached.address.postalCode,
+                    country = cached.address.country,
+                )
+            )
         }
         return repository.fetchPlaceDetails(
             placeId = placeId,
             sessionToken = token,
+            locale = locale.toLanguageTag(),
         ).map { result ->
-            synchronized(lock) { lastResolvedAddress = result.address }
-            FetchPlaceResponse(Place(addressComponents = null))
+            Address(
+                line1 = result.address?.line1,
+                line2 = result.address?.line2,
+                city = result.address?.city,
+                state = result.address?.state,
+                postalCode = result.address?.postalCode,
+                country = result.address?.country,
+            )
         }
-    }
-
-    override fun transformToAddress(locale: Locale): Address {
-        val address = synchronized(lock) { lastResolvedAddress }
-        return Address(
-            line1 = address?.line1,
-            line2 = address?.line2,
-            city = address?.city,
-            state = address?.state,
-            postalCode = address?.postalCode,
-            country = address?.country,
-        )
     }
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -31,6 +31,10 @@ import javax.inject.Singleton
     ]
 )
 internal class AddressElementViewModelModule {
+    companion object {
+        internal const val INLINE_PLACES_CLIENT = "inline_places_client"
+    }
+
     @Provides
     @Singleton
     fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
@@ -66,7 +70,8 @@ internal class AddressElementViewModelModule {
 
     @Provides
     @Singleton
-    internal fun provideGooglePlacesClient(
+    @Named(INLINE_PLACES_CLIENT)
+    internal fun provideInlinePlacesClient(
         context: Context,
         args: AddressElementActivityContract.Args,
         stripeAutocompleteRepository: StripeAutocompleteRepository,
@@ -78,6 +83,22 @@ internal class AddressElementViewModelModule {
                 googleApiKey = config.googlePlacesApiKey,
             )
         }
+        return config.googlePlacesApiKey?.let {
+            PlacesClientProxy.create(
+                context,
+                it,
+                errorReporter = ErrorReporter.createFallbackInstance(context),
+            )
+        }
+    }
+
+    @Provides
+    @Singleton
+    internal fun provideGooglePlacesClient(
+        context: Context,
+        args: AddressElementActivityContract.Args,
+    ): PlacesClientProxy? {
+        val config = args.config ?: return null
         return config.googlePlacesApiKey?.let {
             PlacesClientProxy.create(
                 context,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -65,7 +65,6 @@ internal class AddressElementViewModelModule {
         stripeNetworkClient = stripeNetworkClient,
         apiRequestFactory = apiRequestFactory,
         publishableKeyProvider = { args.publishableKey },
-        stripeAccountIdProvider = { args.stripeAccountId },
     )
 
     @Provides
@@ -77,12 +76,11 @@ internal class AddressElementViewModelModule {
         googlePlacesClient: PlacesClientProxy?,
     ): PlacesClientProxy? {
         val config = args.config ?: return null
-        if (config.useStripeHostedAutocomplete) {
-            return StripeHostedPlacesClientProxy(
-                repository = stripeAutocompleteRepository,
-            )
+        return if (config.useStripeHostedAutocomplete) {
+            StripeHostedPlacesClientProxy(repository = stripeAutocompleteRepository)
+        } else {
+            googlePlacesClient
         }
-        return googlePlacesClient
     }
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -2,11 +2,15 @@ package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressElementNavigator
+import com.stripe.android.paymentsheet.addresselement.DefaultStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.addresselement.NavHostAddressElementNavigator
+import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.addresselement.StripeHostedPlacesClientProxy
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.addresselement.analytics.DefaultAddressLauncherEventReporter
@@ -45,13 +49,34 @@ internal class AddressElementViewModelModule {
 
     @Provides
     @Singleton
+    fun provideApiRequestFactory(): ApiRequest.Factory = ApiRequest.Factory()
+
+    @Provides
+    @Singleton
+    fun provideStripeAutocompleteRepository(
+        stripeNetworkClient: StripeNetworkClient,
+        apiRequestFactory: ApiRequest.Factory,
+        args: AddressElementActivityContract.Args,
+    ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
+        stripeNetworkClient = stripeNetworkClient,
+        apiRequestFactory = apiRequestFactory,
+        publishableKeyProvider = { args.publishableKey },
+        stripeAccountIdProvider = { args.stripeAccountId },
+    )
+
+    @Provides
+    @Singleton
     internal fun provideGooglePlacesClient(
         context: Context,
-        args: AddressElementActivityContract.Args
+        args: AddressElementActivityContract.Args,
+        stripeAutocompleteRepository: StripeAutocompleteRepository,
     ): PlacesClientProxy? {
         val config = args.config ?: return null
         if (config.useStripeHostedAutocomplete) {
-            return StripeHostedPlacesClientProxy()
+            return StripeHostedPlacesClientProxy(
+                repository = stripeAutocompleteRepository,
+                googleApiKey = config.googlePlacesApiKey,
+            )
         }
         return config.googlePlacesApiKey?.let {
             PlacesClientProxy.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -53,17 +53,12 @@ internal class AddressElementViewModelModule {
 
     @Provides
     @Singleton
-    fun provideApiRequestFactory(): ApiRequest.Factory = ApiRequest.Factory()
-
-    @Provides
-    @Singleton
     fun provideStripeAutocompleteRepository(
         stripeNetworkClient: StripeNetworkClient,
-        apiRequestFactory: ApiRequest.Factory,
         args: AddressElementActivityContract.Args,
     ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
         stripeNetworkClient = stripeNetworkClient,
-        apiRequestFactory = apiRequestFactory,
+        apiRequestFactory = ApiRequest.Factory(),
         publishableKeyProvider = { args.publishableKey },
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -72,9 +72,9 @@ internal class AddressElementViewModelModule {
     @Singleton
     @Named(INLINE_PLACES_CLIENT)
     internal fun provideInlinePlacesClient(
-        context: Context,
         args: AddressElementActivityContract.Args,
         stripeAutocompleteRepository: StripeAutocompleteRepository,
+        googlePlacesClient: PlacesClientProxy?,
     ): PlacesClientProxy? {
         val config = args.config ?: return null
         if (config.useStripeHostedAutocomplete) {
@@ -82,13 +82,7 @@ internal class AddressElementViewModelModule {
                 repository = stripeAutocompleteRepository,
             )
         }
-        return config.googlePlacesApiKey?.let {
-            PlacesClientProxy.create(
-                context,
-                it,
-                errorReporter = ErrorReporter.createFallbackInstance(context),
-            )
-        }
+        return googlePlacesClient
     }
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -80,7 +80,6 @@ internal class AddressElementViewModelModule {
         if (config.useStripeHostedAutocomplete) {
             return StripeHostedPlacesClientProxy(
                 repository = stripeAutocompleteRepository,
-                googleApiKey = config.googlePlacesApiKey,
             )
         }
         return config.googlePlacesApiKey?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -25,7 +25,7 @@ internal fun createInlineAutocompletePlacesClient(
     }
 }
 
-private class LazyPlacesClientProxy(
+internal class LazyPlacesClientProxy(
     factory: () -> PlacesClientProxy,
 ) : PlacesClientProxy {
     private val delegate by lazy(factory)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -5,7 +5,6 @@ import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.Address
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import java.util.Locale
 
@@ -38,11 +37,10 @@ internal class LazyPlacesClientProxy(
         limit: Int,
     ): Result<FindAutocompletePredictionsResponse> = delegate.findAutocompletePredictions(query, country, limit)
 
-    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> = delegate.fetchPlace(placeId)
+    override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> =
+        delegate.fetchPlace(placeId, locale)
 
     override fun resetSession() {
         delegate.resetSession()
     }
-
-    override fun transformToAddress(locale: Locale): Address = delegate.transformToAddress(locale)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -44,6 +44,5 @@ internal class LazyPlacesClientProxy(
         delegate.resetSession()
     }
 
-    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address =
-        delegate.transformToAddress(response, locale)
+    override fun transformToAddress(locale: Locale): Address = delegate.transformToAddress(locale)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -2,10 +2,12 @@ package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
 import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.model.Address
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import java.util.Locale
 
 internal fun createInlineAutocompletePlacesClient(
     context: Context,
@@ -41,4 +43,7 @@ internal class LazyPlacesClientProxy(
     override fun resetSession() {
         delegate.resetSession()
     }
+
+    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address =
+        delegate.transformToAddress(response, locale)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -37,4 +37,8 @@ private class LazyPlacesClientProxy(
     ): Result<FindAutocompletePredictionsResponse> = delegate.findAutocompletePredictions(query, country, limit)
 
     override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> = delegate.fetchPlace(placeId)
+
+    override fun resetSession() {
+        delegate.resetSession()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -21,6 +21,7 @@ import javax.inject.Singleton
         PaymentSheetCommonModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
+        PaymentSheetAutocompleteModule::class,
         ElementsSessionClientParamsModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
@@ -14,17 +14,12 @@ import javax.inject.Singleton
 internal class PaymentSheetAutocompleteModule {
     @Provides
     @Singleton
-    fun provideApiRequestFactory(): ApiRequest.Factory = ApiRequest.Factory()
-
-    @Provides
-    @Singleton
     fun provideStripeAutocompleteRepository(
         stripeNetworkClient: StripeNetworkClient,
-        apiRequestFactory: ApiRequest.Factory,
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
     ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
         stripeNetworkClient = stripeNetworkClient,
-        apiRequestFactory = apiRequestFactory,
+        apiRequestFactory = ApiRequest.Factory(),
         publishableKeyProvider = publishableKeyProvider,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.injection
 
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.paymentsheet.addresselement.DefaultStripeAutocompleteRepository
@@ -23,11 +22,9 @@ internal class PaymentSheetAutocompleteModule {
         stripeNetworkClient: StripeNetworkClient,
         apiRequestFactory: ApiRequest.Factory,
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
     ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
         stripeNetworkClient = stripeNetworkClient,
         apiRequestFactory = apiRequestFactory,
         publishableKeyProvider = publishableKeyProvider,
-        stripeAccountIdProvider = stripeAccountIdProvider,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.StripeNetworkClient
+import com.stripe.android.paymentsheet.addresselement.DefaultStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+internal class PaymentSheetAutocompleteModule {
+    @Provides
+    @Singleton
+    fun provideApiRequestFactory(): ApiRequest.Factory = ApiRequest.Factory()
+
+    @Provides
+    @Singleton
+    fun provideStripeAutocompleteRepository(
+        stripeNetworkClient: StripeNetworkClient,
+        apiRequestFactory: ApiRequest.Factory,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+    ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
+        stripeNetworkClient = stripeNetworkClient,
+        apiRequestFactory = apiRequestFactory,
+        publishableKeyProvider = publishableKeyProvider,
+        stripeAccountIdProvider = stripeAccountIdProvider,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -32,6 +32,7 @@ import javax.inject.Singleton
         ElementsSessionClientParamsModule::class,
         LinkHoldbackExposureModule::class,
         PaymentSheetViewModelModule::class,
+        PaymentSheetAutocompleteModule::class,
         TapToAddConnectionStarterModule::class,
         PaymentElementConfirmationModule::class,
         PaymentMethodMessagePromotionsHelperModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -69,7 +69,7 @@ internal abstract class BaseSheetViewModel(
     val customerStateHolderFactory: CustomerStateHolder.Factory,
     val customViewModelScope: CoroutineScope,
     val placesClient: PlacesClientProxy?,
-    val stripeAutocompleteRepository: StripeAutocompleteRepository?,
+    val stripeAutocompleteRepository: StripeAutocompleteRepository,
 ) : ViewModel() {
     private val autocompleteLauncher = DefaultAutocompleteLauncher(
         AutocompleteAppearanceContext.PaymentElement(config.appearance)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNT
 import com.stripe.android.paymentsheet.addresselement.AutocompleteAppearanceContext
 import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
 import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -68,6 +69,7 @@ internal abstract class BaseSheetViewModel(
     val customerStateHolderFactory: CustomerStateHolder.Factory,
     val customViewModelScope: CoroutineScope,
     val placesClient: PlacesClientProxy?,
+    val stripeAutocompleteRepository: StripeAutocompleteRepository?,
 ) : ViewModel() {
     private val autocompleteLauncher = DefaultAutocompleteLauncher(
         AutocompleteAppearanceContext.PaymentElement(config.appearance)
@@ -92,6 +94,7 @@ internal abstract class BaseSheetViewModel(
                 isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
             ),
             placesClient = placesClient,
+            stripeAutocompleteRepository = stripeAutocompleteRepository,
             coroutineScope = viewModelScope,
             shouldUseAutocompleteProxyEndpointsProvider = {
                 _paymentMethodMetadata.value?.shouldUseAutocompleteProxyEndpoints ?: false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -69,7 +69,7 @@ internal abstract class BaseSheetViewModel(
     val customerStateHolderFactory: CustomerStateHolder.Factory,
     val customViewModelScope: CoroutineScope,
     val placesClient: PlacesClientProxy?,
-    val stripeAutocompleteRepository: StripeAutocompleteRepository,
+    stripeAutocompleteRepository: StripeAutocompleteRepository,
 ) : ViewModel() {
     private val autocompleteLauncher = DefaultAutocompleteLauncher(
         AutocompleteAppearanceContext.PaymentElement(config.appearance)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -188,6 +188,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
+                stripeAutocompleteRepository = null,
             )
         }
         return viewModelStoreRule.track(viewModel)
@@ -243,6 +244,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
+                stripeAutocompleteRepository = null,
             )
         }
         return viewModelStoreRule.track(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_SELECTION
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.FakeCvcRecollectionHandler
@@ -188,7 +189,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
-                stripeAutocompleteRepository = null,
+                stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             )
         }
         return viewModelStoreRule.track(viewModel)
@@ -244,7 +245,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
-                stripeAutocompleteRepository = null,
+                stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             )
         }
         return viewModelStoreRule.track(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -536,6 +536,7 @@ internal class PaymentOptionsActivityTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 placesClient = null,
+                stripeAutocompleteRepository = null,
             )
         }.also { viewModelStoreRule.track(it) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_OPTIONS_CONTRACT_ARGS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.StripeAndroidPrimaryButtonBinding
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -536,7 +537,7 @@ internal class PaymentOptionsActivityTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 placesClient = null,
-                stripeAutocompleteRepository = null,
+                stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             )
         }.also { viewModelStoreRule.track(it) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1479,6 +1479,7 @@ internal class PaymentOptionsViewModelTest {
             customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             placesClient = null,
+            stripeAutocompleteRepository = null,
         )
     }.also { viewModelStoreRule.track(it) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -49,6 +49,7 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -1479,7 +1480,7 @@ internal class PaymentOptionsViewModelTest {
             customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             placesClient = null,
-            stripeAutocompleteRepository = null,
+            stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
         )
     }.also { viewModelStoreRule.track(it) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -69,6 +69,7 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.FakeCvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.RecordingCvcRecollectionLauncherFactory
@@ -1343,7 +1344,7 @@ internal class PaymentSheetActivityTest {
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 placesClient = null,
-                stripeAutocompleteRepository = null,
+                stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             )
         }.also { viewModelStoreRule.track(it) }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1259,6 +1259,7 @@ internal class PaymentSheetActivityTest {
         }
     }
 
+    @Suppress("LongMethod")
     private fun createViewModel(
         paymentIntent: PaymentIntent = PAYMENT_INTENT,
         paymentMethods: List<PaymentMethod> = PAYMENT_METHODS,
@@ -1278,7 +1279,6 @@ internal class PaymentSheetActivityTest {
             accountStatus = AccountStatus.SignedOut,
             email = "email@email.com"
         )
-
         TestViewModelFactory.create(
             linkConfigurationCoordinator = coordinator,
         ) { linkHandler, savedStateHandle ->
@@ -1335,9 +1335,7 @@ internal class PaymentSheetActivityTest {
                         args: Args,
                         processing: StateFlow<Boolean>,
                         coroutineScope: CoroutineScope,
-                    ): CvcRecollectionInteractor {
-                        return FakeCvcRecollectionInteractor()
-                    }
+                    ): CvcRecollectionInteractor = FakeCvcRecollectionInteractor()
                 },
                 tapToAddHelperFactory = FakeTapToAddHelper.Factory.noOp(),
                 isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
@@ -1345,6 +1343,7 @@ internal class PaymentSheetActivityTest {
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 placesClient = null,
+                stripeAutocompleteRepository = null,
             )
         }.also { viewModelStoreRule.track(it) }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -81,6 +81,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_SHEET_CALLBA
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
@@ -3505,7 +3506,7 @@ internal class PaymentSheetViewModelTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
-                stripeAutocompleteRepository = null,
+                stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             )
         }
         return viewModelStoreRule.track(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3505,6 +3505,7 @@ internal class PaymentSheetViewModelTest {
                 customViewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
+                stripeAutocompleteRepository = null,
             )
         }
         return viewModelStoreRule.track(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -122,12 +121,10 @@ class AutocompleteScreenTest {
     private class TestPlacesClientProxy(
         private val findAutocompletePredictionsResponse: Result<FindAutocompletePredictionsResponse> =
             Result.failure(IllegalStateException("Failed!")),
-        private val fetchPlaceResponse: Result<FetchPlaceResponse> =
+        private val fetchPlaceResponse: Result<Address> =
             Result.failure(IllegalStateException("Failed!")),
     ) : PlacesClientProxy {
         override fun resetSession() = Unit
-
-        override fun transformToAddress(locale: Locale): Address = Address()
 
         override suspend fun findAutocompletePredictions(
             query: String?,
@@ -136,8 +133,9 @@ class AutocompleteScreenTest {
         ): Result<FindAutocompletePredictionsResponse> = findAutocompletePredictionsResponse
 
         override suspend fun fetchPlace(
-            placeId: String
-        ): Result<FetchPlaceResponse> = fetchPlaceResponse
+            placeId: String,
+            locale: Locale,
+        ): Result<Address> = fetchPlaceResponse
     }
 
     private object TestAddressLauncherEventReporter : AddressLauncherEventReporter {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
@@ -17,11 +18,13 @@ import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import java.util.Locale
 
 @ExperimentalAnimationApi
 @RunWith(AndroidJUnit4::class)
@@ -124,6 +127,10 @@ class AutocompleteScreenTest {
             Result.failure(IllegalStateException("Failed!")),
     ) : PlacesClientProxy {
         override fun resetSession() = Unit
+
+        override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+            return response.place.transformGoogleToStripeAddress(locale)
+        }
 
         override suspend fun findAutocompletePredictions(
             query: String?,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -128,9 +127,7 @@ class AutocompleteScreenTest {
     ) : PlacesClientProxy {
         override fun resetSession() = Unit
 
-        override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
-            return response.place.transformGoogleToStripeAddress(locale)
-        }
+        override fun transformToAddress(locale: Locale): Address = Address()
 
         override suspend fun findAutocompletePredictions(
             query: String?,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -123,6 +123,8 @@ class AutocompleteScreenTest {
         private val fetchPlaceResponse: Result<FetchPlaceResponse> =
             Result.failure(IllegalStateException("Failed!")),
     ) : PlacesClientProxy {
+        override fun resetSession() = Unit
+
         override suspend fun findAutocompletePredictions(
             query: String?,
             country: String,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -5,17 +5,14 @@ import android.text.SpannableString
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import com.stripe.android.uicore.elements.TextFieldIcon
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -57,49 +54,17 @@ class AutocompleteViewModelTest {
     @Test
     fun `selectPrediction emits go back event with selected prediction`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel()
-        val fetchPlaceResponse = Result.success(
-            FetchPlaceResponse(
-                Place(
-                    listOf(
-                        AddressComponent(
-                            shortName = "123",
-                            longName = "123",
-                            types = listOf(Place.Type.STREET_NUMBER.value)
-                        ),
-                        AddressComponent(
-                            shortName = "King Street",
-                            longName = "King Street",
-                            types = listOf(Place.Type.ROUTE.value)
-                        ),
-                        AddressComponent(
-                            shortName = "South SF",
-                            longName = "South San Francisco",
-                            types = listOf(Place.Type.LOCALITY.value)
-                        ),
-                        AddressComponent(
-                            shortName = "CA",
-                            longName = "California",
-                            types = listOf(Place.Type.ADMINISTRATIVE_AREA_LEVEL_1.value)
-                        ),
-                        AddressComponent(
-                            shortName = "US",
-                            longName = "United States",
-                            types = listOf(Place.Type.COUNTRY.value)
-                        ),
-                        AddressComponent(
-                            shortName = "99999",
-                            longName = "99999",
-                            types = listOf(Place.Type.POSTAL_CODE.value)
-                        )
-                    )
+        whenever(mockClient.fetchPlace(any(), any())).thenReturn(
+            Result.success(
+                Address(
+                    line1 = "123 King Street",
+                    city = "South San Francisco",
+                    state = "CA",
+                    country = "US",
+                    postalCode = "99999",
                 )
             )
         )
-        whenever(mockClient.fetchPlace(any())).thenReturn(fetchPlaceResponse)
-        whenever(mockClient.transformToAddress(any())).thenAnswer { invocation ->
-            val locale = invocation.getArgument<java.util.Locale>(0)
-            fetchPlaceResponse.getOrNull()!!.place.transformGoogleToStripeAddress(locale)
-        }
 
         viewModel.event.test {
             viewModel.selectPrediction(
@@ -131,10 +96,10 @@ class AutocompleteViewModelTest {
     fun `selectPrediction failure emits go back event with no address`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel()
         val exception = Exception("fake exception")
-        val result = Result.failure<FetchPlaceResponse>(exception)
+        val result = Result.failure<Address>(exception)
 
         mockClient.stub {
-            on { fetchPlace(any()) }.thenReturn(result)
+            on { fetchPlace(any(), any()) }.thenReturn(result)
         }
 
         viewModel.event.test {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -96,10 +96,9 @@ class AutocompleteViewModelTest {
             )
         )
         whenever(mockClient.fetchPlace(any())).thenReturn(fetchPlaceResponse)
-        whenever(mockClient.transformToAddress(any(), any())).thenAnswer { invocation ->
-            val response = invocation.getArgument<FetchPlaceResponse>(0)
-            val locale = invocation.getArgument<java.util.Locale>(1)
-            response.place.transformGoogleToStripeAddress(locale)
+        whenever(mockClient.transformToAddress(any())).thenAnswer { invocation ->
+            val locale = invocation.getArgument<java.util.Locale>(0)
+            fetchPlaceResponse.getOrNull()!!.place.transformGoogleToStripeAddress(locale)
         }
 
         viewModel.event.test {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import com.stripe.android.uicore.elements.TextFieldIcon
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -95,6 +96,11 @@ class AutocompleteViewModelTest {
             )
         )
         whenever(mockClient.fetchPlace(any())).thenReturn(fetchPlaceResponse)
+        whenever(mockClient.transformToAddress(any(), any())).thenAnswer { invocation ->
+            val response = invocation.getArgument<FetchPlaceResponse>(0)
+            val locale = invocation.getArgument<java.util.Locale>(1)
+            response.place.transformGoogleToStripeAddress(locale)
+        }
 
         viewModel.event.test {
             viewModel.selectPrediction(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -2,8 +2,8 @@ package com.stripe.android.paymentsheet.addresselement
 
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.model.Address
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -36,12 +36,12 @@ class BillingInlineAutocompleteAddressInteractorTest {
     fun `onPredictionSelected forwards the resulting event to the registered listener`() = runScenario {
         // Address-mapping detail is covered by InlineAutocompleteControllerTest; here we only
         // verify the event the controller produces reaches the listener wired via register().
-        fakePlacesClient.fetchPlaceResult = Result.success(FetchPlaceResponse(Place(emptyList())))
+        fakePlacesClient.fetchPlaceResult = Result.success(Address())
 
         interactor.onPredictionSelected("place_1")
         advanceTimeBy(100)
 
-        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem().placeId).isEqualTo("place_1")
         fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(eventCalls.awaitItem())
             .isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
@@ -50,7 +50,10 @@ class BillingInlineAutocompleteAddressInteractorTest {
     private fun runScenario(
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
-        val fakePlaces = FakePlacesClientProxy()
+        val fakePlaces = FakePlacesClientProxy(
+            findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+            fetchPlaceResult = Result.success(Address()),
+        )
         val eventCalls = Turbine<AutocompleteAddressInteractor.Event>()
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test_key",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -42,6 +42,7 @@ class BillingInlineAutocompleteAddressInteractorTest {
         advanceTimeBy(100)
 
         assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(eventCalls.awaitItem())
             .isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -44,15 +44,16 @@ internal class FakePlacesClientProxy(
         return fetchPlaceResult
     }
 
-    var resetSessionCallCount = 0
-        private set
+    private val _resetSessionCalls = Turbine<Unit>()
+    val resetSessionCalls: ReceiveTurbine<Unit> = _resetSessionCalls
 
     override fun resetSession() {
-        resetSessionCallCount++
+        _resetSessionCalls.add(Unit)
     }
 
     fun ensureAllEventsConsumed() {
         _findPredictionsCalls.ensureAllEventsConsumed()
         _fetchPlaceCalls.ensureAllEventsConsumed()
+        _resetSessionCalls.ensureAllEventsConsumed()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -2,10 +2,13 @@ package com.stripe.android.paymentsheet.addresselement
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
+import java.util.Locale
 
 internal class FakePlacesClientProxy(
     var findPredictionsResult: Result<FindAutocompletePredictionsResponse> =
@@ -49,6 +52,10 @@ internal class FakePlacesClientProxy(
 
     override fun resetSession() {
         _resetSessionCalls.add(Unit)
+    }
+
+    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
+        return response.place.transformGoogleToStripeAddress(locale)
     }
 
     fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -44,6 +44,13 @@ internal class FakePlacesClientProxy(
         return fetchPlaceResult
     }
 
+    var resetSessionCallCount = 0
+        private set
+
+    override fun resetSession() {
+        resetSessionCallCount++
+    }
+
     fun ensureAllEventsConsumed() {
         _findPredictionsCalls.ensureAllEventsConsumed()
         _fetchPlaceCalls.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -4,17 +4,12 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import java.util.Locale
 
 internal class FakePlacesClientProxy(
-    var findPredictionsResult: Result<FindAutocompletePredictionsResponse> =
-        Result.success(FindAutocompletePredictionsResponse(emptyList())),
-    var fetchPlaceResult: Result<FetchPlaceResponse> =
-        Result.success(FetchPlaceResponse(Place(emptyList()))),
+    var findPredictionsResult: Result<FindAutocompletePredictionsResponse>,
+    var fetchPlaceResult: Result<Address>,
 ) : PlacesClientProxy {
     var onBeforeFindPredictions: (() -> Unit)? = null
     var onBeforeFetchPlace: (suspend () -> Unit)? = null
@@ -28,8 +23,10 @@ internal class FakePlacesClientProxy(
     private val _findPredictionsCalls = Turbine<FindPredictionsCall>()
     val findPredictionsCalls: ReceiveTurbine<FindPredictionsCall> = _findPredictionsCalls
 
-    private val _fetchPlaceCalls = Turbine<String>()
-    val fetchPlaceCalls: ReceiveTurbine<String> = _fetchPlaceCalls
+    data class FetchPlaceCall(val placeId: String, val locale: Locale)
+
+    private val _fetchPlaceCalls = Turbine<FetchPlaceCall>()
+    val fetchPlaceCalls: ReceiveTurbine<FetchPlaceCall> = _fetchPlaceCalls
 
     override suspend fun findAutocompletePredictions(
         query: String?,
@@ -41,12 +38,9 @@ internal class FakePlacesClientProxy(
         return findPredictionsResult
     }
 
-    private var lastFetchedResponse: FetchPlaceResponse? = null
-
-    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
-        _fetchPlaceCalls.add(placeId)
+    override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
+        _fetchPlaceCalls.add(FetchPlaceCall(placeId, locale))
         onBeforeFetchPlace?.invoke()
-        fetchPlaceResult.onSuccess { lastFetchedResponse = it }
         return fetchPlaceResult
     }
 
@@ -54,12 +48,7 @@ internal class FakePlacesClientProxy(
     val resetSessionCalls: ReceiveTurbine<Unit> = _resetSessionCalls
 
     override fun resetSession() {
-        lastFetchedResponse = null
         _resetSessionCalls.add(Unit)
-    }
-
-    override fun transformToAddress(locale: Locale): Address {
-        return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
     }
 
     fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakePlacesClientProxy.kt
@@ -41,9 +41,12 @@ internal class FakePlacesClientProxy(
         return findPredictionsResult
     }
 
+    private var lastFetchedResponse: FetchPlaceResponse? = null
+
     override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
         _fetchPlaceCalls.add(placeId)
         onBeforeFetchPlace?.invoke()
+        fetchPlaceResult.onSuccess { lastFetchedResponse = it }
         return fetchPlaceResult
     }
 
@@ -51,11 +54,12 @@ internal class FakePlacesClientProxy(
     val resetSessionCalls: ReceiveTurbine<Unit> = _resetSessionCalls
 
     override fun resetSession() {
+        lastFetchedResponse = null
         _resetSessionCalls.add(Unit)
     }
 
-    override fun transformToAddress(response: FetchPlaceResponse, locale: Locale): Address {
-        return response.place.transformGoogleToStripeAddress(locale)
+    override fun transformToAddress(locale: Locale): Address {
+        return lastFetchedResponse?.place?.transformGoogleToStripeAddress(locale) ?: Address()
     }
 
     fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakeStripeAutocompleteRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakeStripeAutocompleteRepository.kt
@@ -21,8 +21,14 @@ internal class FakeStripeAutocompleteRepository : StripeAutocompleteRepository {
     private val _findPredictionsCalls = Turbine<FindPredictionsCall>()
     val findPredictionsCalls: ReceiveTurbine<FindPredictionsCall> = _findPredictionsCalls
 
-    private val _fetchPlaceDetailsCalls = Turbine<String>()
-    val fetchPlaceDetailsCalls: ReceiveTurbine<String> = _fetchPlaceDetailsCalls
+    data class FetchPlaceDetailsCall(
+        val placeId: String,
+        val sessionToken: String,
+        val locale: String?,
+    )
+
+    private val _fetchPlaceDetailsCalls = Turbine<FetchPlaceDetailsCall>()
+    val fetchPlaceDetailsCalls: ReceiveTurbine<FetchPlaceDetailsCall> = _fetchPlaceDetailsCalls
 
     override suspend fun findAutocompletePredictions(
         query: String,
@@ -37,9 +43,10 @@ internal class FakeStripeAutocompleteRepository : StripeAutocompleteRepository {
 
     override suspend fun fetchPlaceDetails(
         placeId: String,
-        sessionToken: String
+        sessionToken: String,
+        locale: String?
     ): Result<PlaceDetailsResult> {
-        _fetchPlaceDetailsCalls.add(placeId)
+        _fetchPlaceDetailsCalls.add(FetchPlaceDetailsCall(placeId, sessionToken, locale))
         onBeforeFetchPlaceDetails?.invoke()
         return detailsResult
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -737,6 +737,37 @@ class InlineAutocompleteControllerTest {
         eventCalls.awaitItem()
     }
 
+    @Test
+    fun `onPredictionSelected resets session after successful fetch`() = runScenario {
+        fakePlacesClient.fetchPlaceResult = Result.success(
+            FetchPlaceResponse(
+                Place(
+                    listOf(
+                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
+                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
+                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
+                    )
+                )
+            )
+        )
+
+        delegate.onPredictionSelected("place-id-123")
+
+        fakePlacesClient.fetchPlaceCalls.awaitItem()
+        eventCalls.awaitItem()
+        assertThat(fakePlacesClient.resetSessionCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `onPredictionSelected resets session after failed fetch`() = runScenario {
+        fakePlacesClient.fetchPlaceResult = Result.failure(RuntimeException("error"))
+
+        delegate.onPredictionSelected("place-id-123")
+
+        fakePlacesClient.fetchPlaceCalls.awaitItem()
+        assertThat(fakePlacesClient.resetSessionCallCount).isEqualTo(1)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -644,8 +644,8 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-123")
 
         val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
-        fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(call).isEqualTo("place-id-123")
+        fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem())
             .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -4,11 +4,9 @@ import android.text.SpannableString
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
-import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
-import com.stripe.android.ui.core.elements.autocomplete.model.Place
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor.InlinePredictionsState
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -187,28 +185,19 @@ class InlineAutocompleteControllerTest {
     @Test
     fun `onPredictionSelected fetches place and emits OnValues event`() = runScenario {
         fakePlacesClient.fetchPlaceResult = Result.success(
-            FetchPlaceResponse(
-                Place(
-                    listOf(
-                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                        AddressComponent("SF", "San Francisco", listOf(Place.Type.LOCALITY.value)),
-                        AddressComponent(
-                            "CA",
-                            "California",
-                            listOf(Place.Type.ADMINISTRATIVE_AREA_LEVEL_1.value)
-                        ),
-                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                        AddressComponent("94105", "94105", listOf(Place.Type.POSTAL_CODE.value)),
-                    )
-                )
+            Address(
+                line1 = "123 Main Street",
+                city = "San Francisco",
+                state = "CA",
+                country = "US",
+                postalCode = "94105",
             )
         )
 
         delegate.onPredictionSelected("place_1")
         advanceTimeBy(100)
 
-        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem())
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem().placeId)
             .isEqualTo("place_1")
         fakePlacesClient.resetSessionCalls.awaitItem()
         val event = eventCalls.awaitItem()
@@ -225,9 +214,7 @@ class InlineAutocompleteControllerTest {
 
     @Test
     fun `onPredictionSelected resets state to Idle`() = runScenario {
-        fakePlacesClient.fetchPlaceResult = Result.success(
-            FetchPlaceResponse(Place(emptyList()))
-        )
+        fakePlacesClient.fetchPlaceResult = Result.success(Address())
 
         delegate.onPredictionSelected("place_1")
         advanceTimeBy(100)
@@ -256,9 +243,7 @@ class InlineAutocompleteControllerTest {
     @Test
     fun `onDismissed cancels an in-flight prediction selection`() = runScenario {
         val fetchGate = CompletableDeferred<Unit>()
-        fakePlacesClient.fetchPlaceResult = Result.success(
-            FetchPlaceResponse(Place(emptyList()))
-        )
+        fakePlacesClient.fetchPlaceResult = Result.success(Address())
         fakePlacesClient.onBeforeFetchPlace = { fetchGate.await() }
 
         delegate.onPredictionSelected("place_1")
@@ -271,7 +256,7 @@ class InlineAutocompleteControllerTest {
         fetchGate.complete(Unit)
         advanceTimeBy(100)
 
-        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem()).isEqualTo("place_1")
+        assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem().placeId).isEqualTo("place_1")
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         eventCalls.expectNoEvents()
     }
@@ -280,24 +265,7 @@ class InlineAutocompleteControllerTest {
     fun `onPredictionSelected suppresses next query matching predicted line1`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(
-                    Place(
-                        listOf(
-                            AddressComponent(
-                                "123", "123",
-                                listOf(Place.Type.STREET_NUMBER.value)
-                            ),
-                            AddressComponent(
-                                "Main St", "Main Street",
-                                listOf(Place.Type.ROUTE.value)
-                            ),
-                            AddressComponent(
-                                "US", "United States",
-                                listOf(Place.Type.COUNTRY.value)
-                            ),
-                        )
-                    )
-                )
+                Address(line1 = "123 Main Street", country = "US")
             )
             fakePlacesClient.findPredictionsResult = Result.success(
                 FindAutocompletePredictionsResponse(emptyList())
@@ -322,24 +290,7 @@ class InlineAutocompleteControllerTest {
     fun `suppression only applies once - second matching query fetches normally`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(
-                    Place(
-                        listOf(
-                            AddressComponent(
-                                "123", "123",
-                                listOf(Place.Type.STREET_NUMBER.value)
-                            ),
-                            AddressComponent(
-                                "Main St", "Main Street",
-                                listOf(Place.Type.ROUTE.value)
-                            ),
-                            AddressComponent(
-                                "US", "United States",
-                                listOf(Place.Type.COUNTRY.value)
-                            ),
-                        )
-                    )
-                )
+                Address(line1 = "123 Main Street", country = "US")
             )
             fakePlacesClient.findPredictionsResult = Result.success(
                 FindAutocompletePredictionsResponse(emptyList())
@@ -371,15 +322,7 @@ class InlineAutocompleteControllerTest {
     fun `onDismissed clears suppression - typing previously-selected address fetches normally`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(
-                    Place(
-                        listOf(
-                            AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                            AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                            AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                        )
-                    )
-                )
+                Address(line1 = "123 Main Street", country = "US")
             )
             fakePlacesClient.findPredictionsResult = Result.success(
                 FindAutocompletePredictionsResponse(emptyList())
@@ -405,15 +348,7 @@ class InlineAutocompleteControllerTest {
     fun `query dropping below minimum chars clears suppression - re-typing fetches normally`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(
-                    Place(
-                        listOf(
-                            AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                            AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                            AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                        )
-                    )
-                )
+                Address(line1 = "123 Main Street", country = "US")
             )
             fakePlacesClient.findPredictionsResult = Result.success(
                 FindAutocompletePredictionsResponse(emptyList())
@@ -441,9 +376,7 @@ class InlineAutocompleteControllerTest {
     fun `prediction selected with null line1 does not block subsequent fetches`() =
         runScenario {
             // Place with no street components produces null line1 — no suppression is set.
-            fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(Place(emptyList()))
-            )
+            fakePlacesClient.fetchPlaceResult = Result.success(Address())
             fakePlacesClient.findPredictionsResult = Result.success(
                 FindAutocompletePredictionsResponse(emptyList())
             )
@@ -468,15 +401,7 @@ class InlineAutocompleteControllerTest {
         runScenario {
             // First selection: place with line1="123 Main St" — sets lastPredictionLine1.
             fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(
-                    Place(
-                        listOf(
-                            AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                            AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                            AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                        )
-                    )
-                )
+                Address(line1 = "123 Main Street", country = "US")
             )
             fakePlacesClient.findPredictionsResult = Result.success(
                 FindAutocompletePredictionsResponse(emptyList())
@@ -493,9 +418,7 @@ class InlineAutocompleteControllerTest {
             // Second selection: place with no street components → line1 is null.
             // This must clear lastPredictionLine1 so the previous value doesn't
             // suppress a future fetch for "123 Main St".
-            fakePlacesClient.fetchPlaceResult = Result.success(
-                FetchPlaceResponse(Place(emptyList()))
-            )
+            fakePlacesClient.fetchPlaceResult = Result.success(Address())
 
             delegate.onPredictionSelected("place_2")
             advanceTimeBy(100)
@@ -644,7 +567,7 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-123")
 
         val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
-        assertThat(call).isEqualTo("place-id-123")
+        assertThat(call.placeId).isEqualTo("place-id-123")
         fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem())
@@ -731,22 +654,14 @@ class InlineAutocompleteControllerTest {
     @Test
     fun `no proxy calls Google Places for place selection`() = runScenario {
         fakePlacesClient.fetchPlaceResult = Result.success(
-            FetchPlaceResponse(
-                Place(
-                    listOf(
-                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                    )
-                )
-            )
+            Address(line1 = "123 Main Street", country = "US")
         )
 
         delegate.onPredictionSelected("place-id-123")
 
         val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
         fakePlacesClient.resetSessionCalls.awaitItem()
-        assertThat(call).isEqualTo("place-id-123")
+        assertThat(call.placeId).isEqualTo("place-id-123")
         eventCalls.awaitItem()
     }
 
@@ -756,7 +671,10 @@ class InlineAutocompleteControllerTest {
         shouldUseStripeHostedAutocomplete: Boolean = false,
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
-        val fakePlaces = FakePlacesClientProxy()
+        val fakePlaces = FakePlacesClientProxy(
+            findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+            fetchPlaceResult = Result.success(Address()),
+        )
         val eventCalls = Turbine<AutocompleteAddressInteractor.Event>()
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "test_key",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -210,6 +210,7 @@ class InlineAutocompleteControllerTest {
 
         assertThat(fakePlacesClient.fetchPlaceCalls.awaitItem())
             .isEqualTo("place_1")
+        fakePlacesClient.resetSessionCalls.awaitItem()
         val event = eventCalls.awaitItem()
         assertThat(event)
             .isInstanceOf<AutocompleteAddressInteractor.Event.OnValues>()
@@ -232,6 +233,7 @@ class InlineAutocompleteControllerTest {
         advanceTimeBy(100)
 
         fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
         eventCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
     }
@@ -246,6 +248,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             assertThat(delegate.inlinePredictionsState.value)
                 .isEqualTo(InlinePredictionsState.Idle)
         }
@@ -305,6 +308,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             queryFlow.value = "123 Main Street"
@@ -346,6 +350,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             // First matching query is suppressed
@@ -385,6 +390,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             delegate.onDismissed()
@@ -418,6 +424,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             // Query drops below the minimum — suppression guard should be cleared.
@@ -446,6 +453,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             // lastPredictionLine1 was not set, so the next query must still fetch predictions.
@@ -479,6 +487,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             // Second selection: place with no street components → line1 is null.
@@ -492,6 +501,7 @@ class InlineAutocompleteControllerTest {
             advanceTimeBy(100)
 
             fakePlacesClient.fetchPlaceCalls.awaitItem()
+            fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
             // Typing "123 Main St" must now fetch predictions — not be suppressed.
@@ -634,6 +644,7 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-123")
 
         val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(call).isEqualTo("place-id-123")
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem())
@@ -667,6 +678,7 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-abc")
 
         fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         assertThat(eventCalls.awaitItem()).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
@@ -733,6 +745,7 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-123")
 
         val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(call).isEqualTo("place-id-123")
         eventCalls.awaitItem()
     }
@@ -754,8 +767,8 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-123")
 
         fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
         eventCalls.awaitItem()
-        assertThat(fakePlacesClient.resetSessionCallCount).isEqualTo(1)
     }
 
     @Test
@@ -765,7 +778,7 @@ class InlineAutocompleteControllerTest {
         delegate.onPredictionSelected("place-id-123")
 
         fakePlacesClient.fetchPlaceCalls.awaitItem()
-        assertThat(fakePlacesClient.resetSessionCallCount).isEqualTo(1)
+        fakePlacesClient.resetSessionCalls.awaitItem()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -750,37 +750,6 @@ class InlineAutocompleteControllerTest {
         eventCalls.awaitItem()
     }
 
-    @Test
-    fun `onPredictionSelected resets session after successful fetch`() = runScenario {
-        fakePlacesClient.fetchPlaceResult = Result.success(
-            FetchPlaceResponse(
-                Place(
-                    listOf(
-                        AddressComponent("123", "123", listOf(Place.Type.STREET_NUMBER.value)),
-                        AddressComponent("Main St", "Main Street", listOf(Place.Type.ROUTE.value)),
-                        AddressComponent("US", "United States", listOf(Place.Type.COUNTRY.value)),
-                    )
-                )
-            )
-        )
-
-        delegate.onPredictionSelected("place-id-123")
-
-        fakePlacesClient.fetchPlaceCalls.awaitItem()
-        fakePlacesClient.resetSessionCalls.awaitItem()
-        eventCalls.awaitItem()
-    }
-
-    @Test
-    fun `onPredictionSelected resets session after failed fetch`() = runScenario {
-        fakePlacesClient.fetchPlaceResult = Result.failure(RuntimeException("error"))
-
-        delegate.onPredictionSelected("place-id-123")
-
-        fakePlacesClient.fetchPlaceCalls.awaitItem()
-        fakePlacesClient.resetSessionCalls.awaitItem()
-    }
-
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -44,7 +44,6 @@ class InputAddressViewModelTest {
         return InputAddressViewModel(
             AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
-                stripeAccountId = null,
                 config = config,
             ),
             navigator,
@@ -972,7 +971,6 @@ class InputAddressViewModelTest {
         return InputAddressViewModel(
             AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
-                stripeAccountId = null,
                 config = AddressLauncher.Configuration.Builder()
                     .googlePlacesApiKey(googlePlacesApiKey)
                     .autocompleteCountries(autocompleteCountries)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -44,6 +44,7 @@ class InputAddressViewModelTest {
         return InputAddressViewModel(
             AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
+                stripeAccountId = null,
                 config = config,
             ),
             navigator,
@@ -971,6 +972,7 @@ class InputAddressViewModelTest {
         return InputAddressViewModel(
             AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
+                stripeAccountId = null,
                 config = AddressLauncher.Configuration.Builder()
                     .googlePlacesApiKey(googlePlacesApiKey)
                     .autocompleteCountries(autocompleteCountries)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.CompletableDeferred
@@ -210,7 +212,10 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
             autocompleteConfig = config,
-            placesClient = FakePlacesClientProxy(),
+            placesClient = FakePlacesClientProxy(
+                findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+                fetchPlaceResult = Result.success(Address()),
+            ),
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
@@ -233,7 +238,10 @@ class PaymentElementAutocompleteAddressInteractorTest {
             isPlacesAvailable = true,
             isInlineAutocompleteEnabled = true,
         )
-        val fakePlaces = FakePlacesClientProxy()
+        val fakePlaces = FakePlacesClientProxy(
+            findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+            fetchPlaceResult = Result.success(Address()),
+        )
         val factory = PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = scenario.launcher,
             autocompleteConfig = config,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -187,6 +187,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             launcher = scenario.launcher,
             autocompleteConfig = config,
             placesClient = null,
+            stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
@@ -210,6 +211,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             launcher = scenario.launcher,
             autocompleteConfig = config,
             placesClient = FakePlacesClientProxy(),
+            stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
@@ -236,6 +238,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             launcher = scenario.launcher,
             autocompleteConfig = config,
             placesClient = fakePlaces,
+            stripeAutocompleteRepository = null,
             coroutineScope = backgroundScope,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
@@ -268,6 +271,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             launcher = scenario.launcher,
             autocompleteConfig = config,
             placesClient = null,
+            stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
         )
@@ -278,7 +282,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
-    fun `Factory creates inline interactor when proxy flag is on and placesClient is null`() = test { scenario ->
+    fun `Factory creates inline interactor when proxy flag is on with repository`() = test { scenario ->
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = null,
             autocompleteCountries = setOf("US"),
@@ -290,6 +294,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             launcher = scenario.launcher,
             autocompleteConfig = config,
             placesClient = null,
+            stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { true },
         )
@@ -299,6 +304,29 @@ class PaymentElementAutocompleteAddressInteractorTest {
         assertThat(interactor).isInstanceOf(BillingInlineAutocompleteAddressInteractor::class.java)
         assertThat(interactor.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
         assertThat(interactor.autocompleteConfig.isPlacesAvailable).isFalse()
+    }
+
+    @Test
+    fun `Factory falls back to launcher when proxy flag is on but repository is null`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = null,
+            autocompleteCountries = setOf("US"),
+            isPlacesAvailable = false,
+            isInlineAutocompleteEnabled = true,
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = config,
+            placesClient = null,
+            stripeAutocompleteRepository = null,
+            coroutineScope = this,
+            shouldUseAutocompleteProxyEndpointsProvider = { true },
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -330,6 +330,33 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
+    fun `Factory uses launcher when proxy flag is on but inline disabled`() = test { scenario ->
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = "test-key",
+                autocompleteCountries = setOf("US"),
+                isInlineAutocompleteEnabled = false,
+            ),
+            placesClient = null,
+            stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+            coroutineScope = this,
+            shouldUseAutocompleteProxyEndpointsProvider = { true },
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
+
+        interactor.onAutocomplete("US")
+
+        scenario.launchCalls.expectMostRecentItem().let { call ->
+            assertThat(call.country).isEqualTo("US")
+            assertThat(call.googlePlacesApiKey).isEqualTo("test-key")
+        }
+    }
+
+    @Test
     fun `multiple onAutocomplete calls with different countries`() = test { scenario ->
         val interactor = createInteractor(launcher = scenario.launcher)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepositoryTest.kt
@@ -56,6 +56,7 @@ class StripeAutocompleteRepositoryTest {
         scenario.repository.fetchPlaceDetails(
             placeId = "places/ChIJcznybKSAhYARlTOE-mb13JA",
             sessionToken = "session_123",
+            locale = null,
         )
 
         val request = scenario.networkClient.lastRequest as ApiRequest
@@ -75,6 +76,7 @@ class StripeAutocompleteRepositoryTest {
         val result = scenario.repository.fetchPlaceDetails(
             placeId = "place_123",
             sessionToken = "session_123",
+            locale = null,
         )
 
         assertThat(result.isSuccess).isTrue()
@@ -97,6 +99,7 @@ class StripeAutocompleteRepositoryTest {
         val result = scenario.repository.fetchPlaceDetails(
             placeId = "place_123",
             sessionToken = "session_123",
+            locale = null,
         )
 
         assertThat(result.isFailure).isTrue()
@@ -111,7 +114,6 @@ class StripeAutocompleteRepositoryTest {
             stripeNetworkClient = networkClient,
             apiRequestFactory = ApiRequest.Factory(),
             publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
         )
         return Scenario(networkClient = networkClient, repository = repository)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.addresselement
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
-import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.Locale
@@ -122,7 +121,7 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `fetchPlace inline address produces correct FetchPlaceResponse fields`() = runTest {
+    fun `transformToAddress returns correct fields from cached inline address`() = runTest {
         val inlineAddress = StripeProxyAddress(
             line1 = "123 Main St",
             line2 = "Apt 4",
@@ -144,26 +143,24 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "123", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        val result = proxy.fetchPlace("place_123")
+        val fetchResult = proxy.fetchPlace("place_123")
+        val address = proxy.transformToAddress(fetchResult.getOrThrow(), Locale.US)
 
-        val place = result.getOrThrow().place
-        val routeComponent = place.addressComponents?.find { it.types.contains("route") }
-        val premiseComponent = place.addressComponents?.find { it.types.contains("premise") }
-        val localityComponent = place.addressComponents?.find { it.types.contains("locality") }
-        val stateComponent = place.addressComponents?.find { it.types.contains("administrative_area_level_1") }
-        val postalComponent = place.addressComponents?.find { it.types.contains("postal_code") }
-        val countryComponent = place.addressComponents?.find { it.types.contains("country") }
-        assertThat(routeComponent?.longName).isEqualTo("123 Main St")
-        assertThat(premiseComponent?.longName).isEqualTo("Apt 4")
-        assertThat(localityComponent?.longName).isEqualTo("San Francisco")
-        assertThat(stateComponent?.shortName).isEqualTo("CA")
-        assertThat(postalComponent?.longName).isEqualTo("94105")
-        assertThat(countryComponent?.shortName).isEqualTo("US")
+        assertThat(address).isEqualTo(
+            Address(
+                city = "San Francisco",
+                country = "US",
+                line1 = "123 Main St",
+                line2 = "Apt 4",
+                postalCode = "94105",
+                state = "CA",
+            )
+        )
         repository.ensureAllEventsConsumed()
     }
 
     @Test
-    fun `fetchPlace inline Japanese address preserves flattened lines`() = runTest {
+    fun `transformToAddress preserves Japanese address lines directly`() = runTest {
         val inlineAddress = StripeProxyAddress(
             line1 = "3-chome-6-1 Kameido Koto City",
             line2 = "Unit 201",
@@ -185,9 +182,10 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "Kameido", country = "JP", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        val result = proxy.fetchPlace("place_jp")
+        val fetchResult = proxy.fetchPlace("place_jp")
+        val address = proxy.transformToAddress(fetchResult.getOrThrow(), Locale.getDefault())
 
-        assertThat(result.getOrThrow().place.transformGoogleToStripeAddress(Locale.getDefault())).isEqualTo(
+        assertThat(address).isEqualTo(
             Address(
                 city = "Koto City",
                 country = "JP",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -78,35 +78,6 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `fetchPlace uses cached inline address when available`() = runTest {
-        val inlineAddress = StripeProxyAddress(
-            line1 = "123 Main St",
-            line2 = null,
-            city = "San Francisco",
-            state = "CA",
-            postalCode = "94105",
-            country = "US",
-        )
-        val repository = FakeStripeAutocompleteRepository().apply {
-            predictionsResult = Result.success(
-                AutocompletePredictionsResult(
-                    predictions = listOf(
-                        AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress)
-                    )
-                )
-            )
-        }
-        val proxy = createProxy(repository = repository)
-        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
-        repository.findPredictionsCalls.awaitItem()
-
-        val result = proxy.fetchPlace("place_123")
-
-        assertThat(result.isSuccess).isTrue()
-        repository.ensureAllEventsConsumed()
-    }
-
-    @Test
     fun `fetchPlace calls repository when no inline address cached`() = runTest {
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository)
@@ -143,8 +114,8 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "123", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        val fetchResult = proxy.fetchPlace("place_123")
-        val address = proxy.transformToAddress(fetchResult.getOrThrow(), Locale.US)
+        proxy.fetchPlace("place_123")
+        val address = proxy.transformToAddress(Locale.US)
 
         assertThat(address).isEqualTo(
             Address(
@@ -182,8 +153,8 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "Kameido", country = "JP", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        val fetchResult = proxy.fetchPlace("place_jp")
-        val address = proxy.transformToAddress(fetchResult.getOrThrow(), Locale.getDefault())
+        proxy.fetchPlace("place_jp")
+        val address = proxy.transformToAddress(Locale.getDefault())
 
         assertThat(address).isEqualTo(
             Address(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -84,7 +84,7 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        val result = proxy.fetchPlace("place_123")
+        val result = proxy.fetchPlace("place_123", Locale.US)
 
         assertThat(result.isSuccess).isTrue()
         repository.fetchPlaceDetailsCalls.awaitItem()
@@ -92,7 +92,7 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `transformToAddress returns correct fields from cached inline address`() = runTest {
+    fun `fetchPlace returns correct Address from cached inline address`() = runTest {
         val inlineAddress = StripeProxyAddress(
             line1 = "123 Main St",
             line2 = "Apt 4",
@@ -114,10 +114,9 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "123", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        proxy.fetchPlace("place_123")
-        val address = proxy.transformToAddress(Locale.US)
+        val result = proxy.fetchPlace("place_123", Locale.US)
 
-        assertThat(address).isEqualTo(
+        assertThat(result.getOrThrow()).isEqualTo(
             Address(
                 city = "San Francisco",
                 country = "US",
@@ -131,7 +130,7 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `transformToAddress preserves Japanese address lines directly`() = runTest {
+    fun `fetchPlace preserves Japanese address lines directly`() = runTest {
         val inlineAddress = StripeProxyAddress(
             line1 = "3-chome-6-1 Kameido Koto City",
             line2 = "Unit 201",
@@ -153,10 +152,9 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "Kameido", country = "JP", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        proxy.fetchPlace("place_jp")
-        val address = proxy.transformToAddress(Locale.getDefault())
+        val result = proxy.fetchPlace("place_jp", Locale.getDefault())
 
-        assertThat(address).isEqualTo(
+        assertThat(result.getOrThrow()).isEqualTo(
             Address(
                 city = "Koto City",
                 country = "JP",
@@ -187,7 +185,7 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.resetSession()
 
-        proxy.fetchPlace("place_123")
+        proxy.fetchPlace("place_123", Locale.US)
         repository.fetchPlaceDetailsCalls.awaitItem()
         repository.ensureAllEventsConsumed()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -264,9 +264,7 @@ class StripeHostedPlacesClientProxyTest {
 
     private fun createProxy(
         repository: FakeStripeAutocompleteRepository = defaultRepository(),
-        googleApiKey: String? = null,
     ) = StripeHostedPlacesClientProxy(
         repository = repository,
-        googleApiKey = googleApiKey,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -78,6 +78,24 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
+    fun `fetchPlace uses cached address after first fetchPlaceDetails in same session`() = runTest {
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository)
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        // First fetch hits the network and writes the result back to the cache.
+        proxy.fetchPlace("place_123", Locale.US)
+        repository.fetchPlaceDetailsCalls.awaitItem()
+
+        // Second fetch for the same placeId must not call the repository again.
+        val result = proxy.fetchPlace("place_123", Locale.US)
+
+        assertThat(result.isSuccess).isTrue()
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
     fun `fetchPlace calls repository when no inline address cached`() = runTest {
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository)
@@ -187,6 +205,42 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.fetchPlace("place_123", Locale.US)
         repository.fetchPlaceDetailsCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `findAutocompletePredictions and fetchPlaceDetails share the same session token within a session`() = runTest {
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        val findCall = repository.findPredictionsCalls.awaitItem()
+
+        proxy.fetchPlace("place_123", Locale.US)
+        val detailsCall = repository.fetchPlaceDetailsCalls.awaitItem()
+
+        assertThat(findCall.sessionToken).isEqualTo(detailsCall.sessionToken)
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `fetchPlaceDetails token rotates after resetSession`() = runTest {
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+        proxy.fetchPlace("place_123", Locale.US)
+        val firstDetailsCall = repository.fetchPlaceDetailsCalls.awaitItem()
+
+        proxy.resetSession()
+
+        proxy.findAutocompletePredictions(query = "456 Oak", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+        proxy.fetchPlace("place_123", Locale.US)
+        val secondDetailsCall = repository.fetchPlaceDetailsCalls.awaitItem()
+
+        assertThat(firstDetailsCall.sessionToken).isNotEqualTo(secondDetailsCall.sessionToken)
         repository.ensureAllEventsConsumed()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -1,13 +1,17 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
+import com.stripe.android.ui.core.elements.autocomplete.model.transformGoogleToStripeAddress
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import java.util.Locale
 
 class StripeHostedPlacesClientProxyTest {
+
     @Test
-    fun `findAutocompletePredictions returns failure`() = runTest {
-        val proxy = StripeHostedPlacesClientProxy()
+    fun `findAutocompletePredictions maps result to FindAutocompletePredictionsResponse`() = runTest {
+        val proxy = createProxy()
 
         val result = proxy.findAutocompletePredictions(
             query = "123 Main",
@@ -15,17 +19,254 @@ class StripeHostedPlacesClientProxyTest {
             limit = 4,
         )
 
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
+        assertThat(result.isSuccess).isTrue()
+        val response = result.getOrThrow()
+        assertThat(response.autocompletePredictions).hasSize(1)
+        val prediction = response.autocompletePredictions.single()
+        assertThat(prediction.placeId).isEqualTo("place_123")
+        assertThat(prediction.primaryText.toString()).isEqualTo("123 Main St")
+        assertThat(prediction.secondaryText.toString()).isEqualTo("San Francisco, CA")
     }
 
     @Test
-    fun `fetchPlace returns failure`() = runTest {
-        val proxy = StripeHostedPlacesClientProxy()
+    fun `findAutocompletePredictions respects limit`() = runTest {
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.success(
+                AutocompletePredictionsResult(
+                    predictions = listOf(
+                        AutocompleteSuggestion("p1", "Result 1", "City, CA", null),
+                        AutocompleteSuggestion("p2", "Result 2", "City, CA", null),
+                        AutocompleteSuggestion("p3", "Result 3", "City, CA", null),
+                    )
+                )
+            )
+        }
+        val proxy = createProxy(repository = repository)
 
-        val result = proxy.fetchPlace(placeId = "ChIJ123")
+        val result = proxy.findAutocompletePredictions(query = "123", country = "US", limit = 2)
+
+        assertThat(result.getOrThrow().autocompletePredictions).hasSize(2)
+        repository.findPredictionsCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `findAutocompletePredictions with null query returns empty list`() = runTest {
+        val proxy = createProxy()
+
+        val result = proxy.findAutocompletePredictions(
+            query = null,
+            country = "US",
+            limit = 4,
+        )
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrThrow().autocompletePredictions).isEmpty()
+    }
+
+    @Test
+    fun `findAutocompletePredictions returns failure on repository error`() = runTest {
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.failure(RuntimeException("Network error"))
+        }
+        val proxy = createProxy(repository = repository)
+
+        val result = proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
 
         assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(NotImplementedError::class.java)
+        repository.findPredictionsCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
     }
+
+    @Test
+    fun `fetchPlace uses cached inline address when available`() = runTest {
+        val inlineAddress = StripeProxyAddress(
+            line1 = "123 Main St",
+            line2 = null,
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94105",
+            country = "US",
+        )
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.success(
+                AutocompletePredictionsResult(
+                    predictions = listOf(
+                        AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress)
+                    )
+                )
+            )
+        }
+        val proxy = createProxy(repository = repository)
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        val result = proxy.fetchPlace("place_123")
+
+        assertThat(result.isSuccess).isTrue()
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `fetchPlace calls repository when no inline address cached`() = runTest {
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository)
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        val result = proxy.fetchPlace("place_123")
+
+        assertThat(result.isSuccess).isTrue()
+        repository.fetchPlaceDetailsCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `fetchPlace inline address produces correct FetchPlaceResponse fields`() = runTest {
+        val inlineAddress = StripeProxyAddress(
+            line1 = "123 Main St",
+            line2 = "Apt 4",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94105",
+            country = "US",
+        )
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.success(
+                AutocompletePredictionsResult(
+                    predictions = listOf(
+                        AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress)
+                    )
+                )
+            )
+        }
+        val proxy = createProxy(repository = repository)
+        proxy.findAutocompletePredictions(query = "123", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        val result = proxy.fetchPlace("place_123")
+
+        val place = result.getOrThrow().place
+        val routeComponent = place.addressComponents?.find { it.types.contains("route") }
+        val premiseComponent = place.addressComponents?.find { it.types.contains("premise") }
+        val localityComponent = place.addressComponents?.find { it.types.contains("locality") }
+        val stateComponent = place.addressComponents?.find { it.types.contains("administrative_area_level_1") }
+        val postalComponent = place.addressComponents?.find { it.types.contains("postal_code") }
+        val countryComponent = place.addressComponents?.find { it.types.contains("country") }
+        assertThat(routeComponent?.longName).isEqualTo("123 Main St")
+        assertThat(premiseComponent?.longName).isEqualTo("Apt 4")
+        assertThat(localityComponent?.longName).isEqualTo("San Francisco")
+        assertThat(stateComponent?.shortName).isEqualTo("CA")
+        assertThat(postalComponent?.longName).isEqualTo("94105")
+        assertThat(countryComponent?.shortName).isEqualTo("US")
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `fetchPlace inline Japanese address preserves flattened lines`() = runTest {
+        val inlineAddress = StripeProxyAddress(
+            line1 = "3-chome-6-1 Kameido Koto City",
+            line2 = "Unit 201",
+            city = "Koto City",
+            state = "Tokyo",
+            postalCode = "136-0071",
+            country = "JP",
+        )
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.success(
+                AutocompletePredictionsResult(
+                    predictions = listOf(
+                        AutocompleteSuggestion("place_jp", "Kameido", "Koto City, Tokyo", inlineAddress)
+                    )
+                )
+            )
+        }
+        val proxy = createProxy(repository = repository)
+        proxy.findAutocompletePredictions(query = "Kameido", country = "JP", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        val result = proxy.fetchPlace("place_jp")
+
+        assertThat(result.getOrThrow().place.transformGoogleToStripeAddress(Locale.getDefault())).isEqualTo(
+            Address(
+                city = "Koto City",
+                country = "JP",
+                line1 = "3-chome-6-1 Kameido Koto City",
+                line2 = "Unit 201",
+                postalCode = "136-0071",
+                state = "Tokyo",
+            )
+        )
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `resetSession clears prediction cache`() = runTest {
+        val inlineAddress = StripeProxyAddress(
+            line1 = "123 Main St", line2 = null, city = null, state = null, postalCode = null, country = null
+        )
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.success(
+                AutocompletePredictionsResult(
+                    predictions = listOf(AutocompleteSuggestion("place_123", "123 Main St", "", inlineAddress))
+                )
+            )
+        }
+        val proxy = createProxy(repository = repository)
+        proxy.findAutocompletePredictions(query = "123", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        proxy.resetSession()
+
+        proxy.fetchPlace("place_123")
+        repository.fetchPlaceDetailsCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `resetSession generates new session token for subsequent requests`() = runTest {
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        val firstCall = repository.findPredictionsCalls.awaitItem()
+
+        proxy.resetSession()
+
+        proxy.findAutocompletePredictions(query = "456 Oak", country = "US", limit = 4)
+        val secondCall = repository.findPredictionsCalls.awaitItem()
+
+        assertThat(firstCall.sessionToken).isNotEqualTo(secondCall.sessionToken)
+        repository.ensureAllEventsConsumed()
+    }
+
+    private fun defaultRepository() = FakeStripeAutocompleteRepository().apply {
+        predictionsResult = Result.success(
+            AutocompletePredictionsResult(
+                predictions = listOf(
+                    AutocompleteSuggestion("place_123", "123 Main St", "San Francisco, CA", null)
+                )
+            )
+        )
+        detailsResult = Result.success(
+            PlaceDetailsResult(
+                address = StripeProxyAddress(
+                    line1 = "123 Main St",
+                    line2 = null,
+                    city = "San Francisco",
+                    state = "CA",
+                    postalCode = "94105",
+                    country = "US",
+                )
+            )
+        )
+    }
+
+    private fun createProxy(
+        repository: FakeStripeAutocompleteRepository = defaultRepository(),
+        googleApiKey: String? = null,
+    ) = StripeHostedPlacesClientProxy(
+        repository = repository,
+        googleApiKey = googleApiKey,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -16,7 +16,6 @@ class AddressElementViewModelModuleTest {
         val placesClient = module.provideInlinePlacesClient(
             args = AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
-                stripeAccountId = null,
                 config = AddressLauncher.Configuration(
                     billingAddress = null,
                     useStripeHostedAutocomplete = true,
@@ -30,16 +29,12 @@ class AddressElementViewModelModuleTest {
     }
 
     @Test
-    fun `provideGooglePlacesClient returns null without google api key even when hosted autocomplete is enabled`() {
+    fun `provideGooglePlacesClient returns null without google api key`() {
         val placesClient = module.provideGooglePlacesClient(
             context = mock<Context>(),
             args = AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
-                stripeAccountId = null,
-                config = AddressLauncher.Configuration(
-                    billingAddress = null,
-                    useStripeHostedAutocomplete = true,
-                ),
+                config = AddressLauncher.Configuration(billingAddress = null),
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -14,7 +14,6 @@ class AddressElementViewModelModuleTest {
     @Test
     fun `provideInlinePlacesClient returns hosted client without google api key when hosted autocomplete is enabled`() {
         val placesClient = module.provideInlinePlacesClient(
-            context = mock<Context>(),
             args = AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
                 stripeAccountId = null,
@@ -24,6 +23,7 @@ class AddressElementViewModelModuleTest {
                 ),
             ),
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+            googlePlacesClient = null,
         )
 
         assertThat(placesClient).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
+import com.stripe.android.paymentsheet.addresselement.AddressLauncher
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class AddressElementViewModelModuleTest {
+    private val module = AddressElementViewModelModule()
+
+    @Test
+    fun `provideInlinePlacesClient returns hosted client without google api key when hosted autocomplete is enabled`() {
+        val placesClient = module.provideInlinePlacesClient(
+            context = mock<Context>(),
+            args = AddressElementActivityContract.Args(
+                publishableKey = "pk_123",
+                stripeAccountId = null,
+                config = AddressLauncher.Configuration(
+                    billingAddress = null,
+                    useStripeHostedAutocomplete = true,
+                ),
+            ),
+            stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+        )
+
+        assertThat(placesClient).isNotNull()
+    }
+
+    @Test
+    fun `provideGooglePlacesClient returns null without google api key even when hosted autocomplete is enabled`() {
+        val placesClient = module.provideGooglePlacesClient(
+            context = mock<Context>(),
+            args = AddressElementActivityContract.Args(
+                publishableKey = "pk_123",
+                stripeAccountId = null,
+                config = AddressLauncher.Configuration(
+                    billingAddress = null,
+                    useStripeHostedAutocomplete = true,
+                ),
+            ),
+        )
+
+        assertThat(placesClient).isNull()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClientTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClientTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.addresselement.FakePlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import org.junit.Test
+
+class InlineAutocompletePlacesClientTest {
+
+    @Test
+    fun `resetSession delegates to resolved client`() {
+        val fakePlacesClient = FakePlacesClientProxy()
+        val client = createLazyPlacesClientProxy {
+            fakePlacesClient
+        }
+
+        client.resetSession()
+
+        assertThat(fakePlacesClient.resetSessionCallCount).isEqualTo(1)
+    }
+
+    private fun createLazyPlacesClientProxy(factory: () -> PlacesClientProxy): PlacesClientProxy {
+        val constructor = Class.forName("com.stripe.android.paymentsheet.injection.LazyPlacesClientProxy")
+            .getDeclaredConstructor(kotlin.jvm.functions.Function0::class.java)
+        constructor.isAccessible = true
+        return constructor.newInstance(factory) as PlacesClientProxy
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClientTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClientTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.injection
 
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.addresselement.FakePlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -8,7 +10,10 @@ class InlineAutocompletePlacesClientTest {
 
     @Test
     fun `resetSession delegates to resolved client`() = runTest {
-        val fakePlacesClient = FakePlacesClientProxy()
+        val fakePlacesClient = FakePlacesClientProxy(
+            findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+            fetchPlaceResult = Result.success(Address()),
+        )
         val client = LazyPlacesClientProxy { fakePlacesClient }
 
         client.resetSession()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClientTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClientTest.kt
@@ -1,28 +1,19 @@
 package com.stripe.android.paymentsheet.injection
 
-import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.addresselement.FakePlacesClientProxy
-import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class InlineAutocompletePlacesClientTest {
 
     @Test
-    fun `resetSession delegates to resolved client`() {
+    fun `resetSession delegates to resolved client`() = runTest {
         val fakePlacesClient = FakePlacesClientProxy()
-        val client = createLazyPlacesClientProxy {
-            fakePlacesClient
-        }
+        val client = LazyPlacesClientProxy { fakePlacesClient }
 
         client.resetSession()
 
-        assertThat(fakePlacesClient.resetSessionCallCount).isEqualTo(1)
-    }
-
-    private fun createLazyPlacesClientProxy(factory: () -> PlacesClientProxy): PlacesClientProxy {
-        val constructor = Class.forName("com.stripe.android.paymentsheet.injection.LazyPlacesClientProxy")
-            .getDeclaredConstructor(kotlin.jvm.functions.Function0::class.java)
-        constructor.isAccessible = true
-        return constructor.newInstance(factory) as PlacesClientProxy
+        fakePlacesClient.resetSessionCalls.awaitItem()
+        fakePlacesClient.ensureAllEventsConsumed()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -56,7 +57,7 @@ internal class FakeBaseSheetViewModel private constructor(
     customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
     customViewModelScope = customViewModelScope,
     placesClient = null,
-    stripeAutocompleteRepository = null,
+    stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
 ) {
     companion object {
         fun create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -56,6 +56,7 @@ internal class FakeBaseSheetViewModel private constructor(
     customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
     customViewModelScope = customViewModelScope,
     placesClient = null,
+    stripeAutocompleteRepository = null,
 ) {
     companion object {
         fun create(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Wires Stripe-hosted address autocomplete into PaymentSheet and the Address Element. Builds on the network layer from #13528 by implementing StripeHostedPlacesClientProxy and connecting it to inline autocomplete in PaymentSheet and Address Element flows.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

PR #13528 added the network service layer (StripeAutocompleteRepository). This change completes the integration so that when shouldUseAutocompleteProxyEndpoints / useStripeHostedAutocomplete is enabled, the SDK routes autocomplete through Stripe's proxy instead of calling Google Places directly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
