### PR TITLE
Use effectiveLinkBrand in DefaultCheckoutPaymentOptionDisplayDataFactory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import android.content.Context
 import androidx.compose.ui.text.AnnotatedString
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.NullUiDefinitionFactoryHelper
@@ -29,6 +30,7 @@ internal class DefaultCheckoutPaymentOptionDisplayDataFactory @Inject constructo
     private val iconLoader: PaymentSelection.IconLoader,
     private val cardArtDrawableLoader: PaymentOptionCardArtDrawableLoader,
     private val context: Context,
+    private val linkAccountHolder: LinkAccountHolder,
 ) : CheckoutPaymentOptionDisplayDataFactory {
     override fun create(
         selection: PaymentSelection?,
@@ -61,7 +63,11 @@ internal class DefaultCheckoutPaymentOptionDisplayDataFactory @Inject constructo
                     darkThemeIconUrl = selection.darkThemeIconUrl,
                 )
             },
-            label = selection.label(paymentMethodMetadata.linkBrand).resolve(context),
+            label = selection.label(
+                paymentMethodMetadata.effectiveLinkBrand(
+                    linkAccountHolder.linkAccountInfo.value.account
+                )
+            ).resolve(context),
             paymentMethodType = selection.paymentMethodType,
             mandateText = if (mandate == null) null else AnnotatedString(mandate.resolve(context)),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
@@ -3,8 +3,10 @@ package com.stripe.android.checkout
 import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
@@ -111,6 +113,7 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
                 ),
                 cardArtDrawableLoader = { cardArt },
                 context = context,
+                linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
             ),
             metadata = metadata,
             cardArt = cardArt,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
@@ -6,9 +6,13 @@ import android.graphics.drawable.Drawable
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -99,9 +103,28 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
         assertThat(option?.imageLoader?.invoke()).isNotNull()
     }
 
+    @Test
+    fun `create uses link account brand for saved Link passthrough card label`() = runScenario(
+        linkAccount = LinkAccount(
+            TestFactory.CONSUMER_SESSION.copy(linkBrand = LinkBrand.Onelink),
+        )
+    ) {
+        val option = factory.create(
+            selection = PaymentSelection.Saved(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(isLinkPassthroughMode = true),
+            ),
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                linkBrand = LinkBrand.Link,
+            ),
+        )
+
+        assertThat(option?.label).isEqualTo("Onelink")
+    }
+
     private fun runScenario(
         metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         cardArt: Drawable? = null,
+        linkAccount: LinkAccount? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -113,7 +136,9 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
                 ),
                 cardArtDrawableLoader = { cardArt },
                 context = context,
-                linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+                linkAccountHolder = LinkAccountHolder(SavedStateHandle()).apply {
+                    set(LinkAccountUpdate.Value(linkAccount))
+                },
             ),
             metadata = metadata,
             cardArt = cardArt,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use effectiveLinkBrand in DefaultCheckoutPaymentOptionDisplayDataFactory

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Show correct Link brand for logged in consumer

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
