### PR TITLE
Remove @Singleton annotation from DefaultEmbeddedContentHelper.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
-import javax.inject.Singleton
 
 internal interface EmbeddedContentHelper {
     val embeddedContent: StateFlow<EmbeddedContent?>
@@ -20,7 +19,6 @@ internal interface EmbeddedContentHelper {
     fun presentPaymentOptions()
 }
 
-@Singleton
 internal class DefaultEmbeddedContentHelper @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
     private val state: StateFlow<EmbeddedContentHelperStateHolder.State?>,


### PR DESCRIPTION
# Summary
Removed the @Singleton annotation from DefaultEmbeddedContentHelper in EmbeddedContentHelper.kt.

# Motivation
This class no longer holds state, so the scope is no longer necessary.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
