### PR TITLE
Replace EmbeddedSheetLauncherHolder with SheetStateHolder in Embedded flow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -23,7 +23,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
     private val state: StateFlow<EmbeddedContentHelperStateHolder.State?>,
     private val verticalLayoutInteractorFactory: EmbeddedPaymentMethodVerticalLayoutInteractorFactory,
-    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+    private val sheetStateHolder: SheetStateHolder,
     private val embeddedWalletsHelper: EmbeddedWalletsHelper,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
     private val customerStateHolder: CustomerStateHolder,
@@ -66,7 +66,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             )
             return
         }
-        val launcher = sheetLauncherHolder.sheetLauncher
+        val launcher = sheetStateHolder.sheetLauncher
         if (launcher == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentSavedPaymentMethodMutatorFactory.kt
@@ -26,7 +26,7 @@ internal class EmbeddedContentSavedPaymentMethodMutatorFactory @Inject construct
     private val customerStateHolder: CustomerStateHolder,
     private val linkAccountHolder: LinkAccountHolder,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+    private val sheetStateHolder: SheetStateHolder,
 ) {
     fun create(
         paymentMethodMetadata: PaymentMethodMetadata,
@@ -45,7 +45,7 @@ internal class EmbeddedContentSavedPaymentMethodMutatorFactory @Inject construct
             prePaymentMethodRemoveActions = {},
             postPaymentMethodRemoveActions = {},
             onUpdatePaymentMethod = { _, _, _, _, _ ->
-                sheetLauncherHolder.sheetLauncher?.launchManage(
+                sheetStateHolder.sheetLauncher?.launchManage(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializer.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @EmbeddedPaymentElementScope
 internal class EmbeddedPaymentElementInitializer @Inject constructor(
     private val sheetLauncher: EmbeddedSheetLauncher,
-    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+    private val sheetStateHolder: SheetStateHolder,
     private val lifecycleOwner: LifecycleOwner,
     private val savedStateHandle: SavedStateHandle,
     private val eventReporter: EventReporter,
@@ -30,13 +30,13 @@ internal class EmbeddedPaymentElementInitializer @Inject constructor(
             previouslySentDeepLinkEvent = true
         }
 
-        sheetLauncherHolder.sheetLauncher = sheetLauncher
+        sheetStateHolder.sheetLauncher = sheetLauncher
 
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     PaymentElementCallbackReferences.remove(paymentElementCallbackIdentifier)
-                    sheetLauncherHolder.sheetLauncher = null
+                    sheetStateHolder.sheetLauncher = null
                 }
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -41,7 +41,7 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
     private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+    private val sheetStateHolder: SheetStateHolder,
     private val savedPaymentMethodMutatorFactory: EmbeddedContentSavedPaymentMethodMutatorFactory,
 ) : EmbeddedPaymentMethodVerticalLayoutInteractorFactory {
 
@@ -87,7 +87,7 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
             },
             onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
             transitionToManageScreen = {
-                sheetLauncherHolder.sheetLauncher?.launchManage(
+                sheetStateHolder.sheetLauncher?.launchManage(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),
                     selection = selectionHolder.selection.value,
@@ -95,7 +95,7 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
                 )
             },
             transitionToFormScreen = { code ->
-                sheetLauncherHolder.sheetLauncher?.launchForm(
+                sheetStateHolder.sheetLauncher?.launchForm(
                     code = code,
                     paymentMethodMetadata = paymentMethodMetadata,
                     configuration = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSheetLauncherHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSheetLauncherHolder.kt
@@ -1,9 +1,0 @@
-package com.stripe.android.paymentelement.embedded.content
-
-import javax.inject.Inject
-import javax.inject.Singleton
-
-@Singleton
-internal class EmbeddedSheetLauncherHolder @Inject constructor() {
-    var sheetLauncher: EmbeddedSheetLauncher? = null
-}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/SheetStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/SheetStateHolder.kt
@@ -8,6 +8,8 @@ import javax.inject.Singleton
 internal class SheetStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) {
+    var sheetLauncher: EmbeddedSheetLauncher? = null
+
     var sheetIsOpen: Boolean
         get() = savedStateHandle.get<Boolean>(SHEET_IS_OPEN_KEY) == true
         set(value) = savedStateHandle.set(SHEET_IS_OPEN_KEY, value)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -117,7 +117,7 @@ internal class DefaultEmbeddedContentHelperTest {
             }
         ) {
             val fakeLauncher = RecordingEmbeddedSheetLauncher()
-            sheetLauncherHolder.sheetLauncher = fakeLauncher
+            sheetStateHolder.sheetLauncher = fakeLauncher
             embeddedContentHelper.presentPaymentOptions()
 
             assertThat(fakeLauncher.launchPaymentOptionsCalls.single()).isEqualTo(
@@ -135,7 +135,7 @@ internal class DefaultEmbeddedContentHelperTest {
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
         val state: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
-        val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+        val sheetStateHolder: SheetStateHolder,
         val errorReporter: FakeErrorReporter,
     )
 
@@ -171,7 +171,7 @@ internal class DefaultEmbeddedContentHelperTest {
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
-        val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
 
         val state = MutableStateFlow(initialState)
         val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
@@ -183,7 +183,7 @@ internal class DefaultEmbeddedContentHelperTest {
             customerStateHolder = customerStateHolder,
             linkAccountHolder = linkAccountHolder,
             coroutineScope = backgroundScope,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
         )
         val verticalLayoutInteractorFactory = DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
             eventReporter = eventReporter,
@@ -194,7 +194,7 @@ internal class DefaultEmbeddedContentHelperTest {
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             rowSelectionImmediateActionHandler = immediateActionHandler,
             coroutineScope = backgroundScope,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
             savedPaymentMethodMutatorFactory = savedPaymentMethodMutatorFactory,
         )
 
@@ -202,7 +202,7 @@ internal class DefaultEmbeddedContentHelperTest {
             coroutineScope = backgroundScope,
             state = state,
             verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
             embeddedWalletsHelper = { stateFlowOf(null) },
             internalRowSelectionCallback = { null },
             customerStateHolder = customerStateHolder,
@@ -212,7 +212,7 @@ internal class DefaultEmbeddedContentHelperTest {
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
             state = state,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
             errorReporter = errorReporter,
         ).block()
         confirmationHandler.validate()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -170,7 +170,7 @@ internal class EmbeddedContentUiTest {
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
-        val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
 
         val state = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(null)
         val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
@@ -182,7 +182,7 @@ internal class EmbeddedContentUiTest {
             customerStateHolder = customerStateHolder,
             linkAccountHolder = linkAccountHolder,
             coroutineScope = viewModelScope,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
         )
         val verticalLayoutInteractorFactory = DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
             eventReporter = eventReporter,
@@ -193,7 +193,7 @@ internal class EmbeddedContentUiTest {
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             rowSelectionImmediateActionHandler = immediateActionHandler,
             coroutineScope = viewModelScope,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
             savedPaymentMethodMutatorFactory = savedPaymentMethodMutatorFactory,
         )
 
@@ -202,7 +202,7 @@ internal class EmbeddedContentUiTest {
                 coroutineScope = viewModelScope,
                 state = state,
                 verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
-                sheetLauncherHolder = sheetLauncherHolder,
+                sheetStateHolder = sheetStateHolder,
                 embeddedWalletsHelper = { stateFlowOf(null) },
                 internalRowSelectionCallback = { internalRowSelectionCallback },
                 customerStateHolder = customerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializerTest.kt
@@ -19,11 +19,11 @@ internal class EmbeddedPaymentElementInitializerTest {
 
     @Test
     fun `initialize init and clear sheetLauncher`() = testScenario {
-        assertThat(sheetLauncherHolder.sheetLauncher).isNull()
+        assertThat(sheetStateHolder.sheetLauncher).isNull()
         initializer.initialize(true)
-        assertThat(sheetLauncherHolder.sheetLauncher).isNotNull()
+        assertThat(sheetStateHolder.sheetLauncher).isNotNull()
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-        assertThat(sheetLauncherHolder.sheetLauncher).isNull()
+        assertThat(sheetStateHolder.sheetLauncher).isNull()
     }
 
     @Test
@@ -79,11 +79,11 @@ internal class EmbeddedPaymentElementInitializerTest {
         paymentElementCallbackIdentifier: String = PAYMENT_ELEMENT_CALLBACK_TEST_IDENTIFIER,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val sheetLauncherHolder = EmbeddedSheetLauncherHolder()
+        val sheetStateHolder = SheetStateHolder(SavedStateHandle())
         val eventReporter = FakeEventReporter()
         val initializer = EmbeddedPaymentElementInitializer(
             sheetLauncher = FakeEmbeddedSheetLauncher(),
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
             lifecycleOwner = lifecycleOwner,
             savedStateHandle = SavedStateHandle(),
             eventReporter = eventReporter,
@@ -91,7 +91,7 @@ internal class EmbeddedPaymentElementInitializerTest {
         )
         Scenario(
             initializer = initializer,
-            sheetLauncherHolder = sheetLauncherHolder,
+            sheetStateHolder = sheetStateHolder,
             lifecycleOwner = lifecycleOwner,
             eventReporter = eventReporter,
         ).block()
@@ -100,7 +100,7 @@ internal class EmbeddedPaymentElementInitializerTest {
 
     private class Scenario(
         val initializer: EmbeddedPaymentElementInitializer,
-        val sheetLauncherHolder: EmbeddedSheetLauncherHolder,
+        val sheetStateHolder: SheetStateHolder,
         val lifecycleOwner: TestLifecycleOwner,
         val eventReporter: FakeEventReporter,
     )


### PR DESCRIPTION
# Summary

Migrated from using `EmbeddedSheetLauncherHolder` to `SheetStateHolder` for managing the sheet launcher throughout the Embedded Payment Element flow. Updated all usages, removed the `EmbeddedSheetLauncherHolder` class, and updated tests accordingly.

# Motivation

Simplifies and consolidates state management by using one holder for both sheet state and sheet launcher, improving maintainability and clarity.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
