### PR TITLE
Fix PlaygroundTestDriver retaining destroyed activities (RUN_MOBILESDK-5545)

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
@@ -31,6 +31,9 @@ internal open class BasePlaygroundTest(
 
     @After
     fun after() {
+        // Runs even if the test body threw before its own teardown() call, so a destroyed
+        // activity is never left referenced by the driver.
+        testDriver.teardown()
         Intents.release()
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -113,7 +113,12 @@ internal class PlaygroundTestDriver(
         override fun onActivityPaused(activity: Activity) {}
         override fun onActivityStopped(activity: Activity) {}
         override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
-        override fun onActivityDestroyed(activity: Activity) {}
+        override fun onActivityDestroyed(activity: Activity) {
+            // Never keep a reference to a destroyed activity.
+            if (currentActivity === activity) {
+                currentActivity = null
+            }
+        }
         override fun onActivityResumed(activity: Activity) {
             currentActivity = activity
         }
@@ -1307,6 +1312,8 @@ internal class PlaygroundTestDriver(
 
     private fun monitorCurrentActivity(application: Application) {
         this.application = application
+        // Unregister first so retried attempts (e.g. RetryRule) don't stack callbacks.
+        application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
     }
 
@@ -1802,7 +1809,7 @@ internal class PlaygroundTestDriver(
         launchPlayground.await(5, TimeUnit.SECONDS)
     }
 
-    private fun teardown() {
+    internal fun teardown() {
         application?.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
         playgroundState = null
         currentActivity = null


### PR DESCRIPTION
## Summary
Extracted from #13565 (test-only). `DetectLeaksAfterTestSuccess` flags a destroyed `PaymentLauncherConfirmationActivity` retained by the test harness: `PlaygroundTestDriver.currentActivity` pins it (empty `onActivityDestroyed`), `teardown()` isn't guaranteed on the throw path, and `RetryRule` re-registers the lifecycle callback each attempt. Production releases the Activity correctly, so this is purely test-harness retention.

## What changed
Test-only, `PlaygroundTestDriver` + `BasePlaygroundTest`:
- `onActivityDestroyed` clears `currentActivity` when the destroyed activity is the current one.
- `monitorCurrentActivity` unregisters before registering (idempotent across `RetryRule` attempts).
- `teardown()` made `internal` and called from `@After` so cleanup runs even when a test body throws.

## Testing
Verified green on `run-paymentsheet-e2e`. Test-only; no changelog.

RUN_MOBILESDK-5545

🤖 Generated with [Claude Code](https://claude.com/claude-code)