### PR TITLE
Unify Checkout and PaymentSheet customer state via CheckoutControllerStateHolder.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -5,10 +5,12 @@ import android.os.Bundle
 import android.os.Parcelable
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -21,7 +23,9 @@ import kotlinx.parcelize.Parcelize
  *
  * [CheckoutStateLoader] builds every committed state after a load, but the selection setters on
  * [CheckoutControllerStateHolder] (which implements [EmbeddedSelectionHolder]) also [copy] it to
- * update [paymentSelection]/[temporarySelection]/[previousNewSelections] without a reload.
+ * update [paymentSelection]/[temporarySelection]/[previousNewSelections] without a reload. The
+ * customer setters (it also implements [com.stripe.android.paymentsheet.CustomerStateHolder])
+ * likewise [copy] it to update [customerState]/[mostRecentlySelectedSavedPaymentMethod].
  */
 @OptIn(CheckoutSessionPreview::class)
 @Parcelize
@@ -37,6 +41,8 @@ internal data class CheckoutControllerState(
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,
     val previousNewSelections: Bundle,
+    val customerState: CustomerState?,
+    val mostRecentlySelectedSavedPaymentMethod: PaymentMethod?,
 ) : Parcelable {
     fun asCheckoutSession(
         paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -3,13 +3,20 @@ package com.stripe.android.checkout
 import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
@@ -21,6 +28,11 @@ import javax.inject.Singleton
  * projections (e.g. [checkoutSession]) are derived from the one [stateFlow]. Kept separate from the
  * controller so [CheckoutStateLoader] can commit loaded state directly rather than reaching back
  * into the controller.
+ *
+ * Also serves as the checkout graph's [EmbeddedSelectionHolder] and [CustomerStateHolder]. The
+ * selection projections derive from [stateFlow]; the customer state is set independently of a state
+ * commit, so it's persisted under its own [SavedStateHandle] keys — mirroring
+ * [com.stripe.android.paymentsheet.DefaultCustomerStateHolder].
  */
 @OptIn(CheckoutSessionPreview::class)
 @Singleton
@@ -29,7 +41,7 @@ internal class CheckoutControllerStateHolder @Inject constructor(
     private val errorReporter: ErrorReporter,
     private val paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory,
     private val availableExpressButtonTypesFactory: AvailableExpressButtonTypesFactory,
-) : EmbeddedSelectionHolder {
+) : EmbeddedSelectionHolder, CustomerStateHolder {
     var state: CheckoutControllerState?
         get() = savedStateHandle[STATE_KEY]
         set(value) {
@@ -94,9 +106,9 @@ internal class CheckoutControllerStateHolder @Inject constructor(
     }
 
     /**
-     * The selection lives on [CheckoutControllerState], so the mutators can only act once
-     * [CheckoutStateLoader] has committed a state. A call before then is a programming error (a
-     * mis-ordered selection write); report it and no-op rather than silently dropping the value.
+     * The selection and customer state live on [CheckoutControllerState], so their mutators can only
+     * act once [CheckoutStateLoader] has committed a state. A call before then is a programming error
+     * (a mis-ordered write); report it and no-op rather than silently dropping the value.
      */
     private fun requireState(operation: String): CheckoutControllerState? {
         return state ?: run {
@@ -107,6 +119,117 @@ internal class CheckoutControllerStateHolder @Inject constructor(
             null
         }
     }
+
+    // region CustomerStateHolder
+
+    private val customerMetadata: StateFlow<CustomerMetadata?> =
+        stateFlow.mapAsStateFlow { it?.paymentMethodMetadata?.customerMetadata }
+
+    private val paymentMethodMetadataFlow: StateFlow<PaymentMethodMetadata?> =
+        stateFlow.mapAsStateFlow { it?.paymentMethodMetadata }
+
+    override val customer: StateFlow<CustomerState?> =
+        stateFlow.mapAsStateFlow { it?.customerState }
+
+    /**
+     * The list of saved payment methods for the current customer.
+     * Value is null until it's loaded, and non-null (could be empty) after that.
+     */
+    override val paymentMethods: StateFlow<List<PaymentMethod>> = customer
+        .mapAsStateFlow { state ->
+            state?.paymentMethods ?: emptyList()
+        }
+
+    override val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?> =
+        stateFlow.mapAsStateFlow { it?.mostRecentlySelectedSavedPaymentMethod }
+
+    override val canRemove: StateFlow<Boolean> = combineAsStateFlow(
+        paymentMethods,
+        customerMetadata,
+    ) { paymentMethods, customerMetadata ->
+        customerMetadata?.run {
+            val hasRemovePermissions = customerMetadata.canRemovePaymentMethods
+            val hasRemoveLastPaymentMethodPermissions = customerMetadata.canRemoveLastPaymentMethod
+            when (paymentMethods.size) {
+                0 -> false
+                1 -> hasRemoveLastPaymentMethodPermissions && hasRemovePermissions
+                else -> hasRemovePermissions
+            }
+        } ?: false
+    }
+
+    override val canUpdateCardExpiryAndBillingDetails: StateFlow<Boolean> = customerMetadata.mapAsStateFlow {
+        it?.canUpdateCardExpiryAndBillingDetails ?: false
+    }
+
+    override val canChangeCbc: StateFlow<Boolean> = combineAsStateFlow(
+        customerMetadata,
+        paymentMethodMetadataFlow,
+    ) { metadata, pmMetadata ->
+        val canUpdateBrandChoice = metadata?.canUpdateCardBrandChoice ?: false
+        val isCbcEligible = pmMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible
+        canUpdateBrandChoice && isCbcEligible
+    }
+
+    override fun setCustomerState(customerState: CustomerState?) {
+        val current = requireState(operation = "setCustomerState") ?: return
+        val currentSelection = current.mostRecentlySelectedSavedPaymentMethod
+        val newSelection = customerState?.paymentMethods?.firstOrNull { it.id == currentSelection?.id }
+        state = current.copy(
+            customerState = customerState,
+            mostRecentlySelectedSavedPaymentMethod = newSelection,
+        )
+    }
+
+    override fun setDefaultPaymentMethod(paymentMethod: PaymentMethod?) {
+        val current = requireState(operation = "setDefaultPaymentMethod") ?: return
+        state = current.copy(
+            customerState = current.customerState?.copy(defaultPaymentMethodId = paymentMethod?.id),
+        )
+    }
+
+    override fun updateMostRecentlySelectedSavedPaymentMethod(paymentMethod: PaymentMethod?) {
+        val current = requireState(operation = "updateMostRecentlySelectedSavedPaymentMethod") ?: return
+        state = current.copy(mostRecentlySelectedSavedPaymentMethod = paymentMethod)
+    }
+
+    override fun addPaymentMethod(paymentMethod: PaymentMethod) {
+        val current = requireState(operation = "addPaymentMethod") ?: return
+        val currentCustomer = current.customerState ?: return
+        val currentMetadata = current.paymentMethodMetadata.customerMetadata ?: return
+
+        val newCustomer = when (currentMetadata) {
+            is CustomerMetadata.LegacyEphemeralKey -> {
+                currentCustomer.copy(paymentMethods = currentCustomer.paymentMethods + paymentMethod)
+            }
+            is CustomerMetadata.CustomerSession,
+            is CustomerMetadata.CheckoutSession -> {
+                val currentCustomerPaymentMethods = currentCustomer.paymentMethods
+
+                val samePaymentMethodIndex = currentCustomerPaymentMethods.indexOfFirst { customerPaymentMethod ->
+                    customerPaymentMethod.fingerprint() == paymentMethod.fingerprint()
+                }
+
+                if (samePaymentMethodIndex == -1) {
+                    currentCustomer.copy(paymentMethods = currentCustomerPaymentMethods + paymentMethod)
+                } else {
+                    val mutablePaymentMethods = currentCustomerPaymentMethods.toMutableList()
+                    mutablePaymentMethods[samePaymentMethodIndex] = paymentMethod
+                    currentCustomer.copy(paymentMethods = mutablePaymentMethods)
+                }
+            }
+        }
+
+        state = current.copy(customerState = newCustomer)
+    }
+
+    private fun PaymentMethod.fingerprint(): String? {
+        return card?.fingerprint
+            ?: usBankAccount?.fingerprint
+            ?: sepaDebit?.fingerprint
+    }
+
+    // endregion
 
     companion object {
         const val STATE_KEY = "CheckoutController_InternalState"

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -3,10 +3,12 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Bundle
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 
@@ -94,6 +96,9 @@ internal class CheckoutStateLoader @Inject constructor(
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,
             previousNewSelections = carryForward.previousNewSelections,
+            customerState = carryForward.customerState ?: loaderState.customer,
+            mostRecentlySelectedSavedPaymentMethod = carryForward.mostRecentlySelectedSavedPaymentMethod
+                ?: (selection as? PaymentSelection.Saved)?.paymentMethod,
         )
     }
 
@@ -108,6 +113,8 @@ internal class CheckoutStateLoader @Inject constructor(
         val temporarySelection: String?,
         val previousNewSelections: Bundle,
         val integrationLaunched: Boolean,
+        val customerState: CustomerState?,
+        val mostRecentlySelectedSavedPaymentMethod: PaymentMethod?,
     ) {
         companion object {
             fun initial() = CarryForward(
@@ -116,6 +123,8 @@ internal class CheckoutStateLoader @Inject constructor(
                 temporarySelection = null,
                 previousNewSelections = Bundle(),
                 integrationLaunched = false,
+                customerState = null,
+                mostRecentlySelectedSavedPaymentMethod = null,
             )
 
             fun from(state: CheckoutControllerState) = CarryForward(
@@ -124,6 +133,8 @@ internal class CheckoutStateLoader @Inject constructor(
                 temporarySelection = state.temporarySelection,
                 previousNewSelections = state.previousNewSelections,
                 integrationLaunched = state.integrationLaunched,
+                customerState = state.customerState,
+                mostRecentlySelectedSavedPaymentMethod = state.mostRecentlySelectedSavedPaymentMethod,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -48,7 +48,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -78,7 +77,6 @@ import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.TapToAddAvailabilityFactory
 import com.stripe.android.paymentsheet.state.TapToAddConnectionStarterModule
-import com.stripe.android.uicore.utils.mapAsStateFlow
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -86,7 +84,6 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.StateFlow
 import java.util.UUID
 import javax.inject.Named
 import javax.inject.Singleton
@@ -198,6 +195,9 @@ internal interface CheckoutControllerModule {
     fun bindsEmbeddedSelectionHolder(impl: CheckoutControllerStateHolder): EmbeddedSelectionHolder
 
     @Binds
+    fun bindsCustomerStateHolder(impl: CheckoutControllerStateHolder): CustomerStateHolder
+
+    @Binds
     fun bindsCheckoutPaymentOptionDisplayDataFactory(
         impl: DefaultCheckoutPaymentOptionDisplayDataFactory
     ): CheckoutPaymentOptionDisplayDataFactory
@@ -286,31 +286,6 @@ internal interface CheckoutControllerModule {
             @ViewModelScope coroutineScope: CoroutineScope,
         ): ConfirmationHandler {
             return confirmationHandlerFactory.create(coroutineScope)
-        }
-
-        @Provides
-        @Singleton
-        fun provideCustomerStateHolder(
-            savedStateHandle: SavedStateHandle,
-            selectionHolder: EmbeddedSelectionHolder,
-            paymentMethodMetadataFlow: StateFlow<PaymentMethodMetadata?>,
-        ): CustomerStateHolder {
-            val customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow {
-                it?.customerMetadata
-            }
-            return DefaultCustomerStateHolder(
-                savedStateHandle = savedStateHandle,
-                selection = selectionHolder.selection,
-                customerMetadata = customerMetadata,
-                paymentMethodMetadataFlow = paymentMethodMetadataFlow,
-            )
-        }
-
-        @Provides
-        fun providePaymentMethodMetadataFlow(
-            stateHolder: CheckoutControllerStateHolder,
-        ): StateFlow<PaymentMethodMetadata?> {
-            return stateHolder.stateFlow.mapAsStateFlow { it?.paymentMethodMetadata }
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -7,12 +7,14 @@ import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.checkout.ece.FakeAvailableExpressButtonTypesFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.FakeErrorReporter
 
 @OptIn(CheckoutSessionPreview::class)
@@ -32,6 +34,8 @@ internal object CheckoutControllerStateFactory {
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
+        customerState: CustomerState? = null,
+        mostRecentlySelectedSavedPaymentMethod: PaymentMethod? = null,
     ): CheckoutControllerState {
         return CheckoutControllerState(
             key = key,
@@ -45,6 +49,8 @@ internal object CheckoutControllerStateFactory {
             paymentSelection = paymentSelection,
             temporarySelection = temporarySelection,
             previousNewSelections = previousNewSelections,
+            customerState = customerState,
+            mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.ece.FakeAvailableExpressButtonTypesFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -13,6 +15,7 @@ import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -143,6 +146,129 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
+    fun `customer and paymentMethods project the customer from the committed state`() = testScenario {
+        val customerState = CustomerState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            defaultPaymentMethodId = null,
+        )
+        stateHolder.state = committedState(customerState = customerState)
+
+        assertThat(stateHolder.customer.value).isEqualTo(customerState)
+        assertThat(stateHolder.paymentMethods.value).containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+    }
+
+    @Test
+    fun `mostRecentlySelectedSavedPaymentMethod projects from the committed state`() = testScenario {
+        stateHolder.state = committedState(
+            mostRecentlySelectedSavedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+        )
+
+        assertThat(stateHolder.mostRecentlySelectedSavedPaymentMethod.value)
+            .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+    }
+
+    @Test
+    fun `setCustomerState commits the customer onto the state and emits`() = testScenario {
+        stateHolder.state = committedState()
+        val customerState = CustomerState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            defaultPaymentMethodId = null,
+        )
+
+        stateHolder.customer.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.setCustomerState(customerState)
+            assertThat(awaitItem()).isEqualTo(customerState)
+        }
+
+        assertThat(stateHolder.state?.customerState).isEqualTo(customerState)
+    }
+
+    @Test
+    fun `setCustomerState clears mostRecentlySelectedSavedPaymentMethod when it is no longer present`() =
+        testScenario {
+            stateHolder.state = committedState(
+                customerState = CustomerState(
+                    paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                    defaultPaymentMethodId = null,
+                ),
+                mostRecentlySelectedSavedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            )
+
+            stateHolder.setCustomerState(
+                CustomerState(paymentMethods = emptyList(), defaultPaymentMethodId = null),
+            )
+
+            assertThat(stateHolder.state?.mostRecentlySelectedSavedPaymentMethod).isNull()
+        }
+
+    @Test
+    fun `updateMostRecentlySelectedSavedPaymentMethod commits onto the state and emits`() = testScenario {
+        stateHolder.state = committedState()
+
+        stateHolder.mostRecentlySelectedSavedPaymentMethod.test {
+            assertThat(awaitItem()).isNull()
+            stateHolder.updateMostRecentlySelectedSavedPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            assertThat(awaitItem()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        }
+
+        assertThat(stateHolder.state?.mostRecentlySelectedSavedPaymentMethod)
+            .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+    }
+
+    @Test
+    fun `setDefaultPaymentMethod updates the customer default on the state`() = testScenario {
+        stateHolder.state = committedState(
+            customerState = CustomerState(
+                paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                defaultPaymentMethodId = null,
+            ),
+        )
+
+        stateHolder.setDefaultPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+
+        assertThat(stateHolder.state?.customerState?.defaultPaymentMethodId)
+            .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id)
+    }
+
+    @Test
+    fun `addPaymentMethod appends the payment method to the customer on the state`() = testScenario {
+        stateHolder.state = committedState(
+            customerState = CustomerState(
+                paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+                defaultPaymentMethodId = null,
+            ),
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(hasCustomerConfiguration = true),
+        )
+
+        stateHolder.addPaymentMethod(PaymentMethodFixtures.LINK_PAYMENT_METHOD)
+
+        assertThat(stateHolder.state?.customerState?.paymentMethods).containsExactly(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            PaymentMethodFixtures.LINK_PAYMENT_METHOD,
+        )
+    }
+
+    @Test
+    fun `customer setters no-op before the state is committed`() = testScenario {
+        stateHolder.setCustomerState(CustomerState(paymentMethods = emptyList(), defaultPaymentMethodId = null))
+        assertSetBeforeLoadError(operation = "setCustomerState")
+
+        stateHolder.setDefaultPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        assertSetBeforeLoadError(operation = "setDefaultPaymentMethod")
+
+        stateHolder.updateMostRecentlySelectedSavedPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        assertSetBeforeLoadError(operation = "updateMostRecentlySelectedSavedPaymentMethod")
+
+        stateHolder.addPaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        assertSetBeforeLoadError(operation = "addPaymentMethod")
+
+        assertThat(stateHolder.state).isNull()
+        assertThat(stateHolder.customer.value).isNull()
+        assertThat(stateHolder.mostRecentlySelectedSavedPaymentMethod.value).isNull()
+    }
+
+    @Test
     fun `selection setters no-op before the state is committed`() = testScenario {
         stateHolder.setSelection(PaymentSelection.GooglePay)
         assertSetBeforeLoadError(operation = "setSelection")
@@ -192,6 +318,9 @@ internal class CheckoutControllerStateHolderTest {
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
+        customerState: CustomerState? = null,
+        mostRecentlySelectedSavedPaymentMethod: PaymentMethod? = null,
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     ) = CheckoutControllerState(
         key = DEFAULT_KEY,
         configuration = CheckoutController.Configuration().build(),
@@ -199,11 +328,13 @@ internal class CheckoutControllerStateHolderTest {
         flagImages = null,
         collectedDetails = CheckoutCollectedDetails(),
         integrationLaunched = false,
-        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        paymentMethodMetadata = paymentMethodMetadata,
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,
+        customerState = customerState,
+        mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
     )
 
     private fun testScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
@@ -161,6 +162,34 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `loadInitial populates customerState from the loaded customer`() = runScenario(
+        loaderCustomer = CustomerState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            defaultPaymentMethodId = null,
+        ),
+    ) {
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        assertThat(stateHolder.state?.customerState?.paymentMethods)
+            .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+    }
+
+    @Test
+    fun `reload keeps the carried-forward customer over the freshly loaded one`() = runScenario(
+        // The loader would reload an empty customer, but an in-session addition must survive the reload.
+        loaderCustomer = CustomerState(paymentMethods = emptyList(), defaultPaymentMethodId = null),
+    ) {
+        val carried = CustomerState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            defaultPaymentMethodId = null,
+        )
+
+        loader.reload(committedState(customerState = carried))
+
+        assertThat(stateHolder.state?.customerState).isEqualTo(carried)
+    }
+
+    @Test
     fun `loadInitial resets the temporary selection and previous new selections`() = runScenario {
         // A prior state carries a temporary selection and a stashed new payment method; a fresh
         // configuration load must start from a clean slate rather than carrying them forward.
@@ -190,6 +219,7 @@ internal class CheckoutStateLoaderTest {
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
         checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
+        customerState: CustomerState? = null,
     ) = CheckoutControllerState(
         key = checkoutSessionResponse.id,
         configuration = CheckoutController.Configuration().build(),
@@ -202,6 +232,8 @@ internal class CheckoutStateLoaderTest {
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,
+        customerState = customerState,
+        mostRecentlySelectedSavedPaymentMethod = null,
     )
 
     // Adaptive pricing (usd → eur) drives flag image resolution during load.
@@ -222,6 +254,7 @@ internal class CheckoutStateLoaderTest {
     private fun runScenario(
         merchantDisplayName: String = "Example, Inc.",
         loaderSelection: PaymentSelection? = null,
+        loaderCustomer: CustomerState? = null,
         chosenSelection: PaymentSelection? = null,
         shouldFail: Boolean = false,
         isGooglePayAvailable: Boolean = false,
@@ -250,6 +283,7 @@ internal class CheckoutStateLoaderTest {
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(merchantDisplayName),
             flagImageResolver = flagImageResolver,
             paymentElementLoader = FakePaymentElementLoader(
+                customer = loaderCustomer,
                 paymentSelection = loaderSelection,
                 shouldFail = shouldFail,
                 isGooglePayAvailable = isGooglePayAvailable,


### PR DESCRIPTION
# Summary
This change migrates Checkout to manage customer state via CheckoutControllerStateHolder, consolidating selection and customer state logic into a single state holder. Removes DefaultCustomerStateHolder from Checkout, and updates construction, persistence, and tests accordingly.

# Motivation
Checkout previously handled customer state and payment method selection separately from PaymentSheet, leading to duplicated logic and potential inconsistencies. Unifying their state management under CheckoutControllerStateHolder improves maintainability and ensures consistent behavior.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
