### PR TITLE
Reload Checkout state with session after confirm, handle errors.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -351,6 +351,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         CHECKOUT_SELECTION_SET_BEFORE_LOAD(
             partialEventName = "checkout.selection_set_before_load"
+        ),
+        CHECKOUT_RELOAD_AFTER_CONFIRM_FAILED(
+            partialEventName = "checkout.reload_after_confirm_failed"
         );
 
         override val eventName: String

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -4,8 +4,11 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
@@ -20,17 +23,24 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 
+@OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val checkoutStateLoader: CheckoutStateLoader,
     private val errorReporter: ErrorReporter,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) : EmbeddedSheetLauncher {
@@ -61,10 +71,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setSelection(result.selection)
-            }
+            is EmbeddedActivityResult.Complete -> handleCompleteResult(result)
             is EmbeddedActivityResult.Cancelled -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
             }
@@ -74,10 +81,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleManageResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setSelection(result.selection)
-            }
+            is EmbeddedActivityResult.Complete -> handleCompleteResult(result)
             is EmbeddedActivityResult.Cancelled -> Unit
             is EmbeddedActivityResult.Error -> Unit
         }
@@ -85,15 +89,41 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handlePaymentOptionsResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setSelection(result.selection)
-            }
+            is EmbeddedActivityResult.Complete -> handleCompleteResult(result)
             is EmbeddedActivityResult.Cancelled -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
                 clearStaleSelection()
             }
             is EmbeddedActivityResult.Error -> Unit
