### PR TITLE
Cancel mandate text collector on screen close to prevent leaks.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -140,6 +140,8 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
                     isVerticalLayout = true,
                 )
             },
+            // Embedded renders mandate text through its own path, not the mandate-above-button handler.
+            updateMandateText = null,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -148,6 +148,8 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                     isVerticalLayout = true,
                 )
             },
+            // Embedded renders mandate text through its own path, not the mandate-above-button handler.
+            updateMandateText = null,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -366,7 +366,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         // Only wired up for flows that surface mandate text above the primary button (PaymentSheet and
         // FlowController). Embedded renders mandates through its own path and passes null. Launched on this
         // interactor's scope so both collectors are cancelled by close() when the screen goes away.
-        val updateMandateText = updateMandateText
         if (updateMandateText != null) {
             coroutineScope.launch(mainDispatcher) {
                 state.mapAsStateFlow { it.mandate }.collect { mandate ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.LinkButtonState
@@ -118,6 +117,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val invokeRowSelectionCallback: (() -> Unit)? = null,
     private val displaysMandatesInFormScreen: Boolean,
     private val onInitiallyDisplayedPaymentMethodVisibilitySnapshot: (List<String>, List<String>) -> Unit,
+    private val updateMandateText: ((mandateText: ResolvableString?, showAbove: Boolean) -> Unit)?,
     dispatcher: CoroutineContext = Dispatchers.Default,
     mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
@@ -203,26 +203,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                         isVerticalLayout = true,
                     )
                 },
+                updateMandateText = viewModel.mandateHandler::updateMandateText,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
-            ).also { interactor ->
-                viewModel.viewModelScope.launch {
-                    interactor.state.mapAsStateFlow { it.mandate }.collect { mandate ->
-                        viewModel.mandateHandler.updateMandateText(
-                            mandateText = mandate,
-                            showAbove = true,
-                        )
-                    }
-                }
-
-                viewModel.viewModelScope.launch {
-                    isCurrentScreen.filter { it }.collect {
-                        viewModel.mandateHandler.updateMandateText(
-                            mandateText = interactor.state.value.mandate,
-                            showAbove = true,
-                        )
-                    }
-                }
-            }
+            )
         }
     }
 
@@ -376,6 +359,24 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                         _verticalModeScreenSelection.value = updatedSelection
                         updateSelection(updatedSelection, false)
                     }
+                }
+            }
+        }
+
+        // Only wired up for flows that surface mandate text above the primary button (PaymentSheet and
+        // FlowController). Embedded renders mandates through its own path and passes null. Launched on this
+        // interactor's scope so both collectors are cancelled by close() when the screen goes away.
+        val updateMandateText = updateMandateText
+        if (updateMandateText != null) {
+            coroutineScope.launch(mainDispatcher) {
+                state.mapAsStateFlow { it.mandate }.collect { mandate ->
+                    updateMandateText(mandate, true)
+                }
+            }
+
+            coroutineScope.launch(mainDispatcher) {
+                isCurrentScreen.filter { it }.collect {
+                    updateMandateText(state.value.mandate, true)
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.R
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
@@ -1506,6 +1507,40 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun `updateMandateText receives updates while open and stops after close`() {
+        val paymentMethodTypes = listOf("card", "cashapp")
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = paymentMethodTypes
+            )
+        )
+        val mandateTurbine = Turbine<Pair<ResolvableString?, Boolean>>()
+        runScenario(
+            paymentMethodMetadata = paymentMethodMetadata,
+            formTypeForCode = { FormHelper.FormType.MandateOnly("Foobar".resolvableString) },
+            updateMandateText = { mandateText, showAbove ->
+                mandateTurbine.add(mandateText to showAbove)
+            },
+        ) {
+            // Initial mandate (no selection) is pushed through the callback.
+            assertThat(mandateTurbine.awaitItem()).isEqualTo(null to true)
+
+            // Selecting a payment method with a mandate pushes the updated text.
+            selectionSource.value = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION
+            assertThat(mandateTurbine.awaitItem()).isEqualTo("Foobar".resolvableString to true)
+
+            // After close(), the collectors are cancelled along with the interactor's scope, so
+            // further mandate changes are no longer pushed. Guards against the previous behavior
+            // where these collectors ran on the viewModelScope and outlived the screen.
+            interactor.close()
+            selectionSource.value = null
+            testScope.testScheduler.advanceUntilIdle()
+            mandateTurbine.expectNoEvents()
+            mandateTurbine.ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
     fun temporarySelection_doesNotAllowChangeDetails_whenSavedCardIsSelected() = runScenario(
         formTypeForCode = {
             FormHelper.FormType.UserInteractionRequired
@@ -1851,6 +1886,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         invokeRowSelectionCallback: (() -> Unit)? = null,
         initialWalletsState: WalletsState? = null,
         displaysMandatesInFormScreen: Boolean = false,
+        updateMandateText: ((mandateText: ResolvableString?, showAbove: Boolean) -> Unit)? = null,
         promotionsHelper: PaymentMethodMessagePromotionsHelper? = null,
         testBlock: suspend TestParams.() -> Unit
     ) {
@@ -1920,6 +1956,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                     Pair(visibleItems, hiddenItems)
                 )
             },
+            updateMandateText = updateMandateText,
             paymentMethodMessagePromotionsHelper = promotionsHelper
         )
         closeInteractorRule.track(interactor)


### PR DESCRIPTION
# Summary
Ensure that mandate text callbacks in PaymentMethodVerticalLayoutInteractor are cancelled when the interactor is closed, preventing leaks and unwanted updates after the UI screen goes away. Also provide a way for embedded use cases to opt out of this handler.

# Motivation
Previously, the mandate text update logic was launched on the ViewModel scope, causing it to live longer than the UI screen. This resulted in callbacks firing after the screen was closed, which could cause bugs and leaks. The new approach ensures that collectors are managed by the interactor's own scope and are properly cancelled on close, and allows Embedded screens to bypass the legacy mandate handler.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
