### PR TITLE
Track integration launched state in CheckoutControllerStateHolder.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -93,10 +93,19 @@ internal class CheckoutControllerStateHolder @Inject constructor(
         )
     }
 
+    fun markIntegrationLaunched() {
+        val current = requireState(operation = "markIntegrationLaunched") ?: return
+        state = current.copy(integrationLaunched = true)
+    }
+
+    fun markIntegrationDismissed() {
+        val current = requireState(operation = "markIntegrationDismissed") ?: return
+        state = current.copy(integrationLaunched = false)
+    }
+
     /**
-     * The selection lives on [CheckoutControllerState], so the mutators can only act once
-     * [CheckoutStateLoader] has committed a state. A call before then is a programming error (a
-     * mis-ordered selection write); report it and no-op rather than silently dropping the value.
+     * State-backed mutators can only act once [CheckoutStateLoader] has committed a state. A call
+     * before then is a programming error; report it and no-op rather than silently dropping the value.
      */
     private fun requireState(operation: String): CheckoutControllerState? {
         return state ?: run {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -28,6 +28,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
+    private val checkoutControllerStateHolder: CheckoutControllerStateHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
@@ -49,6 +50,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val activityLauncher: ActivityResultLauncher<EmbeddedActivityArgs> =
         activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
             sheetStateHolder.sheetIsOpen = false
+            checkoutControllerStateHolder.markIntegrationDismissed()
             when (result.launchMode) {
                 is EmbeddedLaunchMode.Form -> {
                     selectionHolder.setTemporarySelection(null)
@@ -123,6 +125,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
+        checkoutControllerStateHolder.markIntegrationLaunched()
         selectionHolder.setTemporarySelection(code)
         val currentSelection = (selectionHolder.selection.value as? PaymentSelection.New?)
             .takeIf { it?.paymentMethodType == code }
@@ -154,6 +157,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
+        checkoutControllerStateHolder.markIntegrationLaunched()
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
@@ -181,6 +185,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
+        checkoutControllerStateHolder.markIntegrationLaunched()
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
-import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
@@ -38,6 +38,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutSheetLauncherTest {
 
@@ -176,6 +177,23 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `launchForm marks integration launched until activity result is received`() = testScenario {
+        launchForm("card")
+
+        assertThat(checkoutControllerStateHolder.state?.integrationLaunched).isTrue()
+
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(
+            EmbeddedActivityResult.Cancelled(
+                customerState = null,
+                launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
+            )
+        )
+
+        assertThat(checkoutControllerStateHolder.state?.integrationLaunched).isFalse()
+    }
+
+    @Test
     fun `formActivityLauncher sets selection and customer state on complete result`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         launchForm("cashapp")
@@ -304,6 +322,24 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `launchManage marks integration launched until activity result is received`() = testScenario {
+        sheetLauncher.launchManage(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            selection = null,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+        dummyActivityResultCallerScenario.awaitLaunchCall()
+
+        assertThat(checkoutControllerStateHolder.state?.integrationLaunched).isTrue()
+
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(EmbeddedActivityResult.Error(launchMode = EmbeddedLaunchMode.Manage))
+
+        assertThat(checkoutControllerStateHolder.state?.integrationLaunched).isFalse()
+    }
+
+    @Test
     fun `manageSheetLauncher callback updates state on complete result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
@@ -410,6 +446,24 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `launchPaymentOptions marks integration launched until activity result is received`() = testScenario {
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = null,
+            selection = null,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+        dummyActivityResultCallerScenario.awaitLaunchCall()
+
+        assertThat(checkoutControllerStateHolder.state?.integrationLaunched).isTrue()
+
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(EmbeddedActivityResult.Error(launchMode = EmbeddedLaunchMode.PaymentOptions))
+
+        assertThat(checkoutControllerStateHolder.state?.integrationLaunched).isFalse()
+    }
+
+    @Test
     fun `paymentOptionsResult callback updates state on complete result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
@@ -512,8 +566,12 @@ internal class CheckoutSheetLauncherTest {
     ) = runTest {
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
-        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val checkoutControllerStateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+        checkoutControllerStateHolder.state = CheckoutControllerStateFactory.create(
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+        val selectionHolder = checkoutControllerStateHolder
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,
@@ -528,6 +586,7 @@ internal class CheckoutSheetLauncherTest {
                 activityResultCaller = activityResultCaller,
                 lifecycleOwner = lifecycleOwner,
                 selectionHolder = selectionHolder,
+                checkoutControllerStateHolder = checkoutControllerStateHolder,
                 customerStateHolder = customerStateHolder,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
@@ -549,6 +608,7 @@ internal class CheckoutSheetLauncherTest {
                 launcher = launcher,
                 sheetLauncher = sheetLauncher,
                 sheetStateHolder = sheetStateHolder,
+                checkoutControllerStateHolder = checkoutControllerStateHolder,
                 errorReporter = errorReporter,
             ).block()
         }
@@ -563,6 +623,7 @@ internal class CheckoutSheetLauncherTest {
         val launcher: ActivityResultLauncher<*>,
         val sheetLauncher: EmbeddedSheetLauncher,
         val sheetStateHolder: SheetStateHolder,
+        val checkoutControllerStateHolder: CheckoutControllerStateHolder,
         val errorReporter: FakeErrorReporter,
     ) {
         suspend fun launchForm(code: String) {


### PR DESCRIPTION
# Summary
Track and expose the `integrationLaunched` state in `CheckoutControllerStateHolder`, updating it on sheet launch and dismissal. Update `CheckoutSheetLauncher` to mark integration launched/dismissed appropriately. Extend tests to verify this behavior.

# Motivation
This change ensures the SDK provides clear tracking of whether the embedded integration has been launched or dismissed, enabling downstream consumers or analytics to reliably detect integration lifecycle events.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
