### PR TITLE
Fix Alipay reporting failure after Alipay+ EVO redirect migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
 ### Payments
-* [FIXED][13518](https://github.com/stripe/stripe-android/pull/13518) Alipay payments on Android no longer incorrectly report failure to the merchant app when the payment actually succeeds, following Stripe's Alipay+ EVO redirect migration.
+* [FIXED][13544](https://github.com/stripe/stripe-android/pull/13544) Fixed an issue where the SDK could fail to correctly reconcile and close out an Alipay payment, primarily in test mode.
 
 ## 23.13.0 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### Payments
+* [FIXED][13518](https://github.com/stripe/stripe-android/pull/13518) Alipay payments on Android no longer incorrectly report failure to the merchant app when the payment actually succeeds, following Stripe's Alipay+ EVO redirect migration.
+
 ## 23.13.0 - 2026-07-20
 
 ### Payments

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
@@ -147,9 +147,11 @@ internal class WebIntentNextActionHandler @Inject constructor(
             paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.AuthRedirect)
         )
 
+        // Post-EVO (gated) Alipay return_url is a trampoline URL; watch the SDK default instead (like CashApp).
         return WebAuthParams(
             authUrl = webViewUrl.toString(),
-            returnUrl = returnUrl,
+            returnUrl = defaultReturnUrl.value,
+            shouldCancelIntentOnUserNavigation = false,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
@@ -147,7 +147,6 @@ internal class WebIntentNextActionHandler @Inject constructor(
             paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.AuthRedirect)
         )
 
-        // Post-EVO (gated) Alipay return_url is a trampoline URL; watch the SDK default instead (like CashApp).
         return WebAuthParams(
             authUrl = webViewUrl.toString(),
             returnUrl = defaultReturnUrl.value,

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandlerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandlerTest.kt
@@ -110,6 +110,21 @@ class WebIntentNextActionHandlerTest {
     }
 
     @Test
+    fun authenticate_whenRedirectingToAlipay() {
+        // The fixture's next_action.return_url is "example://return_url"; asserting the SDK default
+        // instead proves the handler no longer trusts next_action.return_url (the EVO trampoline).
+        verifyAuthenticate(
+            stripeIntent = PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION,
+            expectedUrl = "https://hooks.stripe.com/redirect/authenticate/src_1HDEFWKlwPmebFhp6tcpln8T" +
+                "?client_secret=src_client_secret_S6H9mVMKK6qxk9YxsUvbH55K",
+            expectedReturnUrl = "stripesdk://payment_return_url/some_package_name",
+            expectedRequestCode = PAYMENT_REQUEST_CODE,
+            expectedAnalyticsEvent = null,
+            expectedShouldCancelIntentOnUserNavigation = false,
+        )
+    }
+
+    @Test
     fun authenticate_whenRedirectingToWeChatPay() {
         val mockResolvedUrl = "https://resolved_url.wow"
 


### PR DESCRIPTION
# Summary

After Stripe's Alipay+ "EVO" migration, `next_action.alipay_handle_redirect.return_url` points at Stripe's `pm-redirects.stripe.com` **redirect trampoline** instead of the merchant's own return URL (default or custom app scheme). `WebIntentNextActionHandler` passed that value to the auth WebView, and because `PaymentAuthWebViewClient` matches return URLs on scheme+host and the trampoline's intermediate hops share that host, the WebView closed as soon as it hit one of those hops, **before** the trampoline finished finalizing the PaymentIntent server-side and redirecting onward. Depending on the return URL in play, this could surface the payment to the app as unsuccessful even though it ultimately succeeded, or leave the authorization page frozen with no redirect and no dismissal (see incident `ir-cursor-reinforce`).

**Fix:** for Alipay, watch the SDK's own default return URL (`defaultReturnUrl.value`) instead of `next_action.return_url`, mirroring the existing `CashAppRedirect` / `SwishRedirect` handling in the same file. `shouldCancelIntentOnUserNavigation` is also set to `false` to match those methods.

## Flow

```mermaid
sequenceDiagram
    participant SDK as SDK
    participant TR as pm-redirects.stripe.com<br/>(trampoline)
    participant AP as Alipay+

    SDK->>TR: open next_action.url  (/authorize hop)
    TR->>AP: redirect to Alipay+
    AP-->>TR: user authorizes → /return hop
    Note over TR: finalizes PaymentIntent (server-side)
    TR-->>SDK: redirect to the SDK default return URL

    Note over SDK: before: watched next_action.return_url<br/>(the trampoline hop) → closed here, too early
    Note over SDK: after: watches the SDK default return URL<br/>(where the trampoline lands) → completes correctly
```

## What changed

`AlipayRedirect.webAuthParams()` now returns `returnUrl = defaultReturnUrl.value` and `shouldCancelIntentOnUserNavigation = false`, identical to the existing `CashAppRedirect` / `SwishRedirect` branches. One-line behavior change plus a unit test.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

- `authenticate_whenRedirectingToAlipay` (mirrors `authenticate_whenRedirectingToCashApp`): asserts the WebView watches `defaultReturnUrl.value` rather than the fixture's `next_action.return_url` (`example://return_url`), and that `shouldCancelIntentOnUserNavigation == false`.
- Manually verified against a CN test merchant gated on `alipay_cn_to_alipay_plus_migration_gate`: the payment sheet now closes correctly and quickly with a successful result.

# Notes
- Root cause is server-side (incident `ir-cursor-reinforce` / `MOBILESDK-4700`); this is the client-side mitigation.
- Impact is primarily test mode: the Alipay+ EVO migration is ~99% complete (since March 2026), post-migration conversion is up, and there have been no live merchant complaints; gated live payments generally complete via app-to-app redirect + intent polling regardless of this bug. That said, the underlying mechanism isn't inherently test-mode-only, so this may still affect some live payments depending on integration (tracked in `ir-cursor-reinforce`).
- Client-side polling can't recover this: matching the trampoline URL makes the WebView swallow the `/return` navigation that triggers the server-side finalization, so the PaymentIntent stays `requires_action` and a poll has nothing to converge to.
- Follow-up (backlog, out of scope): `CashAppRedirect` / `SwishRedirect` share this hardcoded-default behavior; and the redirect params' `return_url` should be made `val` since merchant-set custom return URLs aren't intended for these mobile redirect flows.

# Changelog
- [Fixed] Fixed an issue where the SDK could fail to correctly reconcile and close out an Alipay payment, primarily in test mode.
