### PR TITLE
Add specific errors for mobile wallets in NFC scanning flow

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -112,6 +112,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_nfc_scan_hold_card_behind_phone">Hold card behind phone</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card is not supported by Stripe or by the merchant -->
   <string name="stripe_nfc_scan_unsupported_card">Card not supported. Try another card.</string>
+  <!-- Error with action to take shown in the NFC scanning flow if a mobile wallet was scanned -->
+  <string name="stripe_nfc_scan_error_mobile_wallet">Mobile wallets not supported. Try using a card.</string>
   <!-- Text for separator within a separator that separates a button to tap to add a card and the card form -->
   <string name="stripe_or_enter_manually">or enter manually</string>
   <!-- Text for the 'Pay with Link' button. 'Link' is a Stripe brand, please do not translate the word 'Link'. -->

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -14,6 +14,7 @@ import kotlin.coroutines.CoroutineContext
 internal interface NfcCardReader {
     interface ErrorCreator {
         fun create(error: Throwable): Result.Error
+        fun create(records: MutableMap<String, ByteArray>): Result.Error
     }
 
     suspend fun readCard(transceiver: NfcTagTransceiver): Result
@@ -29,23 +30,21 @@ internal interface NfcCardReader {
 
 internal class ApduCardReader @Inject constructor(
     @IOContext private val workContext: CoroutineContext,
-    private val errorMapper: NfcCardReader.ErrorCreator,
+    private val errorCreator: NfcCardReader.ErrorCreator,
     private val cardDataParser: NfcCardDataParser,
 ) : NfcCardReader {
     override suspend fun readCard(transceiver: NfcTagTransceiver): NfcCardReader.Result {
         return runCatching {
             readFromTransceiver(transceiver)
         }.fold(
-            onSuccess = { cardData ->
-                NfcCardReader.Result.Found(scannedCardData = cardData)
-            },
-            onFailure = errorMapper::create,
+            onSuccess = { it },
+            onFailure = errorCreator::create,
         )
     }
 
     private suspend fun readFromTransceiver(
         transceiver: NfcTagTransceiver
-    ): ScannedCardData = withContext(workContext) {
+    ): NfcCardReader.Result = withContext(workContext) {
         try {
             transceiver.open()
             val applicationIdentifier = SelectPpseCommand.transceiveWith(transceiver).getOrThrow()
@@ -72,8 +71,9 @@ internal class ApduCardReader @Inject constructor(
                 }
             }
 
-            cardDataParser.parse(records)
-                ?: throw IllegalStateException("Could not parse card data from NFC tag")
+            cardDataParser.parse(records)?.let { scannedCardData ->
+                NfcCardReader.Result.Found(scannedCardData)
+            } ?: errorCreator.create(records)
         } finally {
             transceiver.close()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
@@ -37,6 +37,14 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
         }
     }
 
+    override fun create(records: MutableMap<String, ByteArray>): NfcCardReader.Result.Error {
+        return if (TAG_MOBILE_WALLET in records) {
+            mobileWalletNotSupported()
+        } else {
+            unsupportedCard()
+        }
+    }
+
     private fun mapCommandError(error: ApduResponseError.Command): NfcCardReader.Result.Error {
         return when {
             isDeclined(error) -> declined()
@@ -80,7 +88,15 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
         )
     }
 
+    private fun mobileWalletNotSupported(): NfcCardReader.Result.Error {
+        return NfcCardReader.Result.Error(
+            errorCode = MOBILE_WALLET_NOT_SUPPORTED_ERROR_CODE,
+            userMessage = R.string.stripe_nfc_scan_error_mobile_wallet.resolvableString,
+        )
+    }
+
     private companion object {
+        const val TAG_MOBILE_WALLET = "9F71"
         const val TRANSCEIVER_SECURITY_ERROR_CODE = "nfcTransceiverSecurityError"
         const val TRANSCEIVER_IO_ERROR_CODE = "nfcTransceiverIoError"
         const val UNKNOWN_ERROR_CODE = "unknownNfcReaderError"
@@ -90,6 +106,7 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
 
         const val UNSUPPORTED_CARD_ERROR_CODE = "cardUnsupportedByNfc"
         const val CARD_DECLINED_ERROR_CODE = "cardDeclinedByNfc"
+        const val MOBILE_WALLET_NOT_SUPPORTED_ERROR_CODE = "mobileWalletNotSupportedByNfc"
         const val GENERAL_READ_ERROR_CODE = "nfcCardReadFailed"
 
         const val FILE_NOT_FOUND_SW1 = 0x6A.toByte()

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -143,6 +143,17 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
+    fun `mobile wallet shows error and keeps activity open`() = test {
+        NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
+            scenario = this,
+            responses = NfcScanningActivityTestFixtures.mobileWalletResponses(),
+            errorText = context.getString(R.string.stripe_nfc_scan_error_mobile_wallet),
+        )
+
+        assertThat(isActivityDestroyed()).isFalse()
+    }
+
+    @Test
     fun `finish applies fade out transition`() {
         configureNfc(context)
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -107,4 +107,10 @@ internal object NfcScanningActivityTestFixtures {
         apduSuccessResponse(byteArrayOf()),
         apduSuccessResponse(tlv(tag = 0x57, value = EXPIRED_TRACK_2_DATA)),
     )
+
+    fun mobileWalletResponses(): List<ByteArray> = listOf(
+        apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+        apduSuccessResponse(byteArrayOf()),
+        apduSuccessResponse(tlv(tag = 0x9F.toByte(), tagContinuation = 0x71, value = byteArrayOf(0x10, 0x49))),
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -28,7 +28,7 @@ internal class ApduCardReaderTest {
         val result = cardReader.readCard(transceiver)
 
         assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
+        assertThat(errorCreator.createFromRecordsCalls.awaitItem()).isEmpty()
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -50,7 +50,7 @@ internal class ApduCardReaderTest {
         val result = cardReader.readCard(transceiver)
 
         assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
+        assertThat(errorCreator.createFromRecordsCalls.awaitItem()).isEmpty()
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -187,8 +187,9 @@ internal class ApduCardReaderTest {
         val result = cardReader.readCard(transceiver)
 
         assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem())
-            .isInstanceOf<IllegalStateException>()
+        val records = errorCreator.createFromRecordsCalls.awaitItem()
+        assertThat(records).containsKey("5A")
+        assertThat(records).containsKey("5F24")
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -241,7 +242,7 @@ internal class ApduCardReaderTest {
         )
         val reader = ApduCardReader(
             workContext = UnconfinedTestDispatcher(testScheduler),
-            errorMapper = fakeErrorCreator,
+            errorCreator = fakeErrorCreator,
             cardDataParser = fakeCardDataParser,
         )
 
@@ -277,8 +278,8 @@ internal class ApduCardReaderTest {
         const val MAX_RECORDS_PER_SFI = 8
 
         val PARSE_FAILURE_ERROR = NfcCardReader.Result.Error(
-            errorCode = "nfcCardReadFailed",
-            userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+            errorCode = "cardUnsupportedByNfc",
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
         )
 
         val UNSUPPORTED_CARD_ERROR = NfcCardReader.Result.Error(

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardReaderErrorCreator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardReaderErrorCreator.kt
@@ -10,13 +10,20 @@ internal class FakeNfcCardReaderErrorCreator(
     ),
 ) : NfcCardReader.ErrorCreator {
     val createCalls = Turbine<Throwable>()
+    val createFromRecordsCalls = Turbine<Map<String, ByteArray>>()
 
     override fun create(error: Throwable): NfcCardReader.Result.Error {
         createCalls.add(error)
         return result
     }
 
+    override fun create(records: MutableMap<String, ByteArray>): NfcCardReader.Result.Error {
+        createFromRecordsCalls.add(records)
+        return result
+    }
+
     fun ensureAllEventsConsumed() {
         createCalls.ensureAllEventsConsumed()
+        createFromRecordsCalls.ensureAllEventsConsumed()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
@@ -162,4 +162,28 @@ internal class ApduErrorCreatorTest {
             ),
         )
     }
+
+    @Test
+    fun `create returns mobile wallet error when tag 9F71 is present`() {
+        val result = errorMapper.create(
+            mutableMapOf("9F71" to byteArrayOf(0x10, 0x49)),
+        )
+
+        assertThat(result.errorCode).isEqualTo("mobileWalletNotSupportedByNfc")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_nfc_scan_error_mobile_wallet.resolvableString,
+        )
+    }
+
+    @Test
+    fun `create returns unsupported card error when parseable records are missing`() {
+        val result = errorMapper.create(
+            mutableMapOf("5A" to byteArrayOf(0x41, 0x11)),
+        )
+
+        assertThat(result.errorCode).isEqualTo("cardUnsupportedByNfc")
+        assertThat(result.userMessage).isEqualTo(
+            R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+    }
 }


### PR DESCRIPTION
# Summary
Add specific errors for mobile wallets in NFC scanning flow by looking for mobile wallet specific tag (9F71) if we could not read card data properly.

# Motivation
Ensure customers know that mobile wallets are not supported by the NFC scanning flow

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
