### PR TITLE
Update FakeExpressCheckoutElementConfirmationPerformer to use a Turbine

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -156,23 +156,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
     }
 
     @Test
-    fun `handleViewAction OnWalletTapped reports wallet tapped event`() = runScenario(
-        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            availableWallets = listOf(WalletType.GooglePay),
-        ),
-    ) {
-        interactor.handleViewAction(
-            ExpressCheckoutElementInteractor.ViewAction.OnWalletTapped(
-                expressButton = interactor.state.value.expressButtons.single(),
-            )
-        )
-
-        assertThat(eventReporter.calls)
-            .containsExactly(FakeExpressCheckoutElementEventReporter.Call.OnEceWalletTapped)
-    }
-
-    @Test
-    fun `handleViewAction OnWalletTapped starts confirmation`() = runScenario(
+    fun `handleViewAction OnWalletTapped reports wallet tapped event and starts confirmation`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             availableWallets = listOf(WalletType.GooglePay),
         ),
@@ -181,12 +165,12 @@ internal class DefaultExpressCheckoutElementInteractorTest {
 
         interactor.handleViewAction(
             ExpressCheckoutElementInteractor.ViewAction.OnWalletTapped(
-                expressButton = expressButton,
+                expressButton = interactor.state.value.expressButtons.single(),
             )
         )
 
-        assertThat(confirmationPerformer.calls)
-            .containsExactly(expressButton)
+        val confirmedButton = confirmationPerformer.calls.awaitItem()
+        assertThat(confirmedButton).isEqualTo(expressButton)
 
         assertThat(eventReporter.calls)
             .containsExactly(FakeExpressCheckoutElementEventReporter.Call.OnEceWalletTapped)
@@ -235,6 +219,8 @@ internal class DefaultExpressCheckoutElementInteractorTest {
             googlePayConfiguration = googlePayConfiguration,
             interactorFactory = interactorFactory,
         ).block()
+
+        confirmationPerformer.ensureAllEventsConsumed()
     }
 
     private fun createStateHolder(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -165,7 +165,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
 
         interactor.handleViewAction(
             ExpressCheckoutElementInteractor.ViewAction.OnWalletTapped(
-                expressButton = interactor.state.value.expressButtons.single(),
+                expressButton = expressButton
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/FakeExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/FakeExpressCheckoutElementConfirmationPerformer.kt
@@ -1,9 +1,15 @@
 package com.stripe.android.checkout.ece
 
+import app.cash.turbine.Turbine
+
 internal class FakeExpressCheckoutElementConfirmationPerformer : ExpressCheckoutElementConfirmationPerformer {
-    val calls = mutableListOf<ExpressButton>()
+    val calls = Turbine<ExpressButton>()
 
     override fun confirm(expressButton: ExpressButton) {
         calls.add(expressButton)
+    }
+
+    fun ensureAllEventsConsumed() {
+        calls.ensureAllEventsConsumed()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update FakeExpressCheckoutElementConfirmationPerformer to use a Turbine

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/13587#discussion_r3640471133

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
