### PR TITLE
Wire up PaymentElement and confirmation logic in Checkout flow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
+import com.stripe.android.paymentelement.confirmation.toConfirmationOption
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
+
+internal class CheckoutConfirmationPerformer @Inject constructor(
+    private val confirmationHandler: ConfirmationHandler,
+    private val stateHolder: CheckoutControllerStateHolder,
+    @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
+) {
+    fun confirm() {
+        val arguments = confirmationArgs() ?: return
+        viewModelScope.launch {
+            confirmationHandler.start(arguments)
+        }
+    }
+
+    private fun confirmationArgs(): ConfirmationHandler.Args? {
+        val state = stateHolder.state ?: return null
+        val configuration = state.embeddedConfiguration.asCommonConfiguration()
+        val confirmationOption = state.paymentSelection?.toConfirmationOption(
+            configuration = configuration,
+            linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,
+            cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
+            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(state.paymentMethodMetadata),
+            googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
+                configuration = configuration,
+                paymentMethodMetadata = state.paymentMethodMetadata,
+            ),
+        ) ?: return null
+
+        return ConfirmationHandler.Args(
+            confirmationOption = confirmationOption,
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            statusBarColor = statusBarColor,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -7,8 +7,11 @@ import androidx.annotation.RestrictTo
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
+import com.stripe.android.common.ui.PaymentElementActivityResultCaller
 import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.validateShippingCountry
@@ -40,6 +43,7 @@ class CheckoutController @Inject internal constructor(
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) {
     val checkoutSession: StateFlow<CheckoutSession?>
         get() = stateHolder.checkoutSession
@@ -293,7 +297,16 @@ class CheckoutController @Inject internal constructor(
     }
 
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {
-        return checkoutPresenterSubcomponentFactory.create().presenter
+        val subcomponent = checkoutPresenterSubcomponentFactory.create(
+            activityResultCaller = PaymentElementActivityResultCaller(
+                key = "CheckoutController(instance = $paymentElementCallbackIdentifier)",
+                registryOwner = activity,
+            ),
+            lifecycleOwner = activity,
+            statusBarColor = StatusBarCompat.color(activity),
+        )
+        subcomponent.initializer.initialize()
+        return subcomponent.presenter
     }
 
     fun destroy() {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentElementInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentElementInitializer.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import javax.inject.Inject
+
+internal class CheckoutPaymentElementInitializer @Inject constructor(
+    private val confirmationHandler: ConfirmationHandler,
+    private val activityResultCaller: ActivityResultCaller,
+    private val lifecycleOwner: LifecycleOwner,
+) {
+    fun initialize() {
+        confirmationHandler.register(activityResultCaller, lifecycleOwner)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
@@ -12,6 +12,7 @@ class CheckoutPresenter @Inject internal constructor(
     private val currencySelectorElementProvider: Provider<CurrencySelectorElement>,
     private val shippingAddressElementProvider: Provider<ShippingAddressElement>,
     private val expressCheckoutElementProvider: Provider<ExpressCheckoutElement>,
+    private val checkoutConfirmationPerformerProvider: Provider<CheckoutConfirmationPerformer>,
 ) {
 
     fun paymentElement(): PaymentElement {
@@ -31,6 +32,6 @@ class CheckoutPresenter @Inject internal constructor(
     }
 
     fun confirm() {
-        TODO("Not yet implemented")
+        checkoutConfirmationPerformerProvider.get().confirm()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -3,21 +3,27 @@ package com.stripe.android.checkout
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class PaymentElement @Inject internal constructor() {
+class PaymentElement @Inject internal constructor(
+    private val contentHelper: EmbeddedContentHelper,
+) {
 
     @Composable
     fun PaymentOptionsContent() {
-        TODO("Not yet implemented")
+        val embeddedContent by contentHelper.embeddedContent.collectAsState()
+        embeddedContent?.Content()
     }
 
     fun presentPaymentOptions() {
-        TODO("Not yet implemented")
+        contentHelper.presentPaymentOptions()
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -37,6 +37,8 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
@@ -45,14 +47,14 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChoos
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
-import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
-import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
@@ -76,6 +78,7 @@ import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.TapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.TapToAddConnectionStarterModule
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -83,6 +86,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
 import java.util.UUID
 import javax.inject.Named
 import javax.inject.Singleton
@@ -92,6 +96,7 @@ import javax.inject.Singleton
     modules = [
         CheckoutControllerModule::class,
         CheckoutModule::class,
+        ExtendedPaymentElementConfirmationModule::class,
         CoreCommonModule::class,
         CoroutineContextModule::class,
         ElementsSessionClientParamsModule::class,
@@ -260,12 +265,6 @@ internal interface CheckoutControllerModule {
         }
 
         @Provides
-        @Singleton
-        fun provideCvcRecollectionHandler(): CvcRecollectionHandler {
-            return CvcRecollectionHandlerImpl()
-        }
-
-        @Provides
         fun providePaymentMethodMetadata(
             stateHolder: CheckoutControllerStateHolder,
         ): PaymentMethodMetadata? {
@@ -278,6 +277,40 @@ internal interface CheckoutControllerModule {
             @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
         ): AnalyticEventCallback? {
             return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]?.analyticEventCallback
+        }
+
+        @Provides
+        @Singleton
+        fun provideConfirmationHandler(
+            confirmationHandlerFactory: ConfirmationHandler.Factory,
+            @ViewModelScope coroutineScope: CoroutineScope,
+        ): ConfirmationHandler {
+            return confirmationHandlerFactory.create(coroutineScope)
+        }
+
+        @Provides
+        @Singleton
+        fun provideCustomerStateHolder(
+            savedStateHandle: SavedStateHandle,
+            selectionHolder: EmbeddedSelectionHolder,
+            paymentMethodMetadataFlow: StateFlow<PaymentMethodMetadata?>,
+        ): CustomerStateHolder {
+            val customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow {
+                it?.customerMetadata
+            }
+            return DefaultCustomerStateHolder(
+                savedStateHandle = savedStateHandle,
+                selection = selectionHolder.selection,
+                customerMetadata = customerMetadata,
+                paymentMethodMetadataFlow = paymentMethodMetadataFlow,
+            )
+        }
+
+        @Provides
+        fun providePaymentMethodMetadataFlow(
+            stateHolder: CheckoutControllerStateHolder,
+        ): StateFlow<PaymentMethodMetadata?> {
+            return stateHolder.stateFlow.mapAsStateFlow { it?.paymentMethodMetadata }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
@@ -2,21 +2,33 @@
 
 package com.stripe.android.checkout.injection
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.checkout.CheckoutPaymentElementInitializer
 import com.stripe.android.checkout.CheckoutPresenter
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import dagger.BindsInstance
 import dagger.Subcomponent
+import javax.inject.Named
 
 @Subcomponent(
     modules = [
         CurrencySelectorElementModule::class,
         ExpressCheckoutElementModule::class,
+        PaymentElementModule::class,
     ]
 )
 internal interface CheckoutPresenterSubcomponent {
     val presenter: CheckoutPresenter
+    val initializer: CheckoutPaymentElementInitializer
 
     @Subcomponent.Factory
     interface Factory {
-        fun create(): CheckoutPresenterSubcomponent
+        fun create(
+            @BindsInstance activityResultCaller: ActivityResultCaller,
+            @BindsInstance lifecycleOwner: LifecycleOwner,
+            @BindsInstance @Named(STATUS_BAR_COLOR) statusBarColor: Int?,
+        ): CheckoutPresenterSubcomponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.checkout.injection
+
+import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedLinkHelper
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedWalletsHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentMethodVerticalLayoutInteractorFactory
+import com.stripe.android.paymentelement.embedded.content.EmbeddedWalletsHelper
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.flow.StateFlow
+
+@Module
+internal interface PaymentElementModule {
+    @Binds
+    fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
+
+    @Binds
+    fun bindsEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
+        factory: DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory
+    ): EmbeddedPaymentMethodVerticalLayoutInteractorFactory
+
+    @Binds
+    fun bindsWalletsHelper(helper: DefaultEmbeddedWalletsHelper): EmbeddedWalletsHelper
+
+    @Binds
+    fun bindsLinkHelper(helper: DefaultEmbeddedLinkHelper): EmbeddedLinkHelper
+
+    @Binds
+    fun bindsEmbeddedRowSelectionImmediateActionHandler(
+        handler: DefaultEmbeddedRowSelectionImmediateActionHandler
+    ): EmbeddedRowSelectionImmediateActionHandler
+
+    companion object {
+        @Provides
+        fun provideEmbeddedContentState(
+            stateHolder: CheckoutControllerStateHolder,
+        ): StateFlow<EmbeddedContentHelperStateHolder.State?> {
+            return stateHolder.stateFlow.mapAsStateFlow { state ->
+                state?.let {
+                    EmbeddedContentHelperStateHolder.State(
+                        paymentMethodMetadata = it.paymentMethodMetadata,
+                        appearance = it.embeddedConfiguration.appearance.embeddedAppearance,
+                        embeddedViewDisplaysMandateText = it.embeddedConfiguration.embeddedViewDisplaysMandateText,
+                        configuration = it.embeddedConfiguration,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
+import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutConfirmationPerformerTest {
+
+    @Test
+    fun `confirm does nothing when state is not loaded`() = runScenario(state = null) {
+        performer.confirm()
+    }
+
+    @Test
+    fun `confirm does nothing when there is no selection`() = runScenario(
+        state = googlePayState(paymentSelection = null),
+    ) {
+        performer.confirm()
+    }
+
+    @Test
+    fun `confirm does nothing when the selection cannot be converted to a confirmation option`() = runScenario(
+        // Google Pay is selected but the configuration has no Google Pay set, so toConfirmationOption
+        // returns null and there is nothing to confirm.
+        state = CheckoutControllerStateFactory.create(
+            paymentSelection = PaymentSelection.GooglePay,
+        ),
+    ) {
+        performer.confirm()
+    }
+
+    @Test
+    fun `confirm starts confirmation with a Google Pay option`() = runScenario(
+        statusBarColor = STATUS_BAR_COLOR,
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+    ) {
+        performer.confirm()
+
+        val args = confirmationHandler.startTurbine.awaitItem()
+        assertThat(args.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
+        assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
+        assertThat(args.statusBarColor).isEqualTo(STATUS_BAR_COLOR)
+    }
+
+    @Test
+    fun `confirm starts confirmation with a Link option`() = runScenario(
+        state = CheckoutControllerStateFactory.create(
+            paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                linkState = LinkState(
+                    configuration = LinkTestUtils.createLinkConfiguration(),
+                    loginState = LinkState.LoginState.NeedsVerification,
+                    signupMode = null,
+                ),
+            ),
+        ),
+    ) {
+        performer.confirm()
+
+        val args = confirmationHandler.startTurbine.awaitItem()
+        assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
+    }
+
+    private fun googlePayState(
+        paymentSelection: PaymentSelection?,
+    ): CheckoutControllerState {
+        return CheckoutControllerStateFactory.create(
+            paymentSelection = paymentSelection,
+            embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "US",
+                    )
+                )
+                .build(),
+        )
+    }
+
+    private fun runScenario(
+        state: CheckoutControllerState?,
+        statusBarColor: Int? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val confirmationHandler = FakeConfirmationHandler()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        stateHolder.state = state
+        val performer = CheckoutConfirmationPerformer(
+            confirmationHandler = confirmationHandler,
+            stateHolder = stateHolder,
+            statusBarColor = statusBarColor,
+            viewModelScope = backgroundScope,
+        )
+
+        Scenario(
+            performer = performer,
+            confirmationHandler = confirmationHandler,
+            stateHolder = stateHolder,
+        ).block()
+
+        confirmationHandler.validate()
+    }
+
+    private class Scenario(
+        val performer: CheckoutConfirmationPerformer,
+        val confirmationHandler: FakeConfirmationHandler,
+        val stateHolder: CheckoutControllerStateHolder,
+    )
+
+    private companion object {
+        const val STATUS_BAR_COLOR = 0x00FF00
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPaymentElementInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPaymentElementInitializerTest.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import kotlinx.coroutines.test.runTest
+import org.mockito.kotlin.mock
+import kotlin.test.Test
+
+internal class CheckoutPaymentElementInitializerTest {
+
+    @Test
+    fun `initialize registers the confirmation handler with the caller and lifecycle owner`() = runScenario {
+        initializer.initialize()
+
+        val registerCall = confirmationHandler.registerTurbine.awaitItem()
+        assertThat(registerCall.activityResultCaller).isSameInstanceAs(activityResultCaller)
+        assertThat(registerCall.lifecycleOwner).isSameInstanceAs(lifecycleOwner)
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val confirmationHandler = FakeConfirmationHandler()
+        val activityResultCaller = mock<ActivityResultCaller>()
+        val lifecycleOwner = mock<LifecycleOwner>()
+        val initializer = CheckoutPaymentElementInitializer(
+            confirmationHandler = confirmationHandler,
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
+        )
+
+        Scenario(
+            initializer = initializer,
+            confirmationHandler = confirmationHandler,
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
+        ).block()
+
+        confirmationHandler.validate()
+    }
+
+    private class Scenario(
+        val initializer: CheckoutPaymentElementInitializer,
+        val confirmationHandler: FakeConfirmationHandler,
+        val activityResultCaller: ActivityResultCaller,
+        val lifecycleOwner: LifecycleOwner,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/PaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/PaymentElementTest.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.checkout
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContent
+import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class PaymentElementTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @Test
+    fun `presentPaymentOptions delegates to the content helper`() = runTest {
+        val contentHelper = FakeEmbeddedContentHelper()
+        val paymentElement = PaymentElement(contentHelper)
+
+        paymentElement.presentPaymentOptions()
+
+        contentHelper.presentPaymentOptionsCalls.awaitItem()
+        contentHelper.presentPaymentOptionsCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `PaymentOptionsContent renders nothing when there is no embedded content`() {
+        val contentHelper = FakeEmbeddedContentHelper(embeddedContent = MutableStateFlow(null))
+        val paymentElement = PaymentElement(contentHelper)
+
+        composeRule.setContent {
+            paymentElement.PaymentOptionsContent()
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertDoesNotExist()
+    }
+
+    @Test
+    fun `PaymentOptionsContent renders the current embedded content`() {
+        val content = EmbeddedContent(
+            interactor = FakePaymentMethodVerticalLayoutInteractor.create(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            ),
+            embeddedViewDisplaysMandateText = true,
+            appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
+            isImmediateAction = false,
+        )
+        val contentHelper = FakeEmbeddedContentHelper(embeddedContent = MutableStateFlow(content))
+        val paymentElement = PaymentElement(contentHelper)
+
+        composeRule.setContent {
+            paymentElement.PaymentOptionsContent()
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertIsDisplayed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedContentHelper.kt
@@ -1,9 +1,14 @@
 package com.stripe.android.paymentelement.embedded.content
 
+import app.cash.turbine.Turbine
 import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class FakeEmbeddedContentHelper(
     override val embeddedContent: MutableStateFlow<EmbeddedContent?> = MutableStateFlow(null),
 ) : EmbeddedContentHelper {
-    override fun presentPaymentOptions() = Unit
+    val presentPaymentOptionsCalls: Turbine<Unit> = Turbine()
+
+    override fun presentPaymentOptions() {
+        presentPaymentOptionsCalls.add(Unit)
+    }
 }


### PR DESCRIPTION
# Summary

This PR wires up the `PaymentElement` in the checkout module, connects it to embedded content, and implements confirmation handling to perform the payment confirmation flow. It adds the necessary modules, subcomponent wiring, and logic to present payment options and trigger confirmations.

This is not yet complete, and activity launching does not happen for forms on the embedded content, or the actual present method. This will be wired up in a followup.

# Motivation

The motivation is to bridge the gap between the checkout UI and its business logic, enabling a full payment flow from UI presentation to confirmation using injected dependencies and state. This brings the flow closer to feature completion for the embedded checkout experience.

# Testing

- [x] Added tests
- [x] Modified tests
- [x] Manually verified
