### PR TITLE
Support initial navigator back stack for PaymentOptions with form.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -142,15 +142,15 @@ internal interface EmbeddedActivityModule {
             @ViewModelScope viewModelScope: CoroutineScope,
             eventReporter: EventReporter,
         ): EmbeddedNavigator {
-            val initialScreen = when (launchMode) {
-                is EmbeddedLaunchMode.Form -> formScreenFactory.create(launchMode)
-                is EmbeddedLaunchMode.Manage -> initialManageScreenFactory.createInitialScreen()
+            val initialBackStack = when (launchMode) {
+                is EmbeddedLaunchMode.Form -> listOf(formScreenFactory.create(launchMode))
+                is EmbeddedLaunchMode.Manage -> listOf(initialManageScreenFactory.createInitialScreen())
                 is EmbeddedLaunchMode.PaymentOptions -> initialPaymentOptionsScreenFactory.createInitialScreen()
             }
             return EmbeddedNavigator(
                 coroutineScope = viewModelScope,
                 eventReporter = eventReporter,
-                initialScreen = initialScreen,
+                initialBackStack = initialBackStack,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -51,10 +51,20 @@ internal class EmbeddedNavigator private constructor(
         initialScreen: Screen,
         eventReporter: EventReporter,
     ) : this(
+        coroutineScope = coroutineScope,
+        initialBackStack = listOf(initialScreen),
+        eventReporter = eventReporter,
+    )
+
+    constructor(
+        coroutineScope: CoroutineScope,
+        initialBackStack: List<Screen>,
+        eventReporter: EventReporter,
+    ) : this(
         eventReporter = eventReporter,
         navigationHandler = NavigationHandler(
             coroutineScope = coroutineScope,
-            initialScreen = initialScreen,
+            initialBackStack = initialBackStack,
             shouldRemoveInitialScreenOnTransition = false,
             poppedScreenHandler = {},
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -18,6 +18,8 @@ import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.FormHelper.FormType
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
@@ -45,10 +47,10 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private val formScreenFactory: EmbeddedFormScreenFactory,
     private val linkAccountHolder: LinkAccountHolder,
 ) {
-    fun createInitialScreen(): EmbeddedNavigator.Screen.PaymentOptions {
-        val interactor = createInteractor()
-        return EmbeddedNavigator.Screen.PaymentOptions(
-            interactor = interactor,
+    fun createInitialScreen(): List<EmbeddedNavigator.Screen> {
+        val formHelper = createFormHelper()
+        val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
+            interactor = createInteractor(formHelper),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             sheetActivityState = sheetActivityStateHolder.state,
             onContinueClick = {
@@ -63,11 +65,21 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                 )
             },
         )
+        return buildList {
+            add(paymentOptionsScreen)
+            // When a new payment method requiring a form is already selected, open directly on that
+            // form with the payment options list underneath, so back returns to the list.
+            val selection = selectionHolder.selection.value
+            if (selection is PaymentSelection.New &&
+                formHelper.formTypeForCode(selection.paymentMethodType) == FormType.UserInteractionRequired
+            ) {
+                add(formScreenFactory.createFormScreen(selection.paymentMethodType))
+            }
+        }
     }
 
-    @Suppress("LongMethod")
-    private fun createInteractor(): PaymentMethodVerticalLayoutInteractor {
-        val formHelper = embeddedFormHelperFactory.create(
+    private fun createFormHelper(): FormHelper {
+        return embeddedFormHelperFactory.create(
             coroutineScope = viewModelScope,
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
@@ -78,7 +90,10 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
         )
+    }
 
+    @Suppress("LongMethod")
+    private fun createInteractor(formHelper: FormHelper): PaymentMethodVerticalLayoutInteractor {
         return DefaultPaymentMethodVerticalLayoutInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
             processing = stateFlowOf(false),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -14,10 +14,30 @@ import kotlin.time.Duration.Companion.milliseconds
 
 internal class NavigationHandler<T : Any>(
     private val coroutineScope: CoroutineScope,
-    private val initialScreen: T,
-    private val shouldRemoveInitialScreenOnTransition: Boolean = true,
+    initialBackStack: List<T>,
+    private val shouldRemoveInitialScreenOnTransition: Boolean,
     private val poppedScreenHandler: (T) -> Unit,
 ) {
+    constructor(
+        coroutineScope: CoroutineScope,
+        initialScreen: T,
+        shouldRemoveInitialScreenOnTransition: Boolean = true,
+        poppedScreenHandler: (T) -> Unit,
+    ) : this(
+        coroutineScope = coroutineScope,
+        initialBackStack = listOf(initialScreen),
+        shouldRemoveInitialScreenOnTransition = shouldRemoveInitialScreenOnTransition,
+        poppedScreenHandler = poppedScreenHandler,
+    )
+
+    private val initialBackStack = initialBackStack.toList().also {
+        require(it.isNotEmpty()) {
+            "Initial back stack cannot be empty."
+        }
+    }
+
+    private val initialScreen = this.initialBackStack.first()
+
     private val isTransitioning = AtomicBoolean(false)
 
     // A screen queued by [transitionToWithDelay] whose transition has not been applied yet. Tracked
@@ -27,7 +47,7 @@ internal class NavigationHandler<T : Any>(
     private var pendingTransitionScreen: T? = null
 
     private val backStack = MutableStateFlow<List<T>>(
-        value = listOf(initialScreen),
+        value = initialBackStack,
     )
 
     val currentScreen: StateFlow<T> = backStack

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -339,6 +339,48 @@ internal class EmbeddedNavigatorTest {
     }
 
     @Test
+    fun `initial back stack with a form on top starts on the form and can go back`() = runTest {
+        val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
+        val eventReporter = FakeEventReporter()
+        val paymentOptionsInteractor = FakePaymentMethodVerticalLayoutInteractor.create()
+        val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
+            interactor = paymentOptionsInteractor,
+            isLiveMode = true,
+            sheetActivityState = stateFlowOf(
+                SheetActivityStateHolder.State(
+                    primaryButtonLabel = "".resolvableString,
+                    isEnabled = false,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    isProcessing = false,
+                    shouldDisplayLockIcon = true,
+                    savedPaymentSelectionToConfirm = null,
+                )
+            ),
+            onContinueClick = {},
+        )
+        val (formScreen, formInteractor) = createFormScreen()
+
+        val navigator = EmbeddedNavigator(
+            coroutineScope = scope,
+            eventReporter = eventReporter,
+            initialBackStack = listOf(paymentOptionsScreen, formScreen),
+        )
+
+        // Only the visible top screen is considered shown during initialization.
+        assertThat(navigator.canGoBack).isTrue()
+        assertThat(navigator.screen.value).isEqualTo(formScreen)
+
+        scope.cancel()
+
+        // Both seeded screens are tracked and closed on scope cancellation.
+        assertThat(formInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(paymentOptionsInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+        paymentOptionsInteractor.validate()
+        formInteractor.validate()
+        eventReporter.validate()
+    }
+
+    @Test
     fun `PaymentOptions topBarState returns correct state for live mode`() {
         val screen = createPaymentOptionsScreen(isLiveMode = true)
         val topBarState = screen.topBarState().value!!

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -2,18 +2,25 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.taptoadd.FakeTapToAddHelper
+import com.stripe.android.isInstanceOf
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
+import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
@@ -35,42 +42,78 @@ internal class InitialPaymentOptionsScreenFactoryTest {
     fun `creates initial screen successfully with Google Pay ready`() = testScenario(
         isGooglePayReady = true,
     ) {
-        val screen = factory.createInitialScreen()
-        assertThat(screen).isNotNull()
+        val screens = factory.createInitialScreen()
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
     }
 
     @Test
     fun `creates initial screen successfully without wallets`() = testScenario(
         isGooglePayReady = false,
     ) {
-        val screen = factory.createInitialScreen()
-        assertThat(screen).isNotNull()
+        val screens = factory.createInitialScreen()
+        assertThat(screens).hasSize(1)
     }
 
     @Test
     fun `screen is created with correct isLiveMode`() = testScenario {
-        val screen = factory.createInitialScreen()
+        val screen = factory.createInitialScreen().first()
         val topBarState = screen.topBarState().value!!
         assertThat(topBarState.showTestModeLabel).isTrue()
     }
 
     @Test
     fun `screen isPerformingNetworkOperation returns false`() = testScenario {
-        val screen = factory.createInitialScreen()
+        val screen = factory.createInitialScreen().first()
         assertThat(screen.isPerformingNetworkOperation().value).isFalse()
+    }
+
+    @Test
+    fun `no payment selection creates a single payment options screen`() = testScenario {
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+    }
+
+    @Test
+    fun `new selection requiring a form starts with the form on top of the back stack`() = testScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(2)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens[1]).isInstanceOf<EmbeddedNavigator.Screen.Form>()
+    }
+
+    @Test
+    fun `new selection without a required form does not add a form screen`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            ),
+        ),
+    ) {
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
     }
 
     @Suppress("LongMethod")
     private fun testScenario(
         isGooglePayReady: Boolean = true,
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            isGooglePayReady = isGooglePayReady,
+        ),
         configuration: EmbeddedPaymentElement.Configuration = EmbeddedPaymentElement.Configuration
             .Builder("Example, Inc.")
             .build(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            isGooglePayReady = isGooglePayReady,
-        )
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val customerStateHolder = DefaultCustomerStateHolder(
@@ -93,9 +136,26 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         val manageInteractorFactory = EmbeddedManageScreenInteractorFactory {
             FakeManageScreenInteractor()
         }
-        val formScreenFactory = EmbeddedFormScreenFactory { code ->
-            error("Form screen creation not expected in this test for code: $code")
-        }
+        val formScreenFactory = DefaultEmbeddedFormScreenFactory(
+            formFactory = EmbeddedNavigator.Screen.Form.Factory(
+                interactorFactory = EmbeddedFormInteractorFactory(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    embeddedSelectionHolder = selectionHolder,
+                    embeddedFormHelperFactory = formHelperFactory,
+                    viewModelScope = testScope,
+                    sheetActivityStateHolder = sheetActivityStateHolder,
+                    tapToAddHelper = FakeTapToAddHelper.noOp(),
+                    eventReporter = FakeEventReporter(),
+                    paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                ),
+                eventReporter = FakeEventReporter(),
+                sheetActivityStateHolder = sheetActivityStateHolder,
+                confirmationHelper = FakeSheetActivityConfirmationHelper(),
+                embeddedSelectionHolder = selectionHolder,
+                savedPaymentMethodConfirmInteractorFactory = FakeSavedPaymentMethodConfirmInteractor.Factory(),
+                customerStateHolder = customerStateHolder,
+            ),
+        )
 
         val fakeInteractor =
             com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.Espresso.onIdle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -82,6 +83,27 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
         val cancelled = result as EmbeddedActivityResult.Cancelled
         assertThat(cancelled.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+    }
+
+    @Test
+    fun `new selection requiring a form opens on the form and back returns to the list`() = launch(
+        selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+    ) { scenario ->
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.canGoBack).isTrue()
+            assertThat(activity.embeddedNavigator.screen.value)
+                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+        }
+
+        Espresso.pressBack()
+        onIdle()
+
+        // Back returns to the payment options list rather than cancelling the sheet.
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.canGoBack).isFalse()
+            assertThat(activity.embeddedNavigator.screen.value)
+                .isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import java.io.Closeable
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 
 internal class NavigationHandlerTest {
@@ -28,6 +29,61 @@ internal class NavigationHandlerTest {
             assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
             assertThat(navigationHandler.canGoBack).isFalse()
         }
+    }
+
+    @Test
+    fun `currentScreen is initialized to last screen in initial back stack`() = runTest {
+        val screenOne = mock<PaymentSheetScreen>()
+        val screenTwo = mock<PaymentSheetScreen>()
+        val navigationHandler = NavigationHandler<PaymentSheetScreen>(
+            coroutineScope = this,
+            initialBackStack = listOf(screenOne, screenTwo),
+            shouldRemoveInitialScreenOnTransition = true,
+        ) {}
+
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+            assertThat(navigationHandler.canGoBack).isTrue()
+        }
+    }
+
+    @Test
+    fun `pop from initial back stack returns to previous screen and closes popped screen`() = runTest {
+        val screenOne = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+        val screenTwo = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+        var poppedScreen: PaymentSheetScreen? = null
+        val navigationHandler = NavigationHandler<PaymentSheetScreen>(
+            coroutineScope = this,
+            initialBackStack = listOf(screenOne, screenTwo),
+            shouldRemoveInitialScreenOnTransition = true,
+        ) {
+            poppedScreen = it
+        }
+
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(screenTwo)
+
+            navigationHandler.pop()
+
+            assertThat(awaitItem()).isEqualTo(screenOne)
+            assertThat(navigationHandler.canGoBack).isFalse()
+            assertThat(poppedScreen).isEqualTo(screenTwo)
+            verify(screenTwo as Closeable).close()
+            verify(screenOne as Closeable, never()).close()
+        }
+    }
+
+    @Test
+    fun `initial back stack cannot be empty`() = runTest {
+        val error = assertFailsWith<IllegalArgumentException> {
+            NavigationHandler<PaymentSheetScreen>(
+                coroutineScope = this,
+                initialBackStack = emptyList(),
+                shouldRemoveInitialScreenOnTransition = true,
+            ) {}
+        }
+
+        assertThat(error).hasMessageThat().isEqualTo("Initial back stack cannot be empty.")
     }
 
     @Test


### PR DESCRIPTION
# Summary
Adds support for seeding the navigator's back stack with multiple screens in PaymentOptions launch mode, so a new payment method selection requiring a form can start with the form open and PaymentOptions underneath.

# Motivation
Enables flows where a new payment method is preselected, and it requires a form. The UI then immediately presents the form with the payment options list available on back navigation. This improves UX and aligns with expected behavior.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
