### PR TITLE
Set Google Pay's allowCreditCards value based on card funding filter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.effectiveLinkBrand
+import com.stripe.android.model.CardFunding
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -56,7 +57,7 @@ internal sealed interface ExpressButton {
                 googlePayConfiguration: GooglePayConfiguration.State,
             ): GooglePay {
                 return GooglePay(
-                    allowCreditCards = true,
+                    allowCreditCards = paymentMethodMetadata.cardFundingFilter.isAccepted(CardFunding.Credit),
                     googlePayButtonType = googlePayConfiguration.buttonType.asGooglePayButtonType(),
                     cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
                     cardFundingFilter = paymentMethodMetadata.cardFundingFilter,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
@@ -168,6 +168,36 @@ internal class ExpressButtonTest {
         assertThat(button.cardFundingFilter).isSameInstanceAs(cardFundingFilter)
     }
 
+    @Test
+    fun `GooglePay create allows credit cards when payment method metadata accepts credit funding`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            cardFundingFilter = PaymentSheetCardFundingFilter(
+                allowedCardFundingTypes = listOf(PaymentSheet.CardFundingType.Credit),
+            ),
+        )
+
+        val button = createGooglePayExpressButton(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+
+        assertThat(button.allowCreditCards).isTrue()
+    }
+
+    @Test
+    fun `GooglePay create disallows credit cards when payment method metadata rejects credit funding`() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            cardFundingFilter = PaymentSheetCardFundingFilter(
+                allowedCardFundingTypes = listOf(PaymentSheet.CardFundingType.Debit),
+            ),
+        )
+
+        val button = createGooglePayExpressButton(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+
+        assertThat(button.allowCreditCards).isFalse()
+    }
+
     private fun createGooglePayExpressButton(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         googlePayConfiguration: GooglePayConfiguration.State = createGooglePayConfiguration()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Set Google Pay's allowCreditCards value based on card funding filter

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Parity with other surfaces, respect card funding filtering

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified