### PR TITLE
Remove unused CheckoutInstances mutation methods from integration flows.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutInstances.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.checkout
 
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import java.lang.ref.WeakReference
 
@@ -23,27 +21,6 @@ internal object CheckoutInstances {
         val checkout = factory()
         instanceMap[key] = WeakReference(checkout)
         return checkout
-    }
-
-    @Synchronized
-    fun ensureNoMutationInFlight(key: String) {
-        this[key]?.ensureNoMutationInFlight()
-    }
-
-    @Synchronized
-    fun markIntegrationLaunched(key: String) {
-        this[key]?.markIntegrationLaunched()
-    }
-
-    @Synchronized
-    fun markIntegrationDismissed(key: String) {
-        this[key]?.markIntegrationDismissed()
-    }
-
-    fun markIntegrationDismissed(paymentMethodMetadata: PaymentMethodMetadata?) {
-        val checkoutSession = paymentMethodMetadata
-            ?.integrationMetadata as? IntegrationMetadata.CheckoutSession ?: return
-        markIntegrationDismissed(checkoutSession.instancesKey)
     }
 
     @VisibleForTesting

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import android.content.Context
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
@@ -116,15 +115,6 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     private suspend fun confirmCheckoutSession(
         params: ConfirmCheckoutSessionParams,
     ): ConfirmationDefinition.Action<Args> {
-        try {
-            CheckoutInstances.ensureNoMutationInFlight(integrationMetadata.instancesKey)
-        } catch (e: IllegalStateException) {
-            return ConfirmationDefinition.Action.Fail(
-                cause = e,
-                message = e.stripeErrorMessage(),
-                errorType = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
-            )
-        }
         return checkoutSessionRepository.confirm(
             id = integrationMetadata.id,
             params = params,
@@ -143,8 +133,6 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     private fun handleConfirmResponse(
         response: CheckoutSessionResponse,
     ): ConfirmationDefinition.Action<Args> {
-        CheckoutInstances[integrationMetadata.instancesKey]?.updateWithResponse(response)
-
         val intent: StripeIntent = response.paymentIntent ?: response.setupIntent
             ?: run {
                 val exception = IllegalStateException(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -4,8 +4,6 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.stripe.android.checkout.CheckoutInstances
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -162,11 +160,6 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         customerState: CustomerState?,
         promotion: PaymentMethodMessagePromotion?,
     ) {
-        val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
-        if (checkoutSession != null) {
-            CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
-            CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
-        }
         if (configuration == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
@@ -198,11 +191,6 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         selection: PaymentSelection?,
         configuration: EmbeddedPaymentElement.Configuration?,
     ) {
-        val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
-        if (checkoutSession != null) {
-            CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
-            CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
-        }
         if (configuration == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
@@ -230,11 +218,6 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         selection: PaymentSelection?,
         configuration: EmbeddedPaymentElement.Configuration?,
     ) {
-        val checkoutSession = paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession
-        if (checkoutSession != null) {
-            CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
-            CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
-        }
         if (configuration == null) {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
@@ -202,7 +201,6 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         super.onDestroy()
 
         if (isFinishing) {
-            CheckoutInstances.markIntegrationDismissed(args?.paymentMethodMetadata)
             if (::eventReporter.isInitialized) {
                 eventReporter.onDismiss()
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
@@ -79,13 +78,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionsActivity
                     PaymentSheetScreen(viewModel)
                 }
             }
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (isFinishing) {
-            CheckoutInstances.markIntegrationDismissed(starterArgs?.state?.paymentMethodMetadata)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
@@ -91,13 +90,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                     PaymentSheetScreen(viewModel)
                 }
             }
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (isFinishing && starterArgs != null) {
-            CheckoutInstances.markIntegrationDismissed(viewModel.paymentMethodMetadata.value)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -34,7 +33,6 @@ import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.WalletButtonsPreview
@@ -282,13 +280,6 @@ internal class DefaultFlowController @Inject internal constructor(
 
     override fun presentPaymentOptions() {
         withCurrentState { state ->
-            val checkoutSession = state.paymentSheetState.paymentMethodMetadata
-                .integrationMetadata as? IntegrationMetadata.CheckoutSession
-            if (checkoutSession != null) {
-                CheckoutInstances.ensureNoMutationInFlight(checkoutSession.instancesKey)
-                CheckoutInstances.markIntegrationLaunched(checkoutSession.instancesKey)
-            }
-
             val linkConfiguration = state.paymentSheetState.linkConfiguration
             val paymentSelection = viewModel.paymentSelection
             val linkAccountInfo = linkAccountHolder.linkAccountInfo.value

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutInstancesTest.kt
@@ -8,13 +8,9 @@ import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.testing.PaymentConfigurationTestRule
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
-import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -51,69 +47,6 @@ class CheckoutInstancesTest {
         val checkout2 = createCheckout(key = "key2")
 
         assertThat(checkout1).isNotSameInstanceAs(checkout2)
-    }
-
-    @Test
-    fun `ensureNoMutationInFlight does not throw for unknown key`() {
-        CheckoutInstances.ensureNoMutationInFlight("unknown-key")
-    }
-
-    @Test
-    fun `ensureNoMutationInFlight throws when mutation is in flight`() {
-        val checkout = createCheckout(key = "key1")
-        val requestArrived = CountDownLatch(1)
-        val holdResponse = CountDownLatch(1)
-
-        networkRule.checkoutUpdate { response ->
-            requestArrived.countDown()
-            holdResponse.await(10, TimeUnit.SECONDS)
-            response.setBody("{}")
-        }
-
-        runBlocking {
-            val job = launch(Dispatchers.IO) {
-                checkout.removePromotionCode()
-            }
-
-            assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
-
-            val error = assertThrows(IllegalStateException::class.java) {
-                CheckoutInstances.ensureNoMutationInFlight("key1")
-            }
-            assertThat(error).hasMessageThat()
-                .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
-
-            holdResponse.countDown()
-            job.join()
-        }
-    }
-
-    @Test
-    fun `markIntegrationLaunched blocks mutations`() = runTest {
-        val checkout = createCheckout(key = "key1")
-
-        CheckoutInstances.markIntegrationLaunched("key1")
-
-        val result = checkout.applyPromotionCode("code")
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
-    }
-
-    @Test
-    fun `markIntegrationDismissed unblocks mutations`() = runTest {
-        val checkout = createCheckout(key = "key1")
-
-        CheckoutInstances.markIntegrationLaunched("key1")
-        CheckoutInstances.markIntegrationDismissed("key1")
-
-        networkRule.checkoutUpdate { response ->
-            response.setResponseCode(400)
-            response.setBody("""{"error": {"message": "error"}}""")
-        }
-
-        val result = checkout.applyPromotionCode("code")
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isNotInstanceOf(IllegalStateException::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -2,15 +2,10 @@ package com.stripe.android.paymentelement.confirmation.intent
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
-import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkout.Checkout
-import com.stripe.android.checkout.CheckoutInstancesTestRule
 import com.stripe.android.checkout.CheckoutStateFactory
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutConfirm
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf
@@ -47,17 +42,12 @@ import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
@@ -70,7 +60,6 @@ class CheckoutSessionConfirmationInterceptorTest {
     val ruleChain: RuleChain = RuleChain
         .outerRule(networkRule)
         .around(PaymentConfigurationTestRule(applicationContext))
-        .around(CheckoutInstancesTestRule())
 
     @Test
     fun `intercept with succeeded payment intent returns Complete action`() = runScenario {
@@ -352,157 +341,9 @@ class CheckoutSessionConfirmationInterceptorTest {
         interceptSavedPm()
     }
 
-    @Test
-    fun `successful confirm updates multiple Checkout instances`() = runScenario(
-        checkoutInstanceCount = 2
-    ) {
-        val checkout1 = checkoutInstances[0]
-        val checkout2 = checkoutInstances[1]
-        turbineScope {
-            val checkoutSessionTurbine1 = checkout1.checkoutSession.testIn(backgroundScope)
-            val checkoutSessionTurbine2 = checkout2.checkoutSession.testIn(backgroundScope)
-
-            assertThat(checkoutSessionTurbine1.awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-            assertThat(checkoutSessionTurbine2.awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-
-            networkRule.checkoutConfirm { response ->
-                response.testBodyFromFile("checkout-session-confirm.json")
-            }
-
-            interceptNewPm()
-
-            assertThat(checkoutSessionTurbine1.awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-            assertThat(checkoutSessionTurbine2.awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-        }
-    }
-
-    @Test
-    fun `successful confirm with new PM updates registered Checkout instances`() = runScenario(
-        checkoutInstanceCount = 1
-    ) {
-        val checkout = checkoutInstances.single()
-        checkout.checkoutSession.test {
-            assertThat(awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-
-            networkRule.checkoutConfirm { response ->
-                response.testBodyFromFile("checkout-session-confirm.json")
-            }
-
-            interceptNewPm()
-
-            assertThat(awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-        }
-    }
-
-    @Test
-    fun `successful confirm with saved PM updates registered Checkout instances`() = runScenario(
-        checkoutInstanceCount = 1
-    ) {
-        val checkout = checkoutInstances.single()
-        checkout.checkoutSession.test {
-            assertThat(awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-
-            networkRule.checkoutConfirm { response ->
-                response.testBodyFromFile("checkout-session-confirm.json")
-            }
-
-            interceptSavedPm()
-
-            assertThat(awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-        }
-    }
-
-    @Test
-    fun `intercept with new PM fails when mutation is in flight`() = runScenario(
-        checkoutInstanceCount = 1,
-    ) {
-        val checkout = checkoutInstances.single()
-        val requestArrived = CountDownLatch(1)
-        val holdResponse = CountDownLatch(1)
-
-        networkRule.checkoutUpdate { response ->
-            requestArrived.countDown()
-            holdResponse.await()
-            response.setBody("{}")
-        }
-
-        val job = backgroundScope.launch(Dispatchers.IO) {
-            checkout.removePromotionCode()
-        }
-
-        assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
-
-        val result = interceptNewPm()
-
-        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
-        val failAction = result as ConfirmationDefinition.Action.Fail
-        assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
-        assertThat(failAction.cause.message)
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
-        assertThat(failAction.errorType)
-            .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
-
-        holdResponse.countDown()
-        job.join()
-    }
-
-    @Test
-    fun `intercept with saved PM fails when mutation is in flight`() = runScenario(
-        checkoutInstanceCount = 1,
-    ) {
-        val checkout = checkoutInstances.single()
-        val requestArrived = CountDownLatch(1)
-        val holdResponse = CountDownLatch(1)
-
-        networkRule.checkoutUpdate { response ->
-            requestArrived.countDown()
-            holdResponse.await()
-            response.setBody("{}")
-        }
-
-        val job = backgroundScope.launch(Dispatchers.IO) {
-            checkout.removePromotionCode()
-        }
-
-        assertThat(requestArrived.await(5, TimeUnit.SECONDS)).isTrue()
-
-        val result = interceptSavedPm()
-
-        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
-        val failAction = result as ConfirmationDefinition.Action.Fail
-        assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
-        assertThat(failAction.cause.message)
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
-        assertThat(failAction.errorType)
-            .isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration)
-
-        holdResponse.countDown()
-        job.join()
-    }
-
-    @Test
-    fun `failed confirm does not update registered Checkout instances`() = runScenario(
-        checkoutInstanceCount = 1,
-    ) {
-        networkRule.checkoutConfirm { response ->
-            response.setResponseCode(400)
-            response.setBody("""{"error":{"message":"Checkout session confirmation failed"}}""")
-        }
-
-        val checkout = checkoutInstances.single()
-        checkout.checkoutSession.test {
-            assertThat(awaitItem().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-
-            interceptNewPm()
-
-            ensureAllEventsConsumed()
-        }
-    }
-
     private fun runScenario(
         createPaymentMethodResult: Result<PaymentMethod> = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
         customerMetadata: CustomerMetadata? = null,
-        checkoutInstanceCount: Int = 0,
         block: suspend Scenario.() -> Unit,
     ) {
         val stripeRepository = FakeCreatePaymentMethodRepository(
@@ -542,19 +383,9 @@ class CheckoutSessionConfirmationInterceptorTest {
             requestOptions = ApiRequest.Options(apiKey = "pk_test_123"),
         )
 
-        @Suppress("EmptyRange")
-        val checkoutInstances = (0 until checkoutInstanceCount).map {
-            Checkout.createWithState(
-                context = applicationContext,
-                state = CheckoutStateFactory.create(),
-            )
-        }
-
         runTest {
             val scenario = Scenario(
                 interceptor = interceptor,
-                checkoutInstances = checkoutInstances,
-                backgroundScope = backgroundScope,
             )
 
             scenario.block()
@@ -563,8 +394,6 @@ class CheckoutSessionConfirmationInterceptorTest {
 
     private data class Scenario(
         val interceptor: CheckoutSessionConfirmationInterceptor,
-        val checkoutInstances: List<Checkout>,
-        val backgroundScope: CoroutineScope,
     ) {
         suspend fun interceptNewPm(
             shouldSave: Boolean = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -7,19 +7,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkout.CheckoutInstancesTestRule
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.isInstanceOf
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
-import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
@@ -41,9 +33,7 @@ import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -51,24 +41,19 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.TimeUnit
 
-@OptIn(CheckoutSessionPreview::class)
 @Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultEmbeddedSheetLauncherTest {
 
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
-    private val networkRule = NetworkRule()
 
     private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @get:Rule
     val ruleChain: RuleChain = RuleChain
-        .outerRule(networkRule)
-        .around(coroutineScopeCleanupRule)
+        .outerRule(coroutineScopeCleanupRule)
         .around(PaymentConfigurationTestRule(applicationContext))
-        .around(CheckoutInstancesTestRule())
 
     @Test
     fun `launchForm launches activity with correct parameters`() = testScenario {
@@ -541,70 +526,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     @Test
-    fun `launchForm throws when checkout mutation is in flight`() = testScenario {
-        val checkout = CheckoutStateFactory.createCheckout(applicationContext)
-        networkRule.checkoutUpdate { response ->
-            response.setBodyDelay(5, TimeUnit.SECONDS)
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-        val deferred = testScope.async { checkout.applyPromotionCode("10OFF") }
-        testScope.testScheduler.advanceUntilIdle()
-
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = DEFAULT_CHECKOUT_SESSION_ID,
-                instancesKey = "test_key",
-            ),
-        )
-        val error = runCatching {
-            sheetLauncher.launchForm(
-                code = "card",
-                paymentMethodMetadata = paymentMethodMetadata,
-                configuration = EmbeddedConfigurationFactory.create(),
-                customerState = createCustomerState(),
-                promotion = null,
-            )
-        }.exceptionOrNull()
-        assertThat(error).isInstanceOf(IllegalStateException::class.java)
-        assertThat(error).hasMessageThat()
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
-
-        deferred.cancel()
-    }
-
-    @Test
-    fun `launchManage throws when checkout mutation is in flight`() = testScenario {
-        val checkout = CheckoutStateFactory.createCheckout(applicationContext)
-        networkRule.checkoutUpdate { response ->
-            response.setBodyDelay(5, TimeUnit.SECONDS)
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-        val deferred = testScope.async { checkout.applyPromotionCode("10OFF") }
-        testScope.testScheduler.advanceUntilIdle()
-
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = DEFAULT_CHECKOUT_SESSION_ID,
-                instancesKey = "test_key",
-            ),
-        )
-        val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
-        val error = runCatching {
-            sheetLauncher.launchManage(
-                paymentMethodMetadata = paymentMethodMetadata,
-                customerState = customerState,
-                selection = PaymentSelection.GooglePay,
-                configuration = EmbeddedConfigurationFactory.create(),
-            )
-        }.exceptionOrNull()
-        assertThat(error).isInstanceOf(IllegalStateException::class.java)
-        assertThat(error).hasMessageThat()
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
-
-        deferred.cancel()
-    }
-
-    @Test
     fun `launchPaymentOptions launches activity with correct parameters`() = testScenario {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
@@ -769,7 +690,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
         shouldRowSelectionBeInvoked: Boolean = false,
         block: suspend Scenario.() -> Unit
     ) = runTest {
-        val testScope = this
         var rowSelectionCallbackInvoked = false
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
@@ -812,7 +732,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
 
             Scenario(
-                testScope = testScope,
                 selectionHolder = selectionHolder,
                 lifecycleOwner = lifecycleOwner,
                 customerStateHolder = customerStateHolder,
@@ -832,7 +751,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     private class Scenario(
-        val testScope: TestScope,
         val selectionHolder: EmbeddedSelectionHolder,
         val lifecycleOwner: TestLifecycleOwner,
         val customerStateHolder: CustomerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -16,19 +16,13 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onIdle
 import androidx.test.espresso.Espresso.pressBack
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.checkout.CheckoutInstancesTestRule
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.isInstanceOf
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -39,14 +33,12 @@ import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.paymentelementtestpages.FormPage
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-@OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class EmbeddedSheetActivityTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
@@ -145,33 +137,6 @@ internal class EmbeddedSheetActivityTest {
         assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
         assertThat((result as EmbeddedActivityResult.Cancelled).launchMode)
             .isEqualTo(EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "cashapp"))
-    }
-
-    @Test
-    fun `onDestroy clears checkout integration launched flag`() {
-        val checkout = CheckoutStateFactory.createCheckout(applicationContext)
-        CheckoutInstances.markIntegrationLaunched(CheckoutStateFactory.DEFAULT_KEY)
-
-        launch(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                integrationMetadata = IntegrationMetadata.CheckoutSession(
-                    id = "cs_test",
-                    instancesKey = CheckoutStateFactory.DEFAULT_KEY,
-                ),
-            ),
-        ) { scenario ->
-            scenario.onActivity { it.finish() }
-        }
-
-        // Enqueue a response so the mutation attempt doesn't fail due to missing network stub.
-        networkRule.checkoutUpdate { response ->
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-
-        // If markIntegrationDismissed was not called, this would fail with
-        // "Cannot mutate checkout session while a payment flow is presented."
-        val result = runBlocking { checkout.applyPromotionCode("code") }
-        assertThat(result.isSuccess).isTrue()
     }
 
     private fun launch(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -13,12 +13,8 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.checkout.CheckoutInstancesTestRule
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.model.PaymentMethodRemovePermission
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -26,8 +22,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -44,7 +38,6 @@ import com.stripe.paymentelementnetwork.setupPaymentMethodDetachResponse
 import com.stripe.paymentelementnetwork.setupPaymentMethodUpdateResponse
 import com.stripe.paymentelementtestpages.EditPage
 import com.stripe.paymentelementtestpages.ManagePage
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -53,7 +46,6 @@ import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
-@OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class EmbeddedSheetActivityTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
@@ -254,39 +246,6 @@ internal class EmbeddedSheetActivityTest {
             val updatedCbcCard = completedResultPaymentMethods().single()
             assertThat(updatedCbcCard.card?.displayBrand).isEqualTo("visa")
         }
-    }
-
-    @Test
-    fun `onDestroy clears checkout integration launched flag`() {
-        val checkout = CheckoutStateFactory.createCheckout(applicationContext)
-        CheckoutInstances.markIntegrationLaunched(CheckoutStateFactory.DEFAULT_KEY)
-
-        launch(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                cbcEligibility = CardBrandChoiceEligibility.Eligible(preferredNetworks = listOf()),
-                hasCustomerConfiguration = true,
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = true,
-                canUpdateCardExpiryAndBillingDetails = false,
-                integrationMetadata = IntegrationMetadata.CheckoutSession(
-                    id = "cs_test",
-                    instancesKey = CheckoutStateFactory.DEFAULT_KEY,
-                ),
-            ),
-        ) {
-            Espresso.pressBack()
-        }
-
-        // Enqueue a response so the mutation attempt doesn't fail due to missing network stub.
-        networkRule.checkoutUpdate { response ->
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-
-        // If markIntegrationDismissed was not called, this would fail with
-        // "Cannot mutate checkout session while a payment flow is presented."
-        val result = runBlocking { checkout.applyPromotionCode("code") }
-        assertThat(result.isSuccess).isTrue()
     }
 
     private fun launch(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -26,24 +26,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.checkout.CheckoutInstances
 import com.stripe.android.checkout.CheckoutInstancesTestRule
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.FakeLinkGate
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_OPTIONS_CONTRACT_ARGS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -72,7 +66,6 @@ import com.stripe.android.view.ActivityStarter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
@@ -85,7 +78,6 @@ import org.mockito.kotlin.verify
 import org.robolectric.annotation.Config
 import kotlin.test.BeforeTest
 
-@OptIn(CheckoutSessionPreview::class)
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 internal class PaymentOptionsActivityTest {
@@ -477,41 +469,6 @@ internal class PaymentOptionsActivityTest {
                 mandateNode.assertDoesNotExist()
             }
         }
-    }
-
-    @Test
-    fun `onDestroy clears checkout integration launched flag`() {
-        val checkout = CheckoutStateFactory.createCheckout(context)
-        CheckoutInstances.markIntegrationLaunched(CheckoutStateFactory.DEFAULT_KEY)
-
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.copy(
-            state = PAYMENT_OPTIONS_CONTRACT_ARGS.state.copy(
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                    integrationMetadata = IntegrationMetadata.CheckoutSession(
-                        id = "cs_test",
-                        instancesKey = CheckoutStateFactory.DEFAULT_KEY,
-                    ),
-                ),
-            ),
-        )
-
-        runActivityScenario(args) {
-            it.onActivity {
-                pressBack()
-            }
-            composeTestRule.waitForIdle()
-            idleLooper()
-        }
-
-        // Enqueue a response so the mutation attempt doesn't fail due to missing network stub.
-        networkRule.checkoutUpdate { response ->
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-
-        // After the activity finishes, the integration launched flag should be cleared.
-        // If it wasn't cleared, this would return a failure with "payment flow is presented" message.
-        val result = runBlocking { checkout.applyPromotionCode("code") }
-        assertThat(result.isSuccess).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -37,8 +37,6 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkout.CheckoutInstances
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
@@ -63,8 +61,6 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.createTestConfirmationHandlerFactory
@@ -143,7 +139,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
-@OptIn(CheckoutSessionPreview::class)
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 internal class PaymentSheetActivityTest {
@@ -219,34 +214,6 @@ internal class PaymentSheetActivityTest {
         WeakMapInjectorRegistry.clear()
         CheckoutInstances.clear()
         Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `onDestroy clears checkout integration launched flag`() {
-        val checkout = CheckoutStateFactory.createCheckout(context)
-        CheckoutInstances.markIntegrationLaunched(CheckoutStateFactory.DEFAULT_KEY)
-
-        val viewModel = createViewModel(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = "cs_test",
-                instancesKey = CheckoutStateFactory.DEFAULT_KEY,
-            ),
-        )
-        val scenario = activityScenario(viewModel)
-        scenario.launchForResult(intent).use {
-            it.onActivity { activity ->
-                pressBack()
-            }
-            composeTestRule.waitForIdle()
-        }
-
-        // Enqueue a response so the mutation attempt doesn't fail due to missing network stub.
-        networkRule.checkoutUpdate { response ->
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-
-        val result = runBlocking { checkout.applyPromotionCode("code") }
-        assertThat(result.isSuccess).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -16,9 +16,6 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkout.CheckoutInstancesTestRule
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.strings.resolvableString
@@ -57,7 +54,6 @@ import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
@@ -104,7 +100,6 @@ import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import com.stripe.android.utils.RelayingPaymentElementLoader
-import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -126,7 +121,6 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -2364,38 +2358,6 @@ internal class DefaultFlowControllerTest {
                 assertThat(bootstrapTurbine.awaitItem().paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
             }
         }
-
-    @Test
-    fun `presentPaymentOptions throws when checkout mutation is in flight`() = runTest {
-        val checkout = CheckoutStateFactory.createCheckout(context)
-        val flowController = createFlowController(
-            FakePaymentElementLoader(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                integrationMetadata = IntegrationMetadata.CheckoutSession(
-                    id = DEFAULT_CHECKOUT_SESSION_ID,
-                    instancesKey = "test_key",
-                ),
-                linkState = null,
-            ),
-        )
-        flowController.configureExpectingSuccess()
-
-        networkRule.checkoutUpdate { response ->
-            response.setBodyDelay(5, TimeUnit.SECONDS)
-            response.testBodyFromFile("checkout-session-apply-discount.json")
-        }
-        val deferred = async { checkout.applyPromotionCode("10OFF") }
-        testScheduler.advanceUntilIdle()
-
-        val error = runCatching {
-            flowController.presentPaymentOptions()
-        }.exceptionOrNull()
-        assertThat(error).isInstanceOf(IllegalStateException::class.java)
-        assertThat(error).hasMessageThat()
-            .isEqualTo("Cannot launch while a checkout session mutation is in flight.")
-
-        deferred.cancel()
-    }
 
     private suspend fun FakeFlowControllerConfirmationHandler.Scenario.createAndConfigureFlowControllerForDeferred(
         paymentIntent: PaymentIntent = PaymentIntentFixtures.PI_SUCCEEDED,


### PR DESCRIPTION
# Summary
Removed all usages and definitions of CheckoutInstances mutation-related methods (`ensureNoMutationInFlight`, `markIntegrationLaunched`, `markIntegrationDismissed`) and associated code from embedded sheet, payment sheet, and flow controller classes.

# Motivation
We don't need multiple instances with CheckoutController, so iteratively cleaning this up.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- no user-facing changes -->