### PR TITLE
Add specific errors for mobile wallets in NFC scanning flow

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -108,6 +108,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_nfc_scan_error_declined_card">Card declined. Try another card.</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card is expired -->
   <string name="stripe_nfc_scan_error_expired_card">Card expired. Try another card.</string>
+  <!-- Error with action to take shown in the NFC scanning flow if the scanned credential is a mobile wallet (e.g. Apple Pay, Google Pay) rather than a physical card -->
+  <string name="stripe_nfc_scan_error_mobile_wallet">Mobile wallets are not supported. Try a physical card.</string>
   <!-- Instruction shown below the NFC coil animation while waiting for a card tap -->
   <string name="stripe_nfc_scan_hold_card_behind_phone">Hold card behind phone</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card is not supported by Stripe or by the merchant -->

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
@@ -1,14 +1,44 @@
 package com.stripe.android.common.nfcscan.scanner
 
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
 import javax.inject.Inject
 import kotlin.collections.joinToString
 
 internal interface NfcCardDataParser {
-    fun parse(records: Map<String, ByteArray>): ScannedCardData?
+    fun parse(records: Map<String, ByteArray>): Result
+
+    sealed interface Result {
+        data class Success(val cardData: ScannedCardData) : Result
+
+        data class Error(
+            val errorCode: String,
+            val userMessage: ResolvableString,
+        ) : Result
+    }
 }
 
 internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParser {
-    override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
+    override fun parse(records: Map<String, ByteArray>): NfcCardDataParser.Result {
+        if (isMobileWallet(records)) {
+            return NfcCardDataParser.Result.Error(
+                errorCode = MOBILE_WALLET_UNSUPPORTED_ERROR_CODE,
+                userMessage = R.string.stripe_nfc_scan_error_mobile_wallet.resolvableString,
+            )
+        }
+
+        if (isTokenized(records)) {
+            return unsupportedCard()
+        }
+
+        return when (val cardData = extractCardData(records)) {
+            is ScannedCardData -> NfcCardDataParser.Result.Success(cardData)
+            null -> unsupportedCard()
+        }
+    }
+
+    private fun extractCardData(records: Map<String, ByteArray>): ScannedCardData? {
         // Tag 0x57 — Track 2 Equivalent Data. Preferred when present because it encodes PAN and
         // expiry together in the same format used on magnetic-stripe Track 2.
         records[TAG_TRACK2]?.let {
@@ -29,6 +59,24 @@ internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParse
             expirationMonth = month,
             expirationYear = year,
         )
+    }
+
+    /*
+     * Checks whether the card came from a mobile wallet but looking at Byte 2, Bit 7 of the Application Interchange
+     * Profile (AIP, Tag 82) which indicates whether the transaction originates from a contactless mobile device
+     * (such as a smartphone or digital wallet)
+     */
+    private fun isMobileWallet(records: Map<String, ByteArray>): Boolean {
+        val aip = records[TAG_AIP]?.takeIf { it.size >= 2 } ?: return false
+        return (aip[1].toSingleByte() and AIP_ON_DEVICE_CVM_SUPPORTED_MASK) != 0
+    }
+
+    /*
+     * A tokenized (non-mobile-wallet) credential is identified by the presence of a Token Requestor
+     * ID (0x9F19).
+     */
+    private fun isTokenized(records: Map<String, ByteArray>): Boolean {
+        return records[TAG_TOKEN_REQUESTOR_ID] != null
     }
 
     private fun parseFromTrack2(bytes: ByteArray): ScannedCardData? {
@@ -70,6 +118,13 @@ internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParse
         return month to year
     }
 
+    private fun unsupportedCard(): NfcCardDataParser.Result.Error {
+        return NfcCardDataParser.Result.Error(
+            errorCode = CARD_UNSUPPORTED_ERROR_CODE,
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+    }
+
     private fun ByteArray.toReadableString(): String {
         return joinToString("") { "%02X".format(it) }
     }
@@ -79,9 +134,17 @@ internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParse
         (this shr FIRST_DIGIT_SHIFT) * FIRST_DIGIT_MULTIPLIER + (this and LAST_DIGIT_MASK)
 
     private companion object {
+        const val MOBILE_WALLET_UNSUPPORTED_ERROR_CODE = "mobileWalletUnsupportedByNfc"
+        const val CARD_UNSUPPORTED_ERROR_CODE = "cardUnsupportedByNfc"
+
         const val TAG_TRACK2 = "57"
         const val TAG_PAN = "5A"
         const val TAG_EXPIRY = "5F24"
+
+        const val TAG_AIP = "82"
+        const val TAG_TOKEN_REQUESTOR_ID = "9F19"
+
+        const val AIP_ON_DEVICE_CVM_SUPPORTED_MASK = 0x40
 
         const val TRACK2_SEPARATOR = 'D'
         const val EXPIRATION_YEAR_START = 2000

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -40,16 +40,14 @@ internal class ApduCardReader @Inject constructor(
         return runCatching {
             readFromTransceiver(transceiver)
         }.fold(
-            onSuccess = { cardData ->
-                NfcCardReader.Result.Found(scannedCardData = cardData)
-            },
+            onSuccess = { it },
             onFailure = errorMapper::create,
         )
     }
 
     private suspend fun readFromTransceiver(
         transceiver: NfcTagTransceiver
-    ): ScannedCardData = withContext(workContext) {
+    ): NfcCardReader.Result = withContext(workContext) {
         try {
             transceiver.open()
 
@@ -80,8 +78,15 @@ internal class ApduCardReader @Inject constructor(
                 }
             }
 
-            cardDataParser.parse(records)
-                ?: throw IllegalStateException("Could not parse card data from NFC tag")
+            when (val parseResult = cardDataParser.parse(records)) {
+                is NfcCardDataParser.Result.Success -> NfcCardReader.Result.Found(
+                    scannedCardData = parseResult.cardData
+                )
+                is NfcCardDataParser.Result.Error -> NfcCardReader.Result.Error(
+                    errorCode = parseResult.errorCode,
+                    userMessage = parseResult.userMessage,
+                )
+            }
         } finally {
             transceiver.close()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -29,7 +29,7 @@ internal class ApduCardReaderTest {
             ),
             apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
         ),
-        parseResult = SCANNED_CARD_DATA,
+        parseResult = NfcCardDataParser.Result.Success(SCANNED_CARD_DATA),
     ) {
         val result = cardReader.readCard(transceiver)
 
@@ -57,7 +57,7 @@ internal class ApduCardReaderTest {
                 tlv(tag = 0x77, value = tlv(tag = 0x57, value = TRACK_2_DATA)),
             ),
         ),
-        parseResult = SCANNED_CARD_DATA,
+        parseResult = NfcCardDataParser.Result.Success(SCANNED_CARD_DATA),
     ) {
         val result = cardReader.readCard(transceiver)
 
@@ -86,7 +86,7 @@ internal class ApduCardReaderTest {
             apduSuccessResponse(tlv(tag = 0x5A, value = PAN_DATA)),
             apduSuccessResponse(tlv(tag = 0x5F, tagContinuation = 0x24, value = EXPIRY_DATA)),
         ),
-        parseResult = SCANNED_CARD_DATA,
+        parseResult = NfcCardDataParser.Result.Success(SCANNED_CARD_DATA),
     ) {
         val result = cardReader.readCard(transceiver)
 
@@ -109,19 +109,25 @@ internal class ApduCardReaderTest {
     }
 
     @Test
-    fun `readCard returns parse failure when card data cannot be parsed`() = runScenario(
+    fun `readCard returns parser error when card data cannot be parsed`() = runScenario(
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(EMPTY_PDOL_SELECT_RESPONSE),
             apduSuccessResponse(tlv(tag = 0x77, value = byteArrayOf())),
         ),
-        parseResult = null,
-        errorResult = PARSE_FAILURE_ERROR,
+        parseResult = NfcCardDataParser.Result.Error(
+            errorCode = "cardUnsupportedByNfc",
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        ),
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "cardUnsupportedByNfc",
+                userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+            ),
+        )
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -233,7 +239,7 @@ internal class ApduCardReaderTest {
         ),
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         pdolData: ByteArray = byteArrayOf(),
-        parseResult: ScannedCardData? = null,
+        parseResult: NfcCardDataParser.Result = NfcCardDataParser.Result.Success(SCANNED_CARD_DATA),
         openException: Throwable? = null,
         errorResult: NfcCardReader.Result.Error = PARSE_FAILURE_ERROR,
         block: suspend Scenario.() -> Unit,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.common.nfcscan.scanner
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
 import org.junit.Test
 
 internal class DefaultNfcCardDataParserTest {
@@ -17,45 +19,47 @@ internal class DefaultNfcCardDataParserTest {
         )
 
         assertThat(result).isEqualTo(
-            ScannedCardData(
-                cardNumber = "4111111111111111",
-                expirationMonth = 12,
-                expirationYear = 2025,
+            NfcCardDataParser.Result.Success(
+                ScannedCardData(
+                    cardNumber = "4111111111111111",
+                    expirationMonth = 12,
+                    expirationYear = 2025,
+                ),
             ),
         )
     }
 
     @Test
-    fun `parse returns null when Track 2 is missing field separator`() {
+    fun `parse returns unsupported card error when Track 2 is missing field separator`() {
         val result = parser.parse(
             mapOf(
                 TAG_TRACK2 to hexToBytes("4111111111111111"),
             ),
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     @Test
-    fun `parse returns null when Track 2 expiry is truncated`() {
+    fun `parse returns unsupported card error when Track 2 expiry is truncated`() {
         val result = parser.parse(
             mapOf(
                 TAG_TRACK2 to hexToBytes("4111111111111111D25"),
             ),
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     @Test
-    fun `parse returns null when Track 2 expiry is not numeric`() {
+    fun `parse returns unsupported card error when Track 2 expiry is not numeric`() {
         val result = parser.parse(
             mapOf(
                 TAG_TRACK2 to hexToBytes("4111111111111111DAA12100"),
             ),
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     @Test
@@ -68,10 +72,12 @@ internal class DefaultNfcCardDataParserTest {
         )
 
         assertThat(result).isEqualTo(
-            ScannedCardData(
-                cardNumber = "4111111111111111",
-                expirationMonth = 12,
-                expirationYear = 2025,
+            NfcCardDataParser.Result.Success(
+                ScannedCardData(
+                    cardNumber = "4111111111111111",
+                    expirationMonth = 12,
+                    expirationYear = 2025,
+                ),
             ),
         )
     }
@@ -86,38 +92,40 @@ internal class DefaultNfcCardDataParserTest {
         )
 
         assertThat(result).isEqualTo(
-            ScannedCardData(
-                cardNumber = "411111111111111",
-                expirationMonth = 12,
-                expirationYear = 2025,
+            NfcCardDataParser.Result.Success(
+                ScannedCardData(
+                    cardNumber = "411111111111111",
+                    expirationMonth = 12,
+                    expirationYear = 2025,
+                ),
             ),
         )
     }
 
     @Test
-    fun `parse returns null when PAN tag is missing`() {
+    fun `parse returns unsupported card error when PAN tag is missing`() {
         val result = parser.parse(
             mapOf(
                 TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
             ),
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     @Test
-    fun `parse returns null when expiry tag is missing`() {
+    fun `parse returns unsupported card error when expiry tag is missing`() {
         val result = parser.parse(
             mapOf(
                 TAG_PAN to hexToBytes("4111111111111111"),
             ),
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     @Test
-    fun `parse returns null when expiry data is too short`() {
+    fun `parse returns unsupported card error when expiry data is too short`() {
         val result = parser.parse(
             mapOf(
                 TAG_PAN to hexToBytes("4111111111111111"),
@@ -125,14 +133,70 @@ internal class DefaultNfcCardDataParserTest {
             ),
         )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     @Test
-    fun `parse returns null when no recognized tags are present`() {
+    fun `parse returns unsupported card error when no recognized tags are present`() {
         val result = parser.parse(emptyMap())
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
+    }
+
+    @Test
+    fun `parse returns mobile wallet error when AIP byte 2 bit 7 indicates a contactless mobile device`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111D2512101"),
+                TAG_AIP to byteArrayOf(0x00, AIP_MOBILE_WALLET_BYTE_2),
+            ),
+        )
+
+        assertThat(result).isEqualTo(MOBILE_WALLET_ERROR)
+    }
+
+    @Test
+    fun `parse returns mobile wallet error when AIP indicates a mobile device without card data tags`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_AIP to byteArrayOf(0x00, AIP_MOBILE_WALLET_BYTE_2),
+            ),
+        )
+
+        assertThat(result).isEqualTo(MOBILE_WALLET_ERROR)
+    }
+
+    @Test
+    fun `parse returns card data when AIP does not indicate a contactless mobile device`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111D2512101"),
+                TAG_AIP to byteArrayOf(0x00, 0x00),
+            ),
+        )
+
+        assertThat(result).isEqualTo(
+            NfcCardDataParser.Result.Success(
+                ScannedCardData(
+                    cardNumber = "4111111111111111",
+                    expirationMonth = 12,
+                    expirationYear = 2025,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `parse returns unsupported card error for tokenized credential without mobile wallet AIP`() {
+        val result = parser.parse(
+            mapOf(
+                TAG_TRACK2 to hexToBytes("4111111111111111D2512101"),
+                TAG_AIP to byteArrayOf(0x00, 0x00),
+                TAG_TOKEN_REQUESTOR_ID to hexToBytes("12345678901F"),
+            ),
+        )
+
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
     }
 
     private fun hexToBytes(hex: String): ByteArray {
@@ -145,5 +209,19 @@ internal class DefaultNfcCardDataParserTest {
         const val TAG_TRACK2 = "57"
         const val TAG_PAN = "5A"
         const val TAG_EXPIRY = "5F24"
+        const val TAG_AIP = "82"
+        const val TAG_TOKEN_REQUESTOR_ID = "9F19"
+
+        const val AIP_MOBILE_WALLET_BYTE_2 = 0x40.toByte()
+
+        val UNSUPPORTED_CARD_ERROR = NfcCardDataParser.Result.Error(
+            errorCode = "cardUnsupportedByNfc",
+            userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+
+        val MOBILE_WALLET_ERROR = NfcCardDataParser.Result.Error(
+            errorCode = "mobileWalletUnsupportedByNfc",
+            userMessage = R.string.stripe_nfc_scan_error_mobile_wallet.resolvableString,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
@@ -3,11 +3,11 @@ package com.stripe.android.common.nfcscan.scanner
 import app.cash.turbine.Turbine
 
 internal class FakeNfcCardDataParser(
-    private val parseResult: ScannedCardData? = null,
+    private val parseResult: NfcCardDataParser.Result,
 ) : NfcCardDataParser {
     val parseCalls = Turbine<Map<String, ByteArray>>()
 
-    override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
+    override fun parse(records: Map<String, ByteArray>): NfcCardDataParser.Result {
         parseCalls.add(records)
         return parseResult
     }


### PR DESCRIPTION
# Summary
Add specific errors for mobile wallets in NFC scanning flow.

# Motivation
Better UX for mobile wallet errors.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
First attempt is a mobile wallet, second attempt is a card. Tried with multiple cards to make sure they are still working.

https://github.com/user-attachments/assets/a8c1de61-aa37-409d-91fe-0fd45b527ea1