### PR TITLE
Support `GetProcessingOptions` command

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardDataParser.kt
@@ -4,16 +4,10 @@ import javax.inject.Inject
 import kotlin.collections.joinToString
 
 internal interface NfcCardDataParser {
-    fun canParse(records: Map<String, ByteArray>): Boolean
-
     fun parse(records: Map<String, ByteArray>): ScannedCardData?
 }
 
 internal class DefaultNfcCardDataParser @Inject constructor() : NfcCardDataParser {
-    override fun canParse(records: Map<String, ByteArray>): Boolean {
-        return TAG_TRACK2 in records || (TAG_PAN in records && TAG_EXPIRY in records)
-    }
-
     override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
         // Tag 0x57 — Track 2 Equivalent Data. Preferred when present because it encodes PAN and
         // expiry together in the same format used on magnetic-stripe Track 2.

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.common.nfcscan.scanner
 
-import com.stripe.android.common.nfcscan.scanner.apdu.ApduResponseError
+import com.stripe.android.common.nfcscan.scanner.apdu.GetProcessingOptionsCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.ReadRecordCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectApplicationCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
@@ -51,25 +51,19 @@ internal class ApduCardReader @Inject constructor(
             val applicationIdentifier = SelectPpseCommand.transceiveWith(transceiver).getOrThrow()
             SelectApplicationCommand(applicationIdentifier).transceiveWith(transceiver).getOrThrow()
 
-            val records = mutableMapOf<String, ByteArray>()
+            val processingOptionsInfo = GetProcessingOptionsCommand
+                .transceiveWith(transceiver)
+                .getOrThrow()
 
-            probeFiles@ for (sfi in PROBE_SFIS) {
-                for (record in 1..MAX_RECORDS_PER_SFI) {
-                    val result = ReadRecordCommand(record, sfi)
+            val records = processingOptionsInfo.records.toMutableMap()
+
+            processingOptionsInfo.aflEntries.forEach { entry ->
+                for (record in entry.firstRecord..entry.lastRecord) {
+                    ReadRecordCommand(record, entry.shortFileIdentifier)
                         .transceiveWith(transceiver)
-
-                    result.onSuccess { result ->
-                        records += result
-
-                        if (cardDataParser.canParse(records)) {
-                            break@probeFiles
+                        .onSuccess { readRecords ->
+                            records += readRecords
                         }
-                    }.onFailure { error ->
-                        if (isFileNotFoundError(error)) {
-                            // Breaks the record loop but moves on to the next file
-                            break
-                        }
-                    }
                 }
             }
 
@@ -78,19 +72,5 @@ internal class ApduCardReader @Inject constructor(
         } finally {
             transceiver.close()
         }
-    }
-
-    private fun isFileNotFoundError(error: Throwable): Boolean {
-        return error is ApduResponseError.Command &&
-            error.sw1 == PARAMETER_ERROR_SW1 && error.sw2 == FILE_NOT_FOUND_SW2
-    }
-
-    private companion object {
-        // SFIs 1-3 cover virtually all Visa/Mastercard/Amex/Discover payment records.
-        val PROBE_SFIS = 1..3
-        const val MAX_RECORDS_PER_SFI = 8
-
-        const val PARAMETER_ERROR_SW1 = 0x6A.toByte()
-        const val FILE_NOT_FOUND_SW2 = 0x82.toByte()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+/**
+ * An APDU command for retrieving processing options from a payment application.
+ */
+internal data object GetProcessingOptionsCommand : ApduCommand<ProcessingOptionsInfo>() {
+    override val classByte = 0x80.toByte()
+    override val instructionByte = 0xA8.toByte()
+    override val firstParameterByte = 0x00.toByte()
+    override val secondParameterByte = 0x00.toByte()
+    override val dataArray = byteArrayOf(0x83.toByte(), 0x00)
+
+    override fun responseData(tlv: Map<String, ByteArray>): ProcessingOptionsInfo? {
+        if (tlv.isEmpty()) {
+            return null
+        }
+
+        return ProcessingOptionsInfo(
+            aflEntries = extractAfl(tlv)?.let(::parseAflEntries).orEmpty(),
+            records = tlv,
+        )
+    }
+
+    private fun extractAfl(tlv: Map<String, ByteArray>): ByteArray? {
+        return tlv[TAG_AFL] ?: tlv[TAG_RESPONSE_TEMPLATE_FORMAT_1]?.let { format1Value ->
+            format1Value.takeIf { it.size > AIP_LENGTH }
+                ?.copyOfRange(AIP_LENGTH, format1Value.size)
+        }
+    }
+
+    private fun parseAflEntries(data: ByteArray): List<ProcessingOptionsInfo.AflEntry> {
+        return data.toList()
+            .chunked(AFL_ENTRY_LENGTH)
+            .map { entry ->
+                ProcessingOptionsInfo.AflEntry(
+                    shortFileIdentifier = (entry[0].toInt() shr SFI_SHIFT) and SFI_MASK,
+                    firstRecord = entry[1].toInt() and BYTE_MASK,
+                    lastRecord = entry[2].toInt() and BYTE_MASK,
+                )
+            }
+    }
+
+    private const val TAG_RESPONSE_TEMPLATE_FORMAT_1 = "80"
+    private const val TAG_AFL = "94"
+    private const val AIP_LENGTH = 2
+
+    private const val AFL_ENTRY_LENGTH = 4
+    private const val SFI_SHIFT = 3
+    private const val SFI_MASK = 0x1F
+    private const val BYTE_MASK = 0xFF
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ProcessingOptionsInfo.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ProcessingOptionsInfo.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+internal data class ProcessingOptionsInfo(
+    val aflEntries: List<AflEntry>,
+    val records: Map<String, ByteArray>,
+) {
+    internal data class AflEntry(
+        val shortFileIdentifier: Int,
+        val firstRecord: Int,
+        val lastRecord: Int,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -89,7 +89,9 @@ internal object NfcScanningActivityTestFixtures {
     fun successResponses(): List<ByteArray> = listOf(
         apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
         apduSuccessResponse(byteArrayOf()),
-        apduSuccessResponse(tlv(tag = 0x57, value = VALID_TRACK_2_DATA)),
+        apduSuccessResponse(
+            tlv(tag = 0x77, value = tlv(tag = 0x57, value = VALID_TRACK_2_DATA)),
+        ),
     )
 
     fun declinedCardResponses(): List<ByteArray> = listOf(
@@ -103,6 +105,8 @@ internal object NfcScanningActivityTestFixtures {
     fun expiredCardResponses(): List<ByteArray> = listOf(
         apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
         apduSuccessResponse(byteArrayOf()),
-        apduSuccessResponse(tlv(tag = 0x57, value = EXPIRED_TRACK_2_DATA)),
+        apduSuccessResponse(
+            tlv(tag = 0x77, value = tlv(tag = 0x57, value = EXPIRED_TRACK_2_DATA)),
+        ),
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.nfcscan.scanner
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.scanner.apdu.ApduResponseError
+import com.stripe.android.common.nfcscan.scanner.apdu.GetProcessingOptionsCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectApplicationCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.SelectPpseCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
@@ -16,61 +17,16 @@ import java.io.IOException
 
 internal class ApduCardReaderTest {
     @Test
-    fun `readCard selects PPSE then application then probes records`() = runScenario(
+    fun `readCard runs PPSE, select application, GPO and AFL-directed read record commands`() = runScenario(
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(byteArrayOf()),
-        ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
-        errorResult = PARSE_FAILURE_ERROR,
-    ) {
-        val result = cardReader.readCard(transceiver)
-
-        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
-
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-
-        assertReadRecordProbes()
-
-        assertThat(cardDataParser.parseCalls.awaitItem()).isNotNull()
-    }
-
-    @Test
-    fun `readCard skips remaining records in SFI when read record returns file not found`() = runScenario(
-        transceiveResults = listOf(
-            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-            apduSuccessResponse(byteArrayOf()),
-            FILE_NOT_FOUND_RESPONSE,
-        ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
-        errorResult = PARSE_FAILURE_ERROR,
-    ) {
-        val result = cardReader.readCard(transceiver)
-
-        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem()).isInstanceOf<IllegalStateException>()
-
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
-        assertReadRecordProbes(startingAtIndex = MAX_RECORDS_PER_SFI)
-
-        assertThat(cardDataParser.parseCalls.awaitItem()).isNotNull()
-    }
-
-    @Test
-    fun `readCard finds card data on later SFI when earlier SFI returns file not found`() = runScenario(
-        parseResult = SCANNED_CARD_DATA,
-        transceiveResults = listOf(
-            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-            apduSuccessResponse(byteArrayOf()),
-            FILE_NOT_FOUND_RESPONSE,
+            apduSuccessResponse(
+                tlv(tag = 0x77, value = tlv(tag = 0x94.toByte(), value = AFL_SFI_1_RECORDS_1_TO_1)),
+            ),
             apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
         ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        parseResult = SCANNED_CARD_DATA,
     ) {
         val result = cardReader.readCard(transceiver)
 
@@ -78,22 +34,70 @@ internal class ApduCardReaderTest {
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS[MAX_RECORDS_PER_SFI])
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(GPO_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_SFI_1_RECORD_1_REQUEST)
 
-        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("57")
         assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
-
-        cardDataParser.canParseCalls.ensureAllEventsConsumed()
     }
 
     @Test
-    fun `readCard continues probing when read record returns declined`() = runScenario(
+    fun `readCard parses Track 2 from GPO response without AFL read record commands`() = runScenario(
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(byteArrayOf()),
+            apduSuccessResponse(
+                tlv(tag = 0x77, value = tlv(tag = 0x57, value = TRACK_2_DATA)),
+            ),
         ),
-        transceiveResult = CARD_DECLINED_RESPONSE,
+        parseResult = SCANNED_CARD_DATA,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(GPO_REQUEST)
+
+        assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
+    }
+
+    @Test
+    fun `readCard merges tlv records from AFL directed read record commands`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            apduSuccessResponse(
+                tlv(tag = 0x77, value = tlv(tag = 0x94.toByte(), value = AFL_SFI_1_RECORDS_1_TO_2)),
+            ),
+            apduSuccessResponse(tlv(tag = 0x5A, value = PAN_DATA)),
+            apduSuccessResponse(tlv(tag = 0x5F, tagContinuation = 0x24, value = EXPIRY_DATA)),
+        ),
+        parseResult = SCANNED_CARD_DATA,
+    ) {
+        val result = cardReader.readCard(transceiver)
+
+        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(GPO_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_SFI_1_RECORD_1_REQUEST)
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_SFI_1_RECORD_2_REQUEST)
+
+        val parsedRecords = cardDataParser.parseCalls.awaitItem()
+        assertThat(parsedRecords).containsKey("5A")
+        assertThat(parsedRecords).containsKey("5F24")
+    }
+
+    @Test
+    fun `readCard returns parse failure when card data cannot be parsed`() = runScenario(
+        transceiveResults = listOf(
+            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+            apduSuccessResponse(byteArrayOf()),
+            apduSuccessResponse(tlv(tag = 0x77, value = byteArrayOf())),
+        ),
+        parseResult = null,
         errorResult = PARSE_FAILURE_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
@@ -103,8 +107,7 @@ internal class ApduCardReaderTest {
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-
-        assertReadRecordProbes()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(GPO_REQUEST)
 
         assertThat(cardDataParser.parseCalls.awaitItem()).isNotNull()
     }
@@ -154,80 +157,30 @@ internal class ApduCardReaderTest {
     }
 
     @Test
-    fun `readCard returns parsed card data when parser succeeds`() = runScenario(
-        parseResult = SCANNED_CARD_DATA,
+    fun `readCard propagates GetProcessingOptions failure`() = runScenario(
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(byteArrayOf()),
-            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
         ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
+        transceiveResult = FILE_NOT_FOUND_RESPONSE,
+        errorResult = UNSUPPORTED_CARD_ERROR,
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
+        assertThat(result).isEqualTo(UNSUPPORTED_CARD_ERROR)
+
+        val error = errorCreator.createCalls.awaitItem()
+
+        assertThat(error).isInstanceOf<ApduResponseError.Command>()
+        val commandError = error as ApduResponseError.Command
+
+        assertThat(commandError.apduCommand).isEqualTo(GetProcessingOptionsCommand)
+        assertThat(commandError.sw1).isEqualTo(0x6A.toByte())
+        assertThat(commandError.sw2).isEqualTo(0x82.toByte())
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
-
-        assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
-    }
-
-    @Test
-    fun `readCard stops probing when parser can parse records`() = runScenario(
-        parseResult = SCANNED_CARD_DATA,
-        transceiveResults = listOf(
-            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-            apduSuccessResponse(byteArrayOf()),
-            apduSuccessResponse(tlv(tag = 0x57, value = TRACK_2_DATA)),
-        ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
-    ) {
-        val result = cardReader.readCard(transceiver)
-
-        assertThat(result).isEqualTo(NfcCardReader.Result.Found(SCANNED_CARD_DATA))
-
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
-
-        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("57")
-        assertThat(cardDataParser.parseCalls.awaitItem()).containsKey("57")
-
-        cardDataParser.canParseCalls.ensureAllEventsConsumed()
-    }
-
-    @Test
-    fun `readCard merges tlv records from successful read record commands`() = runScenario(
-        transceiveResults = listOf(
-            apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
-            apduSuccessResponse(byteArrayOf()),
-            apduSuccessResponse(tlv(tag = 0x5A, value = PAN_DATA)),
-            apduSuccessResponse(tlv(tag = 0x5F, tagContinuation = 0x24, value = EXPIRY_DATA)),
-        ),
-        transceiveResult = RECORD_NOT_FOUND_RESPONSE,
-        errorResult = PARSE_FAILURE_ERROR,
-    ) {
-        val result = cardReader.readCard(transceiver)
-
-        assertThat(result).isEqualTo(PARSE_FAILURE_ERROR)
-        assertThat(errorCreator.createCalls.awaitItem())
-            .isInstanceOf<IllegalStateException>()
-
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS.first())
-        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(READ_RECORD_REQUESTS[1])
-
-        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("5A")
-        assertThat(cardDataParser.canParseCalls.awaitItem()).containsKey("5F24")
-
-        val parsedRecords = cardDataParser.parseCalls.awaitItem()
-        assertThat(parsedRecords).containsKey("5A")
-        assertThat(parsedRecords.getValue("5A").contentEquals(PAN_DATA)).isTrue()
-        assertThat(parsedRecords).containsKey("5F24")
-        assertThat(parsedRecords.getValue("5F24").contentEquals(EXPIRY_DATA)).isTrue()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(GPO_REQUEST)
     }
 
     @Test
@@ -289,18 +242,9 @@ internal class ApduCardReaderTest {
         val transceiver: FakeNfcTagTransceiver,
         val cardDataParser: FakeNfcCardDataParser,
         val errorCreator: FakeNfcCardReaderErrorCreator,
-    ) {
-        suspend fun assertReadRecordProbes(startingAtIndex: Int = 0) {
-            for (index in startingAtIndex until READ_RECORD_REQUESTS.size) {
-                assertThat(transceiver.transceiveCalls.awaitItem())
-                    .isEqualTo(READ_RECORD_REQUESTS[index])
-            }
-        }
-    }
+    )
 
     private companion object {
-        const val MAX_RECORDS_PER_SFI = 8
-
         val PARSE_FAILURE_ERROR = NfcCardReader.Result.Error(
             errorCode = "nfcCardReadFailed",
             userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
@@ -354,22 +298,35 @@ internal class ApduCardReaderTest {
             0x01,
         )
 
-        val READ_RECORD_REQUESTS = buildList {
-            for (sfi in 1..3) {
-                val shortFileIdentifierByte = ((sfi shl 3) or 4).toByte()
-                for (record in 1..MAX_RECORDS_PER_SFI) {
-                    add(
-                        byteArrayOf(
-                            0x00,
-                            0xB2.toByte(),
-                            record.toByte(),
-                            shortFileIdentifierByte,
-                            0x00,
-                        ),
-                    )
-                }
-            }
-        }
+        val AFL_SFI_1_RECORDS_1_TO_1 = byteArrayOf(0x08, 0x01, 0x01, 0x00)
+        val AFL_SFI_1_RECORDS_1_TO_2 = byteArrayOf(0x08, 0x01, 0x02, 0x00)
+
+        val READ_RECORD_SFI_1_RECORD_1_REQUEST = byteArrayOf(
+            0x00,
+            0xB2.toByte(),
+            0x01,
+            0x0C,
+            0x00,
+        )
+
+        val READ_RECORD_SFI_1_RECORD_2_REQUEST = byteArrayOf(
+            0x00,
+            0xB2.toByte(),
+            0x02,
+            0x0C,
+            0x00,
+        )
+
+        val GPO_REQUEST = byteArrayOf(
+            0x80.toByte(),
+            0xA8.toByte(),
+            0x00,
+            0x00,
+            0x02,
+            0x83.toByte(),
+            0x00,
+            0x00,
+        )
 
         val VISA_AID = byteArrayOf(
             0xA0.toByte(),
@@ -380,9 +337,7 @@ internal class ApduCardReaderTest {
             0x10,
             0x10,
         )
-        val RECORD_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x83.toByte())
         val FILE_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x82.toByte())
-        val CARD_DECLINED_RESPONSE = byteArrayOf(0x69.toByte(), 0x85.toByte())
         val SELECT_PPSE_REQUEST = byteArrayOf(
             0x00,
             0xA4.toByte(),

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/DefaultNfcCardDataParserTest.kt
@@ -135,56 +135,6 @@ internal class DefaultNfcCardDataParserTest {
         assertThat(result).isNull()
     }
 
-    @Test
-    fun `canParse returns true when Track 2 tag is present`() {
-        assertThat(
-            parser.canParse(
-                mapOf(
-                    TAG_TRACK2 to hexToBytes("4111111111111111D2512101"),
-                ),
-            ),
-        ).isTrue()
-    }
-
-    @Test
-    fun `canParse returns true when both PAN and expiry tags are present`() {
-        assertThat(
-            parser.canParse(
-                mapOf(
-                    TAG_PAN to hexToBytes("4111111111111111"),
-                    TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
-                ),
-            ),
-        ).isTrue()
-    }
-
-    @Test
-    fun `canParse returns false when only PAN tag is present`() {
-        assertThat(
-            parser.canParse(
-                mapOf(
-                    TAG_PAN to hexToBytes("4111111111111111"),
-                ),
-            ),
-        ).isFalse()
-    }
-
-    @Test
-    fun `canParse returns false when only expiry tag is present`() {
-        assertThat(
-            parser.canParse(
-                mapOf(
-                    TAG_EXPIRY to byteArrayOf(0x25, 0x12, 0x01),
-                ),
-            ),
-        ).isFalse()
-    }
-
-    @Test
-    fun `canParse returns false when no recognized tags are present`() {
-        assertThat(parser.canParse(emptyMap())).isFalse()
-    }
-
     private fun hexToBytes(hex: String): ByteArray {
         return hex.chunked(2)
             .map { it.toInt(16).toByte() }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/FakeNfcCardDataParser.kt
@@ -4,17 +4,8 @@ import app.cash.turbine.Turbine
 
 internal class FakeNfcCardDataParser(
     private val parseResult: ScannedCardData? = null,
-    private val canParseResult: Boolean? = null,
 ) : NfcCardDataParser {
     val parseCalls = Turbine<Map<String, ByteArray>>()
-    val canParseCalls = Turbine<Map<String, ByteArray>>()
-
-    private val defaultParser = DefaultNfcCardDataParser()
-
-    override fun canParse(records: Map<String, ByteArray>): Boolean {
-        canParseCalls.add(records)
-        return canParseResult ?: defaultParser.canParse(records)
-    }
 
     override fun parse(records: Map<String, ByteArray>): ScannedCardData? {
         parseCalls.add(records)

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommandTest.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.common.nfcscan.scanner.apdu
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.nfcscan.scanner.FakeNfcTagTransceiver
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class GetProcessingOptionsCommandTest {
+    @Test
+    fun `transceiveWith sends GPO command with empty PDOL`() = test(
+        transceiveResult = apduSuccessResponse(byteArrayOf()),
+    ) {
+        GetProcessingOptionsCommand.transceiveWith(transceiver)
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(
+            byteArrayOf(
+                0x80.toByte(),
+                0xA8.toByte(),
+                0x00,
+                0x00,
+                0x02,
+                0x83.toByte(),
+                0x00,
+                0x00,
+            ),
+        )
+    }
+
+    @Test
+    fun `transceiveWith parses AFL from response template format 2`() = test(
+        transceiveResult = apduSuccessResponse(
+            tlv(
+                tag = 0x77,
+                value = tlv(tag = 0x94.toByte(), value = byteArrayOf(0x08, 0x01, 0x01, 0x00)),
+            ),
+        ),
+    ) {
+        val result = GetProcessingOptionsCommand.transceiveWith(transceiver)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()?.aflEntries).containsExactly(
+            ProcessingOptionsInfo.AflEntry(
+                shortFileIdentifier = 1,
+                firstRecord = 1,
+                lastRecord = 1,
+            ),
+        )
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `transceiveWith parses AFL from response template format 1`() = test(
+        transceiveResult = apduSuccessResponse(
+            tlv(
+                tag = 0x80.toByte(),
+                value = byteArrayOf(
+                    0x00,
+                    0x00,
+                    0x08,
+                    0x01,
+                    0x01,
+                    0x00,
+                ),
+            ),
+        ),
+    ) {
+        val result = GetProcessingOptionsCommand.transceiveWith(transceiver)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()?.aflEntries).containsExactly(
+            ProcessingOptionsInfo.AflEntry(
+                shortFileIdentifier = 1,
+                firstRecord = 1,
+                lastRecord = 1,
+            ),
+        )
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `transceiveWith extracts card records from response template format 2`() = test(
+        transceiveResult = apduSuccessResponse(
+            tlv(
+                tag = 0x77,
+                value = tlv(tag = 0x57, value = TRACK_2_DATA),
+            ),
+        ),
+    ) {
+        val result = GetProcessingOptionsCommand.transceiveWith(transceiver)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()?.records?.getValue("57")?.contentEquals(TRACK_2_DATA)).isTrue()
+        assertThat(result.getOrNull()?.aflEntries).isEmpty()
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    private fun test(
+        transceiveResult: ByteArray,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val fakeTransceiver = FakeNfcTagTransceiver(
+            transceiveResult = transceiveResult,
+        )
+
+        block(Scenario(fakeTransceiver))
+
+        fakeTransceiver.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val transceiver: FakeNfcTagTransceiver,
+    )
+
+    private companion object {
+        val TRACK_2_DATA = byteArrayOf(
+            0x41,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0x11,
+            0xD2.toByte(),
+            0x51,
+            0x21,
+            0x01,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Support `GetProcessingOptions` command to receive the exact payment records that should be read to get the card number and expiration date.

# Motivation
Support for more cards.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified