### PR TITLE
[RUN_MOBILESDK-5542] Fix deterministic LeakCanary failures on the Chrome-bearing managed device after browser-based payment flows

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
@@ -75,9 +75,8 @@ internal class ChallengeFragment(
             )
     }
 
-    val challengeZoneWebView: ChallengeZoneWebView by lazy {
-        challengeEntryViewFactory.createChallengeEntryWebView(cresData)
-    }
+    private var _challengeZoneWebView: ChallengeZoneWebView? = null
+    internal val challengeZoneWebView get() = requireNotNull(_challengeZoneWebView)
 
     val informationZoneView: InformationZoneView by lazy {
         viewBinding.caInformationZone
@@ -146,11 +145,7 @@ internal class ChallengeFragment(
 
         updateBrandZoneImages()
 
-        configure(
-            challengeZoneTextView,
-            challengeZoneSelectView,
-            challengeZoneWebView
-        )
+        configure()
         configureInformationZoneView()
     }
 
@@ -171,15 +166,13 @@ internal class ChallengeFragment(
     }
 
     override fun onDestroyView() {
+        _challengeZoneWebView?.dispose()
+        _challengeZoneWebView = null
         super.onDestroyView()
         _viewBinding = null
     }
 
-    private fun configure(
-        challengeZoneTextView: ChallengeZoneTextView,
-        challengeZoneSelectView: ChallengeZoneSelectView,
-        challengeZoneWebView: ChallengeZoneWebView
-    ) {
+    private fun configure() {
         when (cresData.uiType) {
             UiType.Text -> {
                 challengeZoneView.setChallengeEntryView(challengeZoneTextView)
@@ -200,6 +193,9 @@ internal class ChallengeFragment(
                 )
             }
             UiType.Html -> {
+                val challengeZoneWebView =
+                    challengeEntryViewFactory.createChallengeEntryWebView(cresData)
+                _challengeZoneWebView = challengeZoneWebView
                 challengeZoneView.setChallengeEntryView(challengeZoneWebView)
                 challengeZoneView.setInfoHeaderText(null, null)
                 challengeZoneView.setInfoText(null, null)

--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeZoneWebView.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeZoneWebView.kt
@@ -72,6 +72,13 @@ internal class ChallengeZoneWebView @JvmOverloads constructor(
         this.onClickListener = onClickListener
     }
 
+    internal fun dispose() {
+        onClickListener = null
+        webView.setOnHtmlSubmitListener(null)
+        removeAllViews()
+        webView.destroy()
+    }
+
     private companion object {
         private val PATTERN_METHOD_POST = Pattern.compile(
             "method=\"post\"",

--- a/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/views/ChallengeZoneWebViewTest.kt
+++ b/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/views/ChallengeZoneWebViewTest.kt
@@ -16,6 +16,16 @@ class ChallengeZoneWebViewTest {
             .isEqualTo(HTML_VALID)
     }
 
+    @Test
+    fun dispose_clearsCallbackAndRemovesWebView() {
+        webView.setOnClickListener { }
+
+        webView.dispose()
+
+        assertThat(webView.onClickListener).isNull()
+        assertThat(webView.childCount).isEqualTo(0)
+    }
+
     companion object {
         private const val HTML_INVALID =
             """

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/Test3ds2.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/Test3ds2.kt
@@ -5,12 +5,10 @@ import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@Ignore("#ir-implore-chord")
 internal class Test3ds2 : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "card",

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestPayNow.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestPayNow.kt
@@ -10,12 +10,10 @@ import com.stripe.android.paymentsheet.example.playground.settings.CurrencySetti
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@Ignore("#ir-implore-chord")
 internal class TestPayNow : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "paynow",

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestPromptPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestPromptPay.kt
@@ -10,12 +10,10 @@ import com.stripe.android.paymentsheet.example.playground.settings.MerchantSetti
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@Ignore("#ir-implore-chord")
 internal class TestPromptPay : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "promptpay",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.polling
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidViewBinding
@@ -22,9 +23,8 @@ internal fun QrCodeWebView(
     clientSecret: String,
     onClose: () -> Unit,
 ) {
-    val isPageLoaded = MutableStateFlow(false)
+    val isPageLoaded = remember { MutableStateFlow(false) }
     val isPageLoadedState by isPageLoaded.collectAsState()
-    var binding: StripePaymentAuthWebViewActivityBinding? = null
 
     AndroidViewBinding(
         factory = { layoutInflater, _, _ ->
@@ -50,13 +50,16 @@ internal fun QrCodeWebView(
             localBinding.webView.webViewClient = webViewClient
             localBinding.webView.loadUrl(url)
 
-            binding = localBinding
             localBinding
         },
         modifier = Modifier.fillMaxSize().testTag(QR_CODE_WEB_VIEW_TEST_TAG),
+        onRelease = {
+            webViewContainer.removeAllViews()
+            webView.destroy()
+        },
         update = {
             if (isPageLoadedState) {
-                binding?.progressBar?.isGone = true
+                progressBar.isGone = true
             }
         }
     )


### PR DESCRIPTION
## Purpose

Fix deterministic LeakCanary failures on the Chrome-bearing managed device after browser-based payment flows.

## Root cause

The retained path is native Chromium `WindowAndroid` -> `PhoneWindow` -> `Window.mContext` -> destroyed Activity. It affects `PollingActivity` for PayNow and PromptPay, and `ChallengeActivity` for 3DS2. This is a real WebView lifecycle issue, not a `Window.mCallback` matcher candidate.

## Changes

- Release the polling `PaymentAuthWebView` when its Compose `AndroidViewBinding` leaves composition.
- Create the 3DS2 `ChallengeZoneWebView` only for HTML challenges, avoiding WebView construction for native challenge screens.
- Dispose the HTML challenge WebView when the fragment view is destroyed.
- Keep `TestUSBankAccount` and `TestEmbedded.testUsBankAccount` ignored; Financial Connections remains a separate flow, and the embedded test times out before leak detection.

## Validation

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:detekt :3ds2sdk:detekt`
- Chrome managed-device CI will validate the previously failing PayNow, PromptPay, and 3DS2 tests.