### PR TITLE
Add headless Android release proposal mode

### DIFF
--- a/scripts/deploy/common.rb
+++ b/scripts/deploy/common.rb
@@ -129,12 +129,23 @@ end
 
 private def octokit_client
   @octokit_client ||= begin
-    token = fetch_password("bindings/gh-tokens/#{ENV['USER']}")
-    if token.nil? || token == ""
-      raise "Got empty Github token from password-vault"
-    end
+    if @is_headless
+      token = ENV['GITHUB_TOKEN'] || ENV['GH_TOKEN']
 
-    Octokit::Client.new(access_token: token)
+      if token.nil? || token == ""
+        rputs "Headless mode: using unauthenticated GitHub API access for read-only checks."
+        Octokit::Client.new
+      else
+        Octokit::Client.new(access_token: token)
+      end
+    else
+      token = fetch_password("bindings/gh-tokens/#{ENV['USER']}")
+      if token.nil? || token == ""
+        raise "Got empty Github token from password-vault"
+      end
+
+      Octokit::Client.new(access_token: token)
+    end
   end
 end
 

--- a/scripts/deploy/propose_release.rb
+++ b/scripts/deploy/propose_release.rb
@@ -55,19 +55,29 @@ def cleanup_propose_release_dry_run
     delete_git_branch(release_branch, @deploy_branch)
 end
 
-parse_release_options!(flow_name: 'propose release')
+parse_release_options!(flow_name: 'propose release', allow_headless: true)
 
-steps = [
-    method(:check_permissions),
-    method(:validate_translations_merged),
-    method(:validate_version_number),
-    method(:ensure_clean_repo),
-    method(:pull_latest),
-    method(:create_version_bump_pr),
-    method(:pause_for_pr_merge),
-    method(:create_release_tag),
-    method(:print_propose_release_handoff),
-]
+if @is_headless
+    steps = [
+        method(:validate_translations_merged),
+        method(:validate_version_number),
+        method(:ensure_clean_repo),
+        method(:pull_latest),
+        method(:create_version_bump_pr),
+    ]
+else
+    steps = [
+        method(:check_permissions),
+        method(:validate_translations_merged),
+        method(:validate_version_number),
+        method(:ensure_clean_repo),
+        method(:pull_latest),
+        method(:create_version_bump_pr),
+        method(:pause_for_pr_merge),
+        method(:create_release_tag),
+        method(:print_propose_release_handoff),
+    ]
+end
 
 @propose_release_succeeded = false
 

--- a/scripts/deploy/release_cli.rb
+++ b/scripts/deploy/release_cli.rb
@@ -5,10 +5,11 @@ require 'optparse'
 require_relative 'common'
 require_relative 'validate_version_number'
 
-def parse_release_options!(flow_name:, version_required: false)
+def parse_release_options!(flow_name:, version_required: false, allow_headless: false)
     @flow_name = flow_name
     @step_index = 1
     @is_dry_run = false
+    @is_headless = false
     @deploy_branch = 'master'
     @is_older_version = false
 
@@ -27,6 +28,12 @@ def parse_release_options!(flow_name:, version_required: false)
             @is_dry_run = t
         end
 
+        if allow_headless
+            opts.on('--headless', "Create and push the version bump branch, then print PR handoff details without creating a PR") do |t|
+                @is_headless = t
+            end
+        end
+
         opts.on('--branch BRANCH', "Branch to deploy from") do |t|
             @deploy_branch = t
         end
@@ -36,12 +43,25 @@ def parse_release_options!(flow_name:, version_required: false)
         end
     end.parse!
 
+    if @is_headless && @is_dry_run
+        raise ArgumentError, "--headless cannot be combined with --dry-run"
+    end
+
     if @version.nil?
         if version_required
             raise ArgumentError, "--version is required for #{flow_name}"
         end
         @version = infer_version_from_changelog()
     end
+end
+
+def release_command
+    command = "./scripts/deploy/#{File.basename($PROGRAM_NAME)}"
+    command += " --headless" if @is_headless
+    command += " --dry-run" if @is_dry_run
+    command += " --branch #{@deploy_branch}" if @deploy_branch != 'master'
+    command += " --release-older-version" if @is_older_version
+    command
 end
 
 def execute_steps(steps, before_resume: nil)
@@ -67,8 +87,7 @@ def execute_steps(steps, before_resume: nil)
     rescue SystemExit, Interrupt
         raise
     rescue Exception
-        command = "./scripts/deploy/#{File.basename($PROGRAM_NAME)}"
-        rputs "Restart #{@flow_name} with `#{command} --continue-from #{step_index} --version #{@version}` to re-run from this step."
+        rputs "Restart #{@flow_name} with `#{release_command} --continue-from #{step_index} --version #{@version}` to re-run from this step."
         raise
     end
 end

