### PR TITLE
Plumb status bar color through to confirmation args and launcher.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -60,7 +60,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.PaymentConfigurationModule
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -204,11 +203,6 @@ internal interface TapToAddViewModelModule {
         @Singleton
         @Named(ALLOWS_MANUAL_CONFIRMATION)
         fun provideAllowsManualConfirmation() = true
-
-        @Provides
-        @Singleton
-        @Named(STATUS_BAR_COLOR)
-        fun providesStatusBarColor(): Int? = null
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -175,6 +175,7 @@ internal class DefaultTapToAddConfirmationInteractor(
                 arguments = ConfirmationHandler.Args(
                     confirmationOption = confirmationOption,
                     paymentMethodMetadata = paymentMethodMetadata,
+                    statusBarColor = null,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -98,6 +98,7 @@ internal class CustomerSheetViewModel(
     private val savedSelectionDataSourceProvider: Single<CustomerSheetSavedSelectionDataSource>,
     private val configuration: CustomerSheet.Configuration,
     private val integrationType: CustomerSheetIntegration.Type,
+    private val statusBarColor: Int?,
     private val logger: Logger,
     private val eventReporter: CustomerSheetEventReporter,
     private val workContext: CoroutineContext = Dispatchers.IO,
@@ -117,6 +118,7 @@ internal class CustomerSheetViewModel(
         originalPaymentSelection: PaymentSelection?,
         configuration: CustomerSheet.Configuration,
         integrationType: CustomerSheetIntegration.Type,
+        args: CustomerSheetContract.Args,
         logger: Logger,
         eventReporter: CustomerSheetEventReporter,
         @IOContext workContext: CoroutineContext = Dispatchers.IO,
@@ -135,6 +137,7 @@ internal class CustomerSheetViewModel(
         savedSelectionDataSourceProvider = CustomerSheetHacks.savedSelectionDataSource,
         configuration = configuration,
         integrationType = integrationType,
+        statusBarColor = args.statusBarColor,
         logger = logger,
         eventReporter = eventReporter,
         workContext = workContext,
@@ -1000,6 +1003,7 @@ internal class CustomerSheetViewModel(
                         shouldSave = true,
                     ),
                     paymentMethodMetadata = metadata,
+                    statusBarColor = statusBarColor,
                 )
             )
 
@@ -1318,7 +1322,7 @@ internal class CustomerSheetViewModel(
                 .create(
                     application = extras.requireApplication(),
                     configuration = args.configuration,
-                    statusBarColor = args.statusBarColor,
+                    args = args,
                     integrationType = args.integrationType,
                     savedStateHandle = extras.createSavedStateHandle(),
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -4,17 +4,16 @@ import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.CustomerSheetContract
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.injection.CustomerSheetConfirmationModule
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import dagger.BindsInstance
 import dagger.Component
-import javax.inject.Named
 
 @CustomerSheetViewModelScope
 @Component(
@@ -39,8 +38,7 @@ internal interface CustomerSheetViewModelComponent {
             @BindsInstance
             configuration: CustomerSheet.Configuration,
             @BindsInstance
-            @Named(STATUS_BAR_COLOR)
-            statusBarColor: Int?,
+            args: CustomerSheetContract.Args,
             @BindsInstance
             integrationType: CustomerSheetIntegration.Type,
             @BindsInstance

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -576,7 +576,6 @@ internal class LinkActivityViewModel @Inject constructor(
                         paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                         context = app,
                         savedStateHandle = handle,
-                        statusBarColor = null,
                         application = app,
                         linkExpressMode = args.linkExpressMode,
                         linkLaunchMode = args.launchMode,

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -182,6 +182,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = paymentMethodMetadata,
+            statusBarColor = null,
         )
     }
 
@@ -216,6 +217,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 newPMTransformedForConfirmation = newPMTransformedForConfirmation
             ),
             paymentMethodMetadata = paymentMethodMetadata,
+            statusBarColor = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.uicore.navigation.NavigationManager
@@ -94,9 +93,6 @@ internal interface NativeLinkComponent {
             context: Context,
             @BindsInstance
             savedStateHandle: SavedStateHandle,
-            @BindsInstance
-            @Named(STATUS_BAR_COLOR)
-            statusBarColor: Int?,
             @BindsInstance
             application: Application,
             @BindsInstance

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.annotation.ColorInt
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
@@ -73,6 +74,12 @@ internal interface ConfirmationHandler {
          * The immutable data created during configuration.
          */
         val paymentMethodMetadata: PaymentMethodMetadata,
+        /**
+         * The status bar color of the host activity, forwarded to auth surfaces that briefly take
+         * over the screen (the 3DS2 challenge activity and browser Custom Tab) so they match the
+         * merchant's chrome. Always `null` on API 35+, where the platform enforces edge-to-edge.
+         */
+        @ColorInt val statusBarColor: Int?,
     ) : Parcelable {
         /**
          * The [StripeIntent] that is being potentially confirmed by the handler

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -20,10 +20,11 @@ import kotlinx.parcelize.Parcelize
 
 internal class IntentConfirmationDefinition(
     private val intentConfirmationInterceptorFactory: IntentConfirmationInterceptor.Factory,
-    private val paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>) -> PaymentLauncher,
+    private val paymentLauncherFactory:
+        (ActivityResultLauncher<PaymentLauncherContract.Args>, Int?) -> PaymentLauncher,
 ) : ConfirmationDefinition<
     PaymentMethodConfirmationOption,
-    PaymentLauncher,
+    ActivityResultLauncher<PaymentLauncherContract.Args>,
     IntentConfirmationDefinition.Args,
     InternalPaymentResult
     > {
@@ -72,24 +73,27 @@ internal class IntentConfirmationDefinition(
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
         onResult: (InternalPaymentResult) -> Unit
-    ): PaymentLauncher {
-        return paymentLauncherFactory(
-            activityResultCaller.registerForActivityResult(
-                PaymentLauncherContract(),
-                onResult
-            )
+    ): ActivityResultLauncher<PaymentLauncherContract.Args> {
+        return activityResultCaller.registerForActivityResult(
+            PaymentLauncherContract(),
+            onResult
         )
     }
 
+    override fun unregister(launcher: ActivityResultLauncher<PaymentLauncherContract.Args>) {
+        launcher.unregister()
+    }
+
     override fun launch(
-        launcher: PaymentLauncher,
+        launcher: ActivityResultLauncher<PaymentLauncherContract.Args>,
         arguments: Args,
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
     ) {
+        val paymentLauncher = paymentLauncherFactory(launcher, confirmationArgs.statusBarColor)
         when (arguments) {
-            is Args.Confirm -> launchConfirm(launcher, arguments.confirmNextParams)
-            is Args.NextAction -> launcher.handleNextActionForStripeIntent(arguments.intent)
+            is Args.Confirm -> launchConfirm(paymentLauncher, arguments.confirmNextParams)
+            is Args.NextAction -> paymentLauncher.handleNextActionForStripeIntent(arguments.intent)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
-import androidx.annotation.ColorInt
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
@@ -8,13 +7,11 @@ import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
-import javax.inject.Named
 import javax.inject.Provider
 
 @Module
@@ -48,12 +45,11 @@ internal class IntentConfirmationModule {
     fun providesIntentConfirmationDefinition(
         interceptorFactory: IntentConfirmationInterceptor.Factory,
         stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
-        @Named(STATUS_BAR_COLOR) @ColorInt statusBarColor: Int?,
         paymentConfigurationProvider: Provider<PaymentConfiguration>,
     ): ConfirmationDefinition<*, *, *, *> {
         return IntentConfirmationDefinition(
             intentConfirmationInterceptorFactory = interceptorFactory,
-            paymentLauncherFactory = { hostActivityLauncher ->
+            paymentLauncherFactory = { hostActivityLauncher, statusBarColor ->
                 stripePaymentLauncherAssistedFactory.create(
                     publishableKey = { paymentConfigurationProvider.get().publishableKey },
                     stripeAccountId = { paymentConfigurationProvider.get().stripeAccountId },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -6,10 +6,12 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.ConfigureResult
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 internal interface EmbeddedConfigurationCoordinator {
@@ -27,6 +29,7 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
     private val selectionChooser: EmbeddedSelectionChooser,
     private val stateHelper: EmbeddedStateHelper,
     @ViewModelScope private val viewModelScope: CoroutineScope,
+    @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
 ) : EmbeddedConfigurationCoordinator {
     override suspend fun configure(
         configuration: EmbeddedPaymentElement.Configuration,
@@ -69,6 +72,7 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
                 paymentMethodMetadata = state.paymentMethodMetadata,
                 selection = newPaymentSelection,
                 configuration = configuration,
+                statusBarColor = statusBarColor,
             ),
             customer = state.customer,
             previousNewSelections = Bundle(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -68,6 +68,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = confirmationState.paymentMethodMetadata,
+            statusBarColor = confirmationState.statusBarColor,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
@@ -42,6 +42,7 @@ internal class EmbeddedConfirmationStateHolder @Inject constructor(
         val paymentMethodMetadata: PaymentMethodMetadata,
         val selection: PaymentSelection?,
         val configuration: EmbeddedPaymentElement.Configuration,
+        val statusBarColor: Int?,
     ) : Parcelable
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -12,11 +12,13 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 internal interface SheetActivityConfirmationHelper {
     fun confirm()
@@ -33,6 +35,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
     private val customerStateHolder: CustomerStateHolder,
     @ViewModelScope private val coroutineScope: CoroutineScope,
     private val launchMode: EmbeddedLaunchMode,
+    @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
 ) : SheetActivityConfirmationHelper {
 
     override fun confirm() {
@@ -80,6 +83,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = paymentMethodMetadata,
+            statusBarColor = statusBarColor,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -590,6 +590,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         paymentMethodMetadata = paymentMethodMetadata,
+                        statusBarColor = args.statusBarColor,
                     ),
                 )
             } ?: run {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -596,6 +596,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         paymentMethodMetadata = state.paymentMethodMetadata,
+                        statusBarColor = viewModel.statusBarColor,
                     )
                 )
             } ?: run {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -29,7 +28,6 @@ import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryMo
 import dagger.BindsInstance
 import dagger.Component
 import kotlinx.coroutines.CoroutineScope
-import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
 
@@ -67,9 +65,6 @@ internal interface FlowControllerStateComponent {
     @Component.Factory
     interface Factory {
         fun create(
-            @BindsInstance
-            @Named(STATUS_BAR_COLOR)
-            statusBarColor: Int?,
             @BindsInstance
             application: Application,
             @BindsInstance

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -22,14 +22,13 @@ internal class FlowControllerViewModel(
     application: Application,
     val handle: SavedStateHandle,
     paymentElementCallbackIdentifier: String,
-    @ColorInt statusBarColor: Int?,
+    @ColorInt val statusBarColor: Int?,
 ) : AndroidViewModel(application) {
 
     val flowControllerStateComponent: FlowControllerStateComponent =
         DaggerFlowControllerStateComponent
             .factory()
             .create(
-                statusBarColor = statusBarColor,
                 application = application,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                 flowControllerViewModel = this,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -5,7 +5,6 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -15,17 +14,10 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 @Module
 internal class PaymentSheetViewModelModule {
-
-    @Provides
-    @Named(STATUS_BAR_COLOR)
-    fun providesStatusBarColor(starterArgs: PaymentSheetContract.Args): Int? {
-        return starterArgs.statusBarColor
-    }
 
     @Provides
     fun providePrefsRepository(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -342,6 +342,7 @@ internal class DefaultWalletButtonsInteractor constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = arguments.paymentMethodMetadata,
+            statusBarColor = arguments.statusBarColor,
         )
     }
 
@@ -351,6 +352,7 @@ internal class DefaultWalletButtonsInteractor constructor(
         val configuration: CommonConfiguration,
         val appearance: PaymentSheet.Appearance,
         val paymentSelection: PaymentSelection?,
+        val statusBarColor: Int?,
     )
 
     companion object {
@@ -374,7 +376,8 @@ internal class DefaultWalletButtonsInteractor constructor(
                             configuration = flowControllerState.paymentSheetState.config,
                             paymentMethodMetadata = flowControllerState.paymentSheetState.paymentMethodMetadata,
                             appearance = configureRequest.configuration.appearance,
-                            paymentSelection = flowControllerViewModel.paymentSelection
+                            paymentSelection = flowControllerViewModel.paymentSelection,
+                            statusBarColor = flowControllerViewModel.statusBarColor,
                         )
                     } else {
                         null
@@ -418,7 +421,8 @@ internal class DefaultWalletButtonsInteractor constructor(
                             configuration = state.configuration.asCommonConfiguration(),
                             paymentMethodMetadata = state.paymentMethodMetadata,
                             appearance = state.configuration.appearance,
-                            paymentSelection = state.selection
+                            paymentSelection = state.selection,
+                            statusBarColor = state.statusBarColor,
                         )
                     }
                 },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -127,6 +127,7 @@ internal interface CustomerSheetTestHelper {
             savedSelectionDataSourceProvider = CompletableSingle(savedSelectionDataSource),
             configuration = configuration,
             integrationType = integrationType,
+            statusBarColor = null,
             paymentConfiguration = PaymentConfiguration(if (isLiveMode) "pk_live" else "pk_test"),
             logger = Logger.noop(),
             productUsage = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -630,6 +630,7 @@ class ConfirmationMediatorTest {
 
         private val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
             confirmationOption = FakeConfirmationOption(),
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -199,4 +199,5 @@ internal val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
         stripeIntent = PAYMENT_INTENT,
         passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
     ),
+    statusBarColor = null,
 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -198,7 +198,7 @@ internal fun createTestConfirmationHandlerFactory(
             confirmationDefinitions = listOf(
                 IntentConfirmationDefinition(
                     intentConfirmationInterceptorFactory = intentConfirmationInterceptorFactory,
-                    paymentLauncherFactory = { launcher ->
+                    paymentLauncherFactory = { launcher, _ ->
                         stripePaymentLauncherAssistedFactory.create(
                             publishableKey = { paymentConfiguration.publishableKey },
                             stripeAccountId = { paymentConfiguration.stripeAccountId },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationOrderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationOrderTest.kt
@@ -34,7 +34,6 @@ class ExtendedPaymentElementConfirmationOrderTest {
                 .create(
                     application = application,
                     savedStateHandle = SavedStateHandle(),
-                    statusBarColor = null,
                     allowsManualConfirmation = false,
                 ).viewModel
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -45,7 +45,6 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -115,7 +114,6 @@ internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivit
                     .create(
                         application = extras.requireApplication(),
                         savedStateHandle = extras.createSavedStateHandle(),
-                        statusBarColor = null,
                         allowsManualConfirmation = false,
                     )
 
@@ -146,9 +144,6 @@ internal interface ExtendedPaymentElementConfirmationTestComponent {
             application: Application,
             @BindsInstance
             savedStateHandle: SavedStateHandle,
-            @BindsInstance
-            @Named(STATUS_BAR_COLOR)
-            statusBarColor: Int?,
             @BindsInstance
             @Named(ALLOWS_MANUAL_CONFIRMATION)
             allowsManualConfirmation: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation
 
+import androidx.activity.result.ActivityResultLauncher
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
@@ -35,23 +36,21 @@ import org.mockito.kotlin.mock
 
 class IntentConfirmationDefinitionTest {
     @Test
-    fun `'createLauncher' should call factory when creating launcher`() {
-        val launcher = FakePaymentLauncher()
+    fun `'createLauncher' should register and return the activity result launcher`() {
+        val registeredLauncher = mock<ActivityResultLauncher<PaymentLauncherContract.Args>>()
 
-        val definition = createIntentConfirmationDefinition(
-            paymentLauncher = launcher,
-        )
+        val definition = createIntentConfirmationDefinition()
 
         val createdLauncher = definition.createLauncher(
             activityResultCaller = mock {
                 on {
                     registerForActivityResult<PaymentLauncherContract.Args, InternalPaymentResult>(any(), any())
-                } doReturn mock()
+                } doReturn registeredLauncher
             },
             onResult = {}
         )
 
-        assertThat(createdLauncher).isEqualTo(launcher)
+        assertThat(createdLauncher).isEqualTo(registeredLauncher)
     }
 
     @Test
@@ -263,7 +262,7 @@ class IntentConfirmationDefinitionTest {
         )
 
         definition.launch(
-            launcher = launcher,
+            launcher = mock(),
             arguments = IntentConfirmationDefinition.Args.Confirm(
                 confirmNextParams = confirmParams,
                 deferredIntentConfirmationType = null,
@@ -287,7 +286,7 @@ class IntentConfirmationDefinitionTest {
         )
 
         definition.launch(
-            launcher = launcher,
+            launcher = mock(),
             arguments = IntentConfirmationDefinition.Args.NextAction(
                 intent = setupIntent,
                 deferredIntentConfirmationType = null,
@@ -315,7 +314,7 @@ class IntentConfirmationDefinitionTest {
         )
 
         definition.launch(
-            launcher = launcher,
+            launcher = mock(),
             arguments = IntentConfirmationDefinition.Args.Confirm(
                 confirmNextParams = confirmParams,
                 deferredIntentConfirmationType = null,
@@ -339,7 +338,7 @@ class IntentConfirmationDefinitionTest {
         )
 
         definition.launch(
-            launcher = launcher,
+            launcher = mock(),
             arguments = IntentConfirmationDefinition.Args.NextAction(
                 intent = paymentIntent,
                 deferredIntentConfirmationType = null,
@@ -364,7 +363,7 @@ class IntentConfirmationDefinitionTest {
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
 
         definition.launch(
-            launcher = launcher,
+            launcher = mock(),
             arguments = IntentConfirmationDefinition.Args.NextAction(
                 intent = paymentIntent,
                 deferredIntentConfirmationType = null,
@@ -389,7 +388,7 @@ class IntentConfirmationDefinitionTest {
         val setupIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
 
         definition.launch(
-            launcher = launcher,
+            launcher = mock(),
             arguments = IntentConfirmationDefinition.Args.NextAction(
                 intent = setupIntent,
                 deferredIntentConfirmationType = null,
@@ -401,6 +400,30 @@ class IntentConfirmationDefinitionTest {
         assertThat(launcher.calls.awaitItem()).isEqualTo(
             FakePaymentLauncher.Call.HandleNextActionWithIntent.Intent(setupIntent)
         )
+    }
+
+    @Test
+    fun `On 'launch', should build payment launcher using 'statusBarColor' from confirmation args`() {
+        var capturedStatusBarColor: Int? = null
+
+        val definition = createIntentConfirmationDefinition(
+            paymentLauncherFactory = { _, statusBarColor ->
+                capturedStatusBarColor = statusBarColor
+                FakePaymentLauncher()
+            },
+        )
+
+        definition.launch(
+            launcher = mock(),
+            arguments = IntentConfirmationDefinition.Args.NextAction(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                deferredIntentConfirmationType = null,
+            ),
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(statusBarColor = 0x00FF00),
+            confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+        )
+
+        assertThat(capturedStatusBarColor).isEqualTo(0x00FF00)
     }
 
     @Test
@@ -493,11 +516,13 @@ class IntentConfirmationDefinitionTest {
                     return FakeIntentConfirmationInterceptor()
                 }
             },
-        paymentLauncher: PaymentLauncher = FakePaymentLauncher()
+        paymentLauncher: PaymentLauncher = FakePaymentLauncher(),
+        paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract.Args>, Int?) -> PaymentLauncher =
+            { _, _ -> paymentLauncher },
     ): IntentConfirmationDefinition {
         return IntentConfirmationDefinition(
             intentConfirmationInterceptorFactory = intentConfirmationInterceptorFactory,
-            paymentLauncherFactory = { paymentLauncher }
+            paymentLauncherFactory = paymentLauncherFactory,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -291,7 +291,7 @@ internal class IntentConfirmationFlowTest {
                     )
                 }
             },
-            paymentLauncherFactory = {
+            paymentLauncherFactory = { _, _ ->
                 FakePaymentLauncher()
             }
         )
@@ -309,6 +309,7 @@ internal class IntentConfirmationFlowTest {
                     phoneNumber = "1234567890"
                 ),
             ),
+            statusBarColor = null,
         )
     }
 
@@ -345,6 +346,7 @@ internal class IntentConfirmationFlowTest {
 
         val DEFERRED_CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
             confirmationOption = FakeConfirmationOption(),
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(id = null, clientSecret = null),
                 shippingDetails = AddressDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationOrderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationOrderTest.kt
@@ -33,7 +33,6 @@ class PaymentElementConfirmationOrderTest {
                 .create(
                     application = application,
                     savedStateHandle = SavedStateHandle(),
-                    statusBarColor = null,
                     allowsManualConfirmation = false,
                 ).viewModel
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -44,7 +44,6 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
@@ -111,7 +110,6 @@ internal class PaymentElementConfirmationTestActivity : AppCompatActivity() {
                     .create(
                         application = extras.requireApplication(),
                         savedStateHandle = extras.createSavedStateHandle(),
-                        statusBarColor = null,
                         allowsManualConfirmation = false,
                     )
 
@@ -141,9 +139,6 @@ internal interface PaymentElementConfirmationTestComponent {
             application: Application,
             @BindsInstance
             savedStateHandle: SavedStateHandle,
-            @BindsInstance
-            @Named(STATUS_BAR_COLOR)
-            statusBarColor: Int?,
             @BindsInstance
             @Named(ALLOWS_MANUAL_CONFIRMATION)
             allowsManualConfirmation: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
@@ -174,6 +174,7 @@ internal class AttestationConfirmationActivityTest {
 
         private val CONFIRMATION_ARGUMENTS_NEW = ConfirmationHandler.Args(
             confirmationOption = NEW_CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 shippingDetails = AddressDetails(),
                 stripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -196,6 +196,7 @@ internal class BacsConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinitionTest.kt
@@ -109,6 +109,7 @@ internal class PaymentOptionCardArtPrefetchConfirmationDefinitionTest {
             fakeImageLoader = fakeImageLoader,
             confirmationArgs = ConfirmationHandler.Args(
                 confirmationOption = FakeConfirmationOption(),
+                statusBarColor = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             ),
         ).apply { block() }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -183,6 +183,7 @@ internal class PassiveChallengeConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -166,6 +166,7 @@ internal class CustomPaymentMethodConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -240,6 +240,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
     companion object {
         private val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
             confirmationOption = FakeConfirmationOption(),
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFactory.create(),
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -179,6 +179,7 @@ internal class CvcRecollectionConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -192,6 +192,7 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -283,6 +283,7 @@ internal class GooglePayConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -103,6 +103,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             confirmationHandler.start(
                 ConfirmationHandler.Args(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
+                    statusBarColor = null,
                     paymentMethodMetadata = paymentMethodMetadata,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
@@ -33,7 +33,6 @@ import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfir
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.StripeNetworkTestClient
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -203,10 +202,6 @@ internal interface LpmNetworkTestModule {
         }
 
         @Provides
-        @Named(STATUS_BAR_COLOR)
-        fun providesStatusBarColor(): Int? = STATUS_BAR_COLOR_VALUE
-
-        @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = ENABLE_LOGGING_VALUE
 
@@ -222,7 +217,6 @@ internal interface LpmNetworkTestModule {
             }
         }
 
-        private val STATUS_BAR_COLOR_VALUE = null
         private const val ENABLE_LOGGING_VALUE = false
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -44,6 +44,7 @@ internal suspend fun assertIntentConfirmed(
         activity.confirmationHandler.start(
             ConfirmationHandler.Args(
                 confirmationOption = option,
+                statusBarColor = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = params.intent,
                     shippingDetails = params.shippingDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
@@ -220,6 +220,7 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
             },
             stateHelper = stateHelper,
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
+            statusBarColor = null,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -121,6 +121,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         return EmbeddedConfirmationStateHolder.State(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             selection = PaymentSelection.GooglePay,
+            statusBarColor = null,
             configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc")
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -269,6 +269,7 @@ internal class DefaultEmbeddedStateHelperTest {
                     paymentMethodMetadata = paymentMethodMetadata,
                     selection = selection,
                     configuration = configuration,
+                    statusBarColor = null,
                 ),
                 customer = customer,
                 previousNewSelections = Bundle(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -41,6 +41,7 @@ class EmbeddedConfirmationStarterTest {
     fun `on confirm, should call 'start' on confirmation handler`() = test {
         val arguments = ConfirmationHandler.Args(
             confirmationOption = FakeConfirmationOption(),
+            statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFactory.create(
                     paymentMethod = PaymentMethodFactory.card(random = true),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateFixtures.kt
@@ -11,6 +11,7 @@ internal object EmbeddedConfirmationStateFixtures {
     ): EmbeddedConfirmationStateHolder.State = EmbeddedConfirmationStateHolder.State(
         paymentMethodMetadata = paymentMethodMetadata,
         selection = null,
+        statusBarColor = null,
         configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
             .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
             .build()
@@ -20,6 +21,7 @@ internal object EmbeddedConfirmationStateFixtures {
         EmbeddedConfirmationStateHolder.State(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             selection = null,
+            statusBarColor = null,
             configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
                 .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
                 .opensCardScannerAutomatically(true)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -125,6 +125,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
             customerStateHolder = customerStateHolder,
             coroutineScope = backgroundScope,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
+            statusBarColor = null,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -936,6 +936,7 @@ class DefaultWalletButtonsInteractorTest {
             ),
             appearance = appearance,
             paymentSelection = null,
+            statusBarColor = null,
         )
     }
 


### PR DESCRIPTION
# Summary
Plumbs status bar color through the confirmation flow, including ConfirmationHandler.Args and relevant ViewModels, and removes unnecessary dependency injection of STATUS_BAR_COLOR.

No behavior changes, just moving this out of the DI graph.

# Motivation
This change ensures that the status bar color is consistently available to confirmation flows for customizing authentication screens such as 3DS2 and browser-based flows. It also simplifies dependency management by removing redundant DI code for the status bar color.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog