### PR TITLE
Remove googleApiKey from new StripeAutocompleteRepository

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/DefaultStripeAutocompleteRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/DefaultStripeAutocompleteRepository.kt
@@ -24,8 +24,7 @@ internal class DefaultStripeAutocompleteRepository(
         query: String,
         country: String,
         sessionToken: String,
-        locale: String?,
-        googleApiKey: String?
+        locale: String?
     ): Result<AutocompletePredictionsResult> {
         val params = buildMap<String, Any> {
             put("search_text", query)
@@ -34,9 +33,6 @@ internal class DefaultStripeAutocompleteRepository(
             put("country_codes", listOf(country))
             if (locale != null) {
                 put("locale", locale)
-            }
-            if (googleApiKey != null) {
-                put("google_api_key", googleApiKey)
             }
         }
         return executeRequestWithResultParser(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepository.kt
@@ -5,8 +5,7 @@ internal interface StripeAutocompleteRepository {
         query: String,
         country: String,
         sessionToken: String,
-        locale: String?,
-        googleApiKey: String?
+        locale: String?
     ): Result<AutocompletePredictionsResult>
 
     suspend fun fetchPlaceDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakeStripeAutocompleteRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakeStripeAutocompleteRepository.kt
@@ -16,7 +16,6 @@ internal class FakeStripeAutocompleteRepository : StripeAutocompleteRepository {
         val country: String,
         val sessionToken: String,
         val locale: String?,
-        val googleApiKey: String?,
     )
 
     private val _findPredictionsCalls = Turbine<FindPredictionsCall>()
@@ -29,11 +28,10 @@ internal class FakeStripeAutocompleteRepository : StripeAutocompleteRepository {
         query: String,
         country: String,
         sessionToken: String,
-        locale: String?,
-        googleApiKey: String?
+        locale: String?
     ): Result<AutocompletePredictionsResult> {
         onBeforeFindAutocompletePredictions?.invoke()
-        _findPredictionsCalls.add(FindPredictionsCall(query, country, sessionToken, locale, googleApiKey))
+        _findPredictionsCalls.add(FindPredictionsCall(query, country, sessionToken, locale))
         return predictionsResult
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteRepositoryTest.kt
@@ -23,7 +23,6 @@ class StripeAutocompleteRepositoryTest {
             country = "US",
             sessionToken = "session_abc",
             locale = null,
-            googleApiKey = null,
         )
 
         val request = scenario.networkClient.lastRequest as ApiRequest
@@ -40,7 +39,6 @@ class StripeAutocompleteRepositoryTest {
             country = "US",
             sessionToken = "session_abc",
             locale = "en",
-            googleApiKey = "key_123",
         )
 
         val request = scenario.networkClient.lastRequest as ApiRequest
@@ -49,7 +47,6 @@ class StripeAutocompleteRepositoryTest {
         assertThat(params["session_token"]).isEqualTo("session_abc")
         assertThat(params["client_type"]).isEqualTo("mobile")
         assertThat(params["locale"]).isEqualTo("en")
-        assertThat(params["google_api_key"]).isEqualTo("key_123")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove googleApiKey parameter from StripeAutocompleteRepository. The Stripe-hosted autocomplete proxy does not require the merchant's Google Places API key, all requests go through Stripe's endpoint directly using the publishable key for authentication.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The googleApiKey parameter was originally included to be passed into the backend, but we decided that the server-side autocomplete proxy will handle all requests rather than using merchants' keys. More details on this decision [here](https://docs.google.com/document/d/1qoSXvOJnIIgZbRKXrbKuCKSKPOfmPK-lLywjcg5lMvc/edit?tab=t.0).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
N/A

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
