### PR TITLE
Make EmbeddedContentHelperStateHolder.State a data class and add test.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelperStateHolder.kt
@@ -24,7 +24,7 @@ internal interface EmbeddedContentHelperStateHolder {
     fun clearEmbeddedContent()
 
     @Parcelize
-    class State(
+    data class State(
         val paymentMethodMetadata: PaymentMethodMetadata,
         val appearance: Embedded,
         val embeddedViewDisplaysMandateText: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperStateHolderTest.kt
@@ -35,6 +35,29 @@ internal class DefaultEmbeddedContentHelperStateHolderTest {
     }
 
     @Test
+    fun `dataLoaded with identical args does not re-emit`() = testScenario {
+        val args = EmbeddedContentHelperStateFactory.create()
+        stateHolder.state.test {
+            assertThat(awaitItem()).isNull()
+            repeat(2) {
+                stateHolder.dataLoaded(
+                    paymentMethodMetadata = args.paymentMethodMetadata,
+                    appearance = args.appearance,
+                    embeddedViewDisplaysMandateText = args.embeddedViewDisplaysMandateText,
+                    configuration = args.configuration,
+                )
+            }
+            assertThat(awaitItem()).isEqualTo(args)
+            // A broken State.equals would cause the SavedStateHandle-backed StateFlow to re-emit
+            // identical data, rebuilding the embedded content and recomposing the UI unnecessarily.
+            expectNoEvents()
+        }
+        // onShowNewPaymentOptions is reported unconditionally per dataLoaded call, so twice here.
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
     fun `clearEmbeddedContent resets state to null`() = testScenario {
         stateHolder.dataLoaded(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),


### PR DESCRIPTION
# Summary
Make EmbeddedContentHelperStateHolder.State a data class, ensuring equals/hashCode work as expected. Add test verifying no redundant emissions occur for identical state.

# Motivation
The previous implementation of State as a regular class could lead to improper state comparisons in the SavedStateHandle, causing redundant emissions and unnecessary recompositions. Making it a data class guarantees correct structural equality. The new test prevents regressions.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
