### PR TITLE
Add ExpressCheckoutElementContent Paparazzi test 🪿✨

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementContentScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementContentScreenshotTest.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.checkout.ece
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.Test
+
+internal class ExpressCheckoutElementContentScreenshotTest {
+    @get:Rule
+    val paparazziRule = PaparazziRule(
+        boxModifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth(),
+    )
+
+    @Test
+    fun testWalletButtons() {
+        paparazziRule.snapshot {
+            ExpressCheckoutElementContent(
+                interactor = FakeExpressCheckoutElementInteractor(
+                    state = ExpressCheckoutElementInteractorStateFactory.create(),
+                )
+            )
+        }
+    }
+
+    private class FakeExpressCheckoutElementInteractor(
+        state: ExpressCheckoutElementInteractor.State,
+    ) : ExpressCheckoutElementInteractor {
+        override val state: StateFlow<ExpressCheckoutElementInteractor.State> = stateFlowOf(state)
+    }
+}


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/35b96360-1069-45a4-aaab-30d872aefc26)

#### 🧑‍💻 Human Summary
<!-- To be filled out by humans -->

#### 🤖 LLM Summary

# Summary
Adds a Paparazzi screenshot test for `ExpressCheckoutElementContent` covering the default wallet-button rendering.

# Motivation
`ExpressCheckoutElementContent` renders the express checkout wallet buttons, and this adds snapshot coverage for that UI state.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| TODO: Add generated baseline screenshot. | TODO: Add generated baseline screenshot. |

# Changelog
Not user-facing; no changelog entry.