### PR TITLE
Block mutate and configure calls while payment flow is presented.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -63,18 +63,25 @@ class CheckoutController @Inject internal constructor(
     suspend fun configure(
         checkoutSessionClientSecret: String,
         configuration: Configuration = Configuration(),
-    ): kotlin.Result<Unit> = runSerialized {
-        val configurationState = configuration.build()
-        val sessionId = checkoutSessionClientSecret.substringBefore("_secret_")
+    ): kotlin.Result<Unit> {
+        // A re-configure while a payment flow is presented would reload the session out from under
+        // the open sheet. The first configure runs with null state, so this only blocks re-configures.
+        if (sheetStateHolder.sheetIsOpen) {
+            return integrationLaunchedFailure()
+        }
+        return runSerialized {
+            val configurationState = configuration.build()
+            val sessionId = checkoutSessionClientSecret.substringBefore("_secret_")
 
-        checkoutSessionRepository.init(
-            sessionId = sessionId,
-            adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
-        ).mapCatching { response ->
-            checkoutStateLoader.loadInitial(
-                configuration = configurationState,
-                checkoutSessionResponse = response,
-            )
+            checkoutSessionRepository.init(
+                sessionId = sessionId,
+                adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
+            ).mapCatching { response ->
+                checkoutStateLoader.loadInitial(
+                    configuration = configurationState,
+                    checkoutSessionResponse = response,
+                )
+            }
         }
     }
 
@@ -270,6 +277,28 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
+     * The gate shared by every mutation entry point: fails if the session hasn't been configured
+     * yet, or if a payment flow is currently presented (per [SheetStateHolder.sheetIsOpen]). On
+     * success it carries the current committed state; callers that only need the gate can ignore
+     * the value.
+     */
+    private fun requireMutableState(): kotlin.Result<CheckoutControllerState> {
+        val currentState = stateHolder.state
+            ?: return kotlin.Result.failure(
+                IllegalStateException("Cannot mutate checkout session before it is configured.")
+            )
+        return if (sheetStateHolder.sheetIsOpen) {
+            integrationLaunchedFailure()
+        } else {
+            kotlin.Result.success(currentState)
+        }
+    }
+
+    private fun integrationLaunchedFailure(): kotlin.Result<Nothing> = kotlin.Result.failure(
+        IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
+    )
+
+    /**
      * Serializes [block] behind [mutex] so configuration and mutations run in sequence, and toggles
      * [isLoading] while any serialized work is in flight (tracked via [pendingMutations] so
      * concurrent callers share a single loading window).
@@ -318,9 +347,12 @@ class CheckoutController @Inject internal constructor(
 
     /**
      * Clears the customer's selected payment option, resetting it to `null`.
+     *
+     * Returns [kotlin.Result.failure] if the session hasn't been configured yet or a payment flow is
+     * currently presented.
      */
-    fun clearPaymentOption() {
-        stateHolder.clearSelection()
+    fun clearPaymentOption(): kotlin.Result<Unit> {
+        return requireMutableState().map { stateHolder.clearSelection() }
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -276,21 +276,15 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
-    /**
-     * The gate shared by every mutation entry point: fails if the session hasn't been configured
-     * yet, or if a payment flow is currently presented (per [SheetStateHolder.sheetIsOpen]). On
-     * success it carries the current committed state; callers that only need the gate can ignore
-     * the value.
-     */
-    private fun requireMutableState(): kotlin.Result<CheckoutControllerState> {
-        val currentState = stateHolder.state
+    private fun requireMutableState(): kotlin.Result<Unit> {
+        stateHolder.state
             ?: return kotlin.Result.failure(
                 IllegalStateException("Cannot mutate checkout session before it is configured.")
             )
         return if (sheetStateHolder.sheetIsOpen) {
             integrationLaunchedFailure()
         } else {
-            kotlin.Result.success(currentState)
+            kotlin.Result.success(Unit)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -288,11 +288,39 @@ internal class CheckoutControllerTest {
         controller.checkoutSession.test {
             assertThat(awaitItem()?.paymentOptionDisplayData).isNotNull()
 
-            controller.clearPaymentOption()
+            assertThat(controller.clearPaymentOption().isSuccess).isTrue()
 
             assertThat(requireNotNull(awaitItem()).paymentOptionDisplayData).isNull()
         }
     }
+
+    @Test
+    fun `clearPaymentOption returns failure before the session is configured`() = runTest {
+        val controller = createController()
+
+        val result = controller.clearPaymentOption()
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate checkout session before it is configured.")
+    }
+
+    @Test
+    fun `clearPaymentOption returns failure and preserves selection when a payment flow is presented`() =
+        runMutationScenario {
+            selectPaymentMethod(PaymentSelection.GooglePay)
+            markIntegrationLaunched()
+
+            val result = controller.clearPaymentOption()
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+            assertThat(result.exceptionOrNull()).hasMessageThat()
+                .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
+            // The rejected clear leaves the selection intact.
+            assertThat(controller.checkoutSession.value?.paymentOptionDisplayData).isNotNull()
+        }
 
     @Test
     fun `callback identifier is generated and stored when absent`() = runTest {
@@ -726,6 +754,31 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `configure returns failure when a payment flow is presented`() = runMutationScenario {
+        markIntegrationLaunched()
+
+        val result = controller.configure(DEFAULT_CLIENT_SECRET)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
+    }
+
+    @Test
+    fun `configure does not open a loading window when a payment flow is presented`() =
+        runMutationScenario(assertLoadingConsumed = true) {
+            markIntegrationLaunched()
+
+            // The guard fast-fails before runSerialized, so isLoading must never flip to true.
+            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+
+            val result = controller.configure(DEFAULT_CLIENT_SECRET)
+
+            assertThat(result.isFailure).isTrue()
+        }
+
+    @Test
     fun `isLoading transitions to true then false on a successful mutation`() = runMutationScenario(
         assertLoadingConsumed = true,
     ) {
@@ -1149,7 +1202,7 @@ internal class CheckoutControllerTest {
             block(
                 MutationScenario(
                     controller = controller,
-                    savedStateHandle = savedStateHandle,
+                    stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle),
                     sheetStateHolder = SheetStateHolder(savedStateHandle),
                     testScope = this@runTest,
                     isLoadingTurbine = isLoadingTurbine,
@@ -1165,7 +1218,7 @@ internal class CheckoutControllerTest {
 
     private class MutationScenario(
         val controller: CheckoutController,
-        private val savedStateHandle: SavedStateHandle,
+        private val stateHolder: CheckoutControllerStateHolder,
         private val sheetStateHolder: SheetStateHolder,
         private val testScope: TestScope,
         val isLoadingTurbine: ReceiveTurbine<Boolean>,
@@ -1182,13 +1235,18 @@ internal class CheckoutControllerTest {
 
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
-        fun committedState(): CheckoutControllerState =
-            requireNotNull(CheckoutControllerStateFactory.createStateHolder(savedStateHandle).state)
+        fun committedState(): CheckoutControllerState = requireNotNull(stateHolder.state)
 
         // Simulates a presented payment flow by opening the sheet through the SheetStateHolder backed
         // by the shared SavedStateHandle, which the mutation guard reads back through the same holder.
         fun markIntegrationLaunched() {
             sheetStateHolder.sheetIsOpen = true
+        }
+
+        // Simulates a payment method already being selected via the same setSelection path the
+        // production embedded selection flow uses.
+        fun selectPaymentMethod(selection: PaymentSelection) {
+            stateHolder.setSelection(selection)
         }
     }
 


### PR DESCRIPTION
# Summary

Ensure that configuration and mutation methods in `CheckoutController` fail fast when a payment flow is presented, preventing state changes that could break the flow. Adds guard logic and test coverage.

# Motivation

Previously, configuration and mutation methods (such as `configure` and `clearPaymentOption`) could be called while a payment flow was presented, risking inconsistent application state and undefined behavior. This change prevents those operations and surfaces failures with clear exceptions.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
