### PR TITLE
Add `android_link_standalone` request surface for Link Standalone

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/RequestSurface.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/RequestSurface.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RestrictTo
 enum class RequestSurface(val value: String) {
     PaymentElement("android_payment_element"),
     CryptoOnramp("android_crypto_onramp"),
+
     // Only for use by the LinkControllerPreview API.
     StandaloneLink("android_link_standalone"),
     ;

--- a/payments-core/src/main/java/com/stripe/android/networking/RequestSurface.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/RequestSurface.kt
@@ -6,6 +6,8 @@ import androidx.annotation.RestrictTo
 enum class RequestSurface(val value: String) {
     PaymentElement("android_payment_element"),
     CryptoOnramp("android_crypto_onramp"),
+    // Only for use by the LinkControllerPreview API.
+    StandaloneLink("android_link_standalone"),
     ;
 
     override fun toString(): String = value

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -22,10 +22,10 @@ internal class DefaultLinkConfigurationLoader @Inject constructor(
 
     override suspend fun load(configuration: LinkController.Configuration.State): Result<LinkMetadata> {
         return paymentElementLoader.load(
-            initializationMode = PaymentElementLoader.InitializationMode.CryptoOnramp(
+            initializationMode = PaymentElementLoader.InitializationMode.StandaloneLink(
                 paymentMethodTypes = configuration.paymentMethodTypes,
             ),
-            integrationConfiguration = PaymentElementLoader.Configuration.CryptoOnramp(configuration),
+            integrationConfiguration = PaymentElementLoader.Configuration.StandaloneLink(configuration),
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = savedStateHandle.contains(
                     LinkControllerInteractor.LINK_CONFIGURED_KEY

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.link.exceptions.LinkUnavailableException
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkMetadata
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 
@@ -17,15 +18,28 @@ internal class DefaultLinkConfigurationLoader @Inject constructor(
     private val paymentElementLoader: PaymentElementLoader,
     private val linkGateFactory: LinkGate.Factory,
     private val savedStateHandle: SavedStateHandle,
+    private val requestSurface: RequestSurface,
 ) : LinkConfigurationLoader {
     private val tag = "LinkConfigurationLoader"
 
     override suspend fun load(configuration: LinkController.Configuration.State): Result<LinkMetadata> {
+        val (initializationMode, integrationConfiguration) = when (requestSurface) {
+            RequestSurface.CryptoOnramp -> Pair(
+                PaymentElementLoader.InitializationMode.CryptoOnramp(
+                    paymentMethodTypes = configuration.paymentMethodTypes,
+                ),
+                PaymentElementLoader.Configuration.CryptoOnramp(configuration),
+            )
+            else -> Pair(
+                PaymentElementLoader.InitializationMode.StandaloneLink(
+                    paymentMethodTypes = configuration.paymentMethodTypes,
+                ),
+                PaymentElementLoader.Configuration.StandaloneLink(configuration),
+            )
+        }
         return paymentElementLoader.load(
-            initializationMode = PaymentElementLoader.InitializationMode.StandaloneLink(
-                paymentMethodTypes = configuration.paymentMethodTypes,
-            ),
-            integrationConfiguration = PaymentElementLoader.Configuration.StandaloneLink(configuration),
+            initializationMode = initializationMode,
+            integrationConfiguration = integrationConfiguration,
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = savedStateHandle.contains(
                     LinkControllerInteractor.LINK_CONFIGURED_KEY

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -951,7 +951,7 @@ class LinkController @Inject internal constructor(
             return create(
                 application = application,
                 savedStateHandle = savedStateHandle,
-                requestSurface = RequestSurface.PaymentElement,
+                requestSurface = RequestSurface.StandaloneLink,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
@@ -12,6 +12,7 @@ internal fun ClientAttributionMetadata.Companion.create(
 ): ClientAttributionMetadata {
     val paymentIntentCreationFlow = when (initializationMode) {
         is PaymentElementLoader.InitializationMode.CryptoOnramp,
+        is PaymentElementLoader.InitializationMode.StandaloneLink,
         is PaymentElementLoader.InitializationMode.DeferredIntent -> PaymentIntentCreationFlow.Deferred
         is PaymentElementLoader.InitializationMode.PaymentIntent,
         is PaymentElementLoader.InitializationMode.SetupIntent -> PaymentIntentCreationFlow.Standard

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
@@ -45,6 +45,9 @@ internal sealed class IntegrationMetadata : Parcelable {
     object CryptoOnramp : IntegrationMetadata()
 
     @Parcelize
+    object StandaloneLink : IntegrationMetadata()
+
+    @Parcelize
     data class CheckoutSession(
         val id: String,
         val instancesKey: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -61,13 +61,10 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                 // CustomerSheet calls confirm with an IntegrationMetadata.IntentFirst setup intent.
                 throw IllegalStateException("CustomerSheet not supported by default confirmation interceptor!")
             }
-            IntegrationMetadata.CryptoOnramp -> {
-                // CryptoOnRamp doesn't call confirm.
-                throw IllegalStateException("No intent confirmation interceptor for CryptoOnramp.")
-            }
+            IntegrationMetadata.CryptoOnramp,
             IntegrationMetadata.StandaloneLink -> {
-                // StandaloneLink doesn't call confirm.
-                throw IllegalStateException("No intent confirmation interceptor for StandaloneLink.")
+                // Neither CryptoOnramp nor StandaloneLink calls confirm.
+                throw IllegalStateException("No intent confirmation interceptor for ${integrationMetadata::class.simpleName}.")
             }
             is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> {
                 confirmationTokenConfirmationInterceptorFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -65,6 +65,10 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                 // CryptoOnRamp doesn't call confirm.
                 throw IllegalStateException("No intent confirmation interceptor for CryptoOnramp.")
             }
+            IntegrationMetadata.StandaloneLink -> {
+                // StandaloneLink doesn't call confirm.
+                throw IllegalStateException("No intent confirmation interceptor for StandaloneLink.")
+            }
             is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> {
                 confirmationTokenConfirmationInterceptorFactory.create(
                     intentConfiguration = integrationMetadata.intentConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -64,8 +64,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
             IntegrationMetadata.CryptoOnramp,
             IntegrationMetadata.StandaloneLink -> {
                 // Neither CryptoOnramp nor StandaloneLink calls confirm.
-                val name = integrationMetadata::class.simpleName
-                throw IllegalStateException("No intent confirmation interceptor for $name.")
+                throw IllegalStateException("No intent confirmation interceptor for CryptoOnramp or StandaloneLink.")
             }
             is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> {
                 confirmationTokenConfirmationInterceptorFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -64,7 +64,8 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
             IntegrationMetadata.CryptoOnramp,
             IntegrationMetadata.StandaloneLink -> {
                 // Neither CryptoOnramp nor StandaloneLink calls confirm.
-                throw IllegalStateException("No intent confirmation interceptor for ${integrationMetadata::class.simpleName}.")
+                val name = integrationMetadata::class.simpleName
+                throw IllegalStateException("No intent confirmation interceptor for $name.")
             }
             is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> {
                 confirmationTokenConfirmationInterceptorFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -286,6 +286,27 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
             )
         }
 
+        is PaymentElementLoader.InitializationMode.StandaloneLink -> {
+            val intentConfiguration = PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
+                paymentMethodTypes = paymentMethodTypes ?: emptyList(),
+            )
+            ElementsSessionParams.DeferredIntentType(
+                locale = clientParams.locale,
+                deferredIntentParams = intentConfiguration.toDeferredIntentParams(),
+                customPaymentMethods = customPaymentMethodIds,
+                externalPaymentMethods = externalPaymentMethods,
+                customerSessionClientSecret = customerSessionClientSecret,
+                legacyCustomerEphemeralKey = legacyCustomerEphemeralKey,
+                savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
+                mobileSessionId = clientParams.mobileSessionId,
+                sellerDetails = intentConfiguration.toSellerDetails(),
+                appId = clientParams.mobileAppId,
+                countryOverride = countryOverride,
+                link = linkParams,
+            )
+        }
+
         is PaymentElementLoader.InitializationMode.CheckoutSession -> {
             throw IllegalStateException("ElementsSessionParams is from server when using CheckoutSession")
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -130,7 +130,8 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
         when (this@analyticsMap) {
             is PaymentElementLoader.Configuration.PaymentSheet -> putAll(analyticsMap())
             is PaymentElementLoader.Configuration.Embedded -> putAll(analyticsMap())
-            is PaymentElementLoader.Configuration.CryptoOnramp -> Unit
+            is PaymentElementLoader.Configuration.CryptoOnramp,
+            is PaymentElementLoader.Configuration.StandaloneLink -> Unit
         }
     }
 
@@ -245,6 +246,7 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
 private val PaymentElementLoader.InitializationMode.defaultAnalyticsValue: String
     get() = when (this) {
         is PaymentElementLoader.InitializationMode.CryptoOnramp -> "crypto_onramp"
+        is PaymentElementLoader.InitializationMode.StandaloneLink -> "standalone_link"
         is PaymentElementLoader.InitializationMode.CheckoutSession -> "checkout_session"
         is PaymentElementLoader.InitializationMode.DeferredIntent -> {
             when (this.intentConfiguration.mode) {
@@ -258,7 +260,8 @@ private val PaymentElementLoader.InitializationMode.defaultAnalyticsValue: Strin
 
 private fun IntegrationMetadata.isDeferred(): Boolean = when (this) {
     is IntegrationMetadata.IntentFirst -> false
-    IntegrationMetadata.CryptoOnramp -> true
+    IntegrationMetadata.CryptoOnramp,
+    IntegrationMetadata.StandaloneLink -> true
     is IntegrationMetadata.CustomerSheet -> true
     is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> true
     is IntegrationMetadata.DeferredIntent.WithPaymentMethod -> true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -101,6 +101,12 @@ internal interface PaymentElementLoader {
         ) : Configuration {
             override val commonConfiguration: CommonConfiguration = configuration.asCommonConfiguration()
         }
+
+        data class StandaloneLink(
+            val configuration: LinkController.Configuration.State
+        ) : Configuration {
+            override val commonConfiguration: CommonConfiguration = configuration.asCommonConfiguration()
+        }
     }
 
     sealed class InitializationMode : Parcelable {
@@ -209,6 +215,19 @@ internal interface PaymentElementLoader {
 
             override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
                 return IntegrationMetadata.CryptoOnramp
+            }
+        }
+
+        @Parcelize
+        data class StandaloneLink(
+            val paymentMethodTypes: List<String>? = null,
+        ) : InitializationMode() {
+            override fun validate() {
+                // Nothing to validate.
+            }
+
+            override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
+                return IntegrationMetadata.StandaloneLink
             }
         }
 
@@ -616,6 +635,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     ): PaymentMethodLayout {
         return when (integrationConfiguration) {
             is PaymentElementLoader.Configuration.CryptoOnramp,
+            is PaymentElementLoader.Configuration.StandaloneLink,
             is PaymentElementLoader.Configuration.Embedded -> PaymentMethodLayout.Vertical
             is PaymentElementLoader.Configuration.PaymentSheet ->
                 if (

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.link.exceptions.LinkUnavailableException
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -45,6 +46,7 @@ internal class DefaultLinkConfigurationLoaderTest {
             paymentElementLoader = paymentElementLoader,
             linkGateFactory = linkGateFactory,
             savedStateHandle = savedStateHandle,
+            requestSurface = RequestSurface.StandaloneLink,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -3,8 +3,8 @@ package com.stripe.android.link
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.networking.RequestSurface
 import com.stripe.android.link.exceptions.LinkUnavailableException
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.LinkState

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.link.exceptions.LinkUnavailableException
-import com.stripe.android.networking.RequestSurface
 import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -76,6 +76,7 @@ internal class FakePaymentElementLoader(
                 ?: PaymentMethodMetadataFactory.defaultIntegrationMetadata(stripeIntent),
             paymentMethodLayout = when (integrationConfiguration) {
                 is PaymentElementLoader.Configuration.CryptoOnramp,
+                is PaymentElementLoader.Configuration.StandaloneLink,
                 is PaymentElementLoader.Configuration.Embedded -> PaymentSheet.PaymentMethodLayout.Vertical
                 is PaymentElementLoader.Configuration.PaymentSheet ->
                     integrationConfiguration.configuration.paymentMethodLayout


### PR DESCRIPTION
# Summary

Adds the new request surface used by the LinkController by default in the Link Standalone flow

Also adds a LinkStandalone initialization mode, instead of always using CryptoOnramp in LinkController

# Motivation

Decouple Link standalone from crypto onramp / payment sheet

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
