### PR TITLE
Restore previous new selection for code when switching payment methods.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import kotlinx.coroutines.CoroutineScope
@@ -41,8 +42,11 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             linkInlineHandler = LinkInlineHandler.create(),
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = {
-                when (val currentSelection = embeddedSelectionHolder.selection.value) {
+            newPaymentSelectionProvider = { code ->
+                val currentSelection = embeddedSelectionHolder.selection.value
+                    ?.takeIf { it.paymentMethodType == code }
+                    ?: embeddedSelectionHolder.getPreviousNewSelection(code)
+                when (currentSelection) {
                     is PaymentSelection.ExternalPaymentMethod -> {
                         NewPaymentOptionSelection.External(currentSelection)
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -38,7 +38,7 @@ internal class DefaultFormHelper(
     private val linkInlineHandler: LinkInlineHandler,
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     private val paymentMethodMetadata: PaymentMethodMetadata,
-    private val newPaymentSelectionProvider: () -> NewPaymentOptionSelection?,
+    private val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
     private val selectionUpdater: (PaymentSelection?) -> Unit,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
     private val setAsDefaultMatchesSaveForFutureUse: Boolean,
@@ -227,7 +227,7 @@ internal class DefaultFormHelper(
     }
 
     private fun createArgumentsFactory(code: String): UiDefinitionFactory.Arguments.Factory {
-        val currentSelection = newPaymentSelectionProvider()?.takeIf { it.getType() == code }
+        val currentSelection = newPaymentSelectionProvider(code)?.takeIf { it.getType() == code }
 
         return UiDefinitionFactory.Arguments.Factory.Default(
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactoryTest.kt
@@ -2,10 +2,16 @@ package com.stripe.android.paymentelement.embedded
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.CoroutineTestRule
@@ -25,6 +31,49 @@ internal class EmbeddedFormHelperFactoryTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `restores previous new selection for code when live selection is for a different code`() {
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
+
+        // Enter and stash a Klarna selection (with a billing email), then switch the live
+        // selection to a different payment method code (card).
+        selectionHolder.setSelection(
+            PaymentSelection.New.GenericPaymentMethod(
+                label = "Klarna".resolvableString,
+                iconResource = 0,
+                iconResourceNight = null,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+                paymentMethodCreateParams = PaymentMethodCreateParams.createKlarna(
+                    billingDetails = PaymentMethod.BillingDetails(email = "example@email.com"),
+                ),
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+                paymentMethodOptionsParams = null,
+                paymentMethodExtraParams = null,
+            )
+        )
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+        val formHelper = createFormHelper(
+            selectionHolder = selectionHolder,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("card", "klarna"),
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                ),
+            ),
+        )
+
+        // The live selection is for "card", so the "klarna" form falls back to the stashed
+        // Klarna selection and restores its previously entered email.
+        val emailField = formHelper.formElementsForCode("klarna")
+            .flatMap { it.getFormFieldValueFlow().value }
+            .first { it.first.v1 == "billing_details[email]" }
+        assertThat(emailField.second.value).isEqualTo("example@email.com")
+    }
 
     @Test
     fun `shouldLaunchCardScanAutomatically is true for an empty card form when configured`() {
@@ -92,6 +141,29 @@ internal class EmbeddedFormHelperFactoryTest {
         )
 
         assertThat(cardDetailsAction?.shouldAutomaticallyLaunchCardScan).isNull()
+    }
+
+    private fun createFormHelper(
+        selectionHolder: EmbeddedSelectionHolder,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): FormHelper {
+        val factory = EmbeddedFormHelperFactory(
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            embeddedSelectionHolder = selectionHolder,
+            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+            savedStateHandle = SavedStateHandle(),
+            isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
+        )
+        return factory.create(
+            coroutineScope = TestScope(UnconfinedTestDispatcher()),
+            setAsDefaultMatchesSaveForFutureUse = false,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = FakeEventReporter(),
+            automaticallyLaunchedCardScanFormDataHelper = null,
+            tapToAddHelper = null,
+            paymentMethodMessagePromotionsHelper = null,
+            selectionUpdater = {},
+        )
     }
 
     private fun createCardScanHelper(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -706,7 +707,8 @@ internal class FormHelperTest {
         tapToAddHelper: TapToAddHelper? = null,
         paymentMethodMessagePromotionsHelper: FakePaymentMethodMessagePromotionsHelper =
             FakePaymentMethodMessagePromotionsHelper(),
-        newPaymentSelectionProvider: () -> NewPaymentOptionSelection? = { throw AssertionError("Not implemented") },
+        newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection? =
+            { throw AssertionError("Not implemented") },
         selectionUpdater: (PaymentSelection?) -> Unit = { throw AssertionError("Not implemented") },
     ): FormHelper {
         return DefaultFormHelper(


### PR DESCRIPTION
# Summary
Restores previously entered data for a payment method's form when a user switches between different payment method types. This uses the stashed "new" selection corresponding to a specific payment method code if the current selection is for another method.

# Motivation
Improves user experience by retaining partially entered form data when users toggle between available payment methods, reducing the need to re-enter information.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
