### PR TITLE
Refactor GooglePayDisplayItemsFactory to use CheckoutSessionResponse.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.toPaymentMethodIncentive
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.LinkDisabledState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.LinkStateResult
@@ -99,6 +100,7 @@ internal data class PaymentMethodMetadata(
     val cardArts: List<PaymentMethod.Card.CardArt>,
     val shouldUseAutocompleteProxyEndpoints: Boolean,
     val requiresBillingAddressForAutomaticTax: Boolean,
+    val checkoutSessionResponse: CheckoutSessionResponse?,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
 ) : Parcelable {
 
@@ -440,6 +442,9 @@ internal data class PaymentMethodMetadata(
                 cardArts = cardArts,
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 requiresBillingAddressForAutomaticTax = initializationMode.requiresBillingAddressForAutomaticTax(),
+                checkoutSessionResponse =
+                    (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
+                        ?.checkoutSessionResponse,
                 paymentMethodLayout = paymentMethodLayout,
             )
         }
@@ -512,6 +517,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 requiresBillingAddressForAutomaticTax = false,
+                checkoutSessionResponse = null,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -1,28 +1,19 @@
 package com.stripe.android.paymentelement.confirmation.gpay
 
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.checkout.CheckoutInstances
-import com.stripe.android.checkout.CheckoutSession
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
-@OptIn(CheckoutSessionPreview::class)
 internal object GooglePayDisplayItemsFactory {
 
     fun create(paymentMethodMetadata: PaymentMethodMetadata): List<GooglePayJsonFactory.DisplayItem> {
-        val checkoutSessionMetadata = paymentMethodMetadata.integrationMetadata
-            as? IntegrationMetadata.CheckoutSession ?: return emptyList()
+        val response = paymentMethodMetadata.checkoutSessionResponse ?: return emptyList()
 
-        val checkout = CheckoutInstances[checkoutSessionMetadata.instancesKey]
-            ?: return emptyList()
-
-        val checkoutSession = checkout.checkoutSession.value
         val items = mutableListOf<GooglePayJsonFactory.DisplayItem>()
 
-        items += checkoutSession.lineItems.map { it.asDisplayItem() }
+        items += response.lineItems.map { it.asDisplayItem() }
 
-        checkoutSession.totalSummary?.let { summary ->
+        response.totalSummary?.let { summary ->
             items += summary.discountAmounts.map { it.asDisplayItem() }
             items += summary.taxAmounts.map { it.asDisplayItem() }
         }
@@ -30,7 +21,7 @@ internal object GooglePayDisplayItemsFactory {
         return items
     }
 
-    private fun CheckoutSession.LineItem.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+    private fun CheckoutSessionResponse.LineItem.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
         val label = if (quantity > 1) "$name x$quantity" else name
         return GooglePayJsonFactory.DisplayItem(
             label = label,
@@ -39,7 +30,7 @@ internal object GooglePayDisplayItemsFactory {
         )
     }
 
-    private fun CheckoutSession.DiscountAmount.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+    private fun CheckoutSessionResponse.DiscountAmount.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
         return GooglePayJsonFactory.DisplayItem(
             label = displayName,
             type = GooglePayJsonFactory.DisplayItem.Type.DISCOUNT,
@@ -47,7 +38,7 @@ internal object GooglePayDisplayItemsFactory {
         )
     }
 
-    private fun CheckoutSession.TaxAmount.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
+    private fun CheckoutSessionResponse.TaxAmount.asDisplayItem(): GooglePayJsonFactory.DisplayItem {
         return GooglePayJsonFactory.DisplayItem(
             label = displayName,
             type = GooglePayJsonFactory.DisplayItem.Type.TAX,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.LinkStateResult
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
@@ -82,6 +83,7 @@ internal object PaymentMethodMetadataFactory {
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
         requiresBillingAddressForAutomaticTax: Boolean = false,
+        checkoutSessionResponse: CheckoutSessionResponse? = null,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
@@ -156,6 +158,7 @@ internal object PaymentMethodMetadataFactory {
             cardArts = cardArts,
             shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
             requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
+            checkoutSessionResponse = checkoutSessionResponse,
             paymentMethodLayout = paymentMethodLayout,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1222,6 +1222,7 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             requiresBillingAddressForAutomaticTax = false,
+            checkoutSessionResponse = null,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
 
@@ -1383,6 +1384,7 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             requiresBillingAddressForAutomaticTax = false,
+            checkoutSessionResponse = null,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -1,57 +1,17 @@
 package com.stripe.android.paymentelement.confirmation.gpay
 
-import android.app.Application
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.checkout.Checkout
-import com.stripe.android.checkout.CheckoutInstances
-import com.stripe.android.checkout.CheckoutStateFactory
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
-import com.stripe.android.testing.PaymentConfigurationTestRule
-import org.junit.After
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@OptIn(CheckoutSessionPreview::class)
-@RunWith(RobolectricTestRunner::class)
 class GooglePayDisplayItemsFactoryTest {
 
-    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
-
-    @get:Rule
-    val paymentConfigRule = PaymentConfigurationTestRule(applicationContext)
-
-    @After
-    fun tearDown() {
-        CheckoutInstances.clear()
-    }
-
     @Test
-    fun `returns empty list when integration metadata is not CheckoutSession`() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            integrationMetadata = IntegrationMetadata.IntentFirst(clientSecret = "pi_xxx_secret_yyy"),
-        )
-
-        val result = GooglePayDisplayItemsFactory.create(metadata)
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `returns empty list when no checkout instance exists for key`() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = "cs_xxx",
-                instancesKey = "nonexistent_key",
-            ),
-        )
+    fun `returns empty list when checkoutSessionResponse is null`() {
+        val metadata = PaymentMethodMetadataFactory.create(checkoutSessionResponse = null)
 
         val result = GooglePayDisplayItemsFactory.create(metadata)
 
@@ -92,6 +52,26 @@ class GooglePayDisplayItemsFactoryTest {
                 price = 500L,
             ),
         ).inOrder()
+    }
+
+    @Test
+    fun `uses total when line item has no unit amount`() {
+        val result = createAndGetDisplayItems(
+            lineItems = listOf(
+                lineItem(
+                    id = "li_1", name = "Widget", quantity = 1,
+                    unitAmount = null, subtotal = 2000L, total = 1800L,
+                ),
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            displayItem(
+                label = "Widget",
+                type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                price = 1800L,
+            ),
+        )
     }
 
     @Test
@@ -199,21 +179,10 @@ class GooglePayDisplayItemsFactoryTest {
         lineItems: List<CheckoutSessionResponse.LineItem>,
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
     ): List<GooglePayJsonFactory.DisplayItem> {
-        Checkout.createWithState(
-            context = applicationContext,
-            state = CheckoutStateFactory.create(
-                key = INSTANCES_KEY,
-                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                    lineItems = lineItems,
-                    totalSummary = totalSummary,
-                ),
-            ),
-        )
-
         val metadata = PaymentMethodMetadataFactory.create(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = "cs_xxx",
-                instancesKey = INSTANCES_KEY,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                lineItems = lineItems,
+                totalSummary = totalSummary,
             ),
         )
 
@@ -221,13 +190,11 @@ class GooglePayDisplayItemsFactoryTest {
     }
 
     private companion object {
-        const val INSTANCES_KEY = "test_key"
-
         fun lineItem(
             id: String,
             name: String,
             quantity: Int,
-            unitAmount: Long,
+            unitAmount: Long?,
             subtotal: Long,
             total: Long,
         ) = CheckoutSessionResponse.LineItem(


### PR DESCRIPTION
# Summary
Refactors GooglePayDisplayItemsFactory and related tests to use CheckoutSessionResponse directly instead of relying on CheckoutSession and IntegrationMetadata indirection. Updates PaymentMethodMetadata to hold a nullable CheckoutSessionResponse where applicable.

# Motivation
Simplifies the code by avoiding reliance on CheckoutInstances and IntegrationMetadata. This makes display item generation for Google Pay clearer, faster, and more testable, as test code can inject a stub CheckoutSessionResponse directly.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Changed] GooglePayDisplayItemsFactory now consumes CheckoutSessionResponse from PaymentMethodMetadata, improving clarity and testability.