### PR TITLE
Plumb status bar color through Link and Tap to Add confirmation flows.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddContract.kt
@@ -28,6 +28,7 @@ internal object TapToAddContract : ActivityResultContract<TapToAddContract.Args,
         val paymentMethodMetadata: PaymentMethodMetadata,
         val paymentElementCallbackIdentifier: String,
         val productUsage: Set<String>,
+        val statusBarColor: Int?,
     ) : Parcelable {
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
@@ -48,6 +48,7 @@ internal interface TapToAddHelper {
             updateSelection: (PaymentSelection.Saved) -> Unit,
             customerStateHolder: CustomerStateHolder,
             linkSignupMode: StateFlow<LinkSignupMode?>,
+            statusBarColor: Int?,
         ): TapToAddHelper
     }
 }
@@ -64,6 +65,7 @@ internal class DefaultTapToAddHelper(
     private val updateSelection: (PaymentSelection.Saved) -> Unit,
     private val customerStateHolder: CustomerStateHolder,
     private val linkSignupMode: StateFlow<LinkSignupMode?>,
+    private val statusBarColor: Int?,
 ) : TapToAddHelper {
     override val isTapToAddEnabled: StateFlow<Boolean> =
         savedStateHandle.getStateFlow(IS_TAP_TO_ADD_ENABLED_KEY, true)
@@ -157,6 +159,7 @@ internal class DefaultTapToAddHelper(
                     paymentMethodMetadata = paymentMethodMetadata,
                     paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                     productUsage = productUsage,
+                    statusBarColor = statusBarColor,
                 ),
                 options = ActivityOptionsCompat.makeCustomAnimation(
                     context,
@@ -181,6 +184,7 @@ internal class DefaultTapToAddHelper(
             updateSelection: (PaymentSelection.Saved) -> Unit,
             customerStateHolder: CustomerStateHolder,
             linkSignupMode: StateFlow<LinkSignupMode?>,
+            statusBarColor: Int?,
         ): TapToAddHelper {
             return DefaultTapToAddHelper(
                 context = context,
@@ -194,6 +198,7 @@ internal class DefaultTapToAddHelper(
                 eventReporter = eventReporter,
                 customerStateHolder = customerStateHolder,
                 linkSignupMode = linkSignupMode,
+                statusBarColor = statusBarColor,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModel.kt
@@ -33,6 +33,7 @@ internal class TapToAddViewModel @Inject constructor(
                 paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                 eventMode = args.eventMode,
                 productUsage = args.productUsage,
+                statusBarColor = args.statusBarColor,
             )
 
             return component.viewModel as T

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -60,6 +60,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.PaymentConfigurationModule
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -116,6 +117,9 @@ internal interface TapToAddViewModelComponent {
             productUsage: Set<String>,
             @BindsInstance application: Application,
             @BindsInstance savedStateHandle: SavedStateHandle,
+            @Named(STATUS_BAR_COLOR)
+            @BindsInstance
+            statusBarColor: Int?,
         ): TapToAddViewModelComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
@@ -90,6 +92,7 @@ internal class DefaultTapToAddConfirmationInteractor(
     private val confirmationHandler: ConfirmationHandler,
     private val cvcFormHelper: CvcFormHelper,
     private val eventReporter: EventReporter,
+    private val statusBarColor: Int?,
     private val onComplete: () -> Unit,
 ) : TapToAddConfirmationInteractor {
     private val coroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
@@ -175,7 +178,7 @@ internal class DefaultTapToAddConfirmationInteractor(
                 arguments = ConfirmationHandler.Args(
                     confirmationOption = confirmationOption,
                     paymentMethodMetadata = paymentMethodMetadata,
-                    statusBarColor = null,
+                    statusBarColor = statusBarColor,
                 )
             )
         }
@@ -280,6 +283,7 @@ internal class DefaultTapToAddConfirmationInteractor(
         private val cvcFormHelperFactory: CvcFormHelper.Factory,
         private val confirmationHandler: ConfirmationHandler,
         private val eventReporter: EventReporter,
+        @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
         private val tapToAddNavigator: Provider<TapToAddNavigator>,
     ) : TapToAddConfirmationInteractor.Factory {
         override fun create(
@@ -296,6 +300,7 @@ internal class DefaultTapToAddConfirmationInteractor(
                 eventReporter = eventReporter,
                 coroutineContext = coroutineContext,
                 cvcFormHelper = cvcFormHelperFactory.create(paymentMethod),
+                statusBarColor = statusBarColor,
                 onComplete = {
                     tapToAddNavigator.get().performAction(
                         action = TapToAddNavigator.Action.Complete,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -142,6 +142,9 @@ internal class LinkActivity : ComponentActivity() {
                     lastUpdateReason = null
                 ),
                 launchMode = LinkLaunchMode.Full,
+                // Web flow renders in a Custom Tab that manages its own chrome; no status bar
+                // color to forward.
+                statusBarColor = null,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -42,6 +42,7 @@ internal class LinkActivityContract @Inject internal constructor(
         internal val linkExpressMode: LinkExpressMode,
         internal val linkAccountInfo: LinkAccountUpdate.Value,
         internal val launchMode: LinkLaunchMode,
+        internal val statusBarColor: Int?,
     )
 
     data class Result(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -581,6 +581,7 @@ internal class LinkActivityViewModel @Inject constructor(
                         linkLaunchMode = args.launchMode,
                         linkAccountUpdate = args.linkAccountInfo,
                         requestSurface = args.requestSurface,
+                        statusBarColor = args.statusBarColor,
                     )
                     .viewModel
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link
 
+import android.app.Activity
 import android.app.Application
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistryOwner
@@ -8,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.link.injection.LinkControllerPresenterScope
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.MandateDataParams
@@ -19,6 +21,7 @@ import javax.inject.Inject
 @LinkControllerPresenterScope
 internal class LinkControllerCoordinator @Inject constructor(
     private val application: Application,
+    activity: Activity,
     private val interactor: LinkControllerInteractor,
     private val lifecycleOwner: LifecycleOwner,
     activityResultRegistryOwner: ActivityResultRegistryOwner,
@@ -45,7 +48,7 @@ internal class LinkControllerCoordinator @Inject constructor(
         paymentLauncher = PaymentLauncherFactory(
             activityResultRegistryOwner = activityResultRegistryOwner,
             lifecycleOwner = lifecycleOwner,
-            statusBarColor = null,
+            statusBarColor = StatusBarCompat.color(activity),
             callback = PaymentLauncher.InternalPaymentResultCallback { result ->
                 interactor.onSetupIntentConfirmationResult(result)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -719,6 +719,10 @@ internal class LinkControllerInteractor @Inject constructor(
                         linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         launchMode = launchMode,
+                        // LinkController launches Link for selection/authentication only (never
+                        // in-Link confirmation), and this singleton has no host Activity to read a
+                        // status bar color from.
+                        statusBarColor = null,
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -80,6 +80,7 @@ internal class LinkPaymentLauncher @Inject internal constructor(
         linkAccountInfo: LinkAccountUpdate.Value,
         launchMode: LinkLaunchMode,
         linkExpressMode: LinkExpressMode,
+        statusBarColor: Int?,
     ) {
         val args = LinkActivityContract.Args(
             configuration = configuration,
@@ -87,6 +88,7 @@ internal class LinkPaymentLauncher @Inject internal constructor(
             linkExpressMode = linkExpressMode,
             linkAccountInfo = linkAccountInfo,
             launchMode = launchMode,
+            statusBarColor = statusBarColor,
         )
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -32,6 +32,7 @@ internal class NativeLinkActivityContract @Inject constructor(
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                 linkAccountInfo = input.linkAccountInfo,
+                statusBarColor = input.statusBarColor,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
@@ -16,4 +16,5 @@ internal data class NativeLinkArgs(
     val linkAccountInfo: LinkAccountUpdate.Value,
     val paymentElementCallbackIdentifier: String,
     val launchMode: LinkLaunchMode,
+    val statusBarColor: Int?,
 ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -21,12 +21,15 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationOption
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.R
 import javax.inject.Inject
+import javax.inject.Named
 
 internal class DefaultLinkConfirmationHandler @Inject constructor(
     private val configuration: LinkConfiguration,
     private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val statusBarColor: Int?,
     private val logger: Logger,
     private val confirmationHandler: ConfirmationHandler,
 ) : LinkConfirmationHandler {
@@ -182,7 +185,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = paymentMethodMetadata,
-            statusBarColor = null,
+            statusBarColor = statusBarColor,
         )
     }
 
@@ -217,13 +220,14 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 newPMTransformedForConfirmation = newPMTransformedForConfirmation
             ),
             paymentMethodMetadata = paymentMethodMetadata,
-            statusBarColor = null,
+            statusBarColor = statusBarColor,
         )
     }
 
     class Factory @Inject constructor(
         private val configuration: LinkConfiguration,
         private val paymentMethodMetadata: PaymentMethodMetadata,
+        @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
         private val logger: Logger,
     ) : LinkConfirmationHandler.Factory {
         override fun create(confirmationHandler: ConfirmationHandler): LinkConfirmationHandler {
@@ -231,7 +235,8 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 confirmationHandler = confirmationHandler,
                 logger = logger,
                 configuration = configuration,
-                paymentMethodMetadata = paymentMethodMetadata
+                paymentMethodMetadata = paymentMethodMetadata,
+                statusBarColor = statusBarColor,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.uicore.navigation.NavigationManager
@@ -104,6 +105,9 @@ internal interface NativeLinkComponent {
             linkAccountUpdate: LinkAccountUpdate.Value,
             @BindsInstance
             requestSurface: RequestSurface,
+            @BindsInstance
+            @Named(STATUS_BAR_COLOR)
+            statusBarColor: Int?,
         ): NativeLinkComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -119,6 +119,9 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
                     linkAccountInfo = accountManager.linkAccountInfo.value,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(null),
                     linkExpressMode = LinkExpressMode.ENABLED,
+                    // Selection-only launch; Link returns a selection here and never confirms, so
+                    // there is no auth surface to color.
+                    statusBarColor = null,
                 )
                 // No UI changes - keep the 2FA until we get a result from the Link payment selection flow.
             }.onFailure { error ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -64,6 +64,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
             linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
             launchMode = confirmationOption.linkLaunchMode,
             linkExpressMode = confirmationOption.linkExpressMode,
+            statusBarColor = confirmationArgs.statusBarColor,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentelement.embedded.sheet.InitialPaymentOptionsScr
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmationHelper
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -59,6 +60,7 @@ import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Suppress("TooManyFunctions")
@@ -184,6 +186,7 @@ internal interface EmbeddedActivityModule {
             embeddedSelectionHolder: EmbeddedSelectionHolder,
             customerStateHolder: CustomerStateHolder,
             paymentMethodMetadata: PaymentMethodMetadata,
+            @Named(STATUS_BAR_COLOR) statusBarColor: Int?,
         ): TapToAddHelper {
             return tapToAddHelperFactory.create(
                 coroutineScope = coroutineScope,
@@ -194,6 +197,7 @@ internal interface EmbeddedActivityModule {
                 updateSelection = embeddedSelectionHolder::setSelection,
                 customerStateHolder = customerStateHolder,
                 linkSignupMode = stateFlowOf(paymentMethodMetadata.linkState?.signupMode),
+                statusBarColor = statusBarColor,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -125,6 +125,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
         updateSelection = ::updateSelection,
         customerStateHolder = customerStateHolder,
         linkSignupMode = paymentMethodMetadata.mapAsStateFlow { it?.linkState?.signupMode },
+        // Continue mode returns the selection to the FlowController host, which confirms with its
+        // own status bar color; Tap to Add never confirms in this flow.
+        statusBarColor = null,
     )
 
     private val _paymentOptionsActivityResult = MutableSharedFlow<PaymentOptionsActivityResult>(replay = 1)
@@ -384,6 +387,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment = null),
                     linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                     linkExpressMode = LinkExpressMode.ENABLED,
+                    // Selection-only launch; Link returns a selection here and never confirms, so
+                    // there is no auth surface to color.
+                    statusBarColor = null,
                 )
             } else {
                 _paymentOptionsActivityResult.tryEmit(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -146,6 +146,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         updateSelection = ::updateSelection,
         customerStateHolder = customerStateHolder,
         linkSignupMode = paymentMethodMetadata.mapAsStateFlow { it?.linkState?.signupMode },
+        statusBarColor = args.statusBarColor,
     )
 
     private val _paymentSheetResult = MutableSharedFlow<PaymentSheetResult>(replay = 1)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -330,6 +330,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     launchMode = LinkLaunchMode.PaymentMethodSelection(
                         selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
                     ),
+                    statusBarColor = viewModel.statusBarColor,
                 )
             } else {
                 showPaymentOptionList(state, paymentSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -282,6 +282,7 @@ internal class DefaultWalletButtonsInteractor constructor(
                 linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                 launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment?.details),
                 linkExpressMode = LinkExpressMode.ENABLED,
+                statusBarColor = arguments.statusBarColor,
             )
         } else {
             handleButtonPressed(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
@@ -70,6 +70,7 @@ internal class FakeTapToAddHelper : TapToAddHelper {
             updateSelection: (PaymentSelection.Saved) -> Unit,
             customerStateHolder: CustomerStateHolder,
             linkSignupMode: StateFlow<LinkSignupMode?>,
+            statusBarColor: Int?,
         ): TapToAddHelper {
             val helper = FakeTapToAddHelper()
             createCalls.add(CreateCall(coroutineScope, tapToAddMode))

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -547,7 +547,8 @@ class TapToAddActivityTest {
                                 eventMode = EventReporter.Mode.Custom,
                                 paymentMethodMetadata = metadata,
                                 paymentElementCallbackIdentifier = PAYMENT_ELEMENT_CALLBACK_IDENTIFIER,
-                                productUsage = emptySet()
+                                productUsage = emptySet(),
+                                statusBarColor = null,
                             )
                         )
                     ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
@@ -365,6 +365,7 @@ class TapToAddHelperTest {
             updateSelection = updateSelection,
             customerStateHolder = customerStateHolder,
             linkSignupMode = stateFlowOf(linkSignupMode),
+            statusBarColor = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -161,6 +161,20 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     }
 
     @Test
+    fun `PrimaryButtonPressed forwards statusBarColor to confirmation args`() = runScenario(
+        paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
+        statusBarColor = 0x00FF00,
+    ) {
+        interactor.performAction(TapToAddConfirmationInteractor.Action.PrimaryButtonPressed)
+
+        assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isFalse()
+        val args = confirmationHandlerScenario.startTurbine.awaitItem()
+
+        assertThat(args.statusBarColor).isEqualTo(0x00FF00)
+    }
+
+    @Test
     fun `PrimaryButtonPressed in Complete mode when not Idle does not call confirmationHandler start`() {
         val paymentMethod = PaymentMethodFactory.card(last4 = "4242")
 
@@ -540,6 +554,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
         initialCvcState: CvcFormHelper.State = CvcFormHelper.State.NotRequired,
+        statusBarColor: Int? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val eventReporter = FakeEventReporter()
@@ -558,6 +573,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                 confirmationHandler = handler,
                 cvcFormHelper = cvcFormHelper,
                 eventReporter = eventReporter,
+                statusBarColor = statusBarColor,
                 onComplete = {
                     onCompleteCalls.add(Unit)
                 },

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -29,6 +29,7 @@ class LinkActivityContractTest {
             lastUpdateReason = null
         ),
         launchMode = LinkLaunchMode.Full,
+        statusBarColor = null,
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -161,6 +161,7 @@ internal class LinkActivityViewModelTest {
             ),
             paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
             launchMode = LinkLaunchMode.Full,
+            statusBarColor = null,
         )
         val savedStateHandle = SavedStateHandle()
         val factory = LinkActivityViewModel.factory(savedStateHandle)

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -65,6 +65,7 @@ internal class LinkControllerCoordinatorTest {
 
         return LinkControllerCoordinator(
             application = ApplicationProvider.getApplicationContext(),
+            activity = mock(),
             interactor = viewModel,
             lifecycleOwner = lifecycleOwner,
             activityResultRegistryOwner = activityResultRegistryOwner,
@@ -161,6 +162,7 @@ internal class LinkControllerCoordinatorTest {
                 linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(null),
                 launchMode = LinkLaunchMode.PaymentMethodSelection(null),
+                statusBarColor = null,
             )
         )
         verify(viewModel).onLinkActivityResult(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -93,6 +93,7 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full,
+                statusBarColor = 0x00FF00,
             )
 
             val launchCall = awaitLaunchCall()
@@ -105,6 +106,7 @@ internal class LinkPaymentLauncherTest {
                         linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                         launchMode = LinkLaunchMode.Full,
+                        statusBarColor = 0x00FF00,
                     )
                 )
 
@@ -128,6 +130,7 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.DISABLED,
                 launchMode = LinkLaunchMode.Full,
+                statusBarColor = null,
             )
 
             val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
@@ -163,6 +166,7 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full,
+                statusBarColor = null,
             )
 
             val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
@@ -274,6 +278,7 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full,
+                statusBarColor = null,
             )
 
             verifyActivityResultCallback(
@@ -306,6 +311,7 @@ internal class LinkPaymentLauncherTest {
                     linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                     linkExpressMode = LinkExpressMode.ENABLED,
                     launchMode = LinkLaunchMode.Full,
+                    statusBarColor = null,
                 )
 
                 val registerCall = awaitRegisterCall()

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -44,6 +44,7 @@ class NativeLinkActivityContractTest {
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
             launchMode = LinkLaunchMode.Full,
+            statusBarColor = 0x00FF00,
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)
@@ -64,6 +65,7 @@ class NativeLinkActivityContractTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
                 launchMode = LinkLaunchMode.Full,
+                statusBarColor = 0x00FF00,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -350,6 +350,7 @@ internal object TestFactory {
         linkAccountInfo = LinkAccountUpdate.Value(LINK_ACCOUNT),
         paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
         launchMode = LinkLaunchMode.Full,
+        statusBarColor = null,
     )
 
     val FINANCIAL_CONNECTIONS_CHECKING_ACCOUNT = FinancialConnectionsAccount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -46,6 +46,7 @@ class WebLinkActivityContractTest {
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
             launchMode = LinkLaunchMode.Full,
+            statusBarColor = null,
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -88,6 +88,32 @@ internal class DefaultLinkConfirmationHandlerTest {
     }
 
     @Test
+    fun `confirm forwards statusBarColor to confirmation args`() = runTest(dispatcher) {
+        val configuration = TestFactory.LINK_CONFIGURATION
+        val confirmationHandler = FakeConfirmationHandler()
+        val handler = createHandler(
+            confirmationHandler = confirmationHandler,
+            configuration = configuration,
+            statusBarColor = 0x00FF00,
+        )
+
+        confirmationHandler.awaitResultTurbine.add(
+            item = ConfirmationHandler.Result.Succeeded(
+                intent = configuration.stripeIntent,
+            )
+        )
+
+        handler.confirm(
+            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            linkAccount = TestFactory.LINK_ACCOUNT,
+            cvc = CVC,
+            billingPhone = null
+        )
+
+        assertThat(confirmationHandler.startTurbine.awaitItem().statusBarColor).isEqualTo(0x00FF00)
+    }
+
+    @Test
     fun `successful confirmation yields success result with setup intent`() = runTest(dispatcher) {
         val configuration = TestFactory.LINK_CONFIGURATION.copy(
             stripeIntent = SetupIntentFixtures.SI_SUCCEEDED
@@ -737,7 +763,8 @@ internal class DefaultLinkConfirmationHandlerTest {
         configuration: LinkConfiguration = TestFactory.LINK_CONFIGURATION,
         logger: Logger = FakeLogger(),
         confirmationHandler: FakeConfirmationHandler = FakeConfirmationHandler(),
-        passiveCaptchaParams: PassiveCaptchaParams? = PASSIVE_CAPTCHA_PARAMS
+        passiveCaptchaParams: PassiveCaptchaParams? = PASSIVE_CAPTCHA_PARAMS,
+        statusBarColor: Int? = null,
     ): DefaultLinkConfirmationHandler {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             passiveCaptchaParams = passiveCaptchaParams,
@@ -748,6 +775,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             configuration = configuration,
             logger = logger,
             paymentMethodMetadata = paymentMethodMetadata,
+            statusBarColor = statusBarColor,
         )
         assertThat(confirmationHandler.bootstrapTurbine.awaitItem().paymentMethodMetadata)
             .isEqualTo(paymentMethodMetadata)

--- a/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
@@ -39,6 +39,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -192,6 +193,7 @@ class DefaultLinkInlineInteractorTest {
                 linkAccountInfo = any(),
                 launchMode = eq(LinkLaunchMode.PaymentMethodSelection(null)),
                 linkExpressMode = any(),
+                statusBarColor = anyOrNull(),
             )
         }
 
@@ -225,6 +227,7 @@ class DefaultLinkInlineInteractorTest {
                 linkAccountInfo = any(),
                 launchMode = eq(LinkLaunchMode.PaymentMethodSelection(null)),
                 linkExpressMode = any(),
+                statusBarColor = anyOrNull(),
             )
 
             assertThat(pmmCaptor.firstValue.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
@@ -527,6 +530,7 @@ class DefaultLinkInlineInteractorTest {
                 linkAccountInfo = any(),
                 launchMode = eq(LinkLaunchMode.PaymentMethodSelection(null)),
                 linkExpressMode = any(),
+                statusBarColor = anyOrNull(),
             )
 
             assertThat(pmmCaptor.firstValue.attestOnIntentConfirmation).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -194,6 +194,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             linkAccountInfo = LinkAccountUpdate.Value(null),
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
                             launchMode = LinkLaunchMode.Full,
+                            statusBarColor = null,
                         )
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -126,6 +126,20 @@ internal class LinkConfirmationDefinitionTest {
     }
 
     @Test
+    fun `'launch' should forward statusBarColor from confirmation args`() = test {
+        val definition = createLinkConfirmationDefinition()
+
+        definition.launch(
+            confirmationOption = LINK_CONFIRMATION_OPTION,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(statusBarColor = 0x00FF00),
+            launcher = launcherScenario.launcher,
+            arguments = EmptyConfirmationLauncherArgs,
+        )
+
+        assertThat(launcherScenario.presentCalls.awaitItem().statusBarColor).isEqualTo(0x00FF00)
+    }
+
+    @Test
     fun `'launch', when linkAccount is provided, should launch properly with provided parameters`() = test {
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -88,6 +88,7 @@ import org.junit.After
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -264,6 +265,7 @@ internal class PaymentOptionsViewModelTest {
             linkAccountInfo = eq(LinkAccountUpdate.Value(unverifiedAccount)),
             launchMode = eq(LinkLaunchMode.PaymentMethodSelection(selectedPayment = null)),
             linkExpressMode = eq(LinkExpressMode.ENABLED),
+            statusBarColor = anyOrNull(),
         )
     }
 
@@ -303,6 +305,7 @@ internal class PaymentOptionsViewModelTest {
             linkAccountInfo = any(),
             launchMode = any(),
             linkExpressMode = any(),
+            statusBarColor = anyOrNull(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -607,6 +607,7 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
             linkExpressMode = any(),
+            statusBarColor = anyOrNull(),
         )
 
         verify(paymentOptionActivityLauncher, never()).launch(any(), anyOrNull())
@@ -652,6 +653,7 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
             linkExpressMode = any(),
+            statusBarColor = anyOrNull(),
         )
 
         // Simulate user dismissing 2FA with back press
@@ -675,6 +677,7 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             linkExpressMode = any(),
             launchMode = any(),
+            statusBarColor = anyOrNull(),
         )
 
         // Verify payment option launcher was called instead

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -49,6 +49,7 @@ internal object RecordingLinkPaymentLauncher {
                     linkAccountInfo = anyOrNull(),
                     launchMode = any(),
                     linkExpressMode = any(),
+                    statusBarColor = anyOrNull(),
                 )
             } doAnswer { invocation ->
                 val arguments = invocation.arguments
@@ -60,6 +61,7 @@ internal object RecordingLinkPaymentLauncher {
                         linkAccount = arguments[2] as? LinkAccount,
                         launchMode = arguments[3] as LinkLaunchMode,
                         linkExpressMode = arguments[4] as LinkExpressMode,
+                        statusBarColor = arguments[5] as? Int,
                     )
                 )
             }
@@ -97,5 +99,6 @@ internal object RecordingLinkPaymentLauncher {
         val linkAccount: LinkAccount?,
         val launchMode: LinkLaunchMode,
         val linkExpressMode: LinkExpressMode,
+        val statusBarColor: Int?,
     )
 }


### PR DESCRIPTION
# Summary
This PR adds plumbing to forward the status bar color into Link and Tap to Add confirmation-related flows. It allows the host status bar color to be respected during authentication and confirmation, improving UI consistency.

This improves wiring, where it was missing before.

# Motivation
Currently, the status bar color is not always propagated from the host through to confirmation/auth surfaces, which results in uneven user experience. This change forwards the status bar color throughout the relevant flows.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Added] Forward status bar color into Link and Tap to Add confirmation flows to better match host UI.