### PR TITLE
Restore selection when backing out of form in EmbeddedNavigator.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -5,7 +5,6 @@ import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
@@ -45,7 +44,6 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private val embeddedNavigatorProvider: Provider<EmbeddedNavigator>,
     private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
     @ViewModelScope private val viewModelScope: CoroutineScope,
-    private val configuration: EmbeddedPaymentElement.Configuration,
     private val manageInteractorFactory: EmbeddedManageScreenInteractorFactory,
     private val updateScreenInteractorFactory: EmbeddedUpdateScreenInteractorFactory,
     private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
@@ -193,14 +191,13 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     }
 
     private fun shouldUpdateSelection(formHelper: FormHelper, paymentMethodCode: String?): Boolean {
-        val isConfirmFlow = configuration.formSheetAction ==
-            EmbeddedPaymentElement.FormSheetAction.Confirm
-        if (isConfirmFlow) {
-            val requiresFormScreen = paymentMethodCode != null &&
-                formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
-            return !requiresFormScreen
-        }
-        return true
+        // Don't fold a selection that requires a form into the vertical list's remembered selection.
+        // The form writes its in-progress selection to the shared holder, so tracking it here would
+        // pollute the list's selection and defeat the restore-on-return behavior that reasserts the
+        // list's selection when it becomes the current screen again (backing out of the form).
+        val requiresFormScreen = paymentMethodCode != null &&
+            formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
+        return !requiresFormScreen
     }
 
     private fun walletsState(): WalletsState? {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -109,9 +108,6 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             isGooglePayReady = isGooglePayReady,
         ),
-        configuration: EmbeddedPaymentElement.Configuration = EmbeddedPaymentElement.Configuration
-            .Builder("Example, Inc.")
-            .build(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val savedStateHandle = SavedStateHandle()
@@ -180,7 +176,6 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             embeddedNavigatorProvider = Provider { navigator },
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = testScope,
-            configuration = configuration,
             manageInteractorFactory = manageInteractorFactory,
             updateScreenInteractorFactory = updateScreenInteractorFactory,
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),


### PR DESCRIPTION
# Summary
When navigating back from a Form screen in EmbeddedNavigator, restores the payment selection to its previous value before the form was shown.

# Motivation
Ensures that changes made to the selection while editing a form are discarded when the user navigates back, improving navigation consistency and preventing unintended selection state mutations.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
