### PR TITLE
Add Tempo support to Crypto Onramp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
-NEXT_VERSION_BUMP: PATCH
+NEXT_VERSION_BUMP: MINOR
 ## XX.XX.XX - 20XX-XX-XX
+
+### CryptoOnramp
+* [ADDED] Added Tempo as a supported wallet network and pinned Crypto Onramp internal API calls to the preview API version required by newer networks.
 
 ## 23.13.1 - 2026-07-23
 

--- a/crypto-onramp/api/crypto-onramp.api
+++ b/crypto-onramp/api/crypto-onramp.api
@@ -183,6 +183,7 @@ public final class com/stripe/android/crypto/onramp/model/CryptoNetwork : java/l
 	public static final field Solana Lcom/stripe/android/crypto/onramp/model/CryptoNetwork;
 	public static final field Stellar Lcom/stripe/android/crypto/onramp/model/CryptoNetwork;
 	public static final field Sui Lcom/stripe/android/crypto/onramp/model/CryptoNetwork;
+	public static final field Tempo Lcom/stripe/android/crypto/onramp/model/CryptoNetwork;
 	public static final field Worldchain Lcom/stripe/android/crypto/onramp/model/CryptoNetwork;
 	public static final field Xrpl Lcom/stripe/android/crypto/onramp/model/CryptoNetwork;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
 import com.stripe.android.Stripe
 import com.stripe.android.common.di.MobileSessionIdModule
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
@@ -20,6 +19,7 @@ import com.stripe.android.crypto.onramp.analytics.OnrampAnalyticsService
 import com.stripe.android.crypto.onramp.analytics.OnrampAnalyticsServiceImpl
 import com.stripe.android.crypto.onramp.model.OnrampSessionClientSecretProvider
 import com.stripe.android.crypto.onramp.repositories.CryptoApiRepository
+import com.stripe.android.crypto.onramp.repositories.CryptoApiRepository.Companion.CRYPTO_ONRAMP_API_VERSION
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeRepository
@@ -65,7 +65,7 @@ internal class OnrampModule {
             stripeRepository = stripeRepository,
             publishableKeyProvider = publishableKeyProvider,
             stripeAccountIdProvider = stripeAccountIdProvider,
-            apiVersion = ApiVersion.get().code,
+            apiVersion = CRYPTO_ONRAMP_API_VERSION,
             linkController = linkController,
             appInfo = Stripe.appInfo
         )

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CryptoNetwork.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CryptoNetwork.kt
@@ -48,5 +48,8 @@ enum class CryptoNetwork(val value: String) {
     Sui("sui"),
 
     @SerialName("arbitrum")
-    Arbitrum("arbitrum")
+    Arbitrum("arbitrum"),
+
+    @SerialName("tempo")
+    Tempo("tempo")
 }

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -503,6 +503,10 @@ internal class CryptoApiRepository @Inject constructor(
     )
 
     internal companion object {
+        // Use a preview API version for networks and parameters behind preview API features.
+        // Bump this when new onramp features require a newer API version.
+        internal const val CRYPTO_ONRAMP_API_VERSION = "2026-03-25.preview"
+
         private const val FIELD_ERROR = "error"
         private const val FIELD_REASON = "reason"
         private const val FIELD_USER_MESSAGE = "user_message"

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/CryptoApiRepositoryTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/CryptoApiRepositoryTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.crypto.onramp
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.HEADER_STRIPE_VERSION
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.core.version.StripeSdkVersion
@@ -18,6 +18,7 @@ import com.stripe.android.crypto.onramp.model.compliance.ComplianceIdentifierTyp
 import com.stripe.android.crypto.onramp.model.compliance.ComplianceRegulation
 import com.stripe.android.crypto.onramp.model.compliance.SubmitIdentifiersResult
 import com.stripe.android.crypto.onramp.repositories.CryptoApiRepository
+import com.stripe.android.crypto.onramp.repositories.CryptoApiRepository.Companion.CRYPTO_ONRAMP_API_VERSION
 import com.stripe.android.link.LinkController
 import com.stripe.android.model.DateOfBirth
 import com.stripe.android.networking.StripeRepository
@@ -45,7 +46,7 @@ class CryptoApiRepositoryTest {
         stripeRepository = stripeRepository,
         publishableKeyProvider = { "pk_test_vOo1umqsYxSrP5UXfOeL3ecm" },
         stripeAccountIdProvider = { "TestAccountId" },
-        apiVersion = ApiVersion(betas = emptySet()).code,
+        apiVersion = CRYPTO_ONRAMP_API_VERSION,
         sdkVersion = StripeSdkVersion.VERSION,
         appInfo = null,
         linkController = linkController
@@ -258,6 +259,8 @@ class CryptoApiRepositoryTest {
 
             assertThat(apiRequest.baseUrl)
                 .isEqualTo("https://api.stripe.com/v1/crypto/internal/identifier_requirements")
+            assertThat(apiRequest.headers[HEADER_STRIPE_VERSION])
+                .isEqualTo(CRYPTO_ONRAMP_API_VERSION)
             assertThat(apiRequest.params)
                 .isEqualTo(mapOf("credentials" to mapOf("consumer_session_client_secret" to "test-secret")))
 
@@ -732,6 +735,8 @@ class CryptoApiRepositoryTest {
 
             assertThat(apiRequest.baseUrl)
                 .isEqualTo("https://api.stripe.com/v1/crypto/internal/wallet")
+            assertThat(apiRequest.headers[HEADER_STRIPE_VERSION])
+                .isEqualTo(CRYPTO_ONRAMP_API_VERSION)
 
             val params = apiRequest.params!!
             assertThat(params["wallet_address"]).isEqualTo("0x1234567890abcdef")


### PR DESCRIPTION
## Summary

Adds Tempo as a supported Crypto Onramp network and pins Crypto Onramp internal API calls to the same preview API version used by the web SDK. This lets mobile register wallets for newer networks that are behind preview API features without changing the global Android SDK API version.

The Crypto Onramp repository now owns this versioning internally instead of defaulting to the SDK API version, which does not work for some crypto onramp internal calls.

This matches the approach in the iOS SDK PR: https://github.com/stripe/stripe-ios/pull/6738

Jira: https://jira.corp.stripe.com/browse/ONRAMP-611

## Testing

- `./gradlew :crypto-onramp:apiCheck`
- `./gradlew :crypto-onramp:testDebugUnitTest --tests com.stripe.android.crypto.onramp.CryptoApiRepositoryTest`
- Manually verified Tempo wallet registration in the Crypto Onramp example app.