### PR TITLE
Restore window focus after Chrome cleanup (RUN_MOBILESDK-5541)

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -68,6 +68,7 @@ import com.stripe.android.test.core.ui.BrowserUI
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.test.core.ui.Selectors
 import com.stripe.android.test.core.ui.UiAutomatorText
+import com.stripe.android.utils.awaitWindowFocus
 import kotlinx.coroutines.launch
 import org.junit.Assert.fail
 import org.junit.Assume
@@ -1259,6 +1260,17 @@ internal class PlaygroundTestDriver(
         }
         Espresso.onIdle()
         composeTestRule.waitForIdle()
+        waitForWindowFocus()
+    }
+
+    /**
+     * Returning from a browser/external activity can leave no window focused. Fail fast with a
+     * clear message here instead of surfacing as an opaque Espresso RootViewPicker timeout later.
+     */
+    private fun waitForWindowFocus() {
+        if (!awaitWindowFocus()) {
+            error("Playground did not regain window focus after returning from an external activity")
+        }
     }
 
     /**

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1260,15 +1260,9 @@ internal class PlaygroundTestDriver(
         }
         Espresso.onIdle()
         composeTestRule.waitForIdle()
-        waitForWindowFocus()
-    }
-
-    /**
-     * Returning from a browser/external activity can leave no window focused. Fail fast with a
-     * clear message here instead of surfacing as an opaque Espresso RootViewPicker timeout later.
-     */
-    private fun waitForWindowFocus() {
         if (!awaitWindowFocus()) {
+            // Returning from a browser/external activity can leave no window focused. Fail fast with a
+            // clear message here instead of surfacing as an opaque Espresso RootViewPicker timeout later.
             error("Playground did not regain window focus after returning from an external activity")
         }
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.utils
 
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -15,9 +16,16 @@ internal object CleanupChromeRule : TestRule {
                 try {
                     base.evaluate()
                 } finally {
-                    val command = "am force-stop com.android.chrome"
-                    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
-                    uiAutomation.executeShellCommand(command).close()
+                    val instrumentation = InstrumentationRegistry.getInstrumentation()
+                    instrumentation.uiAutomation
+                        .executeShellCommand("am force-stop com.android.chrome").close()
+
+                    // Force-stopping Chrome leaves no window focused; restore focus so the next
+                    // test's Espresso RootViewPicker doesn't time out waiting for it.
+                    val device = UiDevice.getInstance(instrumentation)
+                    device.wakeUp()
+                    device.pressHome()
+                    awaitWindowFocus()
                 }
             }
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
@@ -16,9 +16,9 @@ internal object CleanupChromeRule : TestRule {
                 try {
                     base.evaluate()
                 } finally {
-                    val instrumentation = InstrumentationRegistry.getInstrumentation()
-                    instrumentation.uiAutomation
-                        .executeShellCommand("am force-stop com.android.chrome").close()
+                    val command = "am force-stop com.android.chrome"
+                    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
+                    uiAutomation.executeShellCommand(command).close()
 
                     // Force-stopping Chrome leaves no window focused; restore focus so the next
                     // test's Espresso RootViewPicker doesn't time out waiting for it.

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
@@ -16,9 +16,9 @@ internal object CleanupChromeRule : TestRule {
                 try {
                     base.evaluate()
                 } finally {
+                    val instrumentation = InstrumentationRegistry.getInstrumentation()
                     val command = "am force-stop com.android.chrome"
-                    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
-                    uiAutomation.executeShellCommand(command).close()
+                    instrumentation.uiAutomation.executeShellCommand(command).close()
 
                     // Force-stopping Chrome leaves no window focused; restore focus so the next
                     // test's Espresso RootViewPicker doesn't time out waiting for it.

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/WindowFocus.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/WindowFocus.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.utils
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+
+private const val FOCUS_WAIT_TIMEOUT_MS = 5_000L
+private const val FOCUS_POLL_INTERVAL_MS = 100L
+
+/**
+ * Polls up to [timeoutMs] for some window to hold input focus, returning true as soon as one does
+ * and false on timeout.
+ *
+ * Returning from a browser/Custom Tab, or force-stopping Chrome, can briefly leave no window
+ * focused; the next Espresso interaction then blocks in RootViewPicker for 10s. Callers bound that
+ * wait with this. Obtaining [UiDevice] first is required so UiAutomator enables interactive-window
+ * retrieval, otherwise [android.app.UiAutomation.getWindows] can return empty.
+ */
+internal fun awaitWindowFocus(timeoutMs: Long = FOCUS_WAIT_TIMEOUT_MS): Boolean {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    UiDevice.getInstance(instrumentation)
+    val uiAutomation = instrumentation.uiAutomation
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+        if (uiAutomation.windows.any { it.isFocused }) {
+            return true
+        }
+        Thread.sleep(FOCUS_POLL_INTERVAL_MS)
+    }
+    return false
+}


### PR DESCRIPTION
## Summary
Extracted from #13565 (test-only). Browser-redirect e2e tests fail on CI with a `RootViewWithoutFocusException` cascade: `CleanupChromeRule` force-stops Chrome after each test without waiting for window focus to return, so the next test's Espresso `RootViewPicker` times out at 10s and cascades across the shard.

## What changed
After force-stopping Chrome, `CleanupChromeRule` wakes the device, presses home, and waits (bounded 5s) for a focused window via a shared `awaitWindowFocus()` helper (obtains `UiDevice` first so UiAutomator window retrieval is enabled). `PlaygroundTestDriver` fails fast with a clear message if focus never returns after an external-activity redirect.

## Testing
Verified green on `run-paymentsheet-e2e` (zero `RootViewWithoutFocusException` failures after the fix). Test-only; no changelog.

RUN_MOBILESDK-5541

🤖 Generated with [Claude Code](https://claude.com/claude-code)