+        }
+    }
+
+    /**
+     * When the sheet confirmed a payment it returns the post-confirm [CheckoutSessionResponse]; feed
+     * it through [CheckoutStateLoader] so the state holder reflects the final session (the reload
+     * re-derives the customer and selection, so the manual updates are skipped in that case).
+     */
+    private fun handleCompleteResult(result: EmbeddedActivityResult.Complete) {
+        val response = result.checkoutSessionResponse
+        if (response != null) {
+            reloadAfterConfirm(response)
+        } else {
+            result.customerState?.let { customerStateHolder.setCustomerState(it) }
+            selectionHolder.setSelection(result.selection)
+        }
+    }
+
+    private fun reloadAfterConfirm(response: CheckoutSessionResponse) {
+        val current = stateHolder.state ?: return
+        coroutineScope.launch {
+            runCatching {
+                checkoutStateLoader.reload(current.copy(checkoutSessionResponse = response))
+            }.onFailure {
+                errorReporter.report(
+                    errorEvent = ErrorReporter.UnexpectedErrorEvent.CHECKOUT_RELOAD_AFTER_CONFIRM_FAILED,
+                    stripeException = StripeException.create(it),
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -11,14 +11,24 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
-internal class CheckoutStateLoader @Inject constructor(
+internal interface CheckoutStateLoader {
+    suspend fun loadInitial(
+        configuration: CheckoutController.Configuration.State,
+        checkoutSessionResponse: CheckoutSessionResponse,
+    )
+
+    suspend fun reload(state: CheckoutControllerState)
+}
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutStateLoader @Inject constructor(
     private val embeddedConfigurationFactory: CheckoutEmbeddedConfigurationFactory,
     private val flagImageResolver: FlagImageResolver,
     private val paymentElementLoader: PaymentElementLoader,
     private val selectionChooser: EmbeddedSelectionChooser,
     private val stateHolder: CheckoutControllerStateHolder,
-) {
-    suspend fun loadInitial(
+) : CheckoutStateLoader {
+    override suspend fun loadInitial(
         configuration: CheckoutController.Configuration.State,
         checkoutSessionResponse: CheckoutSessionResponse,
     ) {
@@ -30,7 +40,7 @@ internal class CheckoutStateLoader @Inject constructor(
         )
     }
 
-    suspend fun reload(state: CheckoutControllerState) {
+    override suspend fun reload(state: CheckoutControllerState) {
         commit(
             configuration = state.configuration,
             response = state.checkoutSessionResponse,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -11,7 +11,9 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutPaymentOptionDisplayDataFactory
+import com.stripe.android.checkout.CheckoutStateLoader
 import com.stripe.android.checkout.DefaultCheckoutPaymentOptionDisplayDataFactory
+import com.stripe.android.checkout.DefaultCheckoutStateLoader
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.checkout.ece.DefaultAvailableExpressButtonTypesFactory
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
@@ -132,6 +134,9 @@ internal interface CheckoutControllerComponent {
 internal interface CheckoutControllerModule {
     @Binds
     fun bindPaymentElementLoader(loader: DefaultPaymentElementLoader): PaymentElementLoader
+
+    @Binds
+    fun bindsCheckoutStateLoader(loader: DefaultCheckoutStateLoader): CheckoutStateLoader
 
     @Binds
     fun bindsElementsSessionRepository(impl: RealElementsSessionRepository): ElementsSessionRepository

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -151,6 +151,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     intent = intent,
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                        set(CheckoutSessionResponseKey, response)
                     },
                     completedFullPaymentFlow = true,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionResponseKey.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionResponseKey.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentelement.confirmation.intent
+
+import com.stripe.android.paymentelement.confirmation.ConfirmationMetadata
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+
+/**
+ * Carries the full [CheckoutSessionResponse] returned by the checkout session confirm call from
+ * [CheckoutSessionConfirmationInterceptor] through the confirmation result, so the checkout state
+ * can be refreshed with the post-confirm session.
+ */
+internal object CheckoutSessionResponseKey : ConfirmationMetadata.Key<CheckoutSessionResponse>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -18,6 +19,7 @@ internal sealed interface EmbeddedActivityResult : Parcelable {
         val hasBeenConfirmed: Boolean,
         val customerState: CustomerState?,
         val shouldInvokeSelectionCallback: Boolean,
+        val checkoutSessionResponse: CheckoutSessionResponse?,
         override val launchMode: EmbeddedLaunchMode,
     ) : EmbeddedActivityResult
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -216,6 +216,7 @@ internal class EmbeddedNavigator private constructor(
                                 hasBeenConfirmed = true,
                                 customerState = customerStateHolder.customer.value,
                                 shouldInvokeSelectionCallback = false,
+                                checkoutSessionResponse = state.checkoutSessionResponse,
                                 launchMode = launchMode,
                             )
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -236,6 +236,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
                 hasBeenConfirmed = false,
                 customerState = customerStateHolder.customer.value,
                 shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
+                checkoutSessionResponse = null,
                 launchMode = args?.launchMode ?: EmbeddedLaunchMode.Manage,
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -58,6 +58,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
                         shouldInvokeSelectionCallback = false,
+                        checkoutSessionResponse = null,
                         launchMode = EmbeddedLaunchMode.PaymentOptions,
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -54,6 +54,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,
+                            checkoutSessionResponse = null,
                             launchMode = launchMode,
                         )
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -18,6 +19,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.amount
 import com.stripe.android.paymentsheet.model.currency
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.paymentsheet.utils.buyButtonLabel
@@ -55,6 +57,7 @@ internal interface SheetActivityStateHolder {
         val error: ResolvableString? = null,
         val mandateText: ResolvableString? = null,
         val savedPaymentSelectionToConfirm: PaymentSelection.Saved? = null,
+        val checkoutSessionResponse: CheckoutSessionResponse? = null,
     )
 }
 
@@ -105,6 +108,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,
+                            checkoutSessionResponse = null,
                             launchMode = launchMode,
                         )
                     }
@@ -114,6 +118,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                             hasBeenConfirmed = true,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,
+                            checkoutSessionResponse = null,
                             launchMode = launchMode,
                         )
                     }
@@ -124,6 +129,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,
+                            checkoutSessionResponse = null,
                             launchMode = launchMode,
                         )
                     }
@@ -213,7 +219,8 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                 when (state.result) {
                     is ConfirmationHandler.Result.Succeeded -> copy(
                         processingState = PrimaryButtonProcessingState.Completed,
-                        isEnabled = false
+                        isEnabled = false,
+                        checkoutSessionResponse = state.result.metadata[CheckoutSessionResponseKey],
                     )
                     is ConfirmationHandler.Result.Failed -> copy(
                         processingState = PrimaryButtonProcessingState.Idle(null),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -26,6 +27,7 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
 import com.stripe.android.testing.FakeErrorReporter
@@ -38,6 +40,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutSheetLauncherTest {
 
@@ -186,6 +189,7 @@ internal class CheckoutSheetLauncherTest {
             hasBeenConfirmed = false,
             customerState = customerState,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -239,6 +243,7 @@ internal class CheckoutSheetLauncherTest {
             hasBeenConfirmed = true,
             customerState = null,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -248,6 +253,71 @@ internal class CheckoutSheetLauncherTest {
         assertThat(selectionHolder.temporarySelection.value).isNull()
         assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Test
+    fun `complete result with checkout session response reloads state`() = testScenario {
+        val initialResponse = CheckoutSessionResponseFactory.create()
+        stateHolder.state = CheckoutControllerStateFactory.create(checkoutSessionResponse = initialResponse)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+        val confirmedResponse = initialResponse.copy(id = "cs_confirmed")
+        val result = EmbeddedActivityResult.Complete(
+            selection = null,
+            hasBeenConfirmed = true,
+            customerState = null,
+            shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = confirmedResponse,
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
+        )
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(result)
+
+        assertThat(checkoutStateLoader.reloadCalls.awaitItem().checkoutSessionResponse)
+            .isEqualTo(confirmedResponse)
+        // The reload re-derives the selection, so the manual selection update is skipped.
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        checkoutStateLoader.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `complete result with checkout session response is ignored when no state is loaded`() = testScenario {
+        val result = EmbeddedActivityResult.Complete(
+            selection = null,
+            hasBeenConfirmed = true,
+            customerState = null,
+            shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
+        )
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(result)
+
+        checkoutStateLoader.reloadCalls.expectNoEvents()
+        checkoutStateLoader.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `complete result reports error when reload fails`() = testScenario(
+        reloadResult = Result.failure(RuntimeException("boom")),
+    ) {
+        stateHolder.state = CheckoutControllerStateFactory.create()
+        val result = EmbeddedActivityResult.Complete(
+            selection = null,
+            hasBeenConfirmed = true,
+            customerState = null,
+            shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
+        )
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(result)
+
+        // Draining the reload call runs the coroutine through its failure handling.
+        checkoutStateLoader.reloadCalls.awaitItem()
+        assertThat(errorReporter.getLoggedErrors())
+            .contains("unexpected_error.checkout.reload_after_confirm_failed")
+        checkoutStateLoader.ensureAllEventsConsumed()
     }
 
     @Test
@@ -313,6 +383,7 @@ internal class CheckoutSheetLauncherTest {
             selection = selection,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Manage,
         )
 
@@ -419,6 +490,7 @@ internal class CheckoutSheetLauncherTest {
             selection = selection,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
@@ -508,8 +580,10 @@ internal class CheckoutSheetLauncherTest {
     }
 
     private fun testScenario(
+        reloadResult: Result<Unit> = Result.success(Unit),
         block: suspend Scenario.() -> Unit
     ) = runTest {
+        val backgroundScope = this.backgroundScope
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
@@ -521,6 +595,8 @@ internal class CheckoutSheetLauncherTest {
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+        val checkoutStateLoader = FakeCheckoutStateLoader(reloadResult = reloadResult)
         val errorReporter = FakeErrorReporter()
 
         DummyActivityResultCaller.test {
@@ -530,7 +606,10 @@ internal class CheckoutSheetLauncherTest {
                 selectionHolder = selectionHolder,
                 customerStateHolder = customerStateHolder,
                 sheetStateHolder = sheetStateHolder,
+                stateHolder = stateHolder,
+                checkoutStateLoader = checkoutStateLoader,
                 errorReporter = errorReporter,
+                coroutineScope = backgroundScope,
                 statusBarColor = null,
                 paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             )
@@ -549,6 +628,8 @@ internal class CheckoutSheetLauncherTest {
                 launcher = launcher,
                 sheetLauncher = sheetLauncher,
                 sheetStateHolder = sheetStateHolder,
+                stateHolder = stateHolder,
+                checkoutStateLoader = checkoutStateLoader,
                 errorReporter = errorReporter,
             ).block()
         }
@@ -563,6 +644,8 @@ internal class CheckoutSheetLauncherTest {
         val launcher: ActivityResultLauncher<*>,
         val sheetLauncher: EmbeddedSheetLauncher,
         val sheetStateHolder: SheetStateHolder,
+        val stateHolder: CheckoutControllerStateHolder,
+        val checkoutStateLoader: FakeCheckoutStateLoader,
         val errorReporter: FakeErrorReporter,
     ) {
         suspend fun launchForm(code: String) {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -243,7 +243,7 @@ internal class CheckoutStateLoaderTest {
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         val recordingChooser = RecordingSelectionChooser(chosenSelection)
         val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
-        val loader = CheckoutStateLoader(
+        val loader = DefaultCheckoutStateLoader(
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(merchantDisplayName),
             flagImageResolver = flagImageResolver,
             paymentElementLoader = FakePaymentElementLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutStateLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutStateLoader.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+
+@OptIn(CheckoutSessionPreview::class)
+internal class FakeCheckoutStateLoader(
+    private val reloadResult: Result<Unit> = Result.success(Unit),
+) : CheckoutStateLoader {
+    val loadInitialCalls = Turbine<LoadInitialCall>()
+    val reloadCalls = Turbine<CheckoutControllerState>()
+
+    override suspend fun loadInitial(
+        configuration: CheckoutController.Configuration.State,
+        checkoutSessionResponse: CheckoutSessionResponse,
+    ) {
+        loadInitialCalls.add(LoadInitialCall(configuration, checkoutSessionResponse))
+    }
+
+    override suspend fun reload(state: CheckoutControllerState) {
+        reloadCalls.add(state)
+        reloadResult.getOrThrow()
+    }
+
+    fun ensureAllEventsConsumed() {
+        loadInitialCalls.ensureAllEventsConsumed()
+        reloadCalls.ensureAllEventsConsumed()
+    }
+
+    data class LoadInitialCall(
+        val configuration: CheckoutController.Configuration.State,
+        val checkoutSessionResponse: CheckoutSessionResponse,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -32,7 +32,6 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
@@ -73,11 +72,10 @@ class CheckoutSessionConfirmationInterceptorTest {
         val completeAction = result as ConfirmationDefinition.Action.Complete
         assertThat(completeAction.intent).isInstanceOf<PaymentIntent>()
         assertThat((completeAction.intent as PaymentIntent).status).isEqualTo(StripeIntent.Status.Succeeded)
-        assertThat(completeAction.metadata).isEqualTo(
-            MutableConfirmationMetadata().apply {
-                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
-            }
-        )
+        assertThat(completeAction.metadata[DeferredIntentConfirmationTypeKey])
+            .isEqualTo(DeferredIntentConfirmationType.Server)
+        assertThat(completeAction.metadata[CheckoutSessionResponseKey]?.paymentIntent)
+            .isEqualTo(completeAction.intent)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 
@@ -211,11 +209,10 @@ class CheckoutSessionConfirmationInterceptorTest {
         val completeAction = result as ConfirmationDefinition.Action.Complete
         assertThat(completeAction.intent).isInstanceOf<PaymentIntent>()
         assertThat((completeAction.intent as PaymentIntent).status).isEqualTo(StripeIntent.Status.Succeeded)
-        assertThat(completeAction.metadata).isEqualTo(
-            MutableConfirmationMetadata().apply {
-                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
-            }
-        )
+        assertThat(completeAction.metadata[DeferredIntentConfirmationTypeKey])
+            .isEqualTo(DeferredIntentConfirmationType.Server)
+        assertThat(completeAction.metadata[CheckoutSessionResponseKey]?.paymentIntent)
+            .isEqualTo(completeAction.intent)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -204,6 +204,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             hasBeenConfirmed = true,
             customerState = null,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -228,6 +229,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             hasBeenConfirmed = false,
             customerState = null,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -254,6 +256,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 hasBeenConfirmed = false,
                 customerState = null,
                 shouldInvokeSelectionCallback = false,
+                checkoutSessionResponse = null,
                 launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
             )
             val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -276,6 +279,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 hasBeenConfirmed = true,
                 customerState = null,
                 shouldInvokeSelectionCallback = false,
+                checkoutSessionResponse = null,
                 launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
             )
             val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -335,6 +339,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = null,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -410,6 +415,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = selection,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Manage,
         )
 
@@ -434,6 +440,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 selection = selection,
                 hasBeenConfirmed = false,
                 shouldInvokeSelectionCallback = true,
+                checkoutSessionResponse = null,
                 launchMode = EmbeddedLaunchMode.Manage,
             )
 
@@ -455,6 +462,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 selection = selection,
                 hasBeenConfirmed = false,
                 shouldInvokeSelectionCallback = false,
+                checkoutSessionResponse = null,
                 launchMode = EmbeddedLaunchMode.Manage,
             )
 
@@ -498,6 +506,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             hasBeenConfirmed = true,
             customerState = null,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -592,6 +601,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = selection,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
@@ -611,6 +621,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = null,
             hasBeenConfirmed = true,
             shouldInvokeSelectionCallback = false,
+            checkoutSessionResponse = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -94,6 +94,7 @@ internal class EmbeddedSheetActivityTest {
                     hasBeenConfirmed = true,
                     customerState = null,
                     shouldInvokeSelectionCallback = false,
+                    checkoutSessionResponse = null,
                     launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -87,6 +87,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
                 hasBeenConfirmed = false,
                 customerState = null,
                 shouldInvokeSelectionCallback = false,
+                checkoutSessionResponse = null,
                 launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -16,6 +16,8 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
@@ -28,6 +30,7 @@ import com.stripe.android.paymentelement.embedded.form.confirmationStateConfirmi
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.ui.core.R
@@ -159,6 +162,24 @@ class DefaultSheetActivityStateHolderTest {
             val completedState = awaitItem()
             assertThat(completedState.processingState).isEqualTo(PrimaryButtonProcessingState.Completed)
             assertThat(completedState.isProcessing).isFalse()
+        }
+    }
+
+    @Test
+    fun `successful confirmation captures checkout session response into state`() = testScenario {
+        val response = CheckoutSessionResponseFactory.create()
+        stateHolder.state.test {
+            awaitAndVerifyInitialState()
+            confirmationHandler.state.value = ConfirmationHandler.State.Complete(
+                result = ConfirmationHandler.Result.Succeeded(
+                    intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(CheckoutSessionResponseKey, response)
+                    },
+                ),
+            )
+
+            assertThat(awaitItem().checkoutSessionResponse).isEqualTo(response)
         }
     }
 
@@ -349,6 +370,7 @@ class DefaultSheetActivityStateHolderTest {
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
                         shouldInvokeSelectionCallback = false,
+                        checkoutSessionResponse = null,
                         launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
                     )
                 )
@@ -373,6 +395,7 @@ class DefaultSheetActivityStateHolderTest {
                         hasBeenConfirmed = true,
                         customerState = customerStateHolder.customer.value,
                         shouldInvokeSelectionCallback = false,
+                        checkoutSessionResponse = null,
                         launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
                     )
                 )
@@ -403,6 +426,7 @@ class DefaultSheetActivityStateHolderTest {
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
                         shouldInvokeSelectionCallback = false,
+                        checkoutSessionResponse = null,
                         launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -55,6 +55,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                     hasBeenConfirmed = false,
                     customerState = null,
                     shouldInvokeSelectionCallback = false,
+                    checkoutSessionResponse = null,
                     launchMode = EmbeddedLaunchMode.PaymentOptions,
                 )
             )


### PR DESCRIPTION
# Summary
Reloads the Checkout state with the latest `CheckoutSessionResponse` after a successful confirm, ensuring the UI/data stays in sync with the session's completed state. Handles reload failures and reports them via error analytics.

# Motivation
Previously, after confirming a payment, the post-confirm session information was not propagated back to the main Checkout state, which could cause inconsistencies in the UI or state model. This change ensures the latest session data is loaded, and any errors during reload are tracked.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Fixed] Checkout now reloads state with the post-confirm session after confirmation. Errors in reloading are properly reported.