### PR TITLE
Report Express Checkout confirmation early-return errors 🪿✨

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -289,6 +289,12 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         WALLET_BUTTONS_NULL_CONFIRMATION_ARGS_ON_CONFIRM(
             partialEventName = "wallet_buttons.confirmation_arguments.null_on_confirm"
         ),
+        EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM(
+            partialEventName = "express_checkout_element.state.null_on_confirm"
+        ),
+        EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM(
+            partialEventName = "express_checkout_element.confirmation_arguments.null_on_confirm"
+        ),
         INTENT_CONFIRMATION_HANDLER_PASSIVE_CHALLENGE_PARAMS_NULL(
             partialEventName = "intent_confirmation_handler.passive_challenge.params_null"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CoroutineScope
@@ -22,17 +23,28 @@ internal interface ExpressCheckoutElementConfirmationPerformer {
 internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constructor(
     private val stateHolder: CheckoutControllerStateHolder,
     private val confirmationHandler: ConfirmationHandler,
+    private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val state = stateHolder.state ?: return
+        val state = stateHolder.state ?: run {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
+            )
+            return
+        }
         val paymentSelection = expressButton.toSelection()
 
         val confirmationArgs = getConfirmationArgs(
             state = state,
             paymentSelection = paymentSelection,
-        ) ?: return
+        ) ?: run {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
+            )
+            return
+        }
 
         viewModelScope.launch {
             confirmationHandler.start(confirmationArgs)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -15,9 +15,11 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,19 +30,34 @@ import org.robolectric.RobolectricTestRunner
 internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
 
     @Test
-    fun `confirm does nothing when state is not loaded`() = runScenario(
+    fun `confirm reports unexpected error when state is not loaded`() = runScenario(
         state = null,
         expressButton = createGooglePayExpressButton(),
     ) {
         performer.confirm(expressButton)
+
+        val call = errorReporter.awaitCall()
+
+        assertThat(call.errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM)
+        assertThat(call.stripeException).isNull()
+        assertThat(call.additionalNonPiiParams).isEmpty()
     }
 
     @Test
-    fun `confirm does nothing when the button selection cannot be converted to a confirmation option`() = runScenario(
+    fun `confirm reports unexpected error when confirmation args are null`() = runScenario(
         state = CheckoutControllerStateFactory.create(),
         expressButton = createGooglePayExpressButton(),
     ) {
         performer.confirm(expressButton)
+
+        val call = errorReporter.awaitCall()
+
+        assertThat(call.errorEvent).isEqualTo(
+            ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
+        )
+        assertThat(call.stripeException).isNull()
+        assertThat(call.additionalNonPiiParams).isEmpty()
     }
 
     @Test
@@ -118,11 +135,13 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
+        val errorReporter = FakeErrorReporter()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         stateHolder.state = state
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
             stateHolder = stateHolder,
             confirmationHandler = confirmationHandler,
+            errorReporter = errorReporter,
             statusBarColor = null,
             viewModelScope = backgroundScope,
         )
@@ -130,16 +149,19 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         Scenario(
             performer = performer,
             confirmationHandler = confirmationHandler,
+            errorReporter = errorReporter,
             stateHolder = stateHolder,
             expressButton = expressButton,
         ).block()
 
         confirmationHandler.validate()
+        errorReporter.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val performer: DefaultExpressCheckoutElementConfirmationPerformer,
         val confirmationHandler: FakeConfirmationHandler,
+        val errorReporter: FakeErrorReporter,
         val stateHolder: CheckoutControllerStateHolder,
         val expressButton: ExpressButton,
     )


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/cc9adb97-5617-4bcd-bd9d-786bf9d4f083)

#### 🧑‍💻 Human Summary
<!-- To be filled out by humans -->
Add unexpected error events if we exit early from ECE confirmation. Follow up to comments on https://github.com/stripe/stripe-android/pull/13587

#### 🤖 LLM Summary

# Summary
Express Checkout confirmation now reports distinct unexpected error events when confirmation returns early because controller state or confirmation args are missing.

# Motivation
These confirmation early returns should not happen; reporting separate events makes each failure mode visible instead of silently doing nothing.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A | N/A |

# Changelog
No user-facing changelog entry.