### PR TITLE
Add analytics for Stripe-hosted address autocomplete

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -117,7 +117,7 @@ class AutocompleteScreenTest {
         override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
         override fun onAutocompleteFetchStarted() = Unit
         override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) = Unit
-        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) = Unit
+        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
         override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.DefaultStripeTheme
 import java.util.Locale
+import kotlin.time.Duration
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -113,8 +114,29 @@ class AutocompleteScreenTest {
         override fun onCompleted(
             country: String,
             autocompleteResultSelected: Boolean,
-            editDistance: Int?
+            editDistance: Int?,
+            timeToComplete: Duration?,
         ) {
+            // no-op
+        }
+
+        override fun onAutocompleteSessionStarted(sessionToken: String) {
+            // no-op
+        }
+
+        override fun onAutocompleteFetchStarted() {
+            // no-op
+        }
+
+        override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
+            // no-op
+        }
+
+        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
+            // no-op
+        }
+
+        override fun onAutocompleteError(sessionToken: String, error: Throwable) {
             // no-op
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -30,7 +30,7 @@ class AutocompleteScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val application = ApplicationProvider.getApplicationContext<Application>()
-    private val eventReporter = FakeEventReporter()
+    private val eventReporter = NoOpAddressLauncherEventReporter
 
     @Test
     fun ensure_elements_exist() {
@@ -106,38 +106,18 @@ class AutocompleteScreenTest {
         }
     }
 
-    private class FakeEventReporter : AddressLauncherEventReporter {
-        override fun onShow(country: String) {
-            // no-op
-        }
-
+    private object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter {
+        override fun onShow(country: String) = Unit
         override fun onCompleted(
             country: String,
             autocompleteResultSelected: Boolean,
             editDistance: Int?,
             timeToComplete: Duration?,
-        ) {
-            // no-op
-        }
-
-        override fun onAutocompleteSessionStarted(sessionToken: String) {
-            // no-op
-        }
-
-        override fun onAutocompleteFetchStarted() {
-            // no-op
-        }
-
-        override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
-            // no-op
-        }
-
-        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
-            // no-op
-        }
-
-        override fun onAutocompleteError(sessionToken: String, error: Throwable) {
-            // no-op
-        }
+        ) = Unit
+        override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
+        override fun onAutocompleteFetchStarted() = Unit
+        override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) = Unit
+        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) = Unit
+        override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -115,8 +115,11 @@ class AutocompleteScreenTest {
             timeToComplete: Duration?,
         ) = Unit
         override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
-        override fun onAutocompleteFetchStarted() = Unit
-        override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) = Unit
+        override fun onAutocompleteSuggestionsReturned(
+            sessionToken: String,
+            resultCount: Int,
+            fetchDuration: Duration?,
+        ) = Unit
         override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
         override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -12,13 +12,12 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.model.Address
-import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.analytics.NoOpAddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.DefaultStripeTheme
 import java.util.Locale
-import kotlin.time.Duration
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -106,21 +105,4 @@ class AutocompleteScreenTest {
         }
     }
 
-    private object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter {
-        override fun onShow(country: String) = Unit
-        override fun onCompleted(
-            country: String,
-            autocompleteResultSelected: Boolean,
-            editDistance: Int?,
-            timeToComplete: Duration?,
-        ) = Unit
-        override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
-        override fun onAutocompleteSuggestionsReturned(
-            sessionToken: String,
-            resultCount: Int,
-            fetchDuration: Duration?,
-        ) = Unit
-        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
-        override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
 import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.addresselement.analytics.NoOpAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -215,7 +216,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     stripeAutocompleteRepository = null,
                                     coroutineScope = null,
                                     shouldUseAutocompleteProxyEndpointsProvider = { false },
-                                    eventReporter = null,
+                                    eventReporter = NoOpAddressLauncherEventReporter,
                                 ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -215,6 +215,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     stripeAutocompleteRepository = null,
                                     coroutineScope = null,
                                     shouldUseAutocompleteProxyEndpointsProvider = { false },
+                                    eventReporter = null,
                                 ),
                             isLinkUI = true,
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -36,6 +36,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -88,6 +89,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
     placesClient: PlacesClientProxy?,
     stripeAutocompleteRepository: StripeAutocompleteRepository,
+    addressLauncherEventReporter: AddressLauncherEventReporter,
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,
@@ -103,6 +105,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     placesClient = placesClient,
     linkAccountHolder = linkAccountHolder,
     stripeAutocompleteRepository = stripeAutocompleteRepository,
