### PR TITLE
Add horizontal payment method layout for embedded PaymentSheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -28,6 +28,9 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
                 configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
             )
             .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
+            .paymentMethodLayout(
+                configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet()
+            )
             .googlePay(
                 googlePay = checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
                     configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)
@@ -50,6 +53,12 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             )
             .build()
     }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun PaymentMethodLayout.asPaymentSheet(): PaymentSheet.PaymentMethodLayout = when (this) {
+    PaymentMethodLayout.Horizontal -> PaymentSheet.PaymentMethodLayout.Horizontal
+    PaymentMethodLayout.Vertical -> PaymentSheet.PaymentMethodLayout.Vertical
 }
 
 @OptIn(CheckoutSessionPreview::class)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -32,6 +32,7 @@ class PaymentElement @Inject internal constructor(
         private var embeddedViewDisplaysMandateText: Boolean = true
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
+        private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Vertical
 
         fun embeddedViewDisplaysMandateText(
             embeddedViewDisplaysMandateText: Boolean
@@ -45,15 +46,23 @@ class PaymentElement @Inject internal constructor(
             this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
         }
 
+        fun paymentMethodLayout(
+            paymentMethodLayout: PaymentMethodLayout
+        ): Configuration = apply {
+            this.paymentMethodLayout = paymentMethodLayout
+        }
+
         @Parcelize
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
+            val paymentMethodLayout: PaymentMethodLayout,
         ) : Parcelable
 
         internal fun build(): State = State(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
+            paymentMethodLayout = paymentMethodLayout,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentMethodLayout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentMethodLayout.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.checkout
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+
+@CheckoutSessionPreview
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class PaymentMethodLayout {
+    Horizontal,
+    Vertical,
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -264,6 +264,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
         internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
         internal val userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry,
+        internal val paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
     ) : Parcelable {
         @Suppress("TooManyFunctions")
         class Builder(
@@ -301,6 +302,8 @@ class EmbeddedPaymentElement @Inject internal constructor(
             private var opensCardScannerAutomatically: Boolean =
                 ConfigurationDefaults.opensCardScannerAutomatically
             private var userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry
+            private var paymentMethodLayout: PaymentSheet.PaymentMethodLayout =
+                PaymentSheet.PaymentMethodLayout.Vertical
 
             /**
              * If set, the customer can select a previously saved payment method.
@@ -537,6 +540,11 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 this.userOverrideCountry = userOverrideCountry
             }
 
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun paymentMethodLayout(paymentMethodLayout: PaymentSheet.PaymentMethodLayout) = apply {
+                this.paymentMethodLayout = paymentMethodLayout
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -561,6 +569,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 termsDisplay = termsDisplay,
                 opensCardScannerAutomatically = opensCardScannerAutomatically,
                 userOverrideCountry = userOverrideCountry,
+                paymentMethodLayout = paymentMethodLayout,
             )
         }
 
@@ -590,6 +599,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
             .termsDisplay(termsDisplay)
             .opensCardScannerAutomatically(opensCardScannerAutomatically)
             .userOverrideCountry(userOverrideCountry)
+            .paymentMethodLayout(paymentMethodLayout)
             .apply {
                 primaryButtonLabel?.let { primaryButtonLabel(it) }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityRegi
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedFormScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
+import com.stripe.android.paymentelement.embedded.sheet.InitialHorizontalPaymentOptionsScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.InitialPaymentOptionsScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmationHelper
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
@@ -43,6 +44,7 @@ import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -139,13 +141,27 @@ internal interface EmbeddedActivityModule {
             formScreenFactory: EmbeddedNavigator.Screen.Form.Factory,
             initialManageScreenFactory: InitialManageScreenFactory,
             initialPaymentOptionsScreenFactory: InitialPaymentOptionsScreenFactory,
+            initialHorizontalPaymentOptionsScreenFactory: InitialHorizontalPaymentOptionsScreenFactory,
+            configuration: EmbeddedPaymentElement.Configuration,
             @ViewModelScope viewModelScope: CoroutineScope,
             eventReporter: EventReporter,
         ): EmbeddedNavigator {
             val initialBackStack = when (launchMode) {
-                is EmbeddedLaunchMode.Form -> listOf(formScreenFactory.create(launchMode))
+                is EmbeddedLaunchMode.Form -> {
+                    if (configuration.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Horizontal) {
+                        listOf(initialHorizontalPaymentOptionsScreenFactory.createInitialScreen(launchMode))
+                    } else {
+                        listOf(formScreenFactory.create(launchMode))
+                    }
+                }
                 is EmbeddedLaunchMode.Manage -> listOf(initialManageScreenFactory.createInitialScreen())
-                is EmbeddedLaunchMode.PaymentOptions -> initialPaymentOptionsScreenFactory.createInitialScreen()
+                is EmbeddedLaunchMode.PaymentOptions -> {
+                    if (configuration.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Horizontal) {
+                        listOf(initialHorizontalPaymentOptionsScreenFactory.createInitialScreen())
+                    } else {
+                        initialPaymentOptionsScreenFactory.createInitialScreen()
+                    }
+                }
             }
             return EmbeddedNavigator(
                 coroutineScope = viewModelScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -43,18 +43,19 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,
             newPaymentSelectionProvider = { code ->
-                val currentSelection = embeddedSelectionHolder.selection.value
-                    ?.takeIf { it.paymentMethodType == code }
+                // Prefer the live selection when it matches the requested code; otherwise fall back to any
+                // previously entered new selection for that code so switching between horizontal tabs restores input.
+                val selection = embeddedSelectionHolder.selection.value?.takeIf { it.paymentMethodType == code }
                     ?: embeddedSelectionHolder.getPreviousNewSelection(code)
-                when (currentSelection) {
+                when (selection) {
                     is PaymentSelection.ExternalPaymentMethod -> {
-                        NewPaymentOptionSelection.External(currentSelection)
+                        NewPaymentOptionSelection.External(selection)
                     }
                     is PaymentSelection.CustomPaymentMethod -> {
-                        NewPaymentOptionSelection.Custom(currentSelection)
+                        NewPaymentOptionSelection.Custom(selection)
                     }
                     is PaymentSelection.New -> {
-                        NewPaymentOptionSelection.New(currentSelection)
+                        NewPaymentOptionSelection.New(selection)
                     }
                     else -> null
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -13,15 +13,22 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
+import com.stripe.android.paymentelement.embedded.form.FormActivityError
 import com.stripe.android.paymentelement.embedded.form.FormActivityPrimaryButton
 import com.stripe.android.paymentelement.embedded.form.FormScreenContent
+import com.stripe.android.paymentelement.embedded.form.USBankAccountMandate
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.navigation.NavigationHandler
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods.CvcRecollectionState
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
+import com.stripe.android.paymentsheet.ui.SavedPaymentMethodTabLayoutUI
+import com.stripe.android.paymentsheet.ui.SelectSavedPaymentMethodsInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenUI
@@ -41,6 +48,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.Closeable
 import javax.inject.Inject
+import com.stripe.android.paymentsheet.ui.AddPaymentMethod as AddPaymentMethodUI
 
 internal class EmbeddedNavigator private constructor(
     private val eventReporter: EventReporter,
@@ -109,6 +117,8 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageUpdate -> eventReporter.onShowEditablePaymentOption()
             is Screen.Form -> Unit
             is Screen.PaymentOptions -> eventReporter.onShowNewPaymentOptions()
+            is Screen.HorizontalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
+            is Screen.AddPaymentMethod -> eventReporter.onShowNewPaymentOptions()
         }
     }
 
@@ -118,6 +128,8 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageUpdate -> eventReporter.onHideEditablePaymentOption()
             is Screen.Form -> Unit
             is Screen.PaymentOptions -> Unit
+            is Screen.HorizontalPaymentOptions -> Unit
+            is Screen.AddPaymentMethod -> Unit
         }
     }
 
@@ -305,6 +317,95 @@ internal class EmbeddedNavigator private constructor(
                     onClick = onContinueClick,
                 )
                 PaymentSheetContentPadding()
+            }
+
+            override fun close() {
+                interactor.close()
+            }
+        }
+
+        class HorizontalPaymentOptions(
+            private val interactor: SelectSavedPaymentMethodsInteractor,
+            private val isLiveMode: Boolean,
+            private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
+            private val onContinueClick: () -> Unit,
+        ) : Screen(), Closeable {
+            override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
+                PaymentSheetTopBarState(
+                    showTestModeLabel = !isLiveMode,
+                    showEditMenu = false,
+                    isEditing = false,
+                    onEditIconPressed = {},
+                )
+            )
+
+            override fun title(): StateFlow<ResolvableString?> = stateFlowOf(
+                R.string.stripe_paymentsheet_select_your_payment_method.resolvableString
+            )
+
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> = stateFlowOf(false)
+
+            @Composable
+            override fun Content() {
+                SavedPaymentMethodTabLayoutUI(
+                    interactor = interactor,
+                    cvcRecollectionState = CvcRecollectionState.NotRequired,
+                    modifier = Modifier.padding(StripeTheme.getOuterFormInsets()),
+                )
+                Spacer(Modifier.height(40.dp))
+                val state by sheetActivityState.collectAsState()
+                FormActivityPrimaryButton(
+                    state = state,
+                    onClick = onContinueClick,
+                )
+                PaymentSheetContentPadding()
+            }
+
+            override fun close() {
+                interactor.close()
+            }
+        }
+
+        class AddPaymentMethod(
+            private val interactor: AddPaymentMethodInteractor,
+            private val isLiveMode: Boolean,
+            private val eventReporter: EventReporter,
+            private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
+            private val onContinueClick: () -> Unit,
+            private val onProcessingCompleted: () -> Unit,
+        ) : Screen(), Closeable {
+            override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
+                PaymentSheetTopBarState(
+                    showTestModeLabel = !isLiveMode,
+                    showEditMenu = false,
+                    isEditing = false,
+                    onEditIconPressed = {},
+                )
+            )
+
+            override fun title(): StateFlow<ResolvableString?> = stateFlowOf(
+                R.string.stripe_paymentsheet_add_payment_method_title.resolvableString
+            )
+
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> = stateFlowOf(false)
+
+            @Composable
+            override fun Content() {
+                // EventReporterProvider supplies the card scan / form event reporters that the card form requires.
+                EventReporterProvider(eventReporter) {
+                    // AddPaymentMethodUI (PaymentElement) applies its own outer form insets, so we don't add them here.
+                    AddPaymentMethodUI(interactor = interactor)
+                    val state by sheetActivityState.collectAsState()
+                    USBankAccountMandate(state)
+                    FormActivityError(state)
+                    Spacer(Modifier.height(40.dp))
+                    FormActivityPrimaryButton(
+                        state = state,
+                        onClick = onContinueClick,
+                        onProcessingCompleted = onProcessingCompleted,
+                    )
+                    PaymentSheetContentPadding()
+                }
             }
 
             override fun close() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialHorizontalPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialHorizontalPaymentOptionsScreenFactory.kt
@@ -1,0 +1,249 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
+import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.DefaultSelectSavedPaymentMethodsInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal class InitialHorizontalPaymentOptionsScreenFactory @Inject constructor(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val customerStateHolder: CustomerStateHolder,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val eventReporter: EventReporter,
+    private val embeddedNavigatorProvider: Provider<EmbeddedNavigator>,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+    private val updateScreenInteractorFactory: EmbeddedUpdateScreenInteractorFactory,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val savedPaymentMethodMutator: SavedPaymentMethodMutator,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    private val confirmationHelper: SheetActivityConfirmationHelper,
+) {
+    /**
+     * When there are saved payment methods we show the horizontal tab layout of those methods (with an "add" button
+     * that navigates to the add screen). Otherwise we open directly into the horizontal tabs + form add screen.
+     */
+    fun createInitialScreen(): EmbeddedNavigator.Screen {
+        return if (customerStateHolder.paymentMethods.value.isEmpty()) {
+            createAddPaymentMethodScreen(
+                initiallySelectedPaymentMethodCode = initiallySelectedPaymentMethodCode(),
+                onContinueClick = ::completePaymentOptions,
+                onProcessingCompleted = {},
+            )
+        } else {
+            createSelectSavedPaymentMethodsScreen()
+        }
+    }
+
+    /**
+     * Changing form details in the horizontal layout opens the horizontal tabs + form add screen with the tapped
+     * payment method selected. Completion mirrors the vertical form screen: [confirmationHelper] handles both the
+     * Continue and Confirm form sheet actions, so the returned result carries the [launchMode].
+     */
+    fun createInitialScreen(launchMode: EmbeddedLaunchMode.Form): EmbeddedNavigator.Screen.AddPaymentMethod {
+        return createAddPaymentMethodScreen(
+            initiallySelectedPaymentMethodCode = launchMode.selectedPaymentMethodCode,
+            onContinueClick = confirmationHelper::confirm,
+            onProcessingCompleted = { completeConfirmedForm(launchMode) },
+        )
+    }
+
+    private fun createSelectSavedPaymentMethodsScreen(): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
+        val linkAccount = linkAccountHolder.linkAccountInfo.value.account
+        val interactor = DefaultSelectSavedPaymentMethodsInteractor(
+            paymentOptionsItems = savedPaymentMethodMutator.paymentOptionsItems,
+            editing = savedPaymentMethodMutator.editing,
+            canEdit = savedPaymentMethodMutator.canEdit,
+            canRemove = customerStateHolder.canRemove,
+            toggleEdit = savedPaymentMethodMutator::toggleEditing,
+            isProcessing = stateFlowOf(false),
+            isCurrentScreen = stateFlowOf(true),
+            currentSelection = selectionHolder.selection,
+            mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
+            onAddCardPressed = {
+                embeddedNavigatorProvider.get().performAction(
+                    EmbeddedNavigator.Action.GoToScreen(
+                        createAddPaymentMethodScreen(
+                            initiallySelectedPaymentMethodCode = initiallySelectedPaymentMethodCode(),
+                            onContinueClick = ::completePaymentOptions,
+                            onProcessingCompleted = {},
+                        )
+                    )
+                )
+            },
+            onUpdatePaymentMethod = { savedPaymentMethod ->
+                navigateToUpdateScreen(savedPaymentMethod)
+            },
+            updateSelection = { selection, _ ->
+                selectionHolder.setSelection(selection)
+            },
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+            linkBrand = paymentMethodMetadata.effectiveLinkBrand(linkAccount),
+        )
+        return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
+            interactor = interactor,
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+            sheetActivityState = sheetActivityStateHolder.state,
+            onContinueClick = ::completePaymentOptions,
+        )
+    }
+
+    private fun createAddPaymentMethodScreen(
+        initiallySelectedPaymentMethodCode: PaymentMethodCode,
+        onContinueClick: () -> Unit,
+        onProcessingCompleted: () -> Unit,
+    ): EmbeddedNavigator.Screen.AddPaymentMethod {
+        return EmbeddedNavigator.Screen.AddPaymentMethod(
+            interactor = createAddPaymentMethodInteractor(initiallySelectedPaymentMethodCode),
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+            eventReporter = eventReporter,
+            sheetActivityState = sheetActivityStateHolder.state,
+            onContinueClick = onContinueClick,
+            onProcessingCompleted = onProcessingCompleted,
+        )
+    }
+
+    private fun createAddPaymentMethodInteractor(
+        initiallySelectedPaymentMethodCode: PaymentMethodCode,
+    ): AddPaymentMethodInteractor {
+        val hasSavedPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty()
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = viewModelScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            // Card scan auto-launch is only relevant in the vertical form screen, not the horizontal add screen.
+            automaticallyLaunchedCardScanFormDataHelper = null,
+            tapToAddHelper = null,
+            selectionUpdater = { selectionHolder.setSelection(it) },
+            // If no saved payment methods, then first saved payment method is automatically set as default.
+            setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+        )
+        return DefaultAddPaymentMethodInteractor(
+            initiallySelectedPaymentMethodType = initiallySelectedPaymentMethodCode,
+            selection = selectionHolder.selection,
+            processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
+            // Embedded does not support validation at the moment. Should update here once it does.
+            validationRequested = MutableSharedFlow(),
+            incentive = PaymentMethodIncentiveInteractor(
+                paymentMethodMetadata.paymentMethodIncentive
+            ).displayedIncentive,
+            supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods(),
+            createFormArguments = formHelper::createFormArguments,
+            formElementsForCode = formHelper::formElementsForCode,
+            clearErrorMessages = { sheetActivityStateHolder.updateError(null) },
+            reportFieldInteraction = eventReporter::onPaymentMethodFormInteraction,
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportPromotionDisplayed = { code ->
+                paymentMethodMessagePromotionsHelper.reportPromotionDisplayed(code, paymentMethodMetadata)
+            },
+            createUSBankAccountFormArguments = { code ->
+                createUsBankAccountFormArguments(code, hasSavedPaymentMethods)
+            },
+            coroutineScope = viewModelScope,
+            uiContext = Dispatchers.Main,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = null,
+                    isVerticalLayout = false,
+                )
+            },
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+        )
+    }
+
+    private fun createUsBankAccountFormArguments(
+        paymentMethodCode: PaymentMethodCode,
+        hasSavedPaymentMethods: Boolean,
+    ): USBankAccountFormArguments {
+        return USBankAccountFormArguments.createForEmbedded(
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectedPaymentMethodCode = paymentMethodCode,
+            hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
+            setSelection = selectionHolder::setSelection,
+            hasSavedPaymentMethods = hasSavedPaymentMethods,
+            onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
+            onMandateTextChanged = { mandateText, _ ->
+                sheetActivityStateHolder.updateMandate(mandateText)
+            },
+            onUpdatePrimaryButtonUIState = sheetActivityStateHolder::updatePrimaryButton,
+            onError = sheetActivityStateHolder::updateError,
+            onFormCompleted = {
+                eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code)
+            },
+        )
+    }
+
+    private fun initiallySelectedPaymentMethodCode(): PaymentMethodCode {
+        return when (val selection = selectionHolder.selection.value) {
+            is PaymentSelection.New -> selection.paymentMethodCreateParams.typeCode
+            is PaymentSelection.ExternalPaymentMethod -> selection.type
+            is PaymentSelection.CustomPaymentMethod -> selection.id
+            else -> paymentMethodMetadata.supportedPaymentMethodTypes().first()
+        }
+    }
+
+    private fun completePaymentOptions() {
+        sheetActivityStateHolder.setResult(
+            EmbeddedActivityResult.Complete(
+                selection = selectionHolder.selection.value,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = false,
+                customerState = customerStateHolder.customer.value,
+                shouldInvokeSelectionCallback = false,
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
+            )
+        )
+    }
+
+    private fun completeConfirmedForm(launchMode: EmbeddedLaunchMode.Form) {
+        sheetActivityStateHolder.setResult(
+            EmbeddedActivityResult.Complete(
+                selection = null,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = true,
+                customerState = customerStateHolder.customer.value,
+                shouldInvokeSelectionCallback = false,
+                launchMode = launchMode,
+            )
+        )
+    }
+
+    private fun navigateToUpdateScreen(savedPaymentMethod: DisplayableSavedPaymentMethod) {
+        val screen = EmbeddedNavigator.Screen.ManageUpdate(
+            interactor = updateScreenInteractorFactory.createUpdateScreenInteractor(
+                displayableSavedPaymentMethod = savedPaymentMethod
+            )
+        )
+        embeddedNavigatorProvider.get().performAction(EmbeddedNavigator.Action.GoToScreen(screen))
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -392,17 +392,20 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
-    fun `launchPaymentOptions forwards previously entered new selections`() = testScenario {
+    fun `launchPaymentOptions forwards previously entered new selections into the sheet`() = testScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
         sheetLauncher.launchPaymentOptions(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
-            selection = PaymentSelection.GooglePay,
+            customerState = createCustomerState(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             configuration = EmbeddedConfigurationFactory.create(),
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
 
+        assertThat(launchCall.previousNewSelections.previousNewSelection("card"))
+            .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         assertThat(launchCall.previousNewSelections.previousNewSelection("cashapp"))
             .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementConfigurationTest.kt
@@ -68,6 +68,7 @@ class EmbeddedPaymentElementConfigurationTest {
             .termsDisplay(mapOf(PaymentMethod.Type.Card to TermsDisplay.NEVER))
             .opensCardScannerAutomatically(true)
             .userOverrideCountry("GB")
+            .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
             .build()
 
         val roundTripped = original.newBuilder().build()
@@ -85,6 +86,6 @@ class EmbeddedPaymentElementConfigurationTest {
         // When a new property is added, this count will change, signaling that:
         // 1. newBuilder() needs to propagate the new property
         // 2. The round-trip test above needs a non-default value for it
-        assertThat(propertyCount).isEqualTo(23)
+        assertThat(propertyCount).isEqualTo(24)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/HorizontalFormEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/HorizontalFormEmbeddedSheetActivityTest.kt
@@ -1,0 +1,126 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onIdle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.paymentelementtestpages.FormPage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class HorizontalFormEmbeddedSheetActivityTest {
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+    private val composeTestRule = createAndroidComposeRule<EmbeddedSheetActivity>()
+    private val networkRule = NetworkRule()
+
+    private val formPage = FormPage(composeTestRule)
+    private val primaryButton = composeTestRule.onNode(
+        hasTestTag(PRIMARY_BUTTON_TEST_TAG)
+            .and(hasParent(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)))
+    )
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(composeTestRule)
+        .around(networkRule)
+        .around(PaymentConfigurationTestRule(applicationContext))
+
+    @Test
+    fun `Form launch mode with horizontal layout shows the horizontal payment method tabs`() = launch(
+        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+    ) {
+        composeTestRule.onNodeWithTag(TEST_TAG_LIST).assertIsDisplayed()
+        primaryButton.assertExists()
+    }
+
+    @Test
+    fun `Form launch mode with vertical layout shows the vertical form without tabs`() = launch(
+        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+    ) {
+        composeTestRule.onNodeWithTag(TEST_TAG_LIST).assertDoesNotExist()
+    }
+
+    @Test
+    fun `horizontal Form continue returns Complete carrying the Form launch mode`() = launch(
+        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+    ) { scenario ->
+        formPage.fillOutCardDetails()
+        composeTestRule.waitForIdle()
+        primaryButton.assertIsEnabled()
+        primaryButton.performScrollTo()
+        primaryButton.performClick()
+
+        composeTestRule.waitForIdle()
+        onIdle()
+
+        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
+        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
+        assertThat(result).isInstanceOf<EmbeddedActivityResult.Complete>()
+        val complete = result as EmbeddedActivityResult.Complete
+        assertThat(complete.hasBeenConfirmed).isFalse()
+        assertThat(complete.launchMode).isEqualTo(EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"))
+    }
+
+    private fun launch(
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+        selectedPaymentMethodCode: PaymentMethodCode = "card",
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            ),
+        ),
+        block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
+    ) {
+        ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
+            EmbeddedSheetContract.createIntent(
+                context = applicationContext,
+                input = EmbeddedActivityArgs(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+                        .paymentMethodLayout(paymentMethodLayout)
+                        .build(),
+                    statusBarColor = null,
+                    paymentElementCallbackIdentifier = "HorizontalFormTestIdentifier",
+                    selection = null,
+                    customerState = createCustomerState(paymentMethods = emptyList()),
+                    promotion = null,
+                    launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = selectedPaymentMethodCode),
+                    previousNewSelections = Bundle(),
+                ),
+            )
+        ).use { scenario ->
+            block(scenario)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Adds support for a horizontal payment method layout to the embedded PaymentSheet, allowing consumers to choose between horizontal and vertical tab layouts when presenting payment options. Implements new entry points, state forwarding, new tab UI, updates test coverage, and preserves form state between payment method tabs.

# Motivation
Enhance the flexibility and user experience of embedded PaymentSheet integration by providing a horizontal tab layout. This enables merchants to customize the payment sheet to better match their app or site’s UI and improve conversion.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Added] Support for horizontal payment method tab layout in embedded PaymentSheet.