### PR TITLE
Add NFC scan button shown event for Payment Element & Customer Sheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/LocalNfcScanEventShownReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/LocalNfcScanEventShownReporter.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.common.nfcscan
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal val LocalNfcScanEventShownReporter = staticCompositionLocalOf { {} }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAction.kt
@@ -2,6 +2,11 @@ package com.stripe.android.common.nfcscan
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ActivityOptionsCompat
 import com.stripe.android.common.taptoadd.TapToButtonUI
@@ -19,6 +24,15 @@ internal class NfcScanningAction(
         onScannedCard: (ScannedCardDetails) -> Unit
     ) {
         val context = LocalContext.current
+        val reportNfcScanButtonShown = LocalNfcScanEventShownReporter.current
+        var buttonReportedShown by rememberSaveable { mutableStateOf(false) }
+
+        LaunchedEffect(Unit) {
+            if (!buttonReportedShown) {
+                reportNfcScanButtonShown()
+                buttonReportedShown = true
+            }
+        }
 
         val launcher = rememberLauncherForActivityResult(NfcScanningContract) { result ->
             if (result is NfcScanningContract.Result.Complete) {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -17,6 +17,7 @@ internal sealed class CustomerSheetViewAction {
     object OnCardNumberInputCompleted : CustomerSheetViewAction()
     class OnAnalyticsEvent(val event: AnalyticsEvent) : CustomerSheetViewAction()
     class OnCardScanEvent(val event: CardScanEvent) : CustomerSheetViewAction()
+    object OnNfcScanButtonShown : CustomerSheetViewAction()
     object OnAddCardPressed : CustomerSheetViewAction()
     object OnPrimaryButtonPressed : CustomerSheetViewAction()
     object OnCancelClose : CustomerSheetViewAction()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -288,6 +288,7 @@ internal class CustomerSheetViewModel(
             is CustomerSheetViewAction.OnDisallowedCardBrandEntered -> onDisallowedCardBrandEntered(viewAction.brand)
             is CustomerSheetViewAction.OnAnalyticsEvent -> onAnalyticsEvent(viewAction.event)
             is CustomerSheetViewAction.OnCardScanEvent -> onCardScanEvent(viewAction.event)
+            is CustomerSheetViewAction.OnNfcScanButtonShown -> onNfcScanButtonShown()
             is CustomerSheetViewAction.OnBackPressed -> onBackPressed()
             is CustomerSheetViewAction.OnEditPressed -> onEditPressed()
             is CustomerSheetViewAction.OnModifyItem -> onModifyItem(viewAction.paymentMethod)
@@ -958,6 +959,10 @@ internal class CustomerSheetViewModel(
 
     private fun onCardScanEvent(event: CardScanEvent) {
         eventReporter.onCardScanEvent(event)
+    }
+
+    private fun onNfcScanButtonShown() {
+        eventReporter.onNfcScanButtonShown()
     }
 
     private fun onDisallowedCardBrandEntered(brand: CardBrand) {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -350,6 +350,11 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         override val additionalParams: Map<String, Any?> = emptyMap()
     }
 
+    class NfcScanButtonShown : CustomerSheetEvent() {
+        override val eventName: String = CS_NFC_SCAN_BUTTON_SHOWN
+        override val additionalParams: Map<String, Any?> = emptyMap()
+    }
+
     internal companion object {
         const val CS_INIT_WITH_CUSTOMER_ADAPTER = "cs_init_with_customer_adapter"
         const val CS_INIT_WITH_CUSTOMER_SESSION = "cs_init_with_customer_session"
@@ -412,6 +417,7 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         const val CS_CARDSCAN_API_CHECK_SUCCEEDED = "cs_cardscan_api_check_succeeded"
         const val CS_CARDSCAN_API_CHECK_FAILED = "cs_cardscan_api_check_failed"
         const val CS_CARDSCAN_BUTTON_SHOWN = "cs_cardscan_button_shown"
+        const val CS_NFC_SCAN_BUTTON_SHOWN = "cs_nfc_scan_button_shown"
 
         const val FIELD_GOOGLE_PAY_ENABLED = "google_pay_enabled"
         const val FIELD_BILLING = "default_billing_details"

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEventReporter.kt
@@ -148,6 +148,8 @@ internal interface CustomerSheetEventReporter {
 
     fun onCardScanEvent(event: CardScanEvent)
 
+    fun onNfcScanButtonShown()
+
     enum class Screen(val value: String) {
         AddPaymentMethod("add_payment_method"),
         SelectPaymentMethod("select_payment_method"),

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/DefaultCustomerSheetEventReporter.kt
@@ -251,6 +251,10 @@ internal class DefaultCustomerSheetEventReporter @Inject constructor(
         }
     }
 
+    override fun onNfcScanButtonShown() {
+        fireEvent(CustomerSheetEvent.NfcScanButtonShown())
+    }
+
     private fun fireEvent(event: CustomerSheetEvent) {
         CoroutineScope(workContext).launch {
             analyticsRequestExecutor.executeAsync(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stripe.android.common.nfcscan.LocalNfcScanEventShownReporter
 import com.stripe.android.common.ui.BottomSheetLoadingIndicator
 import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.common.ui.PrimaryButton
@@ -261,6 +262,9 @@ internal fun AddPaymentMethod(
             LocalCardBrandDisallowedReporter provides disallowedReporter,
             LocalAnalyticsEventReporter provides analyticsEventReporter,
             LocalCardScanEventsReporter provides cardScanEventReporter,
+            LocalNfcScanEventShownReporter provides {
+                viewActionHandler(CustomerSheetViewAction.OnNfcScanButtonShown)
+            },
         ) {
             PaymentElement(
                 enabled = viewState.enabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -562,6 +562,10 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(PaymentSheetEvent.CardScanButtonShown())
     }
 
+    override fun onNfcScanButtonShown() {
+        fireEvent(PaymentSheetEvent.NfcScanButtonShown())
+    }
+
     override fun onCardScanApiCheckSucceeded(implementation: String) {
         fireEvent(
             PaymentSheetEvent.CardScanApiCheckSucceeded(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -236,6 +236,8 @@ internal interface EventReporter : CardScanEventsReporter {
 
     fun onTapToAddButtonShown()
 
+    fun onNfcScanButtonShown()
+
     fun onTapToAddStarted()
 
     fun onCardAddedWithTapToAdd(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -561,6 +561,10 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val eventName: String = "mc_cardscan_button_shown"
     }
 
+    class NfcScanButtonShown : PaymentSheetEvent() {
+        override val eventName: String = "mc_nfc_scan_button_shown"
+    }
+
     class CardScanApiCheckFailed(
         implementation: String,
         error: Throwable?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EventReporterProviderUtil.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EventReporterProviderUtil.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import com.stripe.android.common.nfcscan.LocalNfcScanEventShownReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.ui.core.cardscan.LocalCardScanEventsReporter
 import com.stripe.android.ui.core.cardscan.LocalElementsSessionId
@@ -22,6 +23,7 @@ internal fun EventReporterProvider(
         LocalCardBrandDisallowedReporter provides eventReporter::onDisallowedCardBrandEntered,
         LocalAnalyticsEventReporter provides eventReporter::onAnalyticsEvent,
         LocalCardScanEventsReporter provides eventReporter,
+        LocalNfcScanEventShownReporter provides eventReporter::onNfcScanButtonShown,
         LocalElementsSessionId provides elementsSessionId,
     ) {
         content()

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActionTest.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -38,19 +39,23 @@ internal class NfcScanningActionTest {
     val composeCleanupRule = createComposeCleanupRule()
 
     @Test
-    fun `when disabled clicking does not launch contract or invoke callback`() = activityResultTest(
+    fun `when disabled clicking does not launch contract or invoke callback`() = test(
         enabled = false,
     ) {
+        clickButton()
+
         onLaunchCalls.expectNoEvents()
         onScannedCalls.expectNoEvents()
     }
 
     @Test
-    fun `when enabled click completes forwards scanned card details`() = activityResultTest(
+    fun `when enabled click completes forwards scanned card details`() = test(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFactory.create(),
         ),
     ) {
+        clickButton()
+
         val launch = onLaunchCalls.awaitItem()
 
         assertThat(launch.contract).isEqualTo(NfcScanningContract)
@@ -79,14 +84,16 @@ internal class NfcScanningActionTest {
     }
 
     @Test
-    fun `when enabled click returns canceled does not invoke callback`() = activityResultTest {
+    fun `when enabled click returns canceled does not invoke callback`() = test {
+        clickButton()
         val launch = onLaunchCalls.awaitItem()
         resultDispatcher(launch.requestCode, Activity.RESULT_CANCELED, null)
         onScannedCalls.expectNoEvents()
     }
 
     @Test
-    fun `when enabled click returns canceled result in intent does not invoke callback`() = activityResultTest {
+    fun `when enabled click returns canceled result in intent does not invoke callback`() = test {
+        clickButton()
         val launch = onLaunchCalls.awaitItem()
         val intent = Intent().apply {
             putExtras(NfcScanningContract.Result.Canceled.toBundle())
@@ -95,12 +102,19 @@ internal class NfcScanningActionTest {
         onScannedCalls.expectNoEvents()
     }
 
-    private fun activityResultTest(
+    @Test
+    fun `does not report nfc scan button shown again when state changes`() = test {
+        setEnabled(false)
+        onNfcScanButtonShownCalls.expectNoEvents()
+    }
+
+    private fun test(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         enabled: Boolean = true,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val onScannedCardCalls = Turbine<OnScannedCall>()
+        val onNfcScanButtonShownCalls = Turbine<Unit>()
 
         val registry = FakeActivityResultRegistry()
         val owner = object : ActivityResultRegistryOwner {
@@ -108,11 +122,17 @@ internal class NfcScanningActionTest {
         }
 
         val onLaunchCalls = registry.onLaunchCalls
+        val enabledState = mutableStateOf(enabled)
 
         composeTestRule.setContent {
-            CompositionLocalProvider(LocalActivityResultRegistryOwner provides owner) {
+            CompositionLocalProvider(
+                LocalActivityResultRegistryOwner provides owner,
+                LocalNfcScanEventShownReporter provides {
+                    onNfcScanButtonShownCalls.add(Unit)
+                },
+            ) {
                 NfcScanningAction(paymentMethodMetadata).Content(
-                    enabled = enabled,
+                    enabled = enabledState.value,
                     onScannedCard = { details ->
                         onScannedCardCalls.add(OnScannedCall(details))
                     },
@@ -121,26 +141,37 @@ internal class NfcScanningActionTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag(TAP_TO_BUTTON_UI_TEST_TAG).performClick()
-        composeTestRule.waitForIdle()
+        assertThat(onNfcScanButtonShownCalls.awaitItem()).isNotNull()
 
         block(
             Scenario(
                 paymentMethodMetadata = paymentMethodMetadata,
                 onLaunchCalls = onLaunchCalls,
                 onScannedCalls = onScannedCardCalls,
+                onNfcScanButtonShownCalls = onNfcScanButtonShownCalls,
+                clickButton = {
+                    composeTestRule.onNodeWithTag(TAP_TO_BUTTON_UI_TEST_TAG).performClick()
+                    composeTestRule.waitForIdle()
+                },
+                setEnabled = {
+                    enabledState.value = it
+                },
                 resultDispatcher = registry::dispatchResult,
             ),
         )
 
         onScannedCardCalls.ensureAllEventsConsumed()
         onLaunchCalls.ensureAllEventsConsumed()
+        onNfcScanButtonShownCalls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val paymentMethodMetadata: PaymentMethodMetadata,
         val onLaunchCalls: ReceiveTurbine<FakeActivityResultRegistry.OnLaunchCall<*, *>>,
         val onScannedCalls: ReceiveTurbine<OnScannedCall>,
+        val onNfcScanButtonShownCalls: ReceiveTurbine<Unit>,
+        val clickButton: () -> Unit,
+        val setEnabled: (Boolean) -> Unit,
         val resultDispatcher: (requestCode: Int, resultCode: Int, data: Intent?) -> Unit,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetEventReporterTest.kt
@@ -631,4 +631,15 @@ class CustomerSheetEventReporterTest {
             }
         )
     }
+
+    @Test
+    fun `onNfcScanButtonShown() should fire analytics request with expected event value`() {
+        eventReporter.onNfcScanButtonShown()
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "cs_nfc_scan_button_shown"
+            }
+        )
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -998,4 +998,6 @@ private class FakeCustomerSheetEventReporter : CustomerSheetEventReporter {
     override fun onAnalyticsEvent(event: AnalyticsEvent) = Unit
 
     override fun onCardScanEvent(event: CardScanEvent) = Unit
+
+    override fun onNfcScanButtonShown() = Unit
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1023,6 +1023,17 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onNfcScanButtonShown fires event`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        eventReporter.onNfcScanButtonShown()
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_nfc_scan_button_shown")
+        assertThat(request.params).containsEntry("example_from_test", true)
+    }
+
+    @Test
     fun `onUsBankAccountFormEvent fires started event`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -309,6 +309,9 @@ internal class FakeEventReporter : EventReporter {
     override fun onCardScanButtonShown() {
     }
 
+    override fun onNfcScanButtonShown() {
+    }
+
     override fun onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
         visiblePaymentMethods: List<String>,
         hiddenPaymentMethods: List<String>,


### PR DESCRIPTION
# Summary
Add NFC scan button shown event for Payment Element & Customer Sheet to indicate the user has seen the NFC scan `Tap to add` button. This event is separate from the 

# Motivation
Improved analytics for OCS.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified