### PR TITLE
Timeout of NFC scanning flow after 20 seconds of inactivity

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningTimeoutManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningTimeoutManager.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.common.nfcscan
+
+import com.stripe.android.core.injection.ViewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+
+internal interface NfcScanningTimeoutManager {
+    val timeout: SharedFlow<Unit>
+
+    fun start()
+
+    fun reset()
+
+    fun cancel()
+}
+
+internal class DefaultNfcScanningTimeoutManager @Inject constructor(
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+) : NfcScanningTimeoutManager {
+    private val _timeout = MutableSharedFlow<Unit>()
+    override val timeout: SharedFlow<Unit> = _timeout.asSharedFlow()
+
+    private var timeoutJob: Job? = null
+
+    override fun start() {
+        scheduleTimeout()
+    }
+
+    override fun reset() {
+        scheduleTimeout()
+    }
+
+    override fun cancel() {
+        timeoutJob?.cancel()
+        timeoutJob = null
+    }
+
+    private fun scheduleTimeout() {
+        timeoutJob?.cancel()
+        timeoutJob = coroutineScope.launch {
+            delay(INACTIVITY_TIMEOUT)
+            _timeout.emit(Unit)
+        }
+    }
+
+    private companion object {
+        val INACTIVITY_TIMEOUT = 20.seconds
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.stripe.android.common.nfcscan.analytics.NfcScanCancellationReason
 import com.stripe.android.common.nfcscan.analytics.NfcScanningEventReporter
 import com.stripe.android.common.nfcscan.scanner.NfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.ScannedCardData
@@ -28,6 +29,7 @@ internal class NfcScanningViewModel @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     tapZoneResolver: TapZoneResolver,
     private val cardScanner: NfcCardScanner,
+    private val timeoutManager: NfcScanningTimeoutManager,
     private val eventReporter: NfcScanningEventReporter,
 ) : ViewModel() {
     private val tapZone = tapZoneResolver.get()
@@ -45,14 +47,18 @@ internal class NfcScanningViewModel @Inject constructor(
 
     private var pendingValidCardData: ScannedCardData? = null
     private var successShownDispatched = false
+    private var isFlowClosed = false
 
     init {
         eventReporter.onNfcScanStarted()
+        timeoutManager.start()
 
         viewModelScope.launch {
             cardScanner.state.collectLatest { state ->
                 when (state) {
                     is NfcCardScanner.State.Scanning -> {
+                        timeoutManager.reset()
+
                         _viewState.emit(
                             NfcScanningViewState(
                                 tapZone = tapZone,
@@ -63,6 +69,8 @@ internal class NfcScanningViewModel @Inject constructor(
                         eventReporter.onNfcScanAttemptStarted()
                     }
                     is NfcCardScanner.State.Failed -> {
+                        timeoutManager.reset()
+
                         _event.emit(NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Failed))
 
                         val error = state.error
@@ -77,6 +85,8 @@ internal class NfcScanningViewModel @Inject constructor(
                         eventReporter.onNfcScanAttemptFailed(errorCode = error.code)
                     }
                     is NfcCardScanner.State.Complete -> {
+                        timeoutManager.cancel()
+
                         _event.emit(NfcScanningEvent.TriggerHapticFeedback(HapticFeedbackType.Success))
 
                         _viewState.emit(
@@ -93,6 +103,14 @@ internal class NfcScanningViewModel @Inject constructor(
                 }
             }
         }
+
+        viewModelScope.launch {
+            timeoutManager.timeout.collectLatest {
+                if (pendingValidCardData == null) {
+                    cancel(NfcScanCancellationReason.Timeout)
+                }
+            }
+        }
     }
 
     fun register(activity: AppCompatActivity) {
@@ -103,8 +121,7 @@ internal class NfcScanningViewModel @Inject constructor(
         when (viewAction) {
             is NfcScanningViewAction.Close -> {
                 viewModelScope.launch {
-                    eventReporter.onNfcScanCancelled()
-                    _event.emit(NfcScanningEvent.CloseWithResult(NfcScanningContract.Result.Canceled))
+                    cancel(NfcScanCancellationReason.UserInitiated)
                 }
             }
             is NfcScanningViewAction.SuccessShown -> {
@@ -131,8 +148,20 @@ internal class NfcScanningViewModel @Inject constructor(
     }
 
     override fun onCleared() {
+        timeoutManager.cancel()
         viewModelScope.cancel()
         super.onCleared()
+    }
+
+    private suspend fun cancel(reason: NfcScanCancellationReason) {
+        if (isFlowClosed) {
+            return
+        }
+
+        isFlowClosed = true
+        timeoutManager.cancel()
+        eventReporter.onNfcScanCancelled(reason)
+        _event.emit(NfcScanningEvent.CloseWithResult(NfcScanningContract.Result.Canceled))
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.common.nfcscan.tapzone.TapZoneModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
@@ -40,13 +41,18 @@ internal interface NfcScanningViewModelComponent {
         TapZoneModule::class,
     ]
 )
-internal object NfcScanningViewModelModule {
-    @Provides
-    @ViewModelScope
-    fun provideViewModelScope(): CoroutineScope {
-        return CoroutineScope(Dispatchers.Main)
-    }
+internal interface NfcScanningViewModelModule {
+    @Binds
+    fun bindsTimeoutManager(manager: DefaultNfcScanningTimeoutManager): NfcScanningTimeoutManager
 
-    @Provides
-    fun providesContext(application: Application): Context = application.applicationContext
+    companion object {
+        @Provides
+        @ViewModelScope
+        fun provideViewModelScope(): CoroutineScope {
+            return CoroutineScope(Dispatchers.Main)
+        }
+
+        @Provides
+        fun providesContext(application: Application): Context = application.applicationContext
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanCancellationReason.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanCancellationReason.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.common.nfcscan.analytics
+
+internal enum class NfcScanCancellationReason(val analyticsValue: String) {
+    UserInitiated("user_initiated"),
+    Timeout("scanning_timeout"),
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
@@ -42,8 +42,10 @@ internal interface NfcScanningEventReporter {
 
     /**
      * The user has chosen to exit the NFC scanning flow without scanning valid card details.
+     *
+     * @param reason why there was an NFC flow cancellation
      */
-    fun onNfcScanCancelled()
+    fun onNfcScanCancelled(reason: NfcScanCancellationReason)
 }
 
 internal class DefaultNfcScanningEventReporter @Inject constructor(
@@ -81,9 +83,13 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
         )
     }
 
-    override fun onNfcScanCancelled() {
-        durationProvider.end(DurationProvider.Key.NfcScan)
-        fireEvent(eventName = SCAN_CANCELED_EVENT_NAME)
+    override fun onNfcScanCancelled(reason: NfcScanCancellationReason) {
+        val duration = durationProvider.end(DurationProvider.Key.NfcScan)
+        fireEvent(
+            eventName = SCAN_CANCELED_EVENT_NAME,
+            additionalParams = duration.mapOfDurationInSeconds() +
+                mapOf(FIELD_CANCELLATION_REASON to reason.analyticsValue)
+        )
     }
 
     private fun fireEvent(
@@ -103,6 +109,7 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
 
     private companion object {
         const val FIELD_ERROR_CODE = "error_code"
+        const val FIELD_CANCELLATION_REASON = "cancellation_reason"
 
         const val SCAN_STARTED_EVENT_NAME = "nfc_scan_started"
         const val SCAN_SUCCESS_EVENT_NAME = "nfc_scan_success"

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/DefaultNfcScanningTimeoutManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/DefaultNfcScanningTimeoutManagerTest.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.common.nfcscan
+
+import app.cash.turbine.test
+import com.stripe.android.testing.CleanupTestRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class DefaultNfcScanningTimeoutManagerTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @Test
+    fun `timeout emits after inactivity duration`() = runTest {
+        val timeoutManager = createTimeoutManager()
+
+        timeoutManager.timeout.test {
+            timeoutManager.start()
+            advanceUntilIdle()
+
+            advanceTimeBy(INACTIVITY_TIMEOUT)
+            advanceUntilIdle()
+
+            awaitItem()
+            ensureAllEventsConsumed()
+        }
+    }
+
+    private fun TestScope.createTimeoutManager(): DefaultNfcScanningTimeoutManager {
+        return DefaultNfcScanningTimeoutManager(
+            coroutineScope = coroutineScopeCleanupRule.track(
+                CoroutineScope(StandardTestDispatcher(testScheduler))
+            ),
+        )
+    }
+
+    private companion object {
+        val INACTIVITY_TIMEOUT = 20.seconds
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeNfcScanningTimeoutManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeNfcScanningTimeoutManager.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.common.nfcscan
+
+import app.cash.turbine.Turbine
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+internal class FakeNfcScanningTimeoutManager(
+    private val timeoutFlow: MutableSharedFlow<Unit> = MutableSharedFlow(extraBufferCapacity = 1),
+) : NfcScanningTimeoutManager {
+    val startCalls = Turbine<Unit>()
+    val resetCalls = Turbine<Unit>()
+    val cancelCalls = Turbine<Unit>()
+
+    override val timeout: SharedFlow<Unit> = timeoutFlow.asSharedFlow()
+
+    override fun start() {
+        startCalls.add(Unit)
+    }
+
+    override fun reset() {
+        resetCalls.add(Unit)
+    }
+
+    override fun cancel() {
+        cancelCalls.add(Unit)
+    }
+
+    suspend fun emitTimeout() {
+        timeoutFlow.emit(Unit)
+    }
+
+    fun ensureAllEventsConsumed() {
+        startCalls.ensureAllEventsConsumed()
+        resetCalls.ensureAllEventsConsumed()
+        cancelCalls.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -149,6 +149,17 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
+    fun `inactivity timeout returns canceled result`() = test {
+        NfcScanningActivityTestHelpers.waitForInitialScanningUi(this)
+
+        NfcScanningActivityTestHelpers.advanceInactivityTimeout(this)
+
+        waitForActivityFinish()
+
+        assertThat(getResult()).isEqualTo(NfcScanningContract.Result.Canceled)
+    }
+
+    @Test
     fun `finish applies fade out transition`() {
         configureNfc(context)
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
@@ -19,7 +19,10 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mockStatic
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowNfcAdapter
+import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.shadows.ShadowVibrator
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 internal object NfcScanningActivityTestHelpers {
     private const val UI_TIMEOUT_MS = 5_000L
@@ -82,6 +85,14 @@ internal object NfcScanningActivityTestHelpers {
         }
     }
 
+    fun advanceInactivityTimeout(scenario: Scenario) {
+        ShadowSystemClock.advanceBy(
+            20.seconds.inWholeSeconds,
+            TimeUnit.SECONDS,
+        )
+        scenario.waitForIdle()
+    }
+
     private fun createScenario(
         context: Context,
         composeRule: ComposeTestRule,
@@ -128,7 +139,7 @@ internal object NfcScanningActivityTestHelpers {
     private fun getNfcAdapter(context: Context) =
         NfcAdapter.getDefaultAdapter(context)?.let { shadowOf(it) }
 
-    private fun waitForInitialScanningUi(scenario: Scenario) {
+    internal fun waitForInitialScanningUi(scenario: Scenario) {
         scenario.composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
             scenario.waitForIdle()
             scenario.composeRule.onAllNodesWithContentDescription("Cancel")

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelStore
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.analytics.FakeNfcScanningEventReporter
+import com.stripe.android.common.nfcscan.analytics.NfcScanCancellationReason
 import com.stripe.android.common.nfcscan.scanner.FakeNfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.NfcCardScanner
 import com.stripe.android.common.nfcscan.scanner.ScannedCardData
@@ -67,7 +68,10 @@ internal class NfcScanningViewModelTest {
             assertThat(resultEvent.result).isEqualTo(NfcScanningContract.Result.Canceled)
         }
 
-        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem()).isNotNull()
+        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem())
+            .isEqualTo(NfcScanCancellationReason.UserInitiated)
+
+        assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -101,6 +105,7 @@ internal class NfcScanningViewModelTest {
         }
 
         assertThat(fakeEventReporter.onNfcScanAttemptStartedCalls.awaitItem()).isNotNull()
+        assertThat(fakeTimeoutManager.resetCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -122,6 +127,7 @@ internal class NfcScanningViewModelTest {
         }
 
         assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
+        assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
     }
 
     @Test
@@ -142,6 +148,7 @@ internal class NfcScanningViewModelTest {
 
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Idle(error = errorMessage))
             assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("unknown")
+            assertThat(fakeTimeoutManager.resetCalls.awaitItem()).isNotNull()
         }
     }
 
@@ -249,21 +256,67 @@ internal class NfcScanningViewModelTest {
     }
 
     @Test
-    fun `onCleared cancels view model scope`() = runTest(dispatcher) {
+    fun `timeout emits Canceled result with timeout reason`() = runScenario {
+        viewModel.event.test {
+            fakeTimeoutManager.emitTimeout()
+
+            val event = awaitItem()
+
+            assertThat(event).isInstanceOf<NfcScanningEvent.CloseWithResult>()
+
+            val resultEvent = event as NfcScanningEvent.CloseWithResult
+
+            assertThat(resultEvent.result).isEqualTo(NfcScanningContract.Result.Canceled)
+        }
+
+        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem())
+            .isEqualTo(NfcScanCancellationReason.Timeout)
+        assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `timeout does not cause flow cancellation after successful scan`() = runScenario {
+        scannerState.emit(
+            NfcCardScanner.State.Complete(
+                ScannedCardData(
+                    cardNumber = "4242424242424242",
+                    expirationMonth = 12,
+                    expirationYear = 2030,
+                ),
+            ),
+        )
+
+        assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
+        assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
+
+        viewModel.event.test {
+            fakeTimeoutManager.emitTimeout()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `onCleared cancels view model scope & timeout manager`() = runTest(dispatcher) {
         val viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher + Job()))
+        val fakeTimeoutManager = FakeNfcScanningTimeoutManager()
         val viewModel = NfcScanningViewModel(
             viewModelScope = viewModelScope,
             tapZoneResolver = FakeTapZoneResolver(),
             cardScanner = FakeNfcCardScanner(),
+            timeoutManager = fakeTimeoutManager,
             eventReporter = FakeNfcScanningEventReporter(),
         ).also { viewModelStoreRule.track(it) }
         val viewModelStore = ViewModelStore().apply {
             put("test", viewModel)
         }
 
+        assertThat(fakeTimeoutManager.startCalls.awaitItem()).isNotNull()
+
         viewModelStore.clear()
 
+        assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
         assertThat(viewModelScope.coroutineContext[Job]?.isCancelled).isTrue()
+        fakeTimeoutManager.ensureAllEventsConsumed()
     }
 
     private fun runScenario(
@@ -273,19 +326,23 @@ internal class NfcScanningViewModelTest {
         val scannerState = MutableSharedFlow<NfcCardScanner.State>()
         val fakeCardScanner = FakeNfcCardScanner(stateFlow = scannerState)
         val fakeEventReporter = FakeNfcScanningEventReporter()
+        val fakeTimeoutManager = FakeNfcScanningTimeoutManager()
         val viewModel = NfcScanningViewModel(
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)),
             tapZoneResolver = FakeTapZoneResolver(tapZone),
             cardScanner = fakeCardScanner,
+            timeoutManager = fakeTimeoutManager,
             eventReporter = fakeEventReporter,
         ).also { viewModelStoreRule.track(it) }
 
         assertThat(fakeEventReporter.onNfcScanStartedCalls.awaitItem()).isNotNull()
+        assertThat(fakeTimeoutManager.startCalls.awaitItem()).isNotNull()
 
         Scenario(
             viewModel = viewModel,
             fakeCardScanner = fakeCardScanner,
             fakeEventReporter = fakeEventReporter,
+            fakeTimeoutManager = fakeTimeoutManager,
             scannerState = scannerState,
         ).block()
 
@@ -297,6 +354,7 @@ internal class NfcScanningViewModelTest {
         val viewModel: NfcScanningViewModel,
         val fakeCardScanner: FakeNfcCardScanner,
         val fakeEventReporter: FakeNfcScanningEventReporter,
+        val fakeTimeoutManager: FakeNfcScanningTimeoutManager,
         val scannerState: MutableSharedFlow<NfcCardScanner.State>,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
@@ -85,8 +85,8 @@ internal class DefaultNfcScanningEventReporterTest {
     }
 
     @Test
-    fun `onNfcScanCancelled ends duration and fires event`() = runScenario {
-        reporter.onNfcScanCancelled()
+    fun `onNfcScanCancelled ends duration and fires event with cancellation reason`() = runScenario {
+        reporter.onNfcScanCancelled(NfcScanCancellationReason.Timeout)
 
         assertThat(
             durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScan))
@@ -94,7 +94,8 @@ internal class DefaultNfcScanningEventReporterTest {
 
         val loggedParams = executor.getExecutedRequests().single().params
         assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_canceled")
-        assertThat(loggedParams).doesNotContainKey("duration")
+        assertThat(loggedParams).containsEntry("duration", 1.0f)
+        assertThat(loggedParams).containsEntry("cancellation_reason", "scanning_timeout")
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
@@ -8,7 +8,7 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
     val onNfcScanAttemptSucceededCalls = Turbine<Unit>()
     val onNfcScanAttemptFailedCalls = Turbine<String>()
     val onNfcScanSucceededCalls = Turbine<Unit>()
-    val onNfcScanCancelledCalls = Turbine<Unit>()
+    val onNfcScanCancelledCalls = Turbine<NfcScanCancellationReason>()
 
     override fun onNfcScanStarted() {
         onNfcScanStartedCalls.add(Unit)
@@ -30,8 +30,8 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
         onNfcScanSucceededCalls.add(Unit)
     }
 
-    override fun onNfcScanCancelled() {
-        onNfcScanCancelledCalls.add(Unit)
+    override fun onNfcScanCancelled(reason: NfcScanCancellationReason) {
+        onNfcScanCancelledCalls.add(reason)
     }
 
     fun ensureAllEventsConsumed() {


### PR DESCRIPTION
# Summary
Timeout of NFC scanning flow after 20 seconds of inactivity.

# Motivation
Prevent holding onto the NFC scanner for longer than required.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified