### PR TITLE
Add clearPaymentOption method to reset selected payment in CheckoutController.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -301,8 +301,11 @@ class CheckoutController @Inject internal constructor(
         stateHolder.state = null
     }
 
+    /**
+     * Clears the customer's selected payment option, resetting it to `null`.
+     */
     fun clearPaymentOption() {
-        TODO("Not yet implemented")
+        stateHolder.clearSelection()
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -84,6 +84,15 @@ internal class CheckoutControllerStateHolder @Inject constructor(
         return previousNewSelections.previousNewSelection(code)
     }
 
+    fun clearSelection() {
+        val current = requireState(operation = "clearSelection") ?: return
+        state = current.copy(
+            paymentSelection = null,
+            temporarySelection = null,
+            previousNewSelections = Bundle(),
+        )
+    }
+
     /**
      * The selection lives on [CheckoutControllerState], so the mutators can only act once
      * [CheckoutStateLoader] has committed a state. A call before then is a programming error (a

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -119,6 +119,30 @@ internal class CheckoutControllerStateHolderTest {
         }
 
     @Test
+    fun `clearSelection resets selection, temporarySelection and previousNewSelections`() = testScenario {
+        stateHolder.state = committedState(
+            paymentSelection = PaymentSelection.GooglePay,
+            temporarySelection = "card",
+            previousNewSelections = Bundle().apply {
+                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            },
+        )
+
+        stateHolder.selection.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSelection.GooglePay)
+            stateHolder.clearSelection()
+            assertThat(awaitItem()).isNull()
+        }
+
+        val clearedState = requireNotNull(stateHolder.state)
+        assertThat(clearedState.paymentSelection).isNull()
+        assertThat(clearedState.temporarySelection).isNull()
+        assertThat(clearedState.previousNewSelections.isEmpty).isTrue()
+        assertThat(stateHolder.temporarySelection.value).isNull()
+        assertThat(stateHolder.getPreviousNewSelection("cashapp")).isNull()
+    }
+
+    @Test
     fun `selection setters no-op before the state is committed`() = testScenario {
         stateHolder.setSelection(PaymentSelection.GooglePay)
         assertSetBeforeLoadError(operation = "setSelection")
@@ -130,6 +154,9 @@ internal class CheckoutControllerStateHolderTest {
             Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
         )
         assertSetBeforeLoadError(operation = "setPreviousNewSelections")
+
+        stateHolder.clearSelection()
+        assertSetBeforeLoadError(operation = "clearSelection")
 
         assertThat(stateHolder.state).isNull()
         assertThat(stateHolder.selection.value).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import android.app.Application
+import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.ReceiveTurbine
@@ -10,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
@@ -17,6 +19,7 @@ import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
@@ -263,6 +266,30 @@ internal class CheckoutControllerTest {
 
         assertThat(committedState).isNull()
         assertThat(controller.checkoutSession.value).isNull()
+    }
+
+    @Test
+    fun `clearPaymentOption clears paymentOptionDisplayData`() = runTest {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                CheckoutControllerStateHolder.STATE_KEY to CheckoutControllerStateFactory.create(
+                    paymentSelection = PaymentSelection.GooglePay,
+                    temporarySelection = "card",
+                    previousNewSelections = Bundle().apply {
+                        putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+                    },
+                ),
+            ),
+        )
+
+        val controller = createController(savedStateHandle)
+        controller.checkoutSession.test {
+            assertThat(awaitItem()?.paymentOptionDisplayData).isNotNull()
+
+            controller.clearPaymentOption()
+
+            assertThat(requireNotNull(awaitItem()).paymentOptionDisplayData).isNull()
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
Adds a `clearPaymentOption` method to `CheckoutController` and implements its logic in `CheckoutControllerStateHolder` to reset the selected payment option, including related state.

# Motivation
Allows resetting or clearing the customer's payment selection in scenarios where the user wishes to start over or deselect their current payment choice. This improves flexibility and state management within the checkout flow.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
