### PR TITLE
Cancel 3DS2 fallback sources natively

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -75,6 +75,8 @@ internal class PaymentBrowserAuthContract :
         val isInstantApp: Boolean,
         val referrer: String? = null,
         val forceInAppWebView: Boolean = false,
+        /** The source to cancel, when it cannot be derived from the authentication URL. */
+        val sourceId: String?,
     ) : Parcelable {
 
         /**
@@ -98,6 +100,7 @@ internal class PaymentBrowserAuthContract :
             parcel.readByte() != 0.toByte(),
             parcel.readString(),
             parcel.readByte() != 0.toByte(),
+            parcel.readString(),
         )
 
         /**
@@ -128,6 +131,7 @@ internal class PaymentBrowserAuthContract :
             parcel.writeByte(if (isInstantApp) 1 else 0)
             parcel.writeString(referrer)
             parcel.writeByte(if (forceInAppWebView) 1 else 0)
+            parcel.writeString(sourceId)
         }
 
         override fun describeContents(): Int {

--- a/payments-core/src/main/java/com/stripe/android/payments/SourceCancellationHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/SourceCancellationHandler.kt
@@ -1,0 +1,123 @@
+package com.stripe.android.payments
+
+import android.content.Context
+import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.Logger
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
+
+/**
+ * Cancels a 3DS source before the authentication activity returns its result to its caller.
+ *
+ * The caller may be destroyed before its parent processes the result, so this operation must not
+ * depend on [PaymentFlowResultProcessor].
+ */
+internal class SourceCancellationHandler(
+    private val args: PaymentBrowserAuthContract.Args,
+    private val stripeRepository: StripeRepository,
+    private val logger: Logger,
+) {
+    suspend fun cancel(): Boolean {
+        if (!args.shouldCancelSource || args.sourceId == null) {
+            return false
+        }
+
+        logger.debug("SourceCancellationHandler#cancel()")
+
+        val requestOptions = ApiRequest.Options(
+            apiKey = args.publishableKey,
+            stripeAccount = args.stripeAccountId,
+        )
+
+        return when {
+            args.clientSecret.startsWith("pi_") -> {
+                val paymentIntent = stripeRepository.retrievePaymentIntent(args.clientSecret, requestOptions)
+                    .getOrElse { return logFailure(it) }
+                cancelPaymentIntentSource(paymentIntent)
+            }
+            args.clientSecret.startsWith("seti_") -> {
+                val setupIntent = stripeRepository.retrieveSetupIntent(args.clientSecret, requestOptions)
+                    .getOrElse { return logFailure(it) }
+                cancelSetupIntentSource(setupIntent)
+            }
+            else -> false
+        }
+    }
+
+    private suspend fun cancelPaymentIntentSource(paymentIntent: PaymentIntent): Boolean {
+        if (!paymentIntent.requiresAction()) {
+            logger.debug("SourceCancellationHandler#cancel() - PaymentIntent no longer requires action")
+            return true
+        }
+
+        val (intentId, requestOptions, sourceId) = cancellationParameters(paymentIntent)
+        val result = stripeRepository.cancelPaymentIntentSource(intentId, sourceId, requestOptions)
+            .exceptionOrNull()
+            ?.let(::logFailure)
+            ?: true
+        if (result) {
+            logger.debug("SourceCancellationHandler#cancel() - PaymentIntent source canceled")
+        }
+        return result
+    }
+
+    private suspend fun cancelSetupIntentSource(setupIntent: SetupIntent): Boolean {
+        if (!setupIntent.requiresAction()) {
+            logger.debug("SourceCancellationHandler#cancel() - SetupIntent no longer requires action")
+            return true
+        }
+
+        val (intentId, requestOptions, sourceId) = cancellationParameters(setupIntent)
+        val result = stripeRepository.cancelSetupIntentSource(intentId, sourceId, requestOptions)
+            .exceptionOrNull()
+            ?.let(::logFailure)
+            ?: true
+        if (result) {
+            logger.debug("SourceCancellationHandler#cancel() - SetupIntent source canceled")
+        }
+        return result
+    }
+
+    private fun cancellationParameters(stripeIntent: StripeIntent): CancellationParameters {
+        val threeDS2Data = stripeIntent.nextActionData as? StripeIntent.NextActionData.SdkData.Use3DS2
+        return CancellationParameters(
+            intentId = threeDS2Data?.threeDS2IntentId ?: stripeIntent.id.orEmpty(),
+            requestOptions = threeDS2Data?.publishableKey?.let { ApiRequest.Options(it) }
+                ?: ApiRequest.Options(args.publishableKey, args.stripeAccountId),
+            sourceId = threeDS2Data?.source ?: requireNotNull(args.sourceId),
+        )
+    }
+
+    private fun logFailure(error: Throwable): Boolean {
+        logger.error("Failed to cancel 3DS source.", error)
+        return false
+    }
+
+    private data class CancellationParameters(
+        val intentId: String,
+        val requestOptions: ApiRequest.Options,
+        val sourceId: String,
+    )
+
+    companion object {
+        fun create(
+            context: Context,
+            args: PaymentBrowserAuthContract.Args,
+            logger: Logger,
+        ): SourceCancellationHandler {
+            return SourceCancellationHandler(
+                args = args,
+                stripeRepository = StripeApiRepository(
+                    context = context,
+                    publishableKeyProvider = { args.publishableKey },
+                    requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
+                ),
+                logger = logger,
+            )
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -10,10 +10,13 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePaddingRelative
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.view.PaymentAuthWebViewActivity
+import kotlinx.coroutines.launch
 
 /**
  * A transparent activity that launches [PaymentBrowserAuthContract.Args.url] in either
@@ -87,18 +90,28 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
     }
 
     private fun finishWithSuccess(args: PaymentBrowserAuthContract.Args) {
-        setResult(
-            Activity.RESULT_OK,
-            viewModel.getResultIntent(args)
-        )
-        finish()
+        finishWithSourceCancellation(args, viewModel::getResultIntent)
     }
 
     private fun finishWithFailure(args: PaymentBrowserAuthContract.Args) {
-        setResult(
-            Activity.RESULT_OK,
-            viewModel.getFailureIntent(args)
-        )
-        finish()
+        finishWithSourceCancellation(args, viewModel::getFailureIntent)
+    }
+
+    private fun finishWithSourceCancellation(
+        args: PaymentBrowserAuthContract.Args,
+        resultIntentFactory: (PaymentBrowserAuthContract.Args) -> android.content.Intent,
+    ) {
+        lifecycleScope.launch {
+            val sourceWasCanceled = SourceCancellationHandler.create(
+                context = applicationContext,
+                args = args,
+                logger = Logger.getInstance(args.enableLogging),
+            ).cancel()
+            val resultArgs = args.copy(
+                shouldCancelSource = args.shouldCancelSource && !sourceWasCanceled,
+            )
+            setResult(Activity.RESULT_OK, resultIntentFactory(resultArgs))
+            finish()
+        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -82,11 +82,10 @@ internal class StripeBrowserLauncherViewModel(
     }
 
     fun getResultIntent(args: PaymentBrowserAuthContract.Args): Intent {
-        val url = Uri.parse(args.url)
         return Intent().putExtras(
             PaymentFlowResult.Unvalidated(
                 clientSecret = args.clientSecret,
-                sourceId = url.lastPathSegment.orEmpty(),
+                sourceId = args.sourceId ?: Uri.parse(args.url).lastPathSegment.orEmpty(),
                 stripeAccountId = args.stripeAccountId,
                 canCancelSource = args.shouldCancelSource
             ).toBundle()
@@ -94,7 +93,6 @@ internal class StripeBrowserLauncherViewModel(
     }
 
     fun getFailureIntent(args: PaymentBrowserAuthContract.Args): Intent {
-        val url = Uri.parse(args.url)
         val exception = LocalStripeException(
             displayMessage = resolveErrorMessage,
             analyticsValue = "failedBrowserLaunchError",
@@ -103,7 +101,7 @@ internal class StripeBrowserLauncherViewModel(
         return Intent().putExtras(
             PaymentFlowResult.Unvalidated(
                 clientSecret = args.clientSecret,
-                sourceId = url.lastPathSegment.orEmpty(),
+                sourceId = args.sourceId ?: Uri.parse(args.url).lastPathSegment.orEmpty(),
                 stripeAccountId = args.stripeAccountId,
                 canCancelSource = args.shouldCancelSource,
                 flowOutcome = StripeIntentResult.Outcome.FAILED,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
@@ -110,6 +110,8 @@ internal class WebIntentNextActionHandler @Inject constructor(
                 isInstantApp = isInstantApp,
                 referrer = referrer,
                 forceInAppWebView = forceInAppWebView,
+                sourceId = (stripeIntent.nextActionData as? StripeIntent.NextActionData.SdkData.Use3DS2)
+                    ?.source,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -184,7 +184,7 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
                 startFrictionlessFlow()
             }
         } else if (result.fallbackRedirectUrl != null) {
-            on3ds2AuthFallback(result.fallbackRedirectUrl)
+            on3ds2AuthFallback(result.fallbackRedirectUrl, sourceId)
         } else {
             val errorMessage = result.error?.let { error ->
                 listOf(
@@ -211,7 +211,8 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
      * Used when standard 3DS2 authentication mechanisms are unavailable.
      */
     private fun on3ds2AuthFallback(
-        fallbackRedirectUrl: String
+        fallbackRedirectUrl: String,
+        sourceId: String,
     ): NextStep {
         analyticsRequestExecutor.executeAsync(
             paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.Auth3ds2Fallback)
@@ -234,6 +235,7 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
                 toolbarCustomization = StripeToolbarCustomization().apply {
                     setButtonText(context.getString(R.string.stripe_cancel))
                 },
+                sourceId = sourceId,
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -24,6 +24,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.databinding.StripePaymentAuthWebViewActivityBinding
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.SourceCancellationHandler
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.stripe3ds2.utils.CustomizeUtils
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,6 +43,17 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
     private val logger: Logger by lazy {
         Logger.getInstance(_args?.enableLogging == true)
     }
+
+    @VisibleForTesting
+    internal var sourceCancellationHandlerFactory:
+        (PaymentBrowserAuthContract.Args, Logger) -> SourceCancellationHandler = { args, activityLogger ->
+            SourceCancellationHandler.create(
+                context = applicationContext,
+                args = args,
+                logger = activityLogger,
+            )
+        }
+
     private val viewModel: PaymentAuthWebViewActivityViewModel by viewModels {
         PaymentAuthWebViewActivityViewModel.Factory(
             application,
@@ -144,24 +156,34 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
                     stripeException = StripeException.create(error),
                 )
             viewModel.logError()
-            setResult(
-                Activity.RESULT_OK,
-                createResultIntent(
-                    PaymentFlowResult.Unvalidated(
-                        clientSecret = viewModel.paymentResult.clientSecret,
-                        flowOutcome = StripeIntentResult.Outcome.FAILED,
-                        exception = StripeException.create(error),
-                        canCancelSource = true,
-                        sourceId = viewModel.paymentResult.sourceId,
-                        source = viewModel.paymentResult.source,
-                        stripeAccountId = viewModel.paymentResult.stripeAccountId
-                    )
+            finishWithSourceCancellation(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = viewModel.paymentResult.clientSecret,
+                    flowOutcome = StripeIntentResult.Outcome.FAILED,
+                    exception = StripeException.create(error),
+                    canCancelSource = true,
+                    sourceId = viewModel.paymentResult.sourceId,
+                    source = viewModel.paymentResult.source,
+                    stripeAccountId = viewModel.paymentResult.stripeAccountId
                 )
             )
         } else {
+            logger.debug(
+                "PaymentAuthWebViewActivity#onAuthComplete() - " +
+                    "returning result with canCancelSource=${_args?.shouldCancelSource == true}"
+            )
             viewModel.logComplete()
+            val paymentResult = viewModel.paymentResult
+            finishWithSourceCancellation(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = paymentResult.clientSecret,
+                    canCancelSource = _args?.shouldCancelSource == true,
+                    sourceId = paymentResult.sourceId,
+                    source = paymentResult.source,
+                    stripeAccountId = paymentResult.stripeAccountId,
+                )
+            )
         }
-        finish()
     }
 
     override fun onDestroy() {
@@ -192,8 +214,30 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
     }
 
     private fun cancelIntentSource() {
-        setResult(Activity.RESULT_OK, viewModel.cancellationResult)
-        finish()
+        finishWithSourceCancellation(
+            PaymentFlowResult.Unvalidated.fromIntent(viewModel.cancellationResult)
+        )
+    }
+
+    private fun finishWithSourceCancellation(result: PaymentFlowResult.Unvalidated) {
+        lifecycleScope.launch {
+            val sourceWasCanceled = sourceCancellationHandlerFactory(requireNotNull(_args), logger).cancel()
+            setResult(
+                Activity.RESULT_OK,
+                createResultIntent(
+                    PaymentFlowResult.Unvalidated(
+                        clientSecret = result.clientSecret,
+                        flowOutcome = result.flowOutcome,
+                        exception = result.exception,
+                        canCancelSource = result.canCancelSource && !sourceWasCanceled,
+                        sourceId = result.sourceId,
+                        source = result.source,
+                        stripeAccountId = result.stripeAccountId,
+                    )
+                )
+            )
+            finish()
+        }
     }
 
     private fun customizeToolbar() {

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -53,7 +53,7 @@ internal class PaymentAuthWebViewActivityViewModel(
         get() {
             return PaymentFlowResult.Unvalidated(
                 clientSecret = args.clientSecret,
-                sourceId = Uri.parse(args.url).lastPathSegment.orEmpty(),
+                sourceId = args.sourceId ?: Uri.parse(args.url).lastPathSegment.orEmpty(),
                 stripeAccountId = args.stripeAccountId
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -148,7 +148,8 @@ class PaymentBrowserAuthStarterTest {
             returnUrl = "stripe://payment-auth",
             statusBarColor = Color.RED,
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            isInstantApp = false
+            isInstantApp = false,
+            sourceId = null,
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -114,7 +114,8 @@ class PaymentBrowserAuthContractTest {
             returnUrl = "myapp://custom",
             statusBarColor = Color.RED,
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            isInstantApp = false
+            isInstantApp = false,
+            sourceId = null,
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/payments/SourceCancellationHandlerNetworkTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SourceCancellationHandlerNetworkTest.kt
@@ -1,0 +1,192 @@
+package com.stripe.android.payments
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.FakeFraudDetectionDataRepository
+import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.Logger
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.copy
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.testing.AbsFakeStripeRepository
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class SourceCancellationHandlerNetworkTest {
+    @get:Rule
+    val networkRule = NetworkRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val apiRepository = StripeApiRepository(
+        context = context,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
+        workContext = testDispatcher,
+        fraudDetectionDataRepository = FakeFraudDetectionDataRepository(),
+    )
+
+    @Test
+    fun `native web view cancellation posts source cancel for a payatt PaymentIntent`() = runTest(testDispatcher) {
+        val sourceId = "payatt_test"
+        val originalPaymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
+        val originalThreeDS2Data =
+            originalPaymentIntent.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
+        val paymentIntent = originalPaymentIntent.copy(
+            nextActionData = originalThreeDS2Data.copy(source = sourceId),
+        )
+        val clientSecret = requireNotNull(paymentIntent.clientSecret)
+        val threeDS2Data = paymentIntent.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
+
+        networkRule.enqueue(
+            path("/v1/payment_intents/${threeDS2Data.threeDS2IntentId}/source_cancel"),
+            method("POST"),
+            bodyPart("source", threeDS2Data.source),
+        ) { response ->
+            response.setBody(paymentIntentResponse(clientSecret))
+        }
+
+        val sourceWasCanceled = SourceCancellationHandler(
+            args = browserAuthArgs(paymentIntent, sourceId),
+            stripeRepository = BrowserResultRepository(
+                apiRepository = apiRepository,
+                paymentIntent = paymentIntent,
+                setupIntent = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
+            ),
+            logger = Logger.noop(),
+        ).cancel()
+
+        assertThat(sourceWasCanceled).isTrue()
+    }
+
+    @Test
+    fun `native browser cancellation posts source cancel for a payatt SetupIntent`() = runTest(testDispatcher) {
+        val sourceId = "payatt_test"
+        val originalSetupIntent = SetupIntentFixtures.SI_3DS2_PROCESSING.copy(
+            status = StripeIntent.Status.RequiresAction,
+        )
+        val originalThreeDS2Data =
+            originalSetupIntent.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
+        val setupIntent = originalSetupIntent.copy(
+            nextActionData = originalThreeDS2Data.copy(source = sourceId),
+        )
+        val clientSecret = requireNotNull(setupIntent.clientSecret)
+        val threeDS2Data = setupIntent.nextActionData as StripeIntent.NextActionData.SdkData.Use3DS2
+
+        networkRule.enqueue(
+            path("/v1/setup_intents/${threeDS2Data.threeDS2IntentId ?: setupIntent.id}/source_cancel"),
+            method("POST"),
+            bodyPart("source", threeDS2Data.source),
+        ) { response ->
+            response.setBody(setupIntentResponse(clientSecret))
+        }
+
+        val sourceWasCanceled = SourceCancellationHandler(
+            args = browserAuthArgs(setupIntent, sourceId),
+            stripeRepository = BrowserResultRepository(
+                apiRepository = apiRepository,
+                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_REDIRECT,
+                setupIntent = setupIntent,
+            ),
+            logger = Logger.noop(),
+        ).cancel()
+
+        assertThat(sourceWasCanceled).isTrue()
+    }
+
+    private fun browserAuthArgs(
+        stripeIntent: StripeIntent,
+        sourceId: String,
+    ): PaymentBrowserAuthContract.Args {
+        return PaymentBrowserAuthContract.Args(
+            objectId = requireNotNull(stripeIntent.id),
+            requestCode = 0,
+            clientSecret = requireNotNull(stripeIntent.clientSecret),
+            url = "https://hooks.stripe.com/3d_secure_2/hosted/complete",
+            statusBarColor = null,
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            isInstantApp = false,
+            shouldCancelSource = true,
+            sourceId = sourceId,
+        )
+    }
+
+    private fun paymentIntentResponse(clientSecret: String): String {
+        return """
+            {
+              "id": "pi_test",
+              "object": "payment_intent",
+              "amount": 1000,
+              "currency": "usd",
+              "client_secret": "$clientSecret",
+              "livemode": false,
+              "payment_method_types": ["card"],
+              "status": "requires_payment_method"
+            }
+        """.trimIndent()
+    }
+
+    private fun setupIntentResponse(clientSecret: String): String {
+        return """
+            {
+              "id": "seti_test",
+              "object": "setup_intent",
+              "client_secret": "$clientSecret",
+              "livemode": false,
+              "payment_method_types": ["card"],
+              "status": "requires_payment_method",
+              "usage": "off_session"
+            }
+        """.trimIndent()
+    }
+
+    private class BrowserResultRepository(
+        private val apiRepository: StripeApiRepository,
+        private val paymentIntent: PaymentIntent,
+        private val setupIntent: SetupIntent,
+    ) : AbsFakeStripeRepository() {
+        override suspend fun retrievePaymentIntent(
+            clientSecret: String,
+            options: com.stripe.android.core.networking.ApiRequest.Options,
+            expandFields: List<String>,
+        ): Result<PaymentIntent> = Result.success(paymentIntent)
+
+        override suspend fun cancelPaymentIntentSource(
+            paymentIntentId: String,
+            sourceId: String,
+            options: com.stripe.android.core.networking.ApiRequest.Options,
+        ): Result<PaymentIntent> {
+            return apiRepository.cancelPaymentIntentSource(paymentIntentId, sourceId, options)
+        }
+
+        override suspend fun retrieveSetupIntent(
+            clientSecret: String,
+            options: com.stripe.android.core.networking.ApiRequest.Options,
+            expandFields: List<String>,
+        ): Result<SetupIntent> = Result.success(setupIntent)
+
+        override suspend fun cancelSetupIntentSource(
+            setupIntentId: String,
+            sourceId: String,
+            options: com.stripe.android.core.networking.ApiRequest.Options,
+        ): Result<SetupIntent> {
+            return apiRepository.cancelSetupIntentSource(setupIntentId, sourceId, options)
+        }
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -71,7 +71,10 @@ class StripeBrowserLauncherViewModelTest {
     fun `getResultIntent() with shouldCancelSource=true should include expected PaymentFlowResult`() {
         val viewModel = createViewModel()
         val intent = viewModel.getResultIntent(
-            ARGS.copy(shouldCancelSource = true)
+            ARGS.copy(
+                shouldCancelSource = true,
+                sourceId = "src_123",
+            )
         )
         val result = intent.getParcelableExtra<PaymentFlowResult.Unvalidated>("extra_args")
         assertThat(result)
@@ -79,7 +82,7 @@ class StripeBrowserLauncherViewModelTest {
                 PaymentFlowResult.Unvalidated(
                     clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
                     canCancelSource = true,
-                    sourceId = ""
+                    sourceId = "src_123"
                 )
             )
     }
@@ -119,7 +122,8 @@ class StripeBrowserLauncherViewModelTest {
             url = "https://bank.com",
             statusBarColor = Color.RED,
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            isInstantApp = false
+            isInstantApp = false,
+            sourceId = null,
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
@@ -10,10 +10,13 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.copy
 import com.stripe.android.networking.StripeRepository
@@ -21,8 +24,10 @@ import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
+import com.stripe.android.stripe3ds2.transaction.Transaction
 import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.testing.fakeCreationExtras
+import com.stripe.android.view.PaymentAuthWebViewActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -80,6 +85,30 @@ class Stripe3ds2TransactionViewModelTest {
                 eq(ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY))
             )
         }
+
+    @Test
+    fun `3DS2 fallback launches the in-app WebView with source cancellation enabled`() = runTest {
+        val result = createViewModel().on3ds2AuthSuccess(
+            result = Stripe3ds2AuthResult(
+                id = "threeds2_123",
+                created = 0,
+                source = "src_123",
+                fallbackRedirectUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin/src_123",
+            ),
+            transaction = mock<Transaction>(),
+            sourceId = "src_123",
+            timeout = 5,
+        )
+
+        val args = (result as NextStep.StartFallback).args
+        val intent = PaymentBrowserAuthContract().createIntent(context, args)
+
+        assertThat(args.returnUrl).isNull()
+        assertThat(args.shouldCancelSource).isTrue()
+        assertThat(args.sourceId).isEqualTo("src_123")
+        assertThat(intent.component?.className)
+            .isEqualTo(PaymentAuthWebViewActivity::class.java.name)
+    }
 
     @Test
     fun `Stripe3ds2TransactionViewModel gets initialized`() {

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -11,8 +11,14 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.SourceCancellationHandler
+import com.stripe.android.testing.AbsFakeStripeRepository
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -75,6 +81,35 @@ internal class PaymentAuthWebViewActivityTest {
         }
     }
 
+    @Test
+    fun `onAuthComplete cancels the explicit source before returning`() {
+        val sourceId = "src_123"
+        val args = ARGS.copy(
+            url = "https://hooks.stripe.com/3d_secure_2/hosted/complete",
+            clientSecret = "seti_xyz_secret_123",
+            shouldCancelSource = true,
+            sourceId = sourceId,
+        )
+        ActivityScenario.launchActivityForResult<PaymentAuthWebViewActivity>(
+            contract.createIntent(context, args)
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                activity.sourceCancellationHandlerFactory = { activityArgs, _ ->
+                    SourceCancellationHandler(
+                        args = activityArgs,
+                        stripeRepository = SourceCancellationRepository,
+                        logger = Logger.noop(),
+                    )
+                }
+                activity.onAuthComplete(null)
+            }
+
+            val result = contract.parseResult(REQUEST_CODE, activityScenario.result.resultData)
+            assertThat(result.canCancelSource).isFalse()
+            assertThat(result.sourceId).isEqualTo(sourceId)
+        }
+    }
+
     private fun runOnActivityScenario(
         onActivityScenario: (ActivityScenario<PaymentAuthWebViewActivity>) -> Unit
     ) {
@@ -99,7 +134,22 @@ internal class PaymentAuthWebViewActivityTest {
             url = "https://example.com",
             statusBarColor = Color.RED,
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            isInstantApp = false
+            isInstantApp = false,
+            sourceId = null,
         )
+
+        private object SourceCancellationRepository : AbsFakeStripeRepository() {
+            override suspend fun retrieveSetupIntent(
+                clientSecret: String,
+                options: ApiRequest.Options,
+                expandFields: List<String>,
+            ): Result<SetupIntent> = Result.success(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
+
+            override suspend fun cancelSetupIntentSource(
+                setupIntentId: String,
+                sourceId: String,
+                options: ApiRequest.Options,
+            ): Result<SetupIntent> = Result.success(SetupIntentFixtures.CANCELLED)
+        }
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -159,7 +159,8 @@ class PaymentAuthWebViewActivityViewModelTest {
             url = "https://example.com",
             statusBarColor = Color.RED,
             publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            isInstantApp = false
+            isInstantApp = false,
+            sourceId = null,
         )
     }
 }


### PR DESCRIPTION
## Summary

The prior result-propagation approach was insufficient: the parent flow can be torn down before `PaymentFlowResultProcessor` receives the browser result, so no cancellation request is sent.

`PaymentAuthWebViewActivity` and `StripeBrowserLauncherActivity` now cancel directly before returning their result. The native helper:

- retrieves the PaymentIntent or SetupIntent;
- cancels only while it is still `requires_action`;
- posts `source_cancel` using the authoritative 3DS2 source (including current `payatt_` identifiers), 3DS2 intent ID, and key when provided;
- preserves the existing result-processor fallback if native cancellation fails.

## Tests

- WebView activity completion invokes native cancellation before returning.
- `SourceCancellationHandlerNetworkTest` uses `NetworkRule` to verify the exact PaymentIntent and SetupIntent `source_cancel` request paths and `payatt_…` body values.
- Focused `:payments-core:testDebugUnitTest`
- `:payments-core:detekt`
- pre-push `:payments-core:apiCheck :payments-core:detekt`

## Follow-up evidence requested

The production `/v1/3ds2/authenticate` response for the repro will let us confirm whether the actual fallback uses any special 3DS2 intent ID or publishable key.