### PR TITLE
Isolate embedded form CoroutineScope to prevent canceling parent scope.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -1,0 +1,127 @@
+package com.stripe.android.checkout
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isSelected
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
+import com.stripe.android.checkouttesting.checkoutInit
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.MainActivity
+import com.stripe.android.paymentsheet.PaymentSheetPage
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutPaymentElementTest {
+    private val networkRule = NetworkRule()
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(networkRule = networkRule)
+
+    private val page = PaymentSheetPage(testRules.compose)
+
+    @Test
+    fun testPaymentOptionsBackNavigationRestoresPreviousSelection() {
+        networkRule.checkoutInit { response ->
+            response.testBodyFromFile("checkout-session-init.json") { json ->
+                json.put("customer_email", "checkout@example.com")
+                json.getJSONObject("elements_session").remove("link_settings")
+            }
+        }
+
+        var checkoutResult: CheckoutController.Result? = null
+        val savedStateHandle = SavedStateHandle()
+
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.moveToState(Lifecycle.State.CREATED)
+
+            lateinit var controller: CheckoutController
+            scenario.onActivity { activity ->
+                PaymentConfiguration.init(activity, "pk_test_123")
+                controller = CheckoutController.Builder(
+                    application = activity.application,
+                    savedStateHandle = savedStateHandle,
+                ).resultCallback {
+                    checkoutResult = it
+                }.build()
+            }
+
+            runBlocking {
+                controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+            }
+            controller.clearPaymentOption().getOrThrow()
+
+            lateinit var paymentElement: PaymentElement
+            scenario.onActivity { activity ->
+                val presenter = controller.createPresenter(activity)
+                paymentElement = presenter.paymentElement()
+                activity.setContent {
+                    paymentElement.PaymentOptionsContent()
+                }
+            }
+
+            scenario.moveToState(Lifecycle.State.RESUMED)
+
+            scenario.onActivity {
+                paymentElement.presentPaymentOptions()
+            }
+
+            clickOnLpm("card")
+            page.waitForCardForm()
+            Espresso.pressBack()
+
+            clickOnLpm("cashapp")
+            assertLpmSelected("cashapp")
+
+            clickOnLpm("card")
+            page.waitForCardForm()
+            Espresso.pressBack()
+
+            assertLpmSelected("cashapp")
+            assertThat(checkoutResult).isNull()
+
+            controller.destroy()
+        }
+    }
+
+    private fun clickOnLpm(code: String) {
+        val matcher = hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$code")
+        testRules.compose.waitUntil(5_000) {
+            testRules.compose
+                .onAllNodes(matcher, useUnmergedTree = true)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+
+        testRules.compose.onNode(matcher, useUnmergedTree = true)
+            .performScrollTo()
+            .performClick()
+    }
+
+    private fun assertLpmSelected(code: String) {
+        val matcher = hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$code").and(isSelected())
+        testRules.compose.waitUntil(5_000) {
+            testRules.compose
+                .onAllNodes(matcher, useUnmergedTree = true)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_CLIENT_SECRET = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -3,7 +3,11 @@ package com.stripe.android.paymentelement.embedded.sheet
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
@@ -11,6 +15,7 @@ import androidx.test.espresso.Espresso.onIdle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
@@ -19,6 +24,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -122,6 +128,35 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     }
 
     @Test
+    fun `back from form keeps PaymentOptions active and preserves previous selection`() = launch(
+        selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+        paymentMethodTypes = listOf("card", "cashapp"),
+    ) { scenario ->
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.screen.value)
+                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+        }
+
+        Espresso.pressBack()
+        onIdle()
+
+        clickOnLpm("cashapp")
+        assertLpmSelected("cashapp")
+
+        clickOnLpm("card")
+
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.screen.value)
+                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+        }
+
+        Espresso.pressBack()
+        onIdle()
+
+        assertLpmSelected("cashapp")
+    }
+
+    @Test
     fun `cancelled result contains customer state`() = launch { scenario ->
         Espresso.pressBack()
 
@@ -135,13 +170,14 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     private fun launch(
         selection: PaymentSelection? = null,
         previousNewSelections: Bundle = Bundle(),
+        paymentMethodTypes: List<String>? = null,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
                 input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                    paymentMethodMetadata = createPaymentMethodMetadata(paymentMethodTypes),
                     configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
@@ -154,6 +190,42 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             )
         ).use { scenario ->
             block(scenario)
+        }
+    }
+
+    private fun createPaymentMethodMetadata(
+        paymentMethodTypes: List<String>?,
+    ) = if (paymentMethodTypes != null) {
+        PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = paymentMethodTypes,
+            ),
+        )
+    } else {
+        PaymentMethodMetadataFactory.create()
+    }
+
+    private fun clickOnLpm(code: String) {
+        val matcher = hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$code")
+        composeTestRule.waitUntil(5_000) {
+            composeTestRule
+                .onAllNodes(matcher, useUnmergedTree = true)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+
+        composeTestRule.onNode(matcher, useUnmergedTree = true)
+            .performScrollTo()
+            .performClick()
+    }
+
+    private fun assertLpmSelected(code: String) {
+        val matcher = hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$code").and(isSelected())
+        composeTestRule.waitUntil(5_000) {
+            composeTestRule
+                .onAllNodes(matcher, useUnmergedTree = true)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
         }
     }
 }


### PR DESCRIPTION
# Summary
Isolated the CoroutineScope used by the embedded form interactor from its parent ViewModel scope to prevent accidental cancellation of the parent's scope. Added a test to verify that closing the embedded form interactor does not cancel the parent scope.

# Motivation
Previously, closing the embedded form interactor could potentially cancel the parent ViewModel scope, leading to unintended consequences elsewhere in the app. This change ensures scope isolation and improves the robustness of coroutine management.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
- [Fixed] Closing the embedded form interactor no longer cancels the parent CoroutineScope.