+    addressLauncherEventReporter = addressLauncherEventReporter,
 ) {
 
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -45,6 +45,7 @@ import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOptio
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
@@ -112,6 +113,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     placesClient: PlacesClientProxy?,
     linkAccountHolder: LinkAccountHolder,
     stripeAutocompleteRepository: StripeAutocompleteRepository,
+    addressLauncherEventReporter: AddressLauncherEventReporter,
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,
@@ -127,6 +129,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     placesClient = placesClient,
     linkAccountHolder = linkAccountHolder,
     stripeAutocompleteRepository = stripeAutocompleteRepository,
+    addressLauncherEventReporter = addressLauncherEventReporter,
 ) {
     private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
         config = config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -29,6 +30,7 @@ internal class InputAddressViewModel @Inject constructor(
     private val eventReporter: AddressLauncherEventReporter,
     @Named(AddressElementViewModelModule.INLINE_PLACES_CLIENT)
     private val placesClient: PlacesClientProxy?,
+    private val durationProvider: DurationProvider,
 ) : ViewModel(), AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
 
@@ -108,6 +110,8 @@ internal class InputAddressViewModel @Inject constructor(
     val checkboxChecked: StateFlow<Boolean> = _checkboxChecked
 
     init {
+        durationProvider.start(DurationProvider.Key.AddressElementCompletion, reset = true)
+
         viewModelScope.launch {
             navigator.getResultFlow<AddressElementNavigator.AutocompleteEvent?>(
                 AddressElementNavigator.AutocompleteEvent.KEY
@@ -210,11 +214,13 @@ internal class InputAddressViewModel @Inject constructor(
 
     @VisibleForTesting
     fun dismissWithAddress(addressDetails: AddressDetails) {
+        val timeToComplete = durationProvider.end(DurationProvider.Key.AddressElementCompletion)
         addressDetails.address?.country?.let { country ->
             eventReporter.onCompleted(
                 country = country,
                 autocompleteResultSelected = collectedAddress.value?.address?.line1 != null,
-                editDistance = addressDetails.editDistance(collectedAddress.value)
+                editDistance = addressDetails.editDistance(collectedAddress.value),
+                timeToComplete = timeToComplete,
             )
         }
         navigator.dismiss(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.model.CountryUtils
-import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -30,7 +29,6 @@ internal class InputAddressViewModel @Inject constructor(
     private val eventReporter: AddressLauncherEventReporter,
     @Named(AddressElementViewModelModule.INLINE_PLACES_CLIENT)
     private val placesClient: PlacesClientProxy?,
-    private val durationProvider: DurationProvider,
 ) : ViewModel(), AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
 
@@ -110,8 +108,6 @@ internal class InputAddressViewModel @Inject constructor(
     val checkboxChecked: StateFlow<Boolean> = _checkboxChecked
 
     init {
-        durationProvider.start(DurationProvider.Key.AddressElementCompletion, reset = true)
-
         viewModelScope.launch {
             navigator.getResultFlow<AddressElementNavigator.AutocompleteEvent?>(
                 AddressElementNavigator.AutocompleteEvent.KEY
@@ -214,13 +210,11 @@ internal class InputAddressViewModel @Inject constructor(
 
     @VisibleForTesting
     fun dismissWithAddress(addressDetails: AddressDetails) {
-        val timeToComplete = durationProvider.end(DurationProvider.Key.AddressElementCompletion)
         addressDetails.address?.country?.let { country ->
             eventReporter.onCompleted(
                 country = country,
                 autocompleteResultSelected = collectedAddress.value?.address?.line1 != null,
                 editDistance = addressDetails.editDistance(collectedAddress.value),
-                timeToComplete = timeToComplete,
             )
         }
         navigator.dismiss(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -56,17 +56,14 @@ internal class PaymentElementAutocompleteAddressInteractor(
         override fun create(): AutocompleteAddressInteractor {
             if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
-                val resolvedClient = if (useStripeHosted) {
-                    if (stripeAutocompleteRepository != null && eventReporter != null) {
+                val resolvedClient = when {
+                    useStripeHosted && stripeAutocompleteRepository != null && eventReporter != null ->
                         StripeHostedPlacesClientProxy(
                             repository = stripeAutocompleteRepository,
                             eventReporter = eventReporter,
                         )
-                    } else {
-                        null
-                    }
-                } else {
-                    placesClient
+                    useStripeHosted -> null
+                    else -> placesClient
                 }
                 if (resolvedClient != null) {
                     activeInlineInteractor?.dispose()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -57,10 +57,13 @@ internal class PaymentElementAutocompleteAddressInteractor(
             if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
                 val resolvedClient = if (useStripeHosted) {
-                    stripeAutocompleteRepository?.let { repo ->
-                        eventReporter?.let { er ->
-                            StripeHostedPlacesClientProxy(repository = repo, eventReporter = er)
-                        }
+                    if (stripeAutocompleteRepository != null && eventReporter != null) {
+                        StripeHostedPlacesClientProxy(
+                            repository = stripeAutocompleteRepository,
+                            eventReporter = eventReporter,
+                        )
+                    } else {
+                        null
                     }
                 } else {
                     placesClient

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.CoroutineScope
@@ -48,6 +49,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private val stripeAutocompleteRepository: StripeAutocompleteRepository?,
         private val coroutineScope: CoroutineScope?,
         private val shouldUseAutocompleteProxyEndpointsProvider: () -> Boolean,
+        private val eventReporter: AddressLauncherEventReporter?,
     ) : AutocompleteAddressInteractor.Factory {
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
@@ -55,7 +57,11 @@ internal class PaymentElementAutocompleteAddressInteractor(
             if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
                 val resolvedClient = if (useStripeHosted) {
-                    stripeAutocompleteRepository?.let { StripeHostedPlacesClientProxy(repository = it) }
+                    stripeAutocompleteRepository?.let { repo ->
+                        eventReporter?.let { er ->
+                            StripeHostedPlacesClientProxy(repository = repo, eventReporter = er)
+                        }
+                    }
                 } else {
                     placesClient
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -49,7 +49,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
         private val stripeAutocompleteRepository: StripeAutocompleteRepository?,
         private val coroutineScope: CoroutineScope?,
         private val shouldUseAutocompleteProxyEndpointsProvider: () -> Boolean,
-        private val eventReporter: AddressLauncherEventReporter?,
+        private val eventReporter: AddressLauncherEventReporter,
     ) : AutocompleteAddressInteractor.Factory {
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
@@ -57,7 +57,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
             if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()
                 val resolvedClient = when {
-                    useStripeHosted && stripeAutocompleteRepository != null && eventReporter != null ->
+                    useStripeHosted && stripeAutocompleteRepository != null ->
                         StripeHostedPlacesClientProxy(
                             repository = stripeAutocompleteRepository,
                             eventReporter = eventReporter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.addresselement
 import android.text.SpannableString
 import androidx.appcompat.app.AppCompatDelegate
 import com.stripe.android.model.Address
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
@@ -11,16 +12,26 @@ import java.util.UUID
 
 internal class StripeHostedPlacesClientProxy(
     private val repository: StripeAutocompleteRepository,
+    private val eventReporter: AddressLauncherEventReporter,
 ) : PlacesClientProxy {
     private val lock = Any()
     private var sessionToken: String = newSessionToken()
+    private var lastQueryLength: Int = 0
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
 
+    init {
+        eventReporter.onAutocompleteSessionStarted(sessionToken)
+    }
+
     override fun resetSession() {
-        synchronized(lock) {
-            sessionToken = newSessionToken()
-            predictionCache.clear()
+        val newToken = synchronized(lock) {
+            newSessionToken().also {
+                sessionToken = it
+                lastQueryLength = 0
+                predictionCache.clear()
+            }
         }
+        eventReporter.onAutocompleteSessionStarted(newToken)
     }
 
     override suspend fun findAutocompletePredictions(
@@ -30,7 +41,11 @@ internal class StripeHostedPlacesClientProxy(
     ): Result<FindAutocompletePredictionsResponse> {
         val q = query ?: return Result.success(FindAutocompletePredictionsResponse(emptyList()))
         val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
-        val token = synchronized(lock) { sessionToken }
+        val token = synchronized(lock) {
+            lastQueryLength = q.length
+            sessionToken
+        }
+        eventReporter.onAutocompleteFetchStarted()
         return repository.findAutocompletePredictions(
             query = q,
             country = country,
@@ -50,14 +65,22 @@ internal class StripeHostedPlacesClientProxy(
                     )
                 }
             )
+        }.onSuccess { response ->
+            eventReporter.onAutocompleteSuggestionsReturned(
+                sessionToken = token,
+                resultCount = response.autocompletePredictions.size,
+            )
+        }.onFailure { error ->
+            eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }
     }
 
     override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
-        val (cached, token) = synchronized(lock) {
-            predictionCache[placeId] to sessionToken
+        val (cached, token, queryLength) = synchronized(lock) {
+            Triple(predictionCache[placeId], sessionToken, lastQueryLength)
         }
         if (cached?.address != null) {
+            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
             return Result.success(
                 Address(
                     line1 = cached.address.line1,
@@ -90,6 +113,10 @@ internal class StripeHostedPlacesClientProxy(
                 postalCode = result.address?.postalCode,
                 country = result.address?.country,
             )
+        }.onSuccess {
+            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
+        }.onFailure { error ->
+            eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -9,6 +9,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import java.util.Locale
 import java.util.UUID
+import kotlin.time.TimeSource
 
 internal class StripeHostedPlacesClientProxy(
     private val repository: StripeAutocompleteRepository,
@@ -45,7 +46,7 @@ internal class StripeHostedPlacesClientProxy(
             lastQueryLength = q.length
             sessionToken
         }
-        eventReporter.onAutocompleteFetchStarted()
+        val fetchStart = TimeSource.Monotonic.markNow()
         return repository.findAutocompletePredictions(
             query = q,
             country = country,
@@ -69,6 +70,7 @@ internal class StripeHostedPlacesClientProxy(
             eventReporter.onAutocompleteSuggestionsReturned(
                 sessionToken = token,
                 resultCount = response.autocompletePredictions.size,
+                fetchDuration = fetchStart.elapsedNow(),
             )
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -24,14 +24,12 @@ internal class StripeHostedPlacesClientProxy(
     }
 
     override fun resetSession() {
-        val newToken = synchronized(lock) {
-            newSessionToken().also {
-                sessionToken = it
-                lastQueryLength = 0
-                predictionCache.clear()
-            }
+        synchronized(lock) {
+            sessionToken = newSessionToken()
+            lastQueryLength = 0
+            predictionCache.clear()
         }
-        eventReporter.onAutocompleteSessionStarted(newToken)
+        eventReporter.onAutocompleteSessionStarted(sessionToken)
     }
 
     override suspend fun findAutocompletePredictions(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -76,11 +76,16 @@ internal class StripeHostedPlacesClientProxy(
     }
 
     override suspend fun fetchPlace(placeId: String, locale: Locale): Result<Address> {
-        val (cached, token, queryLength) = synchronized(lock) {
-            Triple(predictionCache[placeId], sessionToken, lastQueryLength)
+        val cached: AutocompleteSuggestion?
+        val token: String
+        val queryLength: Int
+        synchronized(lock) {
+            cached = predictionCache[placeId]
+            token = sessionToken
+            queryLength = lastQueryLength
         }
+        eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
         if (cached?.address != null) {
-            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
             return Result.success(
                 Address(
                     line1 = cached.address.line1,
@@ -113,8 +118,6 @@ internal class StripeHostedPlacesClientProxy(
                 postalCode = result.address?.postalCode,
                 country = result.address?.country,
             )
-        }.onSuccess {
-            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -9,7 +9,6 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import java.util.Locale
 import java.util.UUID
-import kotlin.time.TimeSource
 
 internal class StripeHostedPlacesClientProxy(
     private val repository: StripeAutocompleteRepository,
@@ -46,7 +45,7 @@ internal class StripeHostedPlacesClientProxy(
             lastQueryLength = q.length
             sessionToken
         }
-        val fetchStart = TimeSource.Monotonic.markNow()
+        eventReporter.onAutocompleteFetchStarted(token)
         return repository.findAutocompletePredictions(
             query = q,
             country = country,
@@ -70,7 +69,6 @@ internal class StripeHostedPlacesClientProxy(
             eventReporter.onAutocompleteSuggestionsReturned(
                 sessionToken = token,
                 resultCount = response.autocompletePredictions.size,
-                fetchDuration = fetchStart.elapsedNow(),
             )
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentsheet.addresselement.analytics
 
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 internal sealed class AddressLauncherEvent : AnalyticsEvent {
     abstract val additionalParams: Map<String, Any>
@@ -22,7 +25,8 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
     class Completed(
         val country: String,
         private val autocompleteResultSelected: Boolean,
-        private val editDistance: Int?
+        private val editDistance: Int?,
+        private val timeToComplete: Duration?,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_completed"
         override val additionalParams: Map<String, Any>
@@ -34,9 +38,86 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                 editDistance?.let {
                     data[FIELD_EDIT_DISTANCE] = it
                 }
+                timeToComplete?.let {
+                    data[FIELD_TIME_TO_COMPLETE] = it.toDouble(DurationUnit.SECONDS).toString()
+                }
                 return mapOf(
                     FIELD_ADDRESS_DATA_BLOB to data
                 )
+            }
+    }
+
+    /**
+     * Emitted when a new autocomplete session token is created by `StripeHostedPlacesClientProxy`
+     * (on construction, and again every time the session is reset after a selection).
+     */
+    class AutocompleteStarted(
+        private val autocompleteSessionToken: String,
+    ) : AddressLauncherEvent() {
+        override val eventName: String = "mc_address_autocomplete_start"
+        override val additionalParams: Map<String, Any>
+            get() = mapOf(
+                FIELD_ADDRESS_DATA_BLOB to mapOf(
+                    FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
+                    FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
+                    FIELD_ADDRESS_INPUT_MODE to ADDRESS_INPUT_MODE_AUTOCOMPLETE,
+                )
+            )
+    }
+
+    /** Emitted after a `StripeHostedPlacesClientProxy` prediction request returns. */
+    class AutocompleteSuggestions(
+        private val autocompleteSessionToken: String,
+        private val timeToFetch: Duration?,
+        private val resultCount: Int,
+        private val sessionElapsed: Duration?,
+    ) : AddressLauncherEvent() {
+        override val eventName: String = "mc_address_autocomplete_suggestions"
+        override val additionalParams: Map<String, Any>
+            get() {
+                val data = mutableMapOf<String, Any>(
+                    FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
+                    FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
+                    FIELD_RESULT_COUNT to resultCount,
+                )
+                timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS).toString() }
+                sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS).toString() }
+                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
+            }
+    }
+
+    /** Emitted when a `StripeHostedPlacesClientProxy` suggestion selection populates the fields. */
+    class AutocompleteSelected(
+        private val autocompleteSessionToken: String,
+        private val queryLength: Int,
+        private val placeId: String?,
+    ) : AddressLauncherEvent() {
+        override val eventName: String = "mc_address_autocomplete_selected"
+        override val additionalParams: Map<String, Any>
+            get() {
+                val data = mutableMapOf<String, Any>(
+                    FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
+                    FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
+                    FIELD_QUERY_LENGTH to queryLength,
+                )
+                placeId?.let { data[FIELD_PLACE_ID] = it }
+                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
+            }
+    }
+
+    /** Emitted when a `StripeHostedPlacesClientProxy` prediction or place-details request fails. */
+    class AutocompleteError(
+        private val autocompleteSessionToken: String,
+        private val error: Throwable,
+    ) : AddressLauncherEvent() {
+        override val eventName: String = "mc_address_autocomplete_error"
+        override val additionalParams: Map<String, Any>
+            get() {
+                val data = buildMap<String, Any> {
+                    put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
+                    putAll(ErrorReporter.getAdditionalParamsFromError(error))
+                }
+                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
             }
     }
 
@@ -45,5 +126,17 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         const val FIELD_ADDRESS_COUNTRY_CODE = "address_country_code"
         const val FIELD_AUTO_COMPLETE_RESULT_SELECTED = "auto_complete_result_selected"
         const val FIELD_EDIT_DISTANCE = "edit_distance"
+        const val FIELD_TIME_TO_COMPLETE = "time_to_complete"
+        const val FIELD_AUTOCOMPLETE_SESSION_TOKEN = "autocomplete_session_token"
+        const val FIELD_SOURCE = "source"
+        const val FIELD_ADDRESS_INPUT_MODE = "address_input_mode"
+        const val FIELD_TIME_TO_FETCH = "time_to_fetch"
+        const val FIELD_RESULT_COUNT = "result_count"
+        const val FIELD_SESSION_ELAPSED = "session_elapsed"
+        const val FIELD_QUERY_LENGTH = "query_length"
+        const val FIELD_PLACE_ID = "place_id"
+
+        private const val SOURCE_STRIPE_HOSTED = "stripe_hosted"
+        private const val ADDRESS_INPUT_MODE_AUTOCOMPLETE = "autocomplete"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -55,7 +55,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             get() = mapOf(
                 FIELD_ADDRESS_DATA_BLOB to mapOf(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
-                    FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
                     FIELD_ADDRESS_INPUT_MODE to ADDRESS_INPUT_MODE_AUTOCOMPLETE,
                 )
             )
@@ -72,7 +71,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             get() {
                 val data = mutableMapOf<String, Any>(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
-                    FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
                     FIELD_RESULT_COUNT to resultCount,
                 )
                 timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
@@ -91,7 +89,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             get() = mapOf(
                 FIELD_ADDRESS_DATA_BLOB to mapOf(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
-                    FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
                     FIELD_QUERY_LENGTH to queryLength,
                     FIELD_PLACE_ID to placeId,
                 )
@@ -120,7 +117,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         const val FIELD_EDIT_DISTANCE = "edit_distance"
         const val FIELD_TIME_TO_COMPLETE = "time_to_complete"
         const val FIELD_AUTOCOMPLETE_SESSION_TOKEN = "autocomplete_session_token"
-        const val FIELD_SOURCE = "source"
         const val FIELD_ADDRESS_INPUT_MODE = "address_input_mode"
         const val FIELD_TIME_TO_FETCH = "time_to_fetch"
         const val FIELD_RESULT_COUNT = "result_count"
@@ -128,7 +124,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         const val FIELD_QUERY_LENGTH = "query_length"
         const val FIELD_PLACE_ID = "place_id"
 
-        private const val SOURCE_STRIPE_HOSTED = "stripe_hosted"
         private const val ADDRESS_INPUT_MODE_AUTOCOMPLETE = "autocomplete"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -47,10 +47,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             }
     }
 
-    /**
-     * Emitted when a new autocomplete session token is created by `StripeHostedPlacesClientProxy`
-     * (on construction, and again every time the session is reset after a selection).
-     */
     class AutocompleteStarted(
         private val autocompleteSessionToken: String,
     ) : AddressLauncherEvent() {
@@ -65,7 +61,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             )
     }
 
-    /** Emitted after a `StripeHostedPlacesClientProxy` prediction request returns. */
     class AutocompleteSuggestions(
         private val autocompleteSessionToken: String,
         private val timeToFetch: Duration?,
@@ -86,7 +81,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             }
     }
 
-    /** Emitted when a `StripeHostedPlacesClientProxy` suggestion selection populates the fields. */
     class AutocompleteSelected(
         private val autocompleteSessionToken: String,
         private val queryLength: Int,
@@ -105,7 +99,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             }
     }
 
-    /** Emitted when a `StripeHostedPlacesClientProxy` prediction or place-details request fails. */
     class AutocompleteError(
         private val autocompleteSessionToken: String,
         private val error: Throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -39,7 +39,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                     data[FIELD_EDIT_DISTANCE] = it
                 }
                 timeToComplete?.let {
-                    data[FIELD_TIME_TO_COMPLETE] = it.toDouble(DurationUnit.SECONDS).toString()
+                    data[FIELD_TIME_TO_COMPLETE] = it.toDouble(DurationUnit.SECONDS)
                 }
                 return mapOf(
                     FIELD_ADDRESS_DATA_BLOB to data
@@ -75,8 +75,8 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                     FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
                     FIELD_RESULT_COUNT to resultCount,
                 )
-                timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS).toString() }
-                sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS).toString() }
+                timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
+                sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
                 return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
             }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -84,19 +84,18 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
     class AutocompleteSelected(
         private val autocompleteSessionToken: String,
         private val queryLength: Int,
-        private val placeId: String?,
+        private val placeId: String,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_selected"
         override val additionalParams: Map<String, Any>
-            get() {
-                val data = mutableMapOf<String, Any>(
+            get() = mapOf(
+                FIELD_ADDRESS_DATA_BLOB to mapOf(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
                     FIELD_SOURCE to SOURCE_STRIPE_HOSTED,
                     FIELD_QUERY_LENGTH to queryLength,
+                    FIELD_PLACE_ID to placeId,
                 )
-                placeId?.let { data[FIELD_PLACE_ID] = it }
-                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
-            }
+            )
     }
 
     class AutocompleteError(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -12,18 +12,13 @@ internal interface AddressLauncherEventReporter {
         timeToComplete: Duration?,
     )
 
-    /** Call when `StripeHostedPlacesClientProxy` creates a new autocomplete session token. */
     fun onAutocompleteSessionStarted(sessionToken: String)
 
-    /** Call immediately before `StripeHostedPlacesClientProxy` issues a prediction request. */
     fun onAutocompleteFetchStarted()
 
-    /** Call after a `StripeHostedPlacesClientProxy` prediction request succeeds. */
     fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int)
 
-    /** Call after a `StripeHostedPlacesClientProxy` suggestion selection populates the fields. */
     fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?)
 
-    /** Call after a `StripeHostedPlacesClientProxy` prediction or place-details request fails. */
     fun onAutocompleteError(sessionToken: String, error: Throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentsheet.addresselement.analytics
 
-import kotlin.time.Duration
-
 internal interface AddressLauncherEventReporter {
     fun onShow(country: String)
 
@@ -9,15 +7,15 @@ internal interface AddressLauncherEventReporter {
         country: String,
         autocompleteResultSelected: Boolean,
         editDistance: Int?,
-        timeToComplete: Duration?,
     )
 
     fun onAutocompleteSessionStarted(sessionToken: String)
 
+    fun onAutocompleteFetchStarted(sessionToken: String)
+
     fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
         resultCount: Int,
-        fetchDuration: Duration?,
     )
 
     fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -14,9 +14,11 @@ internal interface AddressLauncherEventReporter {
 
     fun onAutocompleteSessionStarted(sessionToken: String)
 
-    fun onAutocompleteFetchStarted()
-
-    fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int)
+    fun onAutocompleteSuggestionsReturned(
+        sessionToken: String,
+        resultCount: Int,
+        fetchDuration: Duration?,
+    )
 
     fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -18,7 +18,7 @@ internal interface AddressLauncherEventReporter {
 
     fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int)
 
-    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?)
+    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String)
 
     fun onAutocompleteError(sessionToken: String, error: Throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -1,11 +1,29 @@
 package com.stripe.android.paymentsheet.addresselement.analytics
 
+import kotlin.time.Duration
+
 internal interface AddressLauncherEventReporter {
     fun onShow(country: String)
 
     fun onCompleted(
         country: String,
         autocompleteResultSelected: Boolean,
-        editDistance: Int?
+        editDistance: Int?,
+        timeToComplete: Duration?,
     )
+
+    /** Call when `StripeHostedPlacesClientProxy` creates a new autocomplete session token. */
+    fun onAutocompleteSessionStarted(sessionToken: String)
+
+    /** Call immediately before `StripeHostedPlacesClientProxy` issues a prediction request. */
+    fun onAutocompleteFetchStarted()
+
+    /** Call after a `StripeHostedPlacesClientProxy` prediction request succeeds. */
+    fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int)
+
+    /** Call after a `StripeHostedPlacesClientProxy` suggestion selection populates the fields. */
+    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?)
+
+    /** Call after a `StripeHostedPlacesClientProxy` prediction or place-details request fails. */
+    fun onAutocompleteError(sessionToken: String, error: Throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration
 
 @Singleton
 internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
@@ -20,6 +19,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
 ) : AddressLauncherEventReporter {
 
     override fun onShow(country: String) {
+        durationProvider.start(DurationProvider.Key.AddressElementCompletion, reset = true)
         fireEvent(
             AddressLauncherEvent.Show(
                 country = country
@@ -31,8 +31,8 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         country: String,
         autocompleteResultSelected: Boolean,
         editDistance: Int?,
-        timeToComplete: Duration?,
     ) {
+        val timeToComplete = durationProvider.end(DurationProvider.Key.AddressElementCompletion)
         fireEvent(
             AddressLauncherEvent.Completed(
                 country = country,
@@ -52,11 +52,15 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onAutocompleteFetchStarted(sessionToken: String) {
+        durationProvider.start(DurationProvider.Key.AddressAutocompleteFetch, reset = true)
+    }
+
     override fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
         resultCount: Int,
-        fetchDuration: Duration?,
     ) {
+        val fetchDuration = durationProvider.end(DurationProvider.Key.AddressAutocompleteFetch)
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteSuggestions(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -52,17 +52,16 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteFetchStarted() {
-        durationProvider.start(DurationProvider.Key.AddressAutocompleteFetch, reset = true)
-    }
-
-    override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
-        val timeToFetch = durationProvider.end(DurationProvider.Key.AddressAutocompleteFetch)
+    override fun onAutocompleteSuggestionsReturned(
+        sessionToken: String,
+        resultCount: Int,
+        fetchDuration: Duration?,
+    ) {
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteSuggestions(
                 autocompleteSessionToken = sessionToken,
-                timeToFetch = timeToFetch,
+                timeToFetch = fetchDuration,
                 resultCount = resultCount,
                 sessionElapsed = sessionElapsed,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -69,7 +69,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
         fireEvent(
             AddressLauncherEvent.AutocompleteSelected(
                 autocompleteSessionToken = sessionToken,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -3,16 +3,19 @@ package com.stripe.android.paymentsheet.addresselement.analytics
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.DurationProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
 
 @Singleton
 internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
+    private val durationProvider: DurationProvider,
     @IOContext private val workContext: CoroutineContext
 ) : AddressLauncherEventReporter {
 
@@ -27,13 +30,60 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
     override fun onCompleted(
         country: String,
         autocompleteResultSelected: Boolean,
-        editDistance: Int?
+        editDistance: Int?,
+        timeToComplete: Duration?,
     ) {
         fireEvent(
             AddressLauncherEvent.Completed(
                 country = country,
                 autocompleteResultSelected = autocompleteResultSelected,
-                editDistance = editDistance
+                editDistance = editDistance,
+                timeToComplete = timeToComplete,
+            )
+        )
+    }
+
+    override fun onAutocompleteSessionStarted(sessionToken: String) {
+        durationProvider.start(DurationProvider.Key.AddressAutocompleteSession, reset = true)
+        fireEvent(
+            AddressLauncherEvent.AutocompleteStarted(
+                autocompleteSessionToken = sessionToken
+            )
+        )
+    }
+
+    override fun onAutocompleteFetchStarted() {
+        durationProvider.start(DurationProvider.Key.AddressAutocompleteFetch, reset = true)
+    }
+
+    override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
+        val timeToFetch = durationProvider.end(DurationProvider.Key.AddressAutocompleteFetch)
+        val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
+        fireEvent(
+            AddressLauncherEvent.AutocompleteSuggestions(
+                autocompleteSessionToken = sessionToken,
+                timeToFetch = timeToFetch,
+                resultCount = resultCount,
+                sessionElapsed = sessionElapsed,
+            )
+        )
+    }
+
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
+        fireEvent(
+            AddressLauncherEvent.AutocompleteSelected(
+                autocompleteSessionToken = sessionToken,
+                queryLength = queryLength,
+                placeId = placeId,
+            )
+        )
+    }
+
+    override fun onAutocompleteError(sessionToken: String, error: Throwable) {
+        fireEvent(
+            AddressLauncherEvent.AutocompleteError(
+                autocompleteSessionToken = sessionToken,
+                error = error,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentsheet.addresselement.analytics
+
+internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter {
+    override fun onShow(country: String) = Unit
+    override fun onCompleted(
+        country: String,
+        autocompleteResultSelected: Boolean,
+        editDistance: Int?,
+    ) = Unit
+    override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
+    override fun onAutocompleteFetchStarted(sessionToken: String) = Unit
+    override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) = Unit
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
+    override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -139,7 +139,10 @@ internal class DefaultEventReporter @Inject internal constructor(
                     DurationProvider.Key.Attest,
                     DurationProvider.Key.IntentConfirmationChallenge,
                     DurationProvider.Key.IntentConfirmationChallengeWebViewLoaded,
-                    DurationProvider.Key.PaymentMethodMessaging -> null
+                    DurationProvider.Key.PaymentMethodMessaging,
+                    DurationProvider.Key.AddressAutocompleteSession,
+                    DurationProvider.Key.AddressAutocompleteFetch,
+                    DurationProvider.Key.AddressElementCompletion -> null
                 }
                 )
         }.mapNotNull { (key, name) ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -141,7 +141,6 @@ internal class DefaultEventReporter @Inject internal constructor(
                     DurationProvider.Key.IntentConfirmationChallengeWebViewLoaded,
                     DurationProvider.Key.PaymentMethodMessaging,
                     DurationProvider.Key.AddressAutocompleteSession,
-                    DurationProvider.Key.AddressAutocompleteFetch,
                     DurationProvider.Key.AddressElementCompletion -> null
                 }
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -141,6 +141,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                     DurationProvider.Key.IntentConfirmationChallengeWebViewLoaded,
                     DurationProvider.Key.PaymentMethodMessaging,
                     DurationProvider.Key.AddressAutocompleteSession,
+                    DurationProvider.Key.AddressAutocompleteFetch,
                     DurationProvider.Key.AddressElementCompletion -> null
                 }
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -13,7 +13,6 @@ import com.stripe.android.paymentsheet.addresselement.NavHostAddressElementNavig
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.addresselement.StripeHostedPlacesClientProxy
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
-import com.stripe.android.paymentsheet.addresselement.analytics.DefaultAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import dagger.Binds
@@ -69,10 +68,14 @@ internal class AddressElementViewModelModule {
         args: AddressElementActivityContract.Args,
         stripeAutocompleteRepository: StripeAutocompleteRepository,
         googlePlacesClient: PlacesClientProxy?,
+        addressLauncherEventReporter: AddressLauncherEventReporter,
     ): PlacesClientProxy? {
         val config = args.config ?: return null
         return if (config.useStripeHostedAutocomplete) {
-            StripeHostedPlacesClientProxy(repository = stripeAutocompleteRepository)
+            StripeHostedPlacesClientProxy(
+                repository = stripeAutocompleteRepository,
+                eventReporter = addressLauncherEventReporter,
+            )
         } else {
             googlePlacesClient
         }
@@ -93,12 +96,6 @@ internal class AddressElementViewModelModule {
             )
         }
     }
-
-    @Provides
-    @Singleton
-    fun provideEventReporter(
-        defaultAddressLauncherEventReporter: DefaultAddressLauncherEventReporter
-    ): AddressLauncherEventReporter = defaultAddressLauncherEventReporter
 
     @Module
     interface Bindings {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import com.stripe.android.BuildConfig
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.DefaultDurationProvider
+import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -68,5 +70,11 @@ internal interface AutocompleteViewModelModule {
         fun provideEventReporter(
             defaultAddressLauncherEventReporter: DefaultAddressLauncherEventReporter
         ): AddressLauncherEventReporter = defaultAddressLauncherEventReporter
+
+        @Provides
+        @Singleton
+        fun provideDurationProvider(): DurationProvider {
+            return DefaultDurationProvider.instance
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -41,6 +41,8 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.analytics.DefaultAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
@@ -185,6 +187,11 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsTapToAddHelperFactory(factory: DefaultTapToAddHelper.Factory): TapToAddHelper.Factory
+
+    @Binds
+    abstract fun bindsAddressLauncherEventReporter(
+        impl: DefaultAddressLauncherEventReporter
+    ): AddressLauncherEventReporter
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.addresselement.AutocompleteAppearanceCont
 import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
 import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -72,6 +73,7 @@ internal abstract class BaseSheetViewModel(
     val placesClient: PlacesClientProxy?,
     val linkAccountHolder: LinkAccountHolder,
     stripeAutocompleteRepository: StripeAutocompleteRepository,
+    addressLauncherEventReporter: AddressLauncherEventReporter,
 ) : ViewModel() {
     private val autocompleteLauncher = DefaultAutocompleteLauncher(
         AutocompleteAppearanceContext.PaymentElement(config.appearance)
@@ -101,6 +103,7 @@ internal abstract class BaseSheetViewModel(
             shouldUseAutocompleteProxyEndpointsProvider = {
                 _paymentMethodMetadata.value?.shouldUseAutocompleteProxyEndpoints ?: false
             },
+            eventReporter = addressLauncherEventReporter,
         )
 
     internal val validationRequested = MutableSharedFlow<Unit>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.FakeCvcRecollectionHandler
@@ -190,6 +191,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 placesClient = null,
                 stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+                addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
             )
         }
         return viewModelStoreRule.track(viewModel)
@@ -247,6 +249,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 placesClient = null,
                 linkAccountHolder = LinkAccountHolder(thisSavedStateHandle),
                 stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+                addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
             )
         }
         return viewModelStoreRule.track(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -40,6 +40,7 @@ import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_OPTIONS_CONTRACT_ARGS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.StripeAndroidPrimaryButtonBinding
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -538,6 +539,7 @@ internal class PaymentOptionsActivityTest {
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 placesClient = null,
                 stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+                addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
             )
         }.also { viewModelStoreRule.track(it) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -50,6 +50,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -1481,6 +1482,7 @@ internal class PaymentOptionsViewModelTest {
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             placesClient = null,
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+            addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
         )
     }.also { viewModelStoreRule.track(it) }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -71,6 +71,7 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssisted
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.FakeCvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.RecordingCvcRecollectionLauncherFactory
@@ -1347,6 +1348,7 @@ internal class PaymentSheetActivityTest {
                 placesClient = null,
                 linkAccountHolder = LinkAccountHolder(savedStateHandle),
                 stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+                addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
             )
         }.also { viewModelStoreRule.track(it) }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -83,6 +83,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
@@ -3509,6 +3510,7 @@ internal class PaymentSheetViewModelTest {
                 placesClient = null,
                 linkAccountHolder = LinkAccountHolder(thisSavedStateHandle),
                 stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+                addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
             )
         }
         return viewModelStoreRule.track(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
-import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
@@ -23,7 +23,6 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.Locale
-import kotlin.time.Duration
 
 @ExperimentalAnimationApi
 @RunWith(AndroidJUnit4::class)
@@ -115,7 +114,7 @@ class AutocompleteScreenTest {
     private fun createViewModel() = AutocompleteViewModel(
         placesClient = TestPlacesClientProxy(),
         application = ApplicationProvider.getApplicationContext(),
-        eventReporter = TestAddressLauncherEventReporter,
+        eventReporter = FakeAddressLauncherEventReporter(),
         autocompleteArgs = AutocompleteViewModel.Args(country = "US")
     ).also { viewModelStoreRule.track(it) }
 
@@ -137,40 +136,5 @@ class AutocompleteScreenTest {
             placeId: String,
             locale: Locale,
         ): Result<Address> = fetchPlaceResponse
-    }
-
-    private object TestAddressLauncherEventReporter : AddressLauncherEventReporter {
-        override fun onShow(country: String) {
-            // No-op
-        }
-
-        override fun onCompleted(
-            country: String,
-            autocompleteResultSelected: Boolean,
-            editDistance: Int?,
-            timeToComplete: Duration?,
-        ) {
-            // No-op
-        }
-
-        override fun onAutocompleteSessionStarted(sessionToken: String) {
-            // No-op
-        }
-
-        override fun onAutocompleteFetchStarted() {
-            // No-op
-        }
-
-        override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
-            // No-op
-        }
-
-        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
-            // No-op
-        }
-
-        override fun onAutocompleteError(sessionToken: String, error: Throwable) {
-            // No-op
-        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.Locale
+import kotlin.time.Duration
 
 @ExperimentalAnimationApi
 @RunWith(AndroidJUnit4::class)
@@ -143,7 +144,32 @@ class AutocompleteScreenTest {
             // No-op
         }
 
-        override fun onCompleted(country: String, autocompleteResultSelected: Boolean, editDistance: Int?) {
+        override fun onCompleted(
+            country: String,
+            autocompleteResultSelected: Boolean,
+            editDistance: Int?,
+            timeToComplete: Duration?,
+        ) {
+            // No-op
+        }
+
+        override fun onAutocompleteSessionStarted(sessionToken: String) {
+            // No-op
+        }
+
+        override fun onAutocompleteFetchStarted() {
+            // No-op
+        }
+
+        override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
+            // No-op
+        }
+
+        override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
+            // No-op
+        }
+
+        override fun onAutocompleteError(sessionToken: String, error: Throwable) {
             // No-op
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.AddressElementSameAsBillingPreview
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -17,6 +17,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
+import com.stripe.android.utils.FakeDurationProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -24,16 +25,14 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class InputAddressViewModelTest {
     private val navigator = mock<AddressElementNavigator>()
-    private val eventReporter = mock<AddressLauncherEventReporter>()
+    private val eventReporter = FakeAddressLauncherEventReporter()
 
     private fun createViewModel(
         address: AddressDetails? = null,
@@ -49,6 +48,7 @@ class InputAddressViewModelTest {
             navigator,
             eventReporter,
             placesClient = null,
+            durationProvider = FakeDurationProvider(),
         ).also { viewModelStoreRule.track(it) }
     }
 
@@ -161,11 +161,11 @@ class InputAddressViewModelTest {
                 )
             )
         )
-        verify(eventReporter).onCompleted(
-            country = eq("US"),
-            autocompleteResultSelected = eq(true),
-            editDistance = eq(0)
-        )
+        val completedCall = eventReporter.completedCalls.awaitItem()
+        assertThat(completedCall.country).isEqualTo("US")
+        assertThat(completedCall.autocompleteResultSelected).isTrue()
+        assertThat(completedCall.editDistance).isEqualTo(0)
+        assertThat(completedCall.timeToComplete).isNotNull()
     }
 
     @Test
@@ -979,6 +979,7 @@ class InputAddressViewModelTest {
             navigator,
             eventReporter,
             placesClient = mockPlacesClient,
+            durationProvider = FakeDurationProvider(),
         ).also { viewModelStoreRule.track(it) }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
-import com.stripe.android.utils.FakeDurationProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -48,7 +47,6 @@ class InputAddressViewModelTest {
             navigator,
             eventReporter,
             placesClient = null,
-            durationProvider = FakeDurationProvider(),
         ).also { viewModelStoreRule.track(it) }
     }
 
@@ -165,7 +163,6 @@ class InputAddressViewModelTest {
         assertThat(completedCall.country).isEqualTo("US")
         assertThat(completedCall.autocompleteResultSelected).isTrue()
         assertThat(completedCall.editDistance).isEqualTo(0)
-        assertThat(completedCall.timeToComplete).isNotNull()
     }
 
     @Test
@@ -979,7 +976,6 @@ class InputAddressViewModelTest {
             navigator,
             eventReporter,
             placesClient = mockPlacesClient,
-            durationProvider = FakeDurationProvider(),
         ).also { viewModelStoreRule.track(it) }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.addresselement
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -192,6 +193,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
+            eventReporter = null,
         )
 
         val interactor = factory.create()
@@ -219,6 +221,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
+            eventReporter = null,
         )
 
         val interactor = factory.create()
@@ -249,6 +252,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = backgroundScope,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
+            eventReporter = null,
         )
         val queryFlow = MutableStateFlow("")
         val countryFlow = MutableStateFlow<String?>("US")
@@ -282,6 +286,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
+            eventReporter = null,
         )
 
         val interactor = factory.create()
@@ -305,6 +310,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { true },
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
 
         val interactor = factory.create()
@@ -330,6 +336,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { true },
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
 
         val interactor = factory.create()
@@ -350,6 +357,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { true },
+            eventReporter = null,
         )
 
         val interactor = factory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -193,7 +193,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
-            eventReporter = null,
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
 
         val interactor = factory.create()
@@ -221,7 +221,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
-            eventReporter = null,
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
 
         val interactor = factory.create()
@@ -252,7 +252,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = backgroundScope,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
-            eventReporter = null,
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
         val queryFlow = MutableStateFlow("")
         val countryFlow = MutableStateFlow<String?>("US")
@@ -286,7 +286,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = null,
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { false },
-            eventReporter = null,
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
 
         val interactor = factory.create()
@@ -357,7 +357,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             coroutineScope = this,
             shouldUseAutocompleteProxyEndpointsProvider = { true },
-            eventReporter = null,
+            eventReporter = FakeAddressLauncherEventReporter(),
         )
 
         val interactor = factory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -316,6 +316,7 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
 
         val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
         assertThat(suggestionsCall.resultCount).isEqualTo(1)
@@ -334,6 +335,7 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
 
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
         assertThat(errorCall.error).hasMessageThat().isEqualTo("Network error")
@@ -350,6 +352,7 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.fetchPlace("place_123", Locale.US)
@@ -373,6 +376,7 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.fetchPlace("place_123", Locale.US)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -291,7 +291,7 @@ class StripeHostedPlacesClientProxyTest {
 
         val token = eventReporter.autocompleteSessionStartedCalls.awaitItem()
         assertThat(token).isNotEmpty()
-        eventReporter.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     @Test
@@ -304,7 +304,7 @@ class StripeHostedPlacesClientProxyTest {
 
         val newToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
         assertThat(newToken).isNotEqualTo(initialToken)
-        eventReporter.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     @Test
@@ -321,7 +321,7 @@ class StripeHostedPlacesClientProxyTest {
         val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
         assertThat(suggestionsCall.resultCount).isEqualTo(1)
         repository.ensureAllEventsConsumed()
-        eventReporter.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     @Test
@@ -340,7 +340,7 @@ class StripeHostedPlacesClientProxyTest {
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
         assertThat(errorCall.error).hasMessageThat().isEqualTo("Network error")
         repository.ensureAllEventsConsumed()
-        eventReporter.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     @Test
@@ -362,7 +362,7 @@ class StripeHostedPlacesClientProxyTest {
         assertThat(selectedCall.queryLength).isEqualTo("123 Main".length)
         assertThat(selectedCall.placeId).isEqualTo("place_123")
         repository.ensureAllEventsConsumed()
-        eventReporter.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     @Test
@@ -385,7 +385,7 @@ class StripeHostedPlacesClientProxyTest {
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
         assertThat(errorCall.error).hasMessageThat().isEqualTo("Details error")
         repository.ensureAllEventsConsumed()
-        eventReporter.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     private fun createProxy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -308,7 +308,7 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `findAutocompletePredictions success fires fetch started then suggestions returned`() = runTest {
+    fun `findAutocompletePredictions success fires suggestions returned`() = runTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
@@ -317,7 +317,6 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        eventReporter.autocompleteFetchStartedCalls.awaitItem()
         val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
         assertThat(suggestionsCall.resultCount).isEqualTo(1)
         repository.ensureAllEventsConsumed()
@@ -336,7 +335,6 @@ class StripeHostedPlacesClientProxyTest {
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
 
-        eventReporter.autocompleteFetchStartedCalls.awaitItem()
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
         assertThat(errorCall.error).hasMessageThat().isEqualTo("Network error")
         repository.ensureAllEventsConsumed()
@@ -352,7 +350,6 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
-        eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.fetchPlace("place_123", Locale.US)
@@ -376,7 +373,6 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
-        eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.fetchPlace("place_123", Locale.US)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.addresselement
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.Locale
@@ -283,9 +284,115 @@ class StripeHostedPlacesClientProxyTest {
         )
     }
 
+    @Test
+    fun `constructing the proxy fires onAutocompleteSessionStarted with the initial token`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        createProxy(eventReporter = eventReporter)
+
+        val token = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(token).isNotEmpty()
+        eventReporter.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `resetSession fires onAutocompleteSessionStarted with a new token`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val proxy = createProxy(eventReporter = eventReporter)
+        val initialToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+
+        proxy.resetSession()
+
+        val newToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(newToken).isNotEqualTo(initialToken)
+        eventReporter.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `findAutocompletePredictions success fires fetch started then suggestions returned`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+        assertThat(suggestionsCall.resultCount).isEqualTo(1)
+        repository.ensureAllEventsConsumed()
+        eventReporter.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `findAutocompletePredictions failure fires onAutocompleteError`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.failure(RuntimeException("Network error"))
+        }
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
+        assertThat(errorCall.error).hasMessageThat().isEqualTo("Network error")
+        repository.ensureAllEventsConsumed()
+        eventReporter.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `fetchPlace success fires onAutocompleteSelected with query length and place id`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+
+        proxy.fetchPlace("place_123", Locale.US)
+        repository.fetchPlaceDetailsCalls.awaitItem()
+
+        val selectedCall = eventReporter.autocompleteSelectedCalls.awaitItem()
+        assertThat(selectedCall.queryLength).isEqualTo("123 Main".length)
+        assertThat(selectedCall.placeId).isEqualTo("place_123")
+        repository.ensureAllEventsConsumed()
+        eventReporter.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `fetchPlace failure fires onAutocompleteError`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = defaultRepository().apply {
+            detailsResult = Result.failure(RuntimeException("Details error"))
+        }
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+
+        proxy.fetchPlace("place_123", Locale.US)
+        repository.fetchPlaceDetailsCalls.awaitItem()
+
+        val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
+        assertThat(errorCall.error).hasMessageThat().isEqualTo("Details error")
+        repository.ensureAllEventsConsumed()
+        eventReporter.ensureAllEventsConsumed()
+    }
+
     private fun createProxy(
         repository: FakeStripeAutocompleteRepository = defaultRepository(),
+        eventReporter: FakeAddressLauncherEventReporter = FakeAddressLauncherEventReporter(),
     ) = StripeHostedPlacesClientProxy(
         repository = repository,
+        eventReporter = eventReporter,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -382,6 +382,7 @@ class StripeHostedPlacesClientProxyTest {
         proxy.fetchPlace("place_123", Locale.US)
         repository.fetchPlaceDetailsCalls.awaitItem()
 
+        eventReporter.autocompleteSelectedCalls.awaitItem()
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
         assertThat(errorCall.error).hasMessageThat().isEqualTo("Details error")
         repository.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -1,19 +1,34 @@
 package com.stripe.android.paymentsheet.addresselement.analytics
 
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import kotlin.time.Duration
 
 internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
-    val showCalls = Turbine<ShowCall>()
-    val completedCalls = Turbine<CompletedCall>()
-    val autocompleteSessionStartedCalls = Turbine<String>()
-    val autocompleteFetchStartedCalls = Turbine<Unit>()
-    val autocompleteSuggestionsReturnedCalls = Turbine<SuggestionsReturnedCall>()
-    val autocompleteSelectedCalls = Turbine<SelectedCall>()
-    val autocompleteErrorCalls = Turbine<ErrorCall>()
+    private val _showCalls = Turbine<String>()
+    val showCalls: ReceiveTurbine<String> = _showCalls
+
+    private val _completedCalls = Turbine<CompletedCall>()
+    val completedCalls: ReceiveTurbine<CompletedCall> = _completedCalls
+
+    private val _autocompleteSessionStartedCalls = Turbine<String>()
+    val autocompleteSessionStartedCalls: ReceiveTurbine<String> = _autocompleteSessionStartedCalls
+
+    private val _autocompleteFetchStartedCalls = Turbine<Unit>()
+    val autocompleteFetchStartedCalls: ReceiveTurbine<Unit> = _autocompleteFetchStartedCalls
+
+    private val _autocompleteSuggestionsReturnedCalls = Turbine<SuggestionsReturnedCall>()
+    val autocompleteSuggestionsReturnedCalls: ReceiveTurbine<SuggestionsReturnedCall> =
+        _autocompleteSuggestionsReturnedCalls
+
+    private val _autocompleteSelectedCalls = Turbine<SelectedCall>()
+    val autocompleteSelectedCalls: ReceiveTurbine<SelectedCall> = _autocompleteSelectedCalls
+
+    private val _autocompleteErrorCalls = Turbine<ErrorCall>()
+    val autocompleteErrorCalls: ReceiveTurbine<ErrorCall> = _autocompleteErrorCalls
 
     override fun onShow(country: String) {
-        showCalls.add(ShowCall(country))
+        _showCalls.add(country)
     }
 
     override fun onCompleted(
@@ -22,40 +37,38 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         editDistance: Int?,
         timeToComplete: Duration?,
     ) {
-        completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance, timeToComplete))
+        _completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance, timeToComplete))
     }
 
     override fun onAutocompleteSessionStarted(sessionToken: String) {
-        autocompleteSessionStartedCalls.add(sessionToken)
+        _autocompleteSessionStartedCalls.add(sessionToken)
     }
 
     override fun onAutocompleteFetchStarted() {
-        autocompleteFetchStartedCalls.add(Unit)
+        _autocompleteFetchStartedCalls.add(Unit)
     }
 
     override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
-        autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
+        _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
     }
 
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
-        autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId))
+        _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId))
     }
 
     override fun onAutocompleteError(sessionToken: String, error: Throwable) {
-        autocompleteErrorCalls.add(ErrorCall(sessionToken, error))
+        _autocompleteErrorCalls.add(ErrorCall(sessionToken, error))
     }
 
-    fun ensureAllEventsConsumed() {
-        showCalls.ensureAllEventsConsumed()
-        completedCalls.ensureAllEventsConsumed()
-        autocompleteSessionStartedCalls.ensureAllEventsConsumed()
-        autocompleteFetchStartedCalls.ensureAllEventsConsumed()
-        autocompleteSuggestionsReturnedCalls.ensureAllEventsConsumed()
-        autocompleteSelectedCalls.ensureAllEventsConsumed()
-        autocompleteErrorCalls.ensureAllEventsConsumed()
+    fun validate() {
+        _showCalls.ensureAllEventsConsumed()
+        _completedCalls.ensureAllEventsConsumed()
+        _autocompleteSessionStartedCalls.ensureAllEventsConsumed()
+        _autocompleteFetchStartedCalls.ensureAllEventsConsumed()
+        _autocompleteSuggestionsReturnedCalls.ensureAllEventsConsumed()
+        _autocompleteSelectedCalls.ensureAllEventsConsumed()
+        _autocompleteErrorCalls.ensureAllEventsConsumed()
     }
-
-    data class ShowCall(val country: String)
 
     data class CompletedCall(
         val country: String,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -14,9 +14,6 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     private val _autocompleteSessionStartedCalls = Turbine<String>()
     val autocompleteSessionStartedCalls: ReceiveTurbine<String> = _autocompleteSessionStartedCalls
 
-    private val _autocompleteFetchStartedCalls = Turbine<Unit>()
-    val autocompleteFetchStartedCalls: ReceiveTurbine<Unit> = _autocompleteFetchStartedCalls
-
     private val _autocompleteSuggestionsReturnedCalls = Turbine<SuggestionsReturnedCall>()
     val autocompleteSuggestionsReturnedCalls: ReceiveTurbine<SuggestionsReturnedCall> =
         _autocompleteSuggestionsReturnedCalls
@@ -44,11 +41,11 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteSessionStartedCalls.add(sessionToken)
     }
 
-    override fun onAutocompleteFetchStarted() {
-        _autocompleteFetchStartedCalls.add(Unit)
-    }
-
-    override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
+    override fun onAutocompleteSuggestionsReturned(
+        sessionToken: String,
+        resultCount: Int,
+        fetchDuration: Duration?,
+    ) {
         _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
     }
 
@@ -64,7 +61,6 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _showCalls.ensureAllEventsConsumed()
         _completedCalls.ensureAllEventsConsumed()
         _autocompleteSessionStartedCalls.ensureAllEventsConsumed()
-        _autocompleteFetchStartedCalls.ensureAllEventsConsumed()
         _autocompleteSuggestionsReturnedCalls.ensureAllEventsConsumed()
         _autocompleteSelectedCalls.ensureAllEventsConsumed()
         _autocompleteErrorCalls.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.addresselement.analytics
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
-import kotlin.time.Duration
 
 internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     private val _showCalls = Turbine<String>()
@@ -13,6 +12,9 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
 
     private val _autocompleteSessionStartedCalls = Turbine<String>()
     val autocompleteSessionStartedCalls: ReceiveTurbine<String> = _autocompleteSessionStartedCalls
+
+    private val _autocompleteFetchStartedCalls = Turbine<String>()
+    val autocompleteFetchStartedCalls: ReceiveTurbine<String> = _autocompleteFetchStartedCalls
 
     private val _autocompleteSuggestionsReturnedCalls = Turbine<SuggestionsReturnedCall>()
     val autocompleteSuggestionsReturnedCalls: ReceiveTurbine<SuggestionsReturnedCall> =
@@ -32,19 +34,21 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         country: String,
         autocompleteResultSelected: Boolean,
         editDistance: Int?,
-        timeToComplete: Duration?,
     ) {
-        _completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance, timeToComplete))
+        _completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance))
     }
 
     override fun onAutocompleteSessionStarted(sessionToken: String) {
         _autocompleteSessionStartedCalls.add(sessionToken)
     }
 
+    override fun onAutocompleteFetchStarted(sessionToken: String) {
+        _autocompleteFetchStartedCalls.add(sessionToken)
+    }
+
     override fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
         resultCount: Int,
-        fetchDuration: Duration?,
     ) {
         _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
     }
@@ -61,6 +65,7 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _showCalls.ensureAllEventsConsumed()
         _completedCalls.ensureAllEventsConsumed()
         _autocompleteSessionStartedCalls.ensureAllEventsConsumed()
+        _autocompleteFetchStartedCalls.ensureAllEventsConsumed()
         _autocompleteSuggestionsReturnedCalls.ensureAllEventsConsumed()
         _autocompleteSelectedCalls.ensureAllEventsConsumed()
         _autocompleteErrorCalls.ensureAllEventsConsumed()
@@ -70,7 +75,6 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         val country: String,
         val autocompleteResultSelected: Boolean,
         val editDistance: Int?,
-        val timeToComplete: Duration?,
     )
 
     data class SuggestionsReturnedCall(val sessionToken: String, val resultCount: Int)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -1,0 +1,72 @@
+package com.stripe.android.paymentsheet.addresselement.analytics
+
+import app.cash.turbine.Turbine
+import kotlin.time.Duration
+
+internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
+    val showCalls = Turbine<ShowCall>()
+    val completedCalls = Turbine<CompletedCall>()
+    val autocompleteSessionStartedCalls = Turbine<String>()
+    val autocompleteFetchStartedCalls = Turbine<Unit>()
+    val autocompleteSuggestionsReturnedCalls = Turbine<SuggestionsReturnedCall>()
+    val autocompleteSelectedCalls = Turbine<SelectedCall>()
+    val autocompleteErrorCalls = Turbine<ErrorCall>()
+
+    override fun onShow(country: String) {
+        showCalls.add(ShowCall(country))
+    }
+
+    override fun onCompleted(
+        country: String,
+        autocompleteResultSelected: Boolean,
+        editDistance: Int?,
+        timeToComplete: Duration?,
+    ) {
+        completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance, timeToComplete))
+    }
+
+    override fun onAutocompleteSessionStarted(sessionToken: String) {
+        autocompleteSessionStartedCalls.add(sessionToken)
+    }
+
+    override fun onAutocompleteFetchStarted() {
+        autocompleteFetchStartedCalls.add(Unit)
+    }
+
+    override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) {
+        autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
+    }
+
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
+        autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId))
+    }
+
+    override fun onAutocompleteError(sessionToken: String, error: Throwable) {
+        autocompleteErrorCalls.add(ErrorCall(sessionToken, error))
+    }
+
+    fun ensureAllEventsConsumed() {
+        showCalls.ensureAllEventsConsumed()
+        completedCalls.ensureAllEventsConsumed()
+        autocompleteSessionStartedCalls.ensureAllEventsConsumed()
+        autocompleteFetchStartedCalls.ensureAllEventsConsumed()
+        autocompleteSuggestionsReturnedCalls.ensureAllEventsConsumed()
+        autocompleteSelectedCalls.ensureAllEventsConsumed()
+        autocompleteErrorCalls.ensureAllEventsConsumed()
+    }
+
+    data class ShowCall(val country: String)
+
+    data class CompletedCall(
+        val country: String,
+        val autocompleteResultSelected: Boolean,
+        val editDistance: Int?,
+        val timeToComplete: Duration?,
+    )
+
+    data class SuggestionsReturnedCall(val sessionToken: String, val resultCount: Int)
+
+    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String?)
+
+    data class ErrorCall(val sessionToken: String, val error: Throwable)
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -52,7 +52,7 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
     }
 
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?) {
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
         _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId))
     }
 
@@ -79,7 +79,7 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
 
     data class SuggestionsReturnedCall(val sessionToken: String, val resultCount: Int)
 
-    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String?)
+    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String)
 
     data class ErrorCall(val sessionToken: String, val error: Throwable)
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import org.junit.Test
 import org.mockito.kotlin.mock
 
@@ -23,6 +24,7 @@ class AddressElementViewModelModuleTest {
             ),
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             googlePlacesClient = null,
+            addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
         )
 
         assertThat(placesClient).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -60,6 +61,7 @@ internal class FakeBaseSheetViewModel private constructor(
     placesClient = null,
     linkAccountHolder = LinkAccountHolder(savedStateHandle),
     stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
+    addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
 ) {
     companion object {
         fun create(

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -50,7 +50,6 @@ interface DurationProvider {
         IntentConfirmationChallengeWebViewLoaded,
         PaymentMethodMessaging,
         AddressAutocompleteSession,
-        AddressAutocompleteFetch,
         AddressElementCompletion
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -50,6 +50,7 @@ interface DurationProvider {
         IntentConfirmationChallengeWebViewLoaded,
         PaymentMethodMessaging,
         AddressAutocompleteSession,
+        AddressAutocompleteFetch,
         AddressElementCompletion
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -48,7 +48,10 @@ interface DurationProvider {
         Attest,
         IntentConfirmationChallenge,
         IntentConfirmationChallengeWebViewLoaded,
-        PaymentMethodMessaging
+        PaymentMethodMessaging,
+        AddressAutocompleteSession,
+        AddressAutocompleteFetch,
+        AddressElementCompletion
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Adds analytics logging and event tracking for Stripe-hosted address inline autocomplete. This logs key user interaction events (such as query inputs, suggestion impressions, suggestion selections, and clear actions) to help track autocomplete performance and usage metrics.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Adding visibility into how users interact with the hosted address autocomplete feature

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

Unit Tests: Added unit tests verifying that analytics events fire with correct payload parameters when suggestions are requested, displayed, and selected.

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
