### PR TITLE
Fix early exit when reading locked APDU records

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -21,7 +21,6 @@
     <ID>LargeClass:ConfirmationHandlerOptionKtxTest.kt:ConfirmationHandlerOptionKtxTest</ID>
     <ID>LargeClass:CustomerAdapterTest.kt:CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt:CustomerSheetViewModel : ViewModel</ID>
-    <ID>LargeClass:CustomerSheetViewModelTest.kt:CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultConfirmationHandlerTest.kt:DefaultConfirmationHandlerTest</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt:DefaultEventReporterTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt:DefaultFlowControllerTest</ID>
@@ -53,7 +52,6 @@
     <ID>LongMethod:ElementsSessionJsonParserTest.kt:ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response if 'customer_sheet' is null`</ID>
     <ID>LongMethod:ElementsSessionJsonParserTest.kt:ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response`</ID>
     <ID>LongMethod:ElementsSessionRepository.kt:internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams: ElementsSessionParams</ID>
-    <ID>LongMethod:EmbeddedContentHelper.kt:DefaultEmbeddedContentHelper$private fun createInteractor: PaymentMethodVerticalLayoutInteractor</ID>
     <ID>LongMethod:FormViewModelTest.kt:FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`</ID>
     <ID>LongMethod:FormViewModelTest.kt:FormViewModelTest$@Test fun `Verify params are set when required address fields are complete`</ID>
     <ID>LongMethod:FullScreenContent.kt:@Composable internal fun FullScreenContent</ID>
@@ -78,6 +76,7 @@
     <ID>LongMethod:UpdatePaymentMethodUI.kt:@Composable internal fun UpdatePaymentMethodUI</ID>
     <ID>LongMethod:WalletScreen.kt:@Composable internal fun WalletBody</ID>
     <ID>LongMethod:WalletScreen.kt:@Composable private fun PaymentMethodSection</ID>
+    <ID>LoopWithTooManyJumpStatements:NfcCardReader.kt:ApduCardReader$for</ID>
     <ID>MagicNumber:FlagImageRepository.kt:FlagImageRepository$4</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt:.3f</ID>
     <ID>MagicNumber:NewPaymentMethodTabLayoutUI.kt:.4f</ID>
@@ -105,7 +104,6 @@
     <ID>MaxLineLength:PaymentSheet.kt:PaymentSheet.IntentConfiguration.SetupFutureUse$*</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt:PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt:SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
-    <ID>ThrowsCount:EmbeddedWalletsHelper.kt:DefaultEmbeddedWalletsHelper$override fun walletsState: StateFlow&lt;WalletsState?></ID>
     <ID>TooManyFunctions:CustomerSheetEventReporter.kt:CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultCustomerSheetEventReporter.kt:DefaultCustomerSheetEventReporter : CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt:DefaultFlowController : FlowController</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -65,8 +65,9 @@ internal class ApduCardReader @Inject constructor(
                             break@probeFiles
                         }
                     }.onFailure { error ->
-                        if (!isRecordNotFoundError(error)) {
-                            throw error
+                        if (isFileNotFoundError(error)) {
+                            // Breaks the record loop but moves on to the next file
+                            break
                         }
                     }
                 }
@@ -79,9 +80,9 @@ internal class ApduCardReader @Inject constructor(
         }
     }
 
-    private fun isRecordNotFoundError(error: Throwable): Boolean {
+    private fun isFileNotFoundError(error: Throwable): Boolean {
         return error is ApduResponseError.Command &&
-            error.sw1 == RECORD_NOT_FOUND_SW1 && error.sw2 == RECORD_NOT_FOUND_SW2
+            error.sw1 == PARAMETER_ERROR_SW1 && error.sw2 == FILE_NOT_FOUND_SW2
     }
 
     private companion object {
@@ -89,7 +90,7 @@ internal class ApduCardReader @Inject constructor(
         val PROBE_SFIS = 1..3
         const val MAX_RECORDS_PER_SFI = 8
 
-        const val RECORD_NOT_FOUND_SW1 = 0x6A.toByte()
-        const val RECORD_NOT_FOUND_SW2 = 0x83.toByte()
+        const val PARAMETER_ERROR_SW1 = 0x6A.toByte()
+        const val FILE_NOT_FOUND_SW2 = 0x82.toByte()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
@@ -46,14 +46,14 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
     }
 
     private fun isDeclined(error: ApduResponseError.Command): Boolean {
-        return error.sw1 == CONDITIONS_OF_USE_NOT_SATISFIED_SW1 &&
+        return error.sw1 == COMMAND_NOT_ALLOWED_SW1 &&
             error.sw2 == CONDITIONS_OF_USE_NOT_SATISFIED_SW2
     }
 
     private fun isUnsupported(error: ApduResponseError.Command): Boolean {
         return when (error.apduCommand) {
             is SelectPpseCommand,
-            is SelectApplicationCommand -> error.sw1 == FILE_NOT_FOUND_SW1 && error.sw2 == FILE_NOT_FOUND_SW2
+            is SelectApplicationCommand -> error.sw1 == PARAMETER_ERROR_SW1 && error.sw2 == FILE_NOT_FOUND_SW2
             is ReadRecordCommand -> false
             else -> false
         }
@@ -92,9 +92,9 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
         const val CARD_DECLINED_ERROR_CODE = "cardDeclinedByNfc"
         const val GENERAL_READ_ERROR_CODE = "nfcCardReadFailed"
 
-        const val FILE_NOT_FOUND_SW1 = 0x6A.toByte()
+        const val PARAMETER_ERROR_SW1 = 0x6A.toByte()
         const val FILE_NOT_FOUND_SW2 = 0x82.toByte()
-        const val CONDITIONS_OF_USE_NOT_SATISFIED_SW1 = 0x69.toByte()
+        const val COMMAND_NOT_ALLOWED_SW1 = 0x69.toByte()
         const val CONDITIONS_OF_USE_NOT_SATISFIED_SW2 = 0x85.toByte()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -93,8 +93,6 @@ internal object NfcScanningActivityTestFixtures {
     )
 
     fun declinedCardResponses(): List<ByteArray> = listOf(
-        apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-        apduSuccessResponse(byteArrayOf()),
         CARD_DECLINED_RESPONSE,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.common.nfcscan.scanner
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.scanner.apdu.ApduResponseError
-import com.stripe.android.common.nfcscan.scanner.apdu.ReadRecordCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectApplicationCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
@@ -39,12 +38,62 @@ internal class ApduCardReaderTest {
     }
 
     @Test
-    fun `readCard continues probing when read record commands fail`() = runScenario(
+    fun `readCard skips remaining records in SFI when read record returns file not found`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            FILE_NOT_FOUND_RESPONSE,
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        errorResult = PARSE_FAILURE_ERROR,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
+        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
+        assertReadRecordProbes(startingAtIndex = MAX_RECORDS_PER_SFI)
+
+        assertThat(cardDataParser.parseCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `readCard finds card data on later SFI when earlier SFI returns file not found`() = runScenario(
+        parseResult = SCANNED_CARD_DATA,
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            FILE_NOT_FOUND_RESPONSE,
+            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
+        ),
+        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS[MAX_RECORDS_PER_SFI])
+
+        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("57")
+        assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
+
+        cardDataParser.canParseCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `readCard continues probing when read record returns declined`() = runScenario(
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(byteArrayOf()),
         ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        transceiveResult = CARD_DECLINED_RESPONSE,
         errorResult = PARSE_FAILURE_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
@@ -102,30 +151,6 @@ internal class ApduCardReaderTest {
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-    }
-
-    @Test
-    fun `readCard propagates ReadRecord failure that is not record not found`() = runScenario(
-        transceiveResults = listOf(
-            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-            apduSuccessResponse(byteArrayOf()),
-        ),
-        transceiveResult = CARD_DECLINED_RESPONSE,
-        errorResult = CARD_DECLINED_ERROR,
-    ) {
-        val result = cardReader.readCard(transceiver)
-
-        assertThat(result).isEqualTo(CARD_DECLINED_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem()).isEqualTo(
-            ApduResponseError.Command(
-                apduCommand = ReadRecordCommand(recordNumber = 1, shortFileIdentifier = 1),
-                sw1 = 0x69.toByte(),
-                sw2 = 0x85.toByte(),
-            ),
-        )
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
     }
 
     @Test
@@ -284,11 +309,6 @@ internal class ApduCardReaderTest {
         val UNSUPPORTED_CARD_ERROR = NfcCardReader.Result.Error(
             errorCode = "cardUnsupportedByNfc",
             userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
-        )
-
-        val CARD_DECLINED_ERROR = NfcCardReader.Result.Error(
-            errorCode = "cardDeclinedByNfc",
-            userMessage = R.string.stripe_nfc_scan_error_declined_card.resolvableString,
         )
 
         val TRANSCEIVER_IO_ERROR = NfcCardReader.Result.Error(


### PR DESCRIPTION
# Summary
Fix early exit when reading locked APDU records

# Motivation
Ability to read more cards with NFC scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified