### PR TITLE
Extract CheckoutEmbeddedConfigurationFactory to centralize config logic.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.checkout.injection.MerchantDisplayName
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
+    @MerchantDisplayName private val merchantDisplayName: String,
+) {
+    fun create(
+        configuration: CheckoutController.Configuration.State,
+        sessionData: CheckoutSessionData,
+    ): EmbeddedPaymentElement.Configuration {
+        val response = sessionData.checkoutSessionResponse
+
+        val baseConfig = EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
+            .embeddedViewDisplaysMandateText(
+                configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
+            )
+            .billingDetailsCollectionConfiguration(
+                configuration.paymentElementConfiguration.billingDetailsCollectionConfiguration
+                    .reconcile(response.requiresBillingAddress)
+                    .asPaymentSheet()
+            )
+            .googlePay(
+                googlePay = response.merchantCountry?.let { merchantCountry ->
+                    configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)
+                }
+            )
+            .build()
+
+        return CheckoutConfigurationMerger.EmbeddedConfiguration(baseConfig)
+            .forCheckoutSession(sessionData)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -2,10 +2,8 @@ package com.stripe.android.checkout
 
 import android.graphics.Bitmap
 import android.os.Bundle
-import com.stripe.android.checkout.injection.MerchantDisplayName
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -14,7 +12,7 @@ import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
-    @MerchantDisplayName private val merchantDisplayName: String,
+    private val embeddedConfigurationFactory: CheckoutEmbeddedConfigurationFactory,
     private val flagImageResolver: FlagImageResolver,
     private val paymentElementLoader: PaymentElementLoader,
     private val selectionChooser: EmbeddedSelectionChooser,
@@ -50,24 +48,10 @@ internal class CheckoutStateLoader @Inject constructor(
         // reused when the currencies haven't changed.
         val flagImages = flagImageResolver.resolve(response, cached = carryForward.cachedFlagImages)
 
-        val baseConfig = EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
-            .embeddedViewDisplaysMandateText(
-                configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
-            )
-            .billingDetailsCollectionConfiguration(
-                configuration.paymentElementConfiguration.billingDetailsCollectionConfiguration
-                    .reconcile(response.requiresBillingAddress)
-                    .asPaymentSheet()
-            )
-            .googlePay(
-                googlePay = response.merchantCountry?.let { merchantCountry ->
-                    configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)
-                }
-            )
-            .build()
-
-        val embeddedConfig = CheckoutConfigurationMerger.EmbeddedConfiguration(baseConfig)
-            .forCheckoutSession(sessionData)
+        val embeddedConfig = embeddedConfigurationFactory.create(
+            configuration = configuration,
+            sessionData = sessionData,
+        )
 
         val loaderState = paymentElementLoader.load(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -1,0 +1,229 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import org.junit.Test
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutEmbeddedConfigurationFactoryTest {
+
+    @Test
+    fun `uses the provided merchant display name`() {
+        val result = factory(merchantDisplayName = "Acme Corp")
+            .create(configuration = controllerConfiguration(), sessionData = sessionData())
+
+        assertThat(result.merchantDisplayName).isEqualTo("Acme Corp")
+    }
+
+    @Test
+    fun `propagates embeddedViewDisplaysMandateText when true`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(embeddedViewDisplaysMandateText = true),
+            sessionData = sessionData(),
+        )
+
+        assertThat(result.embeddedViewDisplaysMandateText).isTrue()
+    }
+
+    @Test
+    fun `propagates embeddedViewDisplaysMandateText when false`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(embeddedViewDisplaysMandateText = false),
+            sessionData = sessionData(),
+        )
+
+        assertThat(result.embeddedViewDisplaysMandateText).isFalse()
+    }
+
+    @Test
+    fun `maps billingDetailsCollectionConfiguration address`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(billingDetailsAddress = Full),
+            sessionData = sessionData(requiresBillingAddress = false),
+        )
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(PSFull)
+    }
+
+    @Test
+    fun `upgrades Automatic to Full when the session requires a billing address`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(billingDetailsAddress = Automatic),
+            sessionData = sessionData(requiresBillingAddress = true),
+        )
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(PSFull)
+    }
+
+    @Test
+    fun `leaves Automatic unchanged when the session does not require a billing address`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(billingDetailsAddress = Automatic),
+            sessionData = sessionData(requiresBillingAddress = false),
+        )
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(PSAutomatic)
+    }
+
+    @Test
+    fun `maps googlePayConfiguration using the checkout session country`() {
+        val configuration = controllerConfiguration(
+            googlePayConfiguration = GooglePayConfiguration(GooglePayConfiguration.Environment.Production)
+                .label("Total")
+                .buttonType(GooglePayConfiguration.ButtonType.Checkout)
+                .additionalEnabledNetworks(listOf("INTERAC")),
+        )
+
+        val result = factory().create(
+            configuration = configuration,
+            sessionData = sessionData(merchantCountry = "GB"),
+        )
+
+        val googlePay = requireNotNull(result.googlePay)
+        assertThat(googlePay.environment)
+            .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Production)
+        assertThat(googlePay.countryCode).isEqualTo("GB")
+        assertThat(googlePay.label).isEqualTo("Total")
+        assertThat(googlePay.buttonType)
+            .isEqualTo(PaymentSheet.GooglePayConfiguration.ButtonType.Checkout)
+        assertThat(googlePay.additionalEnabledNetworks).containsExactly("INTERAC")
+    }
+
+    @Test
+    fun `leaves googlePay null when the checkout session country is missing`() {
+        val configuration = controllerConfiguration(
+            googlePayConfiguration = GooglePayConfiguration(GooglePayConfiguration.Environment.Production),
+        )
+
+        val result = factory().create(
+            configuration = configuration,
+            sessionData = sessionData(merchantCountry = null),
+        )
+
+        assertThat(result.googlePay).isNull()
+    }
+
+    @Test
+    fun `leaves googlePay null when the merchant supplied no googlePayConfiguration`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(googlePayConfiguration = null),
+            sessionData = sessionData(merchantCountry = "US"),
+        )
+
+        assertThat(result.googlePay).isNull()
+    }
+
+    @Test
+    fun `sources the billing email from the checkout session customer email`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            sessionData = sessionData(customerEmail = "checkout@example.com"),
+        )
+
+        assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `populates billing details from the session data`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            sessionData = sessionData(
+                billingName = "Jane Billing",
+                billingPhoneNumber = "5559876543",
+                billingAddress = Address.State(
+                    city = "Denver",
+                    country = "US",
+                    line1 = "123 Main St",
+                    line2 = "Apt 4",
+                    postalCode = "80202",
+                    state = "CO",
+                ),
+            ),
+        )
+
+        val billingDetails = requireNotNull(result.defaultBillingDetails)
+        assertThat(billingDetails.name).isEqualTo("Jane Billing")
+        assertThat(billingDetails.phone).isEqualTo("5559876543")
+        assertThat(billingDetails.address?.city).isEqualTo("Denver")
+        assertThat(billingDetails.address?.line1).isEqualTo("123 Main St")
+    }
+
+    @Test
+    fun `populates shipping details from the session data`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            sessionData = sessionData(
+                shippingName = "John Shipping",
+                shippingPhoneNumber = "5551234567",
+            ),
+        )
+
+        assertThat(result.shippingDetails?.name).isEqualTo("John Shipping")
+        assertThat(result.shippingDetails?.phoneNumber).isEqualTo("5551234567")
+    }
+
+    @Test
+    fun `sets attachDefaultsToPaymentMethod to true`() {
+        val result = factory().create(configuration = controllerConfiguration(), sessionData = sessionData())
+
+        assertThat(result.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod).isTrue()
+    }
+
+    private fun factory(
+        merchantDisplayName: String = "Example, Inc.",
+    ) = CheckoutEmbeddedConfigurationFactory(merchantDisplayName = merchantDisplayName)
+
+    private fun controllerConfiguration(
+        embeddedViewDisplaysMandateText: Boolean = true,
+        billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
+        googlePayConfiguration: GooglePayConfiguration? = null,
+    ): CheckoutController.Configuration.State {
+        val builder = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration()
+                    .embeddedViewDisplaysMandateText(embeddedViewDisplaysMandateText)
+                    .billingDetailsCollectionConfiguration(
+                        BillingDetailsCollectionConfiguration().address(billingDetailsAddress)
+                    )
+            )
+        if (googlePayConfiguration != null) {
+            builder.googlePayConfiguration(googlePayConfiguration)
+        }
+        return builder.build()
+    }
+
+    private fun sessionData(
+        customerEmail: String? = null,
+        merchantCountry: String? = "US",
+        requiresBillingAddress: Boolean = false,
+        shippingName: String? = null,
+        billingName: String? = null,
+        shippingPhoneNumber: String? = null,
+        billingPhoneNumber: String? = null,
+        shippingAddress: Address.State? = null,
+        billingAddress: Address.State? = null,
+    ): CheckoutSessionData {
+        return InternalState(
+            key = "CheckoutEmbeddedConfigurationFactoryTest",
+            configuration = Checkout.Configuration().build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                customerEmail = customerEmail,
+                merchantCountry = merchantCountry,
+                requiresBillingAddress = requiresBillingAddress,
+            ),
+            shippingName = shippingName,
+            billingName = billingName,
+            shippingPhoneNumber = shippingPhoneNumber,
+            billingPhoneNumber = billingPhoneNumber,
+            shippingAddress = shippingAddress,
+            billingAddress = billingAddress,
+            flagImages = null,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -6,9 +6,6 @@ import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkout.BillingDetailsCollectionConfiguration
-import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -21,7 +18,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -42,8 +38,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
-import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
@@ -58,131 +52,6 @@ internal class CheckoutStateLoaderTest {
 
         assertThat(stateHolder.state?.paymentMethodMetadata).isNotNull()
     }
-
-    @Test
-    fun `loadInitial uses the provided merchant display name`() = runScenario(
-        merchantDisplayName = "Acme Corp",
-    ) {
-        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
-
-        assertThat(stateHolder.state?.embeddedConfiguration?.merchantDisplayName).isEqualTo("Acme Corp")
-    }
-
-    @Test
-    fun `loadInitial sources the billing email from the checkout session customer email`() = runScenario {
-        val response = CheckoutSessionResponseFactory.create(customerEmail = "checkout@example.com")
-
-        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response)
-
-        assertThat(stateHolder.state?.embeddedConfiguration?.defaultBillingDetails?.email)
-            .isEqualTo("checkout@example.com")
-    }
-
-    @Test
-    fun `loadInitial propagates embeddedViewDisplaysMandateText from the payment element configuration`() =
-        runScenario {
-            val configuration = CheckoutController.Configuration()
-                .paymentElement(PaymentElement.Configuration().embeddedViewDisplaysMandateText(false))
-                .build()
-
-            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
-
-            assertThat(stateHolder.state?.embeddedConfiguration?.embeddedViewDisplaysMandateText)
-                .isFalse()
-        }
-
-    @Test
-    fun `loadInitial propagates billingDetailsCollectionConfiguration from the payment element configuration`() =
-        runScenario {
-            val configuration = CheckoutController.Configuration()
-                .paymentElement(
-                    PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Full))
-                )
-                .build()
-
-            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
-
-            assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
-                .isEqualTo(PSFull)
-        }
-
-    @Test
-    fun `loadInitial uses the checkout session country for googlePayConfiguration`() = runScenario {
-        val configuration = CheckoutController.Configuration()
-            .googlePayConfiguration(
-                GooglePayConfiguration(
-                    GooglePayConfiguration.Environment.Production,
-                )
-                    .label("Total")
-                    .buttonType(GooglePayConfiguration.ButtonType.Checkout)
-                    .additionalEnabledNetworks(listOf("INTERAC"))
-            )
-            .build()
-
-        loader.loadInitial(
-            configuration = configuration,
-            checkoutSessionResponse = response(merchantCountry = "GB"),
-        )
-
-        val actual = requireNotNull(stateHolder.state?.embeddedConfiguration?.googlePay)
-        assertThat(actual.environment)
-            .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Production)
-        assertThat(actual.countryCode).isEqualTo("GB")
-        assertThat(actual.label).isEqualTo("Total")
-        assertThat(actual.buttonType)
-            .isEqualTo(PaymentSheet.GooglePayConfiguration.ButtonType.Checkout)
-        assertThat(actual.additionalEnabledNetworks).containsExactly("INTERAC")
-    }
-
-    @Test
-    fun `loadInitial leaves googlePayConfiguration null when checkout session country is missing`() = runScenario {
-        val configuration = CheckoutController.Configuration()
-            .googlePayConfiguration(
-                GooglePayConfiguration(
-                    GooglePayConfiguration.Environment.Production,
-                )
-            )
-            .build()
-
-        loader.loadInitial(
-            configuration = configuration,
-            checkoutSessionResponse = response(merchantCountry = null),
-        )
-
-        assertThat(stateHolder.state?.embeddedConfiguration?.googlePay).isNull()
-    }
-
-    @Test
-    fun `loadInitial upgrades Automatic to Full when the session requires a billing address`() =
-        runScenario {
-            val configuration = CheckoutController.Configuration()
-                .paymentElement(
-                    PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Automatic))
-                )
-                .build()
-            val response = CheckoutSessionResponseFactory.create(requiresBillingAddress = true)
-
-            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response)
-
-            assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
-                .isEqualTo(PSFull)
-        }
-
-    @Test
-    fun `loadInitial leaves Automatic unchanged when the session does not require a billing address`() =
-        runScenario {
-            val configuration = CheckoutController.Configuration()
-                .paymentElement(
-                    PaymentElement.Configuration().billingDetailsCollectionConfiguration(bdcc(address = Automatic))
-                )
-                .build()
-            val response = CheckoutSessionResponseFactory.create(requiresBillingAddress = false)
-
-            loader.loadInitial(configuration = configuration, checkoutSessionResponse = response)
-
-            assertThat(stateHolder.state?.embeddedConfiguration?.billingDetailsCollectionConfiguration?.address)
-                .isEqualTo(PSAutomatic)
-        }
 
     @Test
     fun `reload routes the selection through the chooser`() = runScenario(
@@ -314,10 +183,6 @@ internal class CheckoutStateLoaderTest {
         merchantCountry: String? = "US",
     ) = CheckoutSessionResponseFactory.create(merchantCountry = merchantCountry)
 
-    private fun bdcc(
-        address: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
-    ) = BillingDetailsCollectionConfiguration().address(address)
-
     // A committed state as [CheckoutStateLoader] would produce it, for exercising reloads. The
     // resolved metadata/configuration are placeholders; reload recomputes and overwrites them.
     private fun committedState(
@@ -382,7 +247,7 @@ internal class CheckoutStateLoaderTest {
         val recordingChooser = RecordingSelectionChooser(chosenSelection)
         val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
         val loader = CheckoutStateLoader(
-            merchantDisplayName = merchantDisplayName,
+            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(merchantDisplayName),
             flagImageResolver = flagImageResolver,
             paymentElementLoader = FakePaymentElementLoader(
                 paymentSelection = loaderSelection,


### PR DESCRIPTION
# Summary
Extracts the configuration creation logic for EmbeddedPaymentElement from CheckoutStateLoader into a new CheckoutEmbeddedConfigurationFactory class. Updates tests to cover the new class and refactors usages accordingly.

# Motivation
Centralizes the logic for building EmbeddedPaymentElement.Configuration, improving separation of concerns, reusability, and testability. This makes further changes or customizations to config construction easier and reduces duplication.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