--- a/scripts/deploy/validate_version_number.rb
+++ b/scripts/deploy/validate_version_number.rb
@@ -94,6 +94,10 @@ def validate_version_matches_changelog(version)
 
   if version != expected_version
     rputs "Warning: CHANGELOG.md specifies a #{bump_type} bump (expected #{expected_version}), but you specified #{version}."
+    if @is_headless
+      abort("Headless propose release cannot prompt for version mismatch confirmation. Update CHANGELOG.md's NEXT_VERSION_BUMP or use --version #{expected_version}.")
+    end
+
     rputs "Do you want to proceed with #{version} anyway? (y/n)"
     response = STDIN.gets.strip.downcase
     unless response == 'y' || response == 'yes'

--- a/scripts/deploy/version_bump_pr_steps.rb
+++ b/scripts/deploy/version_bump_pr_steps.rb
@@ -2,6 +2,7 @@
 
 require 'open3'
 require 'octokit'
+require 'uri'
 
 require_relative 'common'
 
@@ -24,7 +25,11 @@ def revert_version_bump_changes()
 end
 
 def create_version_bump_pr()
-    switch_to_release_branch()
+    if @is_headless
+        switch_to_headless_release_branch()
+    else
+        switch_to_release_branch()
+    end
     update_read_me()
     update_stripe_sdk_version()
     update_gradle_properties()
@@ -34,9 +39,20 @@ def create_version_bump_pr()
     execute_or_fail("git commit -m \"Bump version to #{@version}\"")
 
     begin
-        execute_or_fail("git push -u origin")
-    
+        if @is_headless
+            execute_or_fail("git push --force-with-lease -u origin #{release_branch}")
+        else
+            execute_or_fail("git push -u origin")
+        end
+
         pr_description = create_pr_description()
+        pr_title = "Bump version to #{@version}"
+
+        if @is_headless
+            print_headless_pr_handoff(pr_title, pr_description)
+            return
+        end
+
         if (@is_dry_run)
           user_message = "Verify that a draft PR containing version number bumps was opened."
         else
@@ -45,19 +61,28 @@ def create_version_bump_pr()
 
         create_pr(
            release_branch,
-           "Bump version to #{@version}",
+           pr_title,
            pr_description,
            user_message
         )
     rescue
-        revert_version_bump_changes()
-        execute("git checkout #{@deploy_branch}")
+        if @is_headless
+            execute("git checkout #{@deploy_branch}")
+        else
+            revert_version_bump_changes()
+            execute("git checkout #{@deploy_branch}")
+        end
         raise
     end
 end
 
 private def release_branch
     "release/#{@version}"
+end
+
+private def switch_to_headless_release_branch
+    execute_or_fail("git fetch origin #{@deploy_branch}")
+    execute_or_fail("git checkout -B #{release_branch} origin/#{@deploy_branch}")
 end
 
 private def create_pr_description()
@@ -72,4 +97,27 @@ private def create_pr_description()
 
     template["<!-- Simple summary of what was changed. -->"] = summary
     template
+end
+
+private def print_headless_pr_handoff(pr_title, pr_description)
+    compare_url = "https://github.com/stripe/stripe-android/compare/#{@deploy_branch}...#{release_branch}"
+    create_pr_url = "#{compare_url}?#{URI.encode_www_form(
+        quick_pull: 1,
+        title: pr_title,
+        body: pr_description
+    )}"
+
+    rputs "Headless propose release complete. The release branch was pushed, but no PR was created."
+    puts ""
+    puts "PR title:"
+    puts pr_title
+    puts ""
+    puts "PR body:"
+    puts pr_description
+    puts ""
+    puts "Create PR URL:"
+    puts create_pr_url
+    puts ""
+    puts "Compare URL:"
+    puts compare_url
 end


### PR DESCRIPTION
## Summary
- Add `--headless` to `scripts/deploy/propose_release.rb`
- In headless mode, create/update and push the version bump branch, then print PR title/body/create URL instead of creating a PR
- Skip publish-only permission checks, PR merge wait, signed tag creation, browser opens, and STDIN prompts in the headless path

## Validation
- `ruby -c scripts/deploy/propose_release.rb`
- `ruby -c scripts/deploy/release_cli.rb`
- `ruby -c scripts/deploy/version_bump_pr_steps.rb`
- `ruby -c scripts/deploy/common.rb`
- `ruby -c scripts/deploy/validate_version_number.rb`
- `git diff --check -- scripts/deploy/propose_release.rb scripts/deploy/release_cli.rb scripts/deploy/version_bump_pr_steps.rb scripts/deploy/common.rb scripts/deploy/validate_version_number.rb`
- Push hook static analysis completed successfully

Did not run the full proposer because it would create and push a real release proposal branch.