### PR TITLE
Improve test to verify forwarding of previously entered selections.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -392,17 +392,20 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
-    fun `launchPaymentOptions forwards previously entered new selections`() = testScenario {
+    fun `launchPaymentOptions forwards previously entered new selections into the sheet`() = testScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
         sheetLauncher.launchPaymentOptions(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
-            selection = PaymentSelection.GooglePay,
+            customerState = createCustomerState(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             configuration = EmbeddedConfigurationFactory.create(),
         )
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
 
+        assertThat(launchCall.previousNewSelections.previousNewSelection("card"))
+            .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         assertThat(launchCall.previousNewSelections.previousNewSelection("cashapp"))
             .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }


### PR DESCRIPTION
# Summary
Update `launchPaymentOptions` test to verify both card and cash app previous selections are forwarded into the sheet.

# Motivation
This change ensures the forwarding mechanism for previously entered selections works for multiple payment methods, improving test coverage and confidence.

