### PR TITLE
Add ApiConfiguration for per-element API credentials in EmbeddedPaymentElement 🪿✨

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/ApiConfiguration.kt
+++ b/payments-core/src/main/java/com/stripe/android/ApiConfiguration.kt
@@ -1,0 +1,60 @@
+package com.stripe.android
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Opt-in annotation for [ApiConfiguration], which is currently in preview.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class ApiConfigurationPreview
+
+/**
+ * Holds API credentials (publishable key and optional Stripe account ID) for use with
+ * payment UI components. When not provided, components fall back to
+ * [PaymentConfiguration.getInstance].
+ */
+@ApiConfigurationPreview
+@Parcelize
+class ApiConfiguration private constructor(
+    internal val state: State,
+) : Parcelable {
+    /**
+     * Creates an [ApiConfiguration] with the given publishable key.
+     *
+     * @param publishableKey Your Stripe publishable key.
+     */
+    constructor(publishableKey: String) : this(State(publishableKey = publishableKey))
+
+    /**
+     * Builder for [ApiConfiguration].
+     */
+    class Builder(private val publishableKey: String) {
+        private var stripeAccountId: String? = null
+
+        /**
+         * Sets the Stripe account ID for connected account requests.
+         */
+        fun stripeAccountId(id: String): Builder = apply {
+            this.stripeAccountId = id
+        }
+
+        /**
+         * Builds the [ApiConfiguration].
+         */
+        fun build(): ApiConfiguration = ApiConfiguration(
+            State(
+                publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
+            )
+        )
+    }
+
+    @Parcelize
+    internal data class State(
+        val publishableKey: String,
+        val stripeAccountId: String? = null,
+    ) : Parcelable
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.common.model
 
 import android.os.Parcelable
+import com.stripe.android.ApiConfiguration
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
 import com.stripe.android.link.LinkAppearance
@@ -42,6 +44,7 @@ internal data class CommonConfiguration(
     val opensCardScannerAutomatically: Boolean,
     val userOverrideCountry: String?,
     val appearance: PaymentSheet.Appearance,
+    val apiConfiguration: ApiConfiguration? = null,
 ) : Parcelable {
 
     fun allowedCardFundingTypes(enabled: Boolean): List<PaymentSheet.CardFundingType> {
@@ -250,6 +253,7 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     allowedCardFundingTypes = allowedCardFundingTypes,
 )
 
+@OptIn(ApiConfigurationPreview::class)
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
     merchantDisplayName = merchantDisplayName,
     customer = customer,
@@ -273,6 +277,7 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     userOverrideCountry = userOverrideCountry,
     appearance = appearance,
     allowedCardFundingTypes = allowedCardFundingTypes,
+    apiConfiguration = apiConfiguration,
 )
 
 internal fun LinkController.Configuration.State.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import com.stripe.android.ApiConfiguration
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.checkout.Checkout
@@ -288,6 +290,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
         internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
         internal val userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry,
+        @ApiConfigurationPreview internal val apiConfiguration: ApiConfiguration? = null,
     ) : Parcelable {
         @Suppress("TooManyFunctions")
         class Builder(
@@ -325,6 +328,8 @@ class EmbeddedPaymentElement @Inject internal constructor(
             private var opensCardScannerAutomatically: Boolean =
                 ConfigurationDefaults.opensCardScannerAutomatically
             private var userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry
+            @OptIn(ApiConfigurationPreview::class)
+            private var apiConfiguration: ApiConfiguration? = null
 
             /**
              * If set, the customer can select a previously saved payment method.
@@ -561,6 +566,15 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 this.userOverrideCountry = userOverrideCountry
             }
 
+            /**
+             * Sets the API credentials to use for this payment element.
+             * When not set, falls back to [com.stripe.android.PaymentConfiguration.getInstance].
+             */
+            @ApiConfigurationPreview
+            fun apiConfiguration(apiConfiguration: ApiConfiguration): Builder = apply {
+                this.apiConfiguration = apiConfiguration
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -585,12 +599,14 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 termsDisplay = termsDisplay,
                 opensCardScannerAutomatically = opensCardScannerAutomatically,
                 userOverrideCountry = userOverrideCountry,
+                apiConfiguration = apiConfiguration,
             )
         }
 
         @OptIn(
             ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class,
             CardFundingFilteringPrivatePreview::class,
+            ApiConfigurationPreview::class,
         )
         internal fun newBuilder(): Builder = Builder(merchantDisplayName)
             .customer(customer)
@@ -616,6 +632,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
             .userOverrideCountry(userOverrideCountry)
             .apply {
                 primaryButtonLabel?.let { primaryButtonLabel(it) }
+                apiConfiguration?.let { apiConfiguration(it) }
             }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import androidx.annotation.ColorInt
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
@@ -8,6 +9,7 @@ import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.CreateIntentCallback
@@ -42,6 +44,7 @@ internal class IntentConfirmationModule {
         return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]?.preparePaymentMethodHandler
     }
 
+    @OptIn(ApiConfigurationPreview::class)
     @JvmSuppressWildcards
     @Provides
     @IntoSet
@@ -50,13 +53,20 @@ internal class IntentConfirmationModule {
         stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
         @Named(STATUS_BAR_COLOR) @ColorInt statusBarColor: Int?,
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
+        confirmationStateHolder: EmbeddedConfirmationStateHolder,
     ): ConfirmationDefinition<*, *, *, *> {
         return IntentConfirmationDefinition(
             intentConfirmationInterceptorFactory = interceptorFactory,
             paymentLauncherFactory = { hostActivityLauncher ->
                 stripePaymentLauncherAssistedFactory.create(
-                    publishableKey = { paymentConfigurationProvider.get().publishableKey },
-                    stripeAccountId = { paymentConfigurationProvider.get().stripeAccountId },
+                    publishableKey = {
+                        confirmationStateHolder.state?.configuration?.apiConfiguration?.state?.publishableKey
+                            ?: paymentConfigurationProvider.get().publishableKey
+                    },
+                    stripeAccountId = {
+                        confirmationStateHolder.state?.configuration?.apiConfiguration?.state?.stripeAccountId
+                            ?: paymentConfigurationProvider.get().stripeAccountId
+                    },
                     hostActivityLauncher = hostActivityLauncher,
                     statusBarColor = statusBarColor,
                     includePaymentSheetNextHandlers = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.repositories
 
 import android.app.Application
+import com.stripe.android.ApiConfiguration
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.DefaultFraudDetectionDataRepository
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
@@ -40,6 +42,7 @@ internal interface ElementsSessionRepository {
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
         linkDisallowedFundingSourceCreation: Set<String> = emptySet(),
+        apiConfiguration: ApiConfiguration? = null,
     ): Result<ElementsSession>
 }
 
@@ -62,14 +65,17 @@ internal class RealElementsSessionRepository @Inject constructor(
     )
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
-    // The PaymentConfiguration can change after initialization, so this needs to get a new
-    // request options each time requested.
-    private val requestOptions: ApiRequest.Options
-        get() = ApiRequest.Options(
-            apiKey = lazyPaymentConfig.get().publishableKey,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+    // Resolves request options at call time, preferring apiConfiguration over the
+    // global PaymentConfiguration fallback.
+    @OptIn(ApiConfigurationPreview::class)
+    private fun requestOptions(apiConfiguration: ApiConfiguration?): ApiRequest.Options =
+        ApiRequest.Options(
+            apiKey = apiConfiguration?.state?.publishableKey ?: lazyPaymentConfig.get().publishableKey,
+            stripeAccount = apiConfiguration?.state?.stripeAccountId
+                ?: lazyPaymentConfig.get().stripeAccountId,
         )
 
+    @OptIn(ApiConfigurationPreview::class)
     override suspend fun get(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
@@ -78,6 +84,7 @@ internal class RealElementsSessionRepository @Inject constructor(
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
         linkDisallowedFundingSourceCreation: Set<String>,
+        apiConfiguration: ApiConfiguration?,
     ): Result<ElementsSession> {
         fraudDetectionDataRepository.refresh()
 
@@ -91,12 +98,12 @@ internal class RealElementsSessionRepository @Inject constructor(
             linkDisallowedFundingSourceCreation = linkDisallowedFundingSourceCreation,
         )
 
-        val options = requestOptions
+        val options = requestOptions(apiConfiguration)
         val elementsSession = retrieveElementsSession(params, options)
 
         return elementsSession.getResultOrElse { elementsSessionFailure ->
             if (shouldFallback(elementsSession)) {
-                fallback(params, elementsSessionFailure)
+                fallback(params, elementsSessionFailure, apiConfiguration)
             } else {
                 elementsSession
             }
@@ -148,24 +155,26 @@ internal class RealElementsSessionRepository @Inject constructor(
     private suspend fun fallback(
         params: ElementsSessionParams,
         elementsSessionFailure: Throwable,
+        apiConfiguration: ApiConfiguration?,
     ): Result<ElementsSession> = withContext(workContext) {
+        val options = requestOptions(apiConfiguration)
         val stripeIntent = when (params) {
             is ElementsSessionParams.PaymentIntentType -> {
                 stripeRepository.retrievePaymentIntent(
                     clientSecret = params.clientSecret,
-                    options = requestOptions,
+                    options = options,
                     expandFields = listOf("payment_method")
                 )
             }
             is ElementsSessionParams.SetupIntentType -> {
                 stripeRepository.retrieveSetupIntent(
                     clientSecret = params.clientSecret,
-                    options = requestOptions,
+                    options = options,
                     expandFields = listOf("payment_method")
                 )
             }
             is ElementsSessionParams.DeferredIntentType -> {
-                Result.success(params.toStripeIntent(requestOptions))
+                Result.success(params.toStripeIntent(options))
             }
         }
         stripeIntent.map { intent ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -39,6 +39,7 @@ internal class ElementsSessionLoader @Inject constructor(
             savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
             countryOverride = configuration.userOverrideCountry,
             linkDisallowedFundingSourceCreation = configuration.link.disallowFundingSourceCreation,
+            apiConfiguration = configuration.apiConfiguration,
         ).getOrThrow()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
@@ -479,6 +480,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
         return async {
             durationProvider.measureDuration(DurationProvider.Key.PaymentSheetLoadPrefetchPMs) {
+                @OptIn(ApiConfigurationPreview::class)
+                val resolvedKey = configuration.apiConfiguration?.state?.publishableKey
+                    ?: paymentConfiguration.get().publishableKey
+                val isLiveMode = resolvedKey.startsWith("pk_live_")
                 customerRepository.getPaymentMethods(
                     customerId = customer.id,
                     ephemeralKeySecret = accessType.ephemeralKeySecret,
@@ -487,7 +492,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.SepaDebit,
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
-                    silentlyFail = paymentConfiguration.get().isLiveMode(),
+                    silentlyFail = isLiveMode,
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.model
 
+import com.stripe.android.ApiConfiguration
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -30,7 +31,8 @@ internal object CommonConfigurationFactory {
         opensCardScannerAutomatically: Boolean = false,
         userOverrideCountry: String? = null,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
-        allowedCardFundingTypes: List<CardFundingType> = CardFundingType.entries
+        allowedCardFundingTypes: List<CardFundingType> = CardFundingType.entries,
+        apiConfiguration: ApiConfiguration? = null,
     ): CommonConfiguration = CommonConfiguration(
         merchantDisplayName = merchantDisplayName,
         customer = customer,
@@ -54,5 +56,6 @@ internal object CommonConfigurationFactory {
         userOverrideCountry = userOverrideCountry,
         appearance = appearance,
         allowedCardFundingTypes = allowedCardFundingTypes,
+        apiConfiguration = apiConfiguration,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationTest.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.common.model
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiConfiguration
+import com.stripe.android.ApiConfigurationPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Test
 
@@ -63,5 +66,37 @@ internal class CommonConfigurationTest {
 
         assertThat(config.allowedCardFundingTypes(enabled = false))
             .isEqualTo(PaymentSheet.CardFundingType.entries)
+    }
+
+    @OptIn(ApiConfigurationPreview::class)
+    @Test
+    fun `EmbeddedPaymentElement Configuration asCommonConfiguration maps apiConfiguration`() {
+        val apiConfig = ApiConfiguration("pk_test_embedded")
+        val embeddedConfig = EmbeddedPaymentElement.Configuration.Builder("Merchant")
+            .apiConfiguration(apiConfig)
+            .build()
+
+        val common = embeddedConfig.asCommonConfiguration()
+
+        assertThat(common.apiConfiguration).isEqualTo(apiConfig)
+    }
+
+    @OptIn(ApiConfigurationPreview::class)
+    @Test
+    fun `EmbeddedPaymentElement Configuration asCommonConfiguration defaults apiConfiguration to null`() {
+        val embeddedConfig = EmbeddedPaymentElement.Configuration.Builder("Merchant").build()
+
+        val common = embeddedConfig.asCommonConfiguration()
+
+        assertThat(common.apiConfiguration).isNull()
+    }
+
+    @Test
+    fun `PaymentSheet Configuration asCommonConfiguration has null apiConfiguration`() {
+        val paymentSheetConfig = PaymentSheet.Configuration("Merchant")
+
+        val common = paymentSheetConfig.asCommonConfiguration()
+
+        assertThat(common.apiConfiguration).isNull()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModuleTest.kt
@@ -1,0 +1,185 @@
+package com.stripe.android.paymentelement.confirmation.intent
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiConfiguration
+import com.stripe.android.ApiConfigurationPreview
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
+import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
+import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ApiConfigurationPreview::class)
+internal class IntentConfirmationModuleTest {
+
+    @Test
+    fun `publishableKey lambda uses apiConfiguration when state has one`() = runTest {
+        val confirmationStateHolder = createStateHolder()
+        confirmationStateHolder.state = stateWithApiConfig(
+            publishableKey = "pk_test_api_config_key",
+        )
+
+        val publishableKey = capturePublishableKeyLambda(
+            confirmationStateHolder = confirmationStateHolder,
+            fallbackKey = "pk_test_fallback_key",
+        )
+
+        assertThat(publishableKey()).isEqualTo("pk_test_api_config_key")
+    }
+
+    @Test
+    fun `publishableKey lambda falls back to PaymentConfiguration when state is null`() = runTest {
+        val confirmationStateHolder = createStateHolder()
+        // state is null — no configure() has been called
+
+        val publishableKey = capturePublishableKeyLambda(
+            confirmationStateHolder = confirmationStateHolder,
+            fallbackKey = "pk_test_fallback_key",
+        )
+
+        assertThat(publishableKey()).isEqualTo("pk_test_fallback_key")
+    }
+
+    @Test
+    fun `stripeAccountId lambda uses apiConfiguration when state has one`() = runTest {
+        val confirmationStateHolder = createStateHolder()
+        confirmationStateHolder.state = stateWithApiConfig(
+            publishableKey = "pk_test_api_config_key",
+            stripeAccountId = "acct_test_connected",
+        )
+
+        val stripeAccountId = captureStripeAccountIdLambda(
+            confirmationStateHolder = confirmationStateHolder,
+            fallbackKey = "pk_test_fallback_key",
+        )
+
+        assertThat(stripeAccountId()).isEqualTo("acct_test_connected")
+    }
+
+    @Test
+    fun `stripeAccountId lambda falls back to null when state is null`() = runTest {
+        val confirmationStateHolder = createStateHolder()
+        // state is null
+
+        val stripeAccountId = captureStripeAccountIdLambda(
+            confirmationStateHolder = confirmationStateHolder,
+            fallbackKey = "pk_test_fallback_key",
+        )
+
+        // PaymentConfiguration without stripeAccountId returns null
+        assertThat(stripeAccountId()).isNull()
+    }
+
+    // ---- helpers ----
+
+    private fun createStateHolder(): EmbeddedConfirmationStateHolder {
+        return EmbeddedConfirmationStateHolder(
+            savedStateHandle = SavedStateHandle(),
+            selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
+            coroutineScope = TestScope().backgroundScope,
+        )
+    }
+
+    private fun stateWithApiConfig(
+        publishableKey: String,
+        stripeAccountId: String? = null,
+    ): EmbeddedConfirmationStateHolder.State {
+        val builder = ApiConfiguration.Builder(publishableKey)
+        stripeAccountId?.let { builder.stripeAccountId(it) }
+        return EmbeddedConfirmationStateHolder.State(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            selection = null,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Merchant")
+                .apiConfiguration(builder.build())
+                .build(),
+        )
+    }
+
+    private fun capturePublishableKeyLambda(
+        confirmationStateHolder: EmbeddedConfirmationStateHolder,
+        fallbackKey: String,
+    ): () -> String {
+        var captured: (() -> String)? = null
+        buildAndTriggerDefinition(
+            confirmationStateHolder = confirmationStateHolder,
+            fallbackKey = fallbackKey,
+            onPublishableKey = { captured = it },
+        )
+        return requireNotNull(captured) { "publishableKey lambda was not captured" }
+    }
+
+    private fun captureStripeAccountIdLambda(
+        confirmationStateHolder: EmbeddedConfirmationStateHolder,
+        fallbackKey: String,
+    ): () -> String? {
+        var captured: (() -> String?)? = null
+        buildAndTriggerDefinition(
+            confirmationStateHolder = confirmationStateHolder,
+            fallbackKey = fallbackKey,
+            onStripeAccountId = { captured = it },
+        )
+        return requireNotNull(captured) { "stripeAccountId lambda was not captured" }
+    }
+
+    /**
+     * Creates an [IntentConfirmationDefinition] via [IntentConfirmationModule] and triggers
+     * [IntentConfirmationDefinition.createLauncher] to force [StripePaymentLauncherAssistedFactory.create]
+     * to be called, capturing the key lambdas via [onPublishableKey] and [onStripeAccountId].
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun buildAndTriggerDefinition(
+        confirmationStateHolder: EmbeddedConfirmationStateHolder,
+        fallbackKey: String,
+        onPublishableKey: ((() -> String)) -> Unit = {},
+        onStripeAccountId: ((() -> String?)) -> Unit = {},
+    ) {
+        val mockLauncherFactory = mock<StripePaymentLauncherAssistedFactory> {
+            on {
+                create(
+                    publishableKey = any(),
+                    stripeAccountId = any(),
+                    statusBarColor = anyOrNull(),
+                    includePaymentSheetNextHandlers = any(),
+                    hostActivityLauncher = any(),
+                )
+            } doAnswer { invocation ->
+                onPublishableKey(invocation.getArgument(0) as () -> String)
+                onStripeAccountId(invocation.getArgument(1) as () -> String?)
+                mock<StripePaymentLauncher>()
+            }
+        }
+
+        val definition = IntentConfirmationModule().providesIntentConfirmationDefinition(
+            interceptorFactory = mock(),
+            stripePaymentLauncherAssistedFactory = mockLauncherFactory,
+            statusBarColor = null,
+            paymentConfigurationProvider = { PaymentConfiguration(fallbackKey) },
+            confirmationStateHolder = confirmationStateHolder,
+        ) as IntentConfirmationDefinition
+
+        definition.createLauncher(
+            activityResultCaller = mock {
+                on {
+                    registerForActivityResult(
+                        any<PaymentLauncherContract>(),
+                        any(),
+                    )
+                } doReturn mock<ActivityResultLauncher<PaymentLauncherContract.Args>>()
+            },
+            onResult = {},
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.core.os.LocaleListCompat
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiConfiguration
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
 import com.stripe.android.PaymentConfiguration
@@ -1003,6 +1005,82 @@ internal class ElementsSessionRepositoryTest {
         assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
         assertThat(params["type"]).isEqualTo("deferred_intent")
         assertThat(params["mobile_app_id"]).isEqualTo(APP_ID)
+    }
+
+    @OptIn(ApiConfigurationPreview::class)
+    @Test
+    fun `apiConfiguration publishable key is used when provided`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any())).thenReturn(
+            StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
+        )
+
+        val apiConfig = ApiConfiguration("pk_test_apiconfiguration_key")
+        createRepository().get(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret",
+            ),
+            customer = null,
+            externalPaymentMethods = emptyList(),
+            customPaymentMethods = emptyList(),
+            savedPaymentMethodSelectionId = null,
+            countryOverride = null,
+            apiConfiguration = apiConfig,
+        )
+
+        verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
+        val request = requestCaptor.firstValue as ApiRequest
+        assertThat(request.options.apiKey).isEqualTo("pk_test_apiconfiguration_key")
+    }
+
+    @OptIn(ApiConfigurationPreview::class)
+    @Test
+    fun `falls back to PaymentConfiguration publishable key when apiConfiguration is null`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any())).thenReturn(
+            StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
+        )
+
+        createRepository(publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY).get(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret",
+            ),
+            customer = null,
+            externalPaymentMethods = emptyList(),
+            customPaymentMethods = emptyList(),
+            savedPaymentMethodSelectionId = null,
+            countryOverride = null,
+            apiConfiguration = null,
+        )
+
+        verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
+        val request = requestCaptor.firstValue as ApiRequest
+        assertThat(request.options.apiKey).isEqualTo(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+    }
+
+    @OptIn(ApiConfigurationPreview::class)
+    @Test
+    fun `apiConfiguration stripe account ID is used when provided`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any())).thenReturn(
+            StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
+        )
+
+        val apiConfig = ApiConfiguration.Builder("pk_test_apiconfiguration_key")
+            .stripeAccountId("acct_connected")
+            .build()
+        createRepository().get(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret",
+            ),
+            customer = null,
+            externalPaymentMethods = emptyList(),
+            customPaymentMethods = emptyList(),
+            savedPaymentMethodSelectionId = null,
+            countryOverride = null,
+            apiConfiguration = apiConfig,
+        )
+
+        verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
+        val request = requestCaptor.firstValue as ApiRequest
+        assertThat(request.options.stripeAccount).isEqualTo("acct_connected")
     }
 
     private fun createRepository(


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/9fbc0bb7-0156-40bc-943a-c28f409b6f6a)

#### 🧑‍💻 Human Summary
<!-- To be filled out by humans -->

#### 🤖 LLM Summary

# Summary
Adds `ApiConfiguration` (behind `@ApiConfigurationPreview`) to `EmbeddedPaymentElement.Configuration` and threads it through the loading and confirmation stack. When set, its `publishableKey`/`stripeAccountId` are resolved at the API call site in `RealElementsSessionRepository` and in the `PaymentLauncher` lambdas in `IntentConfirmationModule`; both fall back to `PaymentConfiguration.getInstance()` when `apiConfiguration` is null.

# Motivation
`EmbeddedPaymentElement` had no way to supply credentials independently of the process-global `PaymentConfiguration`. `ApiConfiguration` provides that opt-in escape hatch for use cases such as connected accounts where the publishable key or Stripe account ID differs per element instance.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

New unit tests cover:
- `CommonConfigurationTest`: `apiConfiguration` is mapped through `asCommonConfiguration()` and is null when absent.
- `ElementsSessionRepositoryTest`: `ApiConfiguration` key/account ID take precedence over `PaymentConfiguration`; null falls back correctly.
- `IntentConfirmationModuleTest`: `publishableKey` and `stripeAccountId` lambdas passed to `StripePaymentLauncherAssistedFactory` read from `EmbeddedConfirmationStateHolder` when a config is present and fall back to `PaymentConfiguration` when state is null.

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
- [Added] `ApiConfiguration` class (opt-in `@ApiConfigurationPreview`) and `EmbeddedPaymentElement.Configuration.Builder.apiConfiguration()` to supply per-element API credentials.
