### PR TITLE
Scope coroutines for form interactors lifecycle and add close method.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentMethodVerticalLayoutInteractorFactory.kt
@@ -13,12 +13,14 @@ import com.stripe.android.paymentsheet.FormHelper.FormType
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
@@ -54,11 +56,13 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
         isImmediateAction: Boolean,
         embeddedViewDisplaysMandateText: Boolean,
     ): PaymentMethodVerticalLayoutInteractor {
+        val interactorScope = coroutineScope.childScope(Dispatchers.Default)
+        val formHelperScope = interactorScope.childScope(Dispatchers.Main)
         val paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
             incentive = paymentMethodMetadata.paymentMethodIncentive,
         )
         val formHelper = embeddedFormHelperFactory.createForVerticalLayout(
-            coroutineScope = coroutineScope,
+            coroutineScope = formHelperScope,
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
             selectionUpdater = {
@@ -138,8 +142,9 @@ internal class DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory @Inje
             },
             // Embedded renders mandate text through its own path, not the mandate-above-button handler.
             updateMandateText = null,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             linkAccount = linkAccountHolder.linkAccountInfo,
+            coroutineScope = interactorScope,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -14,14 +14,13 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.job
 import javax.inject.Inject
 
 internal class EmbeddedFormInteractorFactory @Inject constructor(
@@ -38,11 +37,10 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
         paymentMethodCode: PaymentMethodCode,
         hasSavedPaymentMethods: Boolean
     ): DefaultVerticalModeFormInteractor {
-        val formScope = CoroutineScope(
-            viewModelScope.coroutineContext + SupervisorJob(viewModelScope.coroutineContext.job)
-        )
+        val coroutineScope = viewModelScope.childScope(Dispatchers.Default)
+        val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
         val formHelper = embeddedFormHelperFactory.create(
-            coroutineScope = formScope,
+            coroutineScope = formHelperScope,
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
             automaticallyLaunchedCardScanFormDataHelper =
@@ -92,7 +90,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             ).displayedIncentive,
             // Embedded does not support validation at the moment. Should update here once it does.
             validationRequested = MutableSharedFlow(),
-            coroutineScope = formScope,
+            coroutineScope = coroutineScope,
             uiContext = Dispatchers.Main,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -39,21 +42,36 @@ internal fun FormScreenContent(
     savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
 ) {
     val interactorState by interactor.state.collectAsState()
+    val savedPaymentSelectionToConfirm = state.savedPaymentSelectionToConfirm
+    val latestUpdateSelection by rememberUpdatedState(updateSelection)
+    val savedPaymentMethodConfirmInteractor = if (savedPaymentSelectionToConfirm != null) {
+        remember(savedPaymentSelectionToConfirm) {
+            savedPaymentMethodConfirmInteractorFactory.create(
+                initialSelection = savedPaymentSelectionToConfirm,
+                updateSelection = { latestUpdateSelection(it) },
+            )
+        }
+    } else {
+        null
+    }
+
+    DisposableEffect(savedPaymentMethodConfirmInteractor) {
+        onDispose {
+            savedPaymentMethodConfirmInteractor?.close()
+        }
+    }
 
     DismissKeyboardOnProcessing(interactorState.isProcessing)
 
     EventReporterProvider(eventReporter) {
-        if (state.savedPaymentSelectionToConfirm == null) {
+        if (savedPaymentMethodConfirmInteractor == null) {
             VerticalModeFormUI(
                 interactor = interactor,
                 showsWalletHeader = false
             )
         } else {
             SavedPaymentMethodConfirmUI(
-                savedPaymentMethodConfirmInteractor = savedPaymentMethodConfirmInteractorFactory.create(
-                    initialSelection = state.savedPaymentSelectionToConfirm,
-                    updateSelection = updateSelection,
-                ),
+                savedPaymentMethodConfirmInteractor = savedPaymentMethodConfirmInteractor,
             )
         }
         USBankAccountMandate(state)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -22,11 +22,13 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emitAll
@@ -52,9 +54,11 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private val linkAccountHolder: LinkAccountHolder,
 ) {
     fun createInitialScreen(): List<EmbeddedNavigator.Screen> {
-        val formHelper = createFormHelper()
+        val coroutineScope = viewModelScope.childScope(Dispatchers.Default)
+        val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
+        val formHelper = createFormHelper(formHelperScope)
         val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
-            interactor = createInteractor(formHelper),
+            interactor = createInteractor(formHelper, coroutineScope),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             sheetActivityState = sheetActivityStateHolder.state,
             onContinueClick = {
@@ -85,9 +89,9 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
         }
     }
 
-    private fun createFormHelper(): FormHelper {
+    private fun createFormHelper(coroutineScope: CoroutineScope): FormHelper {
         return embeddedFormHelperFactory.createForVerticalLayout(
-            coroutineScope = viewModelScope,
+            coroutineScope = coroutineScope,
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
             selectionUpdater = { selectionHolder.setSelection(it) },
@@ -96,7 +100,10 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     }
 
     @Suppress("LongMethod")
-    private fun createInteractor(formHelper: FormHelper): PaymentMethodVerticalLayoutInteractor {
+    private fun createInteractor(
+        formHelper: FormHelper,
+        coroutineScope: CoroutineScope,
+    ): PaymentMethodVerticalLayoutInteractor {
         return DefaultPaymentMethodVerticalLayoutInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
             processing = stateFlowOf(false),
@@ -147,6 +154,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
             },
             // Embedded renders mandate text through its own path, not the mandate-above-button handler.
             updateMandateText = null,
+            coroutineScope = coroutineScope,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             linkAccount = linkAccountHolder.linkAccountInfo,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
 import com.stripe.android.common.taptoadd.TapToAddHelper
@@ -28,6 +27,7 @@ import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
@@ -55,13 +55,14 @@ internal class DefaultFormHelper(
         internal const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
         fun create(
             viewModel: BaseSheetViewModel,
+            coroutineScope: CoroutineScope,
             paymentMethodMetadata: PaymentMethodMetadata,
             linkInlineHandler: LinkInlineHandler = LinkInlineHandler.create(),
             shouldCreateAutomaticallyLaunchedCardScanFormDataHelper: Boolean = false,
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
         ): FormHelper {
             return DefaultFormHelper(
-                coroutineScope = viewModel.viewModelScope,
+                coroutineScope = coroutineScope,
                 linkInlineHandler = linkInlineHandler,
                 cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
                 paymentMethodMetadata = paymentMethodMetadata,
@@ -126,7 +127,8 @@ internal class DefaultFormHelper(
         }
     }
 
-    private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>()
+    private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>(replay = 1)
+    private var paymentSelectionJob: Job? = null
 
     private val paymentSelection: Flow<PaymentSelection?> = combine(
         lastFormValues,
@@ -145,8 +147,12 @@ internal class DefaultFormHelper(
             savedStateHandle[PREVIOUSLY_COMPLETED_PAYMENT_FORM] = value
         }
 
-    init {
-        coroutineScope.launch {
+    private fun startPaymentSelectionCollection() {
+        if (paymentSelectionJob?.isActive == true) {
+            return
+        }
+
+        paymentSelectionJob = coroutineScope.launch {
             paymentSelection.collect { selection ->
                 selectionUpdater(selection)
                 reportFieldCompleted(selection?.paymentMethodType)
@@ -171,6 +177,8 @@ internal class DefaultFormHelper(
     }
 
     override fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String) {
+        startPaymentSelectionCollection()
+
         coroutineScope.launch {
             lastFormValues.emit(formValues to selectedPaymentMethodCode)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -485,7 +485,7 @@ internal sealed interface PaymentSheetScreen {
     class SavedPaymentMethodConfirm(
         private val interactor: SavedPaymentMethodConfirmInteractor,
         private val isLiveMode: Boolean,
-    ) : PaymentSheetScreen {
+    ) : PaymentSheetScreen, Closeable {
         override val buyButtonState = stateFlowOf(
             BuyButtonState(visible = true)
         )
@@ -518,6 +518,10 @@ internal sealed interface PaymentSheetScreen {
         @Composable
         override fun Content(modifier: Modifier) {
             SavedPaymentMethodConfirmUI(interactor)
+        }
+
+        override fun close() {
+            interactor.close()
         }
 
         companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
@@ -11,12 +12,12 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -92,9 +93,10 @@ internal class DefaultAddPaymentMethodInteractor(
             paymentMethodMetadata: PaymentMethodMetadata,
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
         ): AddPaymentMethodInteractor {
-            val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+            val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
             val formHelper = DefaultFormHelper.create(
                 viewModel = viewModel,
+                coroutineScope = coroutineScope,
                 paymentMethodMetadata = paymentMethodMetadata,
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/CoroutineScopeExtensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/CoroutineScopeExtensions.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.paymentsheet.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
+
+internal fun CoroutineScope.childScope(context: CoroutineContext): CoroutineScope {
+    return CoroutineScope(context + SupervisorJob(coroutineContext[Job]))
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate
@@ -27,6 +28,7 @@ import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotio
 import com.stripe.android.paymentsheet.repositories.PromotionSupportedPaymentMethods
 import com.stripe.android.paymentsheet.state.WalletLocation
 import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -34,7 +36,6 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -121,6 +122,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val updateMandateText: ((mandateText: ResolvableString?, showAbove: Boolean) -> Unit)?,
     private val linkAccount: StateFlow<LinkAccountUpdate.Value>,
     dispatcher: CoroutineContext = Dispatchers.Default,
+    private val coroutineScope: CoroutineScope,
     mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
 ) : PaymentMethodVerticalLayoutInteractor {
@@ -133,8 +135,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             bankFormInteractor: BankFormInteractor,
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
         ): PaymentMethodVerticalLayoutInteractor {
+            val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
+            val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
             val formHelper = DefaultFormHelper.create(
                 viewModel = viewModel,
+                coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )
@@ -206,13 +211,12 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                     )
                 },
                 updateMandateText = viewModel.mandateHandler::updateMandateText,
-                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 linkAccount = viewModel.linkAccountHolder.linkAccountInfo,
+                coroutineScope = coroutineScope,
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             )
         }
     }
-
-    private val coroutineScope = CoroutineScope(dispatcher + SupervisorJob())
 
     private val _verticalModeScreenSelection = MutableStateFlow(selection.value)
     private val verticalModeScreenSelection = _verticalModeScreenSelection

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
@@ -20,6 +20,7 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -27,6 +28,8 @@ import javax.inject.Inject
 
 internal interface SavedPaymentMethodConfirmInteractor {
     val state: StateFlow<State>
+
+    fun close()
 
     data class State(
         val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
@@ -55,7 +58,7 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
     val processing: StateFlow<Boolean>,
     val updateSelection: (PaymentSelection.Saved) -> Unit,
     val paymentMethodMetadata: PaymentMethodMetadata,
-    val coroutineScope: CoroutineScope,
+    coroutineScope: CoroutineScope,
 ) : SavedPaymentMethodConfirmInteractor {
     private val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
         displayName = displayName,
@@ -80,12 +83,14 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
         initialSelection.withLinkState(it)
     }
 
-    init {
-        coroutineScope.launch {
-            selection.collectLatest {
-                updateSelection(it)
-            }
+    private val updateSelectionJob: Job = coroutineScope.launch {
+        selection.collectLatest {
+            updateSelection(it)
         }
+    }
+
+    override fun close() {
+        updateSelectionJob.cancel()
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
@@ -10,12 +11,12 @@ import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -122,9 +123,11 @@ internal class DefaultVerticalModeFormInteractor(
             bankFormInteractor: BankFormInteractor,
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
         ): VerticalModeFormInteractor {
-            val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
+            val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
             val formHelper = DefaultFormHelper.create(
                 viewModel = viewModel,
+                coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultFormHelper
@@ -53,7 +54,11 @@ internal object VerticalModeInitialScreenFactory {
             (viewModel.selection.value as? PaymentSelection.New?)?.let { newPaymentSelection ->
                 val paymentMethodCode = newPaymentSelection.paymentMethodCreateParams.typeCode
 
-                val formHelper = DefaultFormHelper.create(viewModel, paymentMethodMetadata)
+                val formHelper = DefaultFormHelper.create(
+                    viewModel = viewModel,
+                    coroutineScope = viewModel.viewModelScope,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                )
 
                 if (formHelper.formTypeForCode(paymentMethodCode) == FormHelper.FormType.UserInteractionRequired) {
                     add(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormScreenContentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormScreenContentTest.kt
@@ -1,0 +1,197 @@
+package com.stripe.android.paymentelement.embedded.form
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
+import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
+import com.stripe.android.paymentsheet.verticalmode.FakeVerticalModeFormInteractor
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import com.stripe.android.testing.CleanupTestRule
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.uicore.utils.stateFlowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class FormScreenContentTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val closeInteractorRule = CleanupTestRule(SavedPaymentMethodConfirmInteractor::close)
+
+    @Test
+    fun `saved payment method confirm interactor is reused for same selection`() {
+        val factory = TrackingSavedPaymentMethodConfirmInteractorFactory(closeInteractorRule)
+        val selection = savedSelection("pm_1")
+        val state = mutableStateOf(defaultState(savedPaymentSelectionToConfirm = selection))
+
+        setContent(
+            stateProvider = { state.value },
+            savedPaymentMethodConfirmInteractorFactory = factory,
+        )
+
+        composeRule.waitForIdle()
+
+        assertThat(factory.interactors).hasSize(1)
+
+        composeRule.runOnIdle {
+            state.value = state.value.copy(isEnabled = !state.value.isEnabled)
+        }
+
+        composeRule.waitForIdle()
+
+        assertThat(factory.interactors).hasSize(1)
+        assertThat(factory.interactors.single().closeCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun `saved payment method confirm interactor is closed when confirmation leaves composition`() {
+        val factory = TrackingSavedPaymentMethodConfirmInteractorFactory(closeInteractorRule)
+        val selection = savedSelection("pm_1")
+        val state = mutableStateOf(defaultState(savedPaymentSelectionToConfirm = selection))
+
+        setContent(
+            stateProvider = { state.value },
+            savedPaymentMethodConfirmInteractorFactory = factory,
+        )
+
+        composeRule.waitForIdle()
+
+        val interactor = factory.interactors.single()
+
+        composeRule.runOnIdle {
+            state.value = state.value.copy(savedPaymentSelectionToConfirm = null)
+        }
+
+        composeRule.waitForIdle()
+
+        assertThat(interactor.closeCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `saved payment method confirm interactor is recreated when selection changes`() {
+        val factory = TrackingSavedPaymentMethodConfirmInteractorFactory(closeInteractorRule)
+        val state = mutableStateOf(defaultState(savedPaymentSelectionToConfirm = savedSelection("pm_1")))
+
+        setContent(
+            stateProvider = { state.value },
+            savedPaymentMethodConfirmInteractorFactory = factory,
+        )
+
+        composeRule.waitForIdle()
+
+        val firstInteractor = factory.interactors.single()
+
+        composeRule.runOnIdle {
+            state.value = state.value.copy(savedPaymentSelectionToConfirm = savedSelection("pm_2"))
+        }
+
+        composeRule.waitForIdle()
+
+        assertThat(factory.interactors).hasSize(2)
+        assertThat(firstInteractor.closeCalls).isEqualTo(1)
+        assertThat(factory.interactors.last().closeCalls).isEqualTo(0)
+    }
+
+    private fun setContent(
+        stateProvider: () -> SheetActivityStateHolder.State,
+        savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
+    ) {
+        val metadata = PaymentMethodMetadataFactory.create()
+        val interactor = FakeVerticalModeFormInteractor.create(
+            paymentMethodCode = "card",
+            metadata = metadata,
+        )
+
+        composeRule.setContent {
+            ViewModelStoreOwnerContext {
+                FormScreenContent(
+                    interactor = interactor,
+                    eventReporter = FakeEventReporter(),
+                    onClick = {},
+                    onProcessingCompleted = {},
+                    state = stateProvider(),
+                    updateSelection = {},
+                    savedPaymentMethodConfirmInteractorFactory = savedPaymentMethodConfirmInteractorFactory,
+                )
+            }
+        }
+    }
+
+    private fun defaultState(
+        savedPaymentSelectionToConfirm: PaymentSelection.Saved?,
+    ): SheetActivityStateHolder.State {
+        return SheetActivityStateHolder.State(
+            primaryButtonLabel = "Continue".resolvableString,
+            isEnabled = true,
+            processingState = PrimaryButtonProcessingState.Idle(null),
+            isProcessing = false,
+            shouldDisplayLockIcon = false,
+            savedPaymentSelectionToConfirm = savedPaymentSelectionToConfirm,
+        )
+    }
+
+    private fun savedSelection(id: String): PaymentSelection.Saved {
+        return PaymentSelection.Saved(PaymentMethodFactory.card(id = id))
+    }
+
+    private class TrackingSavedPaymentMethodConfirmInteractorFactory(
+        private val closeInteractorRule: CleanupTestRule<SavedPaymentMethodConfirmInteractor>,
+    ) : SavedPaymentMethodConfirmInteractor.Factory {
+        val interactors = mutableListOf<TrackingSavedPaymentMethodConfirmInteractor>()
+
+        override fun create(
+            initialSelection: PaymentSelection.Saved,
+            updateSelection: (PaymentSelection.Saved) -> Unit
+        ): SavedPaymentMethodConfirmInteractor {
+            return TrackingSavedPaymentMethodConfirmInteractor(initialSelection).also {
+                closeInteractorRule.track(it)
+                interactors.add(it)
+            }
+        }
+    }
+
+    private class TrackingSavedPaymentMethodConfirmInteractor(
+        initialSelection: PaymentSelection.Saved,
+    ) : SavedPaymentMethodConfirmInteractor {
+        var closeCalls = 0
+            private set
+
+        override val state = stateFlowOf(
+            SavedPaymentMethodConfirmInteractor.State(
+                displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
+                    displayName = "Card".resolvableString,
+                    paymentMethod = initialSelection.paymentMethod,
+                ),
+                linkBrand = LinkBrand.Link,
+                form = SavedPaymentMethodConfirmInteractor.State.Form(
+                    elements = emptyList(),
+                    enabled = true,
+                ),
+            )
+        )
+
+        override fun close() {
+            closeCalls += 1
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
@@ -153,6 +154,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
     ) {
         val defaultFormHelper = DefaultFormHelper.create(
             viewModel = viewModel,
+            coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = paymentMethodMetadata,
             shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1377,6 +1377,7 @@ internal class PaymentOptionsViewModelTest {
         val linkInlineHandler = LinkInlineHandler.create()
         val formHelper = DefaultFormHelper.create(
             viewModel = viewModel,
+            coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
             linkInlineHandler = linkInlineHandler,
             paymentMethodMessagePromotionsHelper = null

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -814,6 +814,7 @@ internal class PaymentSheetViewModelTest {
             val linkInlineHandler = LinkInlineHandler.create()
             val formHelper = DefaultFormHelper.create(
                 viewModel = viewModel,
+                coroutineScope = viewModel.viewModelScope,
                 paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                 linkInlineHandler = linkInlineHandler,
             )
@@ -1608,6 +1609,7 @@ internal class PaymentSheetViewModelTest {
 
         val observedArgs = DefaultFormHelper.create(
             viewModel = viewModel,
+            coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
         ).createFormArguments(
             paymentMethodCode = LpmRepositoryTestHelpers.card.code,
@@ -2781,6 +2783,7 @@ internal class PaymentSheetViewModelTest {
                 val linkInlineHandler = LinkInlineHandler.create()
                 val formHelper = DefaultFormHelper.create(
                     viewModel = viewModel,
+                    coroutineScope = viewModel.viewModelScope,
                     paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                     linkInlineHandler = linkInlineHandler,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -2025,6 +2025,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             },
             shouldUpdateVerticalModeSelection = shouldUpdateVerticalModeSelection,
             dispatcher = testDispatcher,
+            coroutineScope = TestScope(testDispatcher),
             mainDispatcher = testDispatcher,
             invokeRowSelectionCallback = invokeRowSelectionCallback,
             displaysMandatesInFormScreen = displaysMandatesInFormScreen,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
@@ -21,9 +22,17 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.rules.RuleChain
 import kotlin.test.Test
 
-class DefaultSavedPaymentMethodConfirmInteractorTest {
+internal class DefaultSavedPaymentMethodConfirmInteractorTest {
+    private val closeInteractorRule = CleanupTestRule(DefaultSavedPaymentMethodConfirmInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(closeInteractorRule)
+
     @Test
     fun `form updates enabled state based on processing state`() = runTest {
         val processing = MutableStateFlow(false)
@@ -95,6 +104,39 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
         updateSelectionCalls.ensureAllEventsConsumed()
     }
 
+    @Test
+    fun `when close is called, selection is no longer updated`() = runTest {
+        val linkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
+            initialState = SavedPaymentMethodLinkFormHelper.State.Unused
+        )
+        val updateSelectionCalls = Turbine<PaymentSelection.Saved>()
+        val interactor = getDefaultSavedPaymentMethodConfirmInteractor(
+            linkFormHelper = linkFormHelper,
+            processing = MutableStateFlow(false),
+            updateSelection = { updateSelectionCalls.add(it) },
+            coroutineScope = backgroundScope,
+        )
+
+        val userInput = UserInput.SignIn(email = "test@example.com")
+        linkFormHelper.updateState(
+            SavedPaymentMethodLinkFormHelper.State.Complete(
+                userInput = userInput
+            )
+        )
+
+        advanceUntilIdle()
+
+        assertThat(updateSelectionCalls.awaitItem().linkInput).isEqualTo(userInput)
+
+        interactor.close()
+        linkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Unused)
+
+        advanceUntilIdle()
+
+        updateSelectionCalls.expectNoEvents()
+        updateSelectionCalls.ensureAllEventsConsumed()
+    }
+
     private fun getDefaultSavedPaymentMethodConfirmInteractor(
         linkFormHelper: SavedPaymentMethodLinkFormHelper = FakeSavedPaymentMethodLinkFormHelper(),
         processing: StateFlow<Boolean> = MutableStateFlow(false),
@@ -104,15 +146,17 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
         coroutineScope: CoroutineScope,
     ): DefaultSavedPaymentMethodConfirmInteractor {
         val paymentMethod = PaymentMethodFactory.card()
-        return DefaultSavedPaymentMethodConfirmInteractor(
-            initialSelection = PaymentSelection.Saved(paymentMethod),
-            displayName = "Card".resolvableString,
-            linkAccount = linkAccount,
-            savedPaymentMethodLinkFormHelper = linkFormHelper,
-            processing = processing,
-            updateSelection = updateSelection,
-            paymentMethodMetadata = paymentMethodMetadata,
-            coroutineScope = coroutineScope,
+        return closeInteractorRule.track(
+            DefaultSavedPaymentMethodConfirmInteractor(
+                initialSelection = PaymentSelection.Saved(paymentMethod),
+                displayName = "Card".resolvableString,
+                linkAccount = linkAccount,
+                savedPaymentMethodLinkFormHelper = linkFormHelper,
+                processing = processing,
+                updateSelection = updateSelection,
+                paymentMethodMetadata = paymentMethodMetadata,
+                coroutineScope = coroutineScope,
+            )
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
@@ -57,6 +57,10 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
     )
     override val state: StateFlow<SavedPaymentMethodConfirmInteractor.State> = _state.asStateFlow()
 
+    override fun close() {
+        // No op.
+    }
+
     class Factory : SavedPaymentMethodConfirmInteractor.Factory {
         override fun create(
             initialSelection: PaymentSelection.Saved,


### PR DESCRIPTION
# Summary
This PR scopes the coroutines used in form and interactor classes, such as `SavedPaymentMethodConfirmInteractor`, to explicit lifecycles. It also adds a `close()` method to these interactors to allow for proper resource cleanup.

# Motivation
Unscoped or improperly scoped coroutines can outlive their intended lifecycle, causing memory leaks and unwanted updates after the relevant UI or business objects are destroyed. Adding an explicit `close()` method and using child coroutine scopes ensures that jobs are properly cancelled and memory is managed effectively.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
