### PR TITLE
Preserve and restore previous new selections across Embedded Sheet flows.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -63,6 +63,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
                 selectionHolder.setSelection(result.selection)
             }
             is EmbeddedActivityResult.Cancelled -> {
@@ -76,6 +77,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
                 selectionHolder.setSelection(result.selection)
             }
             is EmbeddedActivityResult.Cancelled -> Unit
@@ -87,6 +89,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
                 selectionHolder.setSelection(result.selection)
             }
             is EmbeddedActivityResult.Cancelled -> {
@@ -133,6 +136,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = currentSelection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = code),
@@ -160,6 +164,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.Manage,
@@ -187,6 +192,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.embedded
 
 import android.content.Intent
+import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -17,6 +18,7 @@ internal data class EmbeddedActivityArgs(
     val paymentElementCallbackIdentifier: String,
     val statusBarColor: Int?,
     val selection: PaymentSelection?,
+    val previousNewSelections: Bundle,
     val customerState: CustomerState?,
     val promotion: PaymentMethodMessagePromotion?,
     val launchMode: EmbeddedLaunchMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.embedded
 
 import android.content.Intent
+import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -15,6 +16,7 @@ internal sealed interface EmbeddedActivityResult : Parcelable {
     @Parcelize
     data class Complete(
         val selection: PaymentSelection?,
+        val previousNewSelections: Bundle,
         val hasBeenConfirmed: Boolean,
         val customerState: CustomerState?,
         val shouldInvokeSelectionCallback: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -90,6 +90,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
                 selectionHolder.setSelection(result.selection)
                 if (result.hasBeenConfirmed) {
                     embeddedResultCallbackHelper.setResult(
@@ -113,6 +114,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
                 selectionHolder.setSelection(result.selection)
                 if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
                     rowSelectionImmediateActionHandler.invoke()
@@ -127,6 +129,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
                 selectionHolder.setSelection(result.selection)
                 if (result.hasBeenConfirmed) {
                     embeddedResultCallbackHelper.setResult(
@@ -178,6 +181,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = currentSelection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = code),
@@ -205,6 +209,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.Manage,
@@ -232,6 +237,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -223,6 +223,7 @@ internal class EmbeddedNavigator private constructor(
                         sheetActivityStateHolder.setResult(
                             EmbeddedActivityResult.Complete(
                                 selection = null,
+                                previousNewSelections = embeddedSelectionHolder.previousNewSelections,
                                 hasBeenConfirmed = true,
                                 customerState = customerStateHolder.customer.value,
                                 shouldInvokeSelectionCallback = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -233,6 +233,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         setActivityResult(
             EmbeddedActivityResult.Complete(
                 selection = selectionHolder.selection.value,
+                previousNewSelections = selectionHolder.previousNewSelections,
                 hasBeenConfirmed = false,
                 customerState = customerStateHolder.customer.value,
                 shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -37,6 +37,7 @@ internal class EmbeddedSheetViewModel @Inject constructor(
             )
 
             component.customerStateHolder.setCustomerState(args.customerState)
+            component.selectionHolder.setPreviousNewSelections(args.previousNewSelections)
             component.selectionHolder.setSelection(args.selection)
 
             return component.viewModel as T

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -63,6 +63,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                 sheetActivityStateHolder.setResult(
                     EmbeddedActivityResult.Complete(
                         selection = selectionHolder.selection.value,
+                        previousNewSelections = selectionHolder.previousNewSelections,
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
                         shouldInvokeSelectionCallback = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -51,6 +51,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
                     stateHelper.setResult(
                         EmbeddedActivityResult.Complete(
                             selection = selectionHolder.selection.value,
+                            previousNewSelections = selectionHolder.previousNewSelections,
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -102,6 +102,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                     is TapToAddNextStep.ShowSavedPaymentMethods -> {
                         EmbeddedActivityResult.Complete(
                             selection = result.paymentSelection,
+                            previousNewSelections = selectionHolder.previousNewSelections,
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,
@@ -111,6 +112,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                     TapToAddNextStep.Complete -> {
                         EmbeddedActivityResult.Complete(
                             selection = null,
+                            previousNewSelections = selectionHolder.previousNewSelections,
                             hasBeenConfirmed = true,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,
@@ -121,6 +123,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                         customerStateHolder.addPaymentMethod(result.paymentSelection.paymentMethod)
                         EmbeddedActivityResult.Complete(
                             selection = result.paymentSelection,
+                            previousNewSelections = selectionHolder.previousNewSelections,
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
                             shouldInvokeSelectionCallback = false,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import android.app.Application
+import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
@@ -20,6 +21,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
@@ -65,6 +67,7 @@ internal class CheckoutSheetLauncherTest {
             paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             statusBarColor = null,
             selection = null,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = code),
@@ -182,6 +185,7 @@ internal class CheckoutSheetLauncherTest {
 
         val customerState = createCustomerState()
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = customerState,
@@ -235,6 +239,7 @@ internal class CheckoutSheetLauncherTest {
     @Test
     fun `form result handled correctly without prior launchForm call (simulates host recreation)`() = testScenario {
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
@@ -260,6 +265,7 @@ internal class CheckoutSheetLauncherTest {
             paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             statusBarColor = null,
             selection = PaymentSelection.GooglePay,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.Manage,
@@ -309,6 +315,7 @@ internal class CheckoutSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -366,6 +373,7 @@ internal class CheckoutSheetLauncherTest {
             paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             statusBarColor = null,
             selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
@@ -381,6 +389,22 @@ internal class CheckoutSheetLauncherTest {
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchPaymentOptions forwards previously entered new selections`() = testScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            selection = PaymentSelection.GooglePay,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+
+        assertThat(launchCall.previousNewSelections.previousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 
     @Test
@@ -415,6 +439,7 @@ internal class CheckoutSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import android.app.Application
+import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
@@ -20,7 +21,9 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
+import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -74,6 +77,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             selection = null,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = code),
@@ -200,6 +204,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         launchForm("test_code")
 
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             selection = null,
             hasBeenConfirmed = true,
             customerState = null,
@@ -224,6 +229,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         launchForm("cashapp")
 
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
@@ -250,6 +256,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             launchForm("cashapp")
 
             val result = EmbeddedActivityResult.Complete(
+                previousNewSelections = Bundle(),
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
                 hasBeenConfirmed = false,
                 customerState = null,
@@ -272,6 +279,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             launchForm("cashapp")
 
             val result = EmbeddedActivityResult.Complete(
+                previousNewSelections = Bundle(),
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
                 hasBeenConfirmed = true,
                 customerState = null,
@@ -331,6 +339,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
 
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             customerState = createCustomerState(),
             selection = null,
             hasBeenConfirmed = false,
@@ -370,6 +379,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             selection = PaymentSelection.GooglePay,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.Manage,
@@ -406,6 +416,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -430,6 +441,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             val result = EmbeddedActivityResult.Complete(
+                previousNewSelections = Bundle(),
                 customerState = customerState,
                 selection = selection,
                 hasBeenConfirmed = false,
@@ -451,6 +463,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             val result = EmbeddedActivityResult.Complete(
+                previousNewSelections = Bundle(),
                 customerState = customerState,
                 selection = selection,
                 hasBeenConfirmed = false,
@@ -494,6 +507,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
     @Test
     fun `form result handled correctly without prior launchForm call (simulates host recreation)`() = testScenario {
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
@@ -536,6 +550,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
@@ -583,11 +598,50 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     @Test
+    fun `launchPaymentOptions forwards previously entered new selections`() = testScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            selection = PaymentSelection.GooglePay,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+
+        assertThat(launchCall.previousNewSelections.previousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `paymentOptionsResult merges returned previous new selections into selection holder`() = testScenario {
+        sheetStateHolder.sheetIsOpen = true
+        val returnedSelections = Bundle().apply {
+            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        }
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = returnedSelections,
+            customerState = null,
+            selection = null,
+            hasBeenConfirmed = false,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(result)
+
+        assertThat(selectionHolder.getPreviousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    @Test
     fun `paymentOptionsResult callback updates state on complete result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -607,6 +661,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
     fun `paymentOptionsResult callback invokes completion callback on confirmed result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
             customerState = null,
             selection = null,
             hasBeenConfirmed = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -90,6 +90,7 @@ internal class EmbeddedSheetActivityTest {
         scenario.onActivity { activity ->
             activity.sheetActivityStateHolder.setResult(
                 EmbeddedActivityResult.Complete(
+                    previousNewSelections = Bundle(),
                     selection = null,
                     hasBeenConfirmed = true,
                     customerState = null,
@@ -153,6 +154,7 @@ internal class EmbeddedSheetActivityTest {
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
                     selection = null,
+                    previousNewSelections = Bundle(),
                     customerState = createCustomerState(paymentMethods = emptyList()),
                     promotion = null,
                     launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = selectedPaymentMethodCode),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -83,6 +83,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
 
         assertThat(stateHelper.resultTurbine.awaitItem()).isEqualTo(
             EmbeddedActivityResult.Complete(
+                previousNewSelections = selectionHolder.previousNewSelections,
                 selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
                 hasBeenConfirmed = false,
                 customerState = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -345,6 +345,7 @@ class DefaultSheetActivityStateHolderTest {
 
                 assertThat(awaitItem()).isEqualTo(
                     EmbeddedActivityResult.Complete(
+                        previousNewSelections = selectionHolder.previousNewSelections,
                         selection = expectedSelection,
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
@@ -369,6 +370,7 @@ class DefaultSheetActivityStateHolderTest {
 
                 assertThat(awaitItem()).isEqualTo(
                     EmbeddedActivityResult.Complete(
+                        previousNewSelections = selectionHolder.previousNewSelections,
                         selection = null,
                         hasBeenConfirmed = true,
                         customerState = customerStateHolder.customer.value,
@@ -399,6 +401,7 @@ class DefaultSheetActivityStateHolderTest {
 
                 assertThat(awaitItem()).isEqualTo(
                     EmbeddedActivityResult.Complete(
+                        previousNewSelections = selectionHolder.previousNewSelections,
                         selection = expectedSelection,
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -269,6 +269,7 @@ internal class EmbeddedSheetActivityTest {
                     paymentElementCallbackIdentifier = "EmbeddedSheetActivityTestCallbackIdentifier",
                     statusBarColor = null,
                     selection = selection,
+                    previousNewSelections = Bundle(),
                     customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                         paymentMethods = paymentMethods,
                     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import android.app.Activity
 import android.app.Application
+import android.os.Bundle
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -15,6 +16,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -52,6 +54,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         scenario.onActivity { activity ->
             activity.sheetActivityStateHolder.setResult(
                 EmbeddedActivityResult.Complete(
+                    previousNewSelections = Bundle(),
                     selection = null,
                     hasBeenConfirmed = false,
                     customerState = null,
@@ -83,6 +86,18 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
         val cancelled = result as EmbeddedActivityResult.Cancelled
         assertThat(cancelled.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+    }
+
+    @Test
+    fun `restores previously entered new selections into the selection holder`() = launch(
+        previousNewSelections = Bundle().apply {
+            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        },
+    ) { scenario ->
+        scenario.onActivity { activity ->
+            assertThat(activity.selectionHolder.getPreviousNewSelection("cashapp"))
+                .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        }
     }
 
     @Test
@@ -119,6 +134,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     private fun launch(
         selection: PaymentSelection? = null,
+        previousNewSelections: Bundle = Bundle(),
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
@@ -130,6 +146,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
                     selection = selection,
+                    previousNewSelections = previousNewSelections,
                     customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                     promotion = null,
                     launchMode = EmbeddedLaunchMode.PaymentOptions,


### PR DESCRIPTION
# Summary
Preserves and restores "previous new selections" (newly entered payment selections) across Embedded Sheet flows, including after activity or process recreation. These selections are now consistently forwarded and merged as needed.

# Motivation
Previously, each Embedded Sheet instance had no persistent memory of "previous new selections"—such as entries in the form flow—across different flows or after the host was recreated. This caused user progress in new payment method entry to be lost. This change fixes that by tracking and forwarding the relevant state.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

