### PR TITLE
Expose LinkAppearance to @LinkControllerPreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ NEXT_VERSION_BUMP: MINOR
 ### CryptoOnramp
 * [ADDED] Added Tempo as a supported wallet network and pinned Crypto Onramp internal API calls to the preview API version required by newer networks.
 
+### PaymentSheet
+* [ADDED] `LinkController` now supports appearance customization via `LinkAppearance` (private preview).
+
 ## 23.13.1 - 2026-07-23
 
 ### Payments

--- a/crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampConfigurationFactory.kt
+++ b/crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampConfigurationFactory.kt
@@ -1,3 +1,5 @@
+@file:OptIn(com.stripe.android.link.LinkControllerPreview::class)
+
 package com.stripe.android.crypto.onramp.example
 
 import androidx.compose.ui.graphics.Color

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkControllerCustomAppearanceSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkControllerCustomAppearanceSettingsDefinition.kt
@@ -1,0 +1,53 @@
+@file:OptIn(LinkControllerPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import androidx.compose.ui.graphics.Color
+import com.stripe.android.link.LinkAppearance
+import com.stripe.android.link.LinkController
+import com.stripe.android.link.LinkControllerPreview
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object LinkControllerCustomAppearanceSettingsDefinition : BooleanSettingsDefinition(
+    key = "linkControllerCustomAppearance",
+    displayName = "LinkController: custom appearance",
+    defaultValue = false,
+) {
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return configurationData.integrationType == PlaygroundConfigurationData.IntegrationType.LinkController
+    }
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: LinkController.Configuration,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.LinkControllerConfigurationData
+    ) {
+        if (value) {
+            val purple = Color(0xFF6B4EFF)
+            configurationBuilder.appearance(
+                LinkAppearance()
+                    .lightColors(
+                        LinkAppearance.Colors()
+                            .primary(purple)
+                            .contentOnPrimary(Color.White)
+                            .borderSelected(purple)
+                    )
+                    .darkColors(
+                        LinkAppearance.Colors()
+                            .primary(purple)
+                            .contentOnPrimary(Color.White)
+                            .borderSelected(purple)
+                    )
+                    .style(LinkAppearance.Style.ALWAYS_DARK)
+                    .primaryButton(
+                        LinkAppearance.PrimaryButton()
+                            .cornerRadiusDp(6f)
+                    )
+            )
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkControllerCustomAppearanceSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkControllerCustomAppearanceSettingsDefinition.kt
@@ -13,6 +13,9 @@ internal object LinkControllerCustomAppearanceSettingsDefinition : BooleanSettin
     displayName = "LinkController: custom appearance",
     defaultValue = false,
 ) {
+    private val customPrimaryColor = Color(0xFF6B4EFF)
+    private const val primaryButtonCornerRadiusDp = 6f
+
     override fun applicable(
         configurationData: PlaygroundConfigurationData,
         settings: Map<PlaygroundSettingDefinition<*>, Any?>,
@@ -27,25 +30,24 @@ internal object LinkControllerCustomAppearanceSettingsDefinition : BooleanSettin
         configurationData: PlaygroundSettingDefinition.LinkControllerConfigurationData
     ) {
         if (value) {
-            val purple = Color(0xFF6B4EFF)
             configurationBuilder.appearance(
                 LinkAppearance()
                     .lightColors(
                         LinkAppearance.Colors()
-                            .primary(purple)
+                            .primary(customPrimaryColor)
                             .contentOnPrimary(Color.White)
-                            .borderSelected(purple)
+                            .borderSelected(customPrimaryColor)
                     )
                     .darkColors(
                         LinkAppearance.Colors()
-                            .primary(purple)
+                            .primary(customPrimaryColor)
                             .contentOnPrimary(Color.White)
-                            .borderSelected(purple)
+                            .borderSelected(customPrimaryColor)
                     )
                     .style(LinkAppearance.Style.ALWAYS_DARK)
                     .primaryButton(
                         LinkAppearance.PrimaryButton()
-                            .cornerRadiusDp(6f)
+                            .cornerRadiusDp(primaryButtonCornerRadiusDp)
                     )
             )
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -562,6 +562,7 @@ internal class PlaygroundSettings private constructor(
                     PlaygroundConfigurationData.IntegrationType.sptFlows().toList(),
             ),
             LinkControllerAllowUserEmailEditsSettingsDefinition,
+            LinkControllerCustomAppearanceSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.forceLinkWebAuth),
             FeatureFlagSettingsDefinition(
                 FeatureFlags.forceEnableLinkPaymentSelectionHint,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -231,6 +231,43 @@ public abstract interface class com/stripe/android/customersheet/SetupIntentClie
 	public abstract fun provideSetupIntentClientSecret (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkAppearance {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun darkColors (Lcom/stripe/android/link/LinkAppearance$Colors;)Lcom/stripe/android/link/LinkAppearance;
+	public final fun lightColors (Lcom/stripe/android/link/LinkAppearance$Colors;)Lcom/stripe/android/link/LinkAppearance;
+	public final fun primaryButton (Lcom/stripe/android/link/LinkAppearance$PrimaryButton;)Lcom/stripe/android/link/LinkAppearance;
+	public final fun reduceLinkBranding (Z)Lcom/stripe/android/link/LinkAppearance;
+	public final fun style (Lcom/stripe/android/link/LinkAppearance$Style;)Lcom/stripe/android/link/LinkAppearance;
+}
+
+public final class com/stripe/android/link/LinkAppearance$Colors {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun borderSelected-8_81llA (J)Lcom/stripe/android/link/LinkAppearance$Colors;
+	public final fun contentOnPrimary-8_81llA (J)Lcom/stripe/android/link/LinkAppearance$Colors;
+	public final fun primary-8_81llA (J)Lcom/stripe/android/link/LinkAppearance$Colors;
+}
+
+public final class com/stripe/android/link/LinkAppearance$PrimaryButton {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun cornerRadiusDp (Ljava/lang/Float;)Lcom/stripe/android/link/LinkAppearance$PrimaryButton;
+	public final fun heightDp (Ljava/lang/Float;)Lcom/stripe/android/link/LinkAppearance$PrimaryButton;
+}
+
+public final class com/stripe/android/link/LinkAppearance$Style : java/lang/Enum, android/os/Parcelable {
+	public static final field ALWAYS_DARK Lcom/stripe/android/link/LinkAppearance$Style;
+	public static final field ALWAYS_LIGHT Lcom/stripe/android/link/LinkAppearance$Style;
+	public static final field AUTOMATIC Lcom/stripe/android/link/LinkAppearance$Style;
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final fun describeContents ()I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/link/LinkAppearance$Style;
+	public static fun values ()[Lcom/stripe/android/link/LinkAppearance$Style;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/link/LinkController {
 	public static final field $stable I
 	public final fun configure-gIAlu-s (Lcom/stripe/android/link/LinkController$Configuration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -249,6 +286,7 @@ public final class com/stripe/android/link/LinkController$Configuration {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun allowLogout (Z)Lcom/stripe/android/link/LinkController$Configuration;
+	public final fun appearance (Lcom/stripe/android/link/LinkAppearance;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun email (Ljava/lang/String;)Lcom/stripe/android/link/LinkController$Configuration;
 	public final fun paymentMethodTypes (Ljava/util/List;)Lcom/stripe/android/link/LinkController$Configuration;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkAppearance.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkAppearance.kt
@@ -1,3 +1,5 @@
+@file:OptIn(LinkControllerPreview::class)
+
 package com.stripe.android.link
 
 import android.os.Parcel
@@ -19,7 +21,7 @@ import kotlinx.parcelize.TypeParceler
  * @param primaryButton Configuration for primary button styling (corner radius, height).
  *
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@LinkControllerPreview
 class LinkAppearance {
 
     private var lightColors: Colors? = null
@@ -73,7 +75,7 @@ class LinkAppearance {
     /**
      * Color configuration for Link components.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     class Colors {
         private var primary: Color? = null
         private var contentOnPrimary: Color? = null
@@ -115,7 +117,7 @@ class LinkAppearance {
      * The light/dark mode style of the appearance.
      */
     @Parcelize
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     enum class Style : Parcelable {
         AUTOMATIC,
         ALWAYS_LIGHT,
@@ -125,7 +127,7 @@ class LinkAppearance {
     /**
      * Configuration for primary button styling.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @LinkControllerPreview
     class PrimaryButton {
         private var cornerRadiusDp: Float? = null
         private var heightDp: Float? = null

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -256,7 +256,7 @@ class LinkController @Inject internal constructor(
             this.supportedPaymentMethodTypes = types
         }
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @LinkControllerPreview
         fun appearance(appearance: LinkAppearance) = apply { this.appearance = appearance }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/link/theme/Theme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/theme/Theme.kt
@@ -55,7 +55,8 @@ internal fun DefaultLinkTheme(
                 textBrand = overrides.primary,
                 onButtonBrand = overrides.contentOnPrimary,
                 buttonBrand = overrides.primary,
-                borderSelected = overrides.borderSelected
+                borderSelected = overrides.borderSelected,
+                iconBrand = overrides.primary,
             )
         }
         ?: defaultColors


### PR DESCRIPTION
# Summary

Adds @LinkControllerPreview annotation to LinkAppearance and fixes as appearance related issues I found along the way (loading indicator theme).

Also adds a toggle in the payment sheet demo app to test a custom appearance.

# Motivation

Allows Link standalone users customize some aspects of the Link flow.

# Testing

https://github.com/user-attachments/assets/8892487a-f611-4271-8c07-5b96d3ac1e4b

# Changelog

```
### PaymentSheet
* [ADDED] `LinkController` now supports appearance customization via `LinkAppearance` (private preview).
```