### PR TITLE
Remove integrationLaunched flag and use SheetStateHolder instead.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.validateShippingCountry
@@ -42,6 +43,7 @@ class CheckoutController @Inject internal constructor(
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
+    private val sheetStateHolder: SheetStateHolder,
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) {
@@ -242,11 +244,11 @@ class CheckoutController @Inject internal constructor(
         additionalStateMutations: CheckoutControllerState.() -> CheckoutControllerState = { this },
         block: suspend CheckoutControllerState.(sessionId: String) -> kotlin.Result<CheckoutSessionResponse>,
     ): kotlin.Result<Unit> {
-        val currentState = stateHolder.state
+        stateHolder.state
             ?: return kotlin.Result.failure(
                 IllegalStateException("Cannot mutate checkout session before it is configured.")
             )
-        if (currentState.integrationLaunched) {
+        if (sheetStateHolder.sheetIsOpen) {
             return kotlin.Result.failure(
                 IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
             )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -31,7 +31,6 @@ internal data class CheckoutControllerState(
     val checkoutSessionResponse: CheckoutSessionResponse,
     val flagImages: Map<String, Bitmap>?,
     val collectedDetails: CheckoutCollectedDetails,
-    val integrationLaunched: Boolean,
     val paymentMethodMetadata: PaymentMethodMetadata,
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
     val paymentSelection: PaymentSelection?,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -88,7 +88,6 @@ internal class CheckoutStateLoader @Inject constructor(
             checkoutSessionResponse = response,
             flagImages = flagImages,
             collectedDetails = collectedDetails,
-            integrationLaunched = carryForward.integrationLaunched,
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
             paymentSelection = selection,
@@ -107,7 +106,6 @@ internal class CheckoutStateLoader @Inject constructor(
         val previousSelection: PaymentSelection?,
         val temporarySelection: String?,
         val previousNewSelections: Bundle,
-        val integrationLaunched: Boolean,
     ) {
         companion object {
             fun initial() = CarryForward(
@@ -115,7 +113,6 @@ internal class CheckoutStateLoader @Inject constructor(
                 previousSelection = null,
                 temporarySelection = null,
                 previousNewSelections = Bundle(),
-                integrationLaunched = false,
             )
 
             fun from(state: CheckoutControllerState) = CarryForward(
@@ -123,7 +120,6 @@ internal class CheckoutStateLoader @Inject constructor(
                 previousSelection = state.paymentSelection,
                 temporarySelection = state.temporarySelection,
                 previousNewSelections = state.previousNewSelections,
-                integrationLaunched = state.integrationLaunched,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -25,7 +25,6 @@ internal object CheckoutControllerStateFactory {
         checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
         flagImages: Map<String, Bitmap>? = null,
         collectedDetails: CheckoutCollectedDetails = CheckoutCollectedDetails(),
-        integrationLaunched: Boolean = false,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
@@ -39,7 +38,6 @@ internal object CheckoutControllerStateFactory {
             checkoutSessionResponse = checkoutSessionResponse,
             flagImages = flagImages,
             collectedDetails = collectedDetails,
-            integrationLaunched = integrationLaunched,
             paymentMethodMetadata = paymentMethodMetadata,
             embeddedConfiguration = embeddedConfiguration,
             paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -198,7 +198,6 @@ internal class CheckoutControllerStateHolderTest {
         checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
         flagImages = null,
         collectedDetails = CheckoutCollectedDetails(),
-        integrationLaunched = false,
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.CleanupTestRule
@@ -1037,6 +1038,7 @@ internal class CheckoutControllerTest {
                 MutationScenario(
                     controller = controller,
                     savedStateHandle = savedStateHandle,
+                    sheetStateHolder = SheetStateHolder(savedStateHandle),
                     testScope = this@runTest,
                     isLoadingTurbine = isLoadingTurbine,
                 )
@@ -1052,6 +1054,7 @@ internal class CheckoutControllerTest {
     private class MutationScenario(
         val controller: CheckoutController,
         private val savedStateHandle: SavedStateHandle,
+        private val sheetStateHolder: SheetStateHolder,
         private val testScope: TestScope,
         val isLoadingTurbine: ReceiveTurbine<Boolean>,
     ) : CoroutineScope by testScope {
@@ -1070,11 +1073,10 @@ internal class CheckoutControllerTest {
         fun committedState(): CheckoutControllerState =
             requireNotNull(CheckoutControllerStateFactory.createStateHolder(savedStateHandle).state)
 
-        // Simulates a presented payment flow by flipping the committed state's integrationLaunched
-        // flag, which the mutation guard reads back through the same SavedStateHandle.
+        // Simulates a presented payment flow by opening the sheet through the SheetStateHolder backed
+        // by the shared SavedStateHandle, which the mutation guard reads back through the same holder.
         fun markIntegrationLaunched() {
-            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-            stateHolder.state = committedState().copy(integrationLaunched = true)
+            sheetStateHolder.sheetIsOpen = true
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -196,7 +196,6 @@ internal class CheckoutStateLoaderTest {
         checkoutSessionResponse = checkoutSessionResponse,
         flagImages = null,
         collectedDetails = CheckoutCollectedDetails(),
-        integrationLaunched = false,
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection = paymentSelection,


### PR DESCRIPTION
# Summary

Removed the `integrationLaunched` field from `CheckoutControllerState` and related classes, and switched to using `SheetStateHolder` to track the sheet presentation state.

# Motivation

This refactor centralizes the tracking of the sheet's open state, reducing redundancy and potential for bugs by replacing the duplicated `integrationLaunched` property with `SheetStateHolder.sheetIsOpen`.

# Testing

- [x] Added tests
- [x] Modified tests
- [x] Manually verified

