### PR TITLE
Refactor `ApduCommand` to support non-TLV responses

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
@@ -40,12 +40,12 @@ internal abstract class ApduCommand<TResponseData> {
         get() = dataArray?.run { size.toByte() }
 
     /**
-     * Converts TLV data into readable response for another command to process or to use when building the final
+     * Converts raw byte data into readable result for another command to process or to use when building the final
      * response.
      *
-     * @param tlv Tag-Length-Value encoded data separated by string keys which return parsable byte array data.
+     * @param data raw byte array data.
      */
-    protected abstract fun responseData(tlv: Map<String, ByteArray>): TResponseData?
+    protected abstract fun responseData(data: ByteArray): ApduDataResult<TResponseData>
 
     /**
      * Sends a command to the NFC tag then parses out the response returned from the NFC tag.
@@ -81,16 +81,10 @@ internal abstract class ApduCommand<TResponseData> {
 
         val rawData = rawResponse.copyOfRange(0, rawResponse.size - 2)
 
-        return TlvParser.parse(rawData).fold(
-            onSuccess = { tlv ->
-                responseData(tlv)?.let { responseData ->
-                    Result.success(responseData)
-                } ?: Result.failure(ApduResponseError.Invalid(rawData))
-            },
-            onFailure = { cause ->
-                Result.failure(ApduResponseError.Parsing(rawData, cause))
-            }
-        )
+        return when (val apduResult = responseData(rawData)) {
+            is ApduDataResult.Success -> Result.success(apduResult.data)
+            is ApduDataResult.Error -> Result.failure(apduResult.throwable)
+        }
     }
 
     private fun buildData(dataLengthByte: Byte?, dataArray: ByteArray?): ByteArray {
@@ -99,5 +93,33 @@ internal abstract class ApduCommand<TResponseData> {
         } else {
             byteArrayOf()
         }
+    }
+
+    protected sealed interface ApduDataResult<TResponseData> {
+        data class Success<TResponseData>(val data: TResponseData) : ApduDataResult<TResponseData>
+        data class Error<TResponseData>(val throwable: ApduResponseError.Data) : ApduDataResult<TResponseData>
+    }
+
+    abstract class Tlv<TResponseData> : ApduCommand<TResponseData>() {
+        final override fun responseData(data: ByteArray): ApduDataResult<TResponseData> {
+            return TlvParser.parse(data).fold(
+                onSuccess = { tlv ->
+                    responseData(tlv)?.let { responseData ->
+                        ApduDataResult.Success(responseData)
+                    } ?: ApduDataResult.Error(ApduResponseError.Data.Invalid(data))
+                },
+                onFailure = { cause ->
+                    ApduDataResult.Error(ApduResponseError.Data.Parsing(data, cause))
+                }
+            )
+        }
+
+        /**
+         * Converts TLV data into readable response for another command to process or to use when building the final
+         * response.
+         *
+         * @param tlv Tag-Length-Value encoded data separated by string keys which return parsable byte array data.
+         */
+        protected abstract fun responseData(tlv: Map<String, ByteArray>): TResponseData?
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
@@ -23,11 +23,11 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
                 errorCode = APDU_RESPONSE_TOO_SHORT_ERROR_CODE,
                 userMessage = R.string.stripe_something_went_wrong.resolvableString,
             )
-            is ApduResponseError.Parsing -> NfcCardReader.Result.Error(
+            is ApduResponseError.Data.Parsing -> NfcCardReader.Result.Error(
                 errorCode = APDU_RESPONSE_PARSING_ERROR_CODE,
                 userMessage = R.string.stripe_something_went_wrong.resolvableString,
             )
-            is ApduResponseError.Invalid -> unsupportedCard()
+            is ApduResponseError.Data.Invalid -> unsupportedCard()
             is ApduResponseError.Command -> mapCommandError(error)
             is IllegalStateException -> generalFailure()
             else -> NfcCardReader.Result.Error(

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
@@ -12,12 +12,19 @@ internal sealed class ApduResponseError(
         val sw2: Byte,
     ) : ApduResponseError("APDU error: SW1=$sw1, SW2=$sw2")
 
-    class Parsing(
-        val data: ByteArray,
-        override val cause: Throwable?,
-    ) : ApduResponseError("Failed to parse response data: ${data.toHexString()}")
+    sealed class Data(
+        message: String?,
+        cause: Throwable? = null,
+    ) : ApduResponseError(message, cause) {
+        abstract val data: ByteArray
 
-    class Invalid(
-        val data: ByteArray
-    ) : ApduResponseError("Invalid data in response: ${data.toHexString()}")
+        class Parsing(
+            override val data: ByteArray,
+            cause: Throwable?,
+        ) : Data("Failed to parse response data: ${data.toHexString()}", cause)
+
+        class Invalid(
+            override val data: ByteArray,
+        ) : Data("Invalid data in response: ${data.toHexString()}")
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommand.kt
@@ -6,7 +6,7 @@ package com.stripe.android.common.nfcscan.scanner.apdu
 internal data class ReadRecordCommand(
     val recordNumber: Int,
     val shortFileIdentifier: Int,
-) : ApduCommand<Map<String, ByteArray>>() {
+) : ApduCommand.Tlv<Map<String, ByteArray>>() {
     /*
      * Interindustry standardized command for ISO 7816-4
      */

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommand.kt
@@ -5,7 +5,7 @@ package com.stripe.android.common.nfcscan.scanner.apdu
  */
 internal data class SelectApplicationCommand(
     val aid: ApplicationIdentifier,
-) : ApduCommand<Unit>() {
+) : ApduCommand.Tlv<Unit>() {
     /*
      * Interindustry standardized command for ISO 7816-4
      */

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommand.kt
@@ -5,7 +5,7 @@ import com.stripe.android.model.CardBrand
 /**
  * An APDU command for retrieving the payment application on the credit card chip
  */
-internal data object SelectPpseCommand : ApduCommand<ApplicationIdentifier>() {
+internal data object SelectPpseCommand : ApduCommand.Tlv<ApplicationIdentifier>() {
     /*
      * Interindustry standardized command for ISO 7816-4
      */

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
@@ -90,35 +90,52 @@ internal class ApduCommandTest {
 
     @Test
     fun `transceiveWith returns Invalid error when response data cannot be parsed`() {
-        val responseData = tlv(tag = 0x4F, value = byteArrayOf(0x01))
+        val responseData = byteArrayOf(0x01)
 
         test(
             transceiveResult = apduSuccessResponse(responseData)
         ) {
-            val command = TestApduCommand(response = null)
+            val command = TestApduCommandWithError()
             val result = command.transceiveWith(transceiver)
 
             val error = result.exceptionOrNull()
-            assertThat(error).isInstanceOf<ApduResponseError.Invalid>()
-            assertThat((error as ApduResponseError.Invalid).data.contentEquals(responseData)).isTrue()
+            assertThat(error).isInstanceOf<ApduResponseError.Data.Invalid>()
+            assertThat((error as ApduResponseError.Data.Invalid).data.contentEquals(responseData)).isTrue()
             assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
         }
     }
 
     @Test
-    fun `transceiveWith returns Parsing error when tlv data is malformed`() {
+    fun `transceiveWith returns Invalid error when response data cannot be parsed with Tlv command`() {
+        val responseData = tlv(tag = 0x4F, value = byteArrayOf(0x01))
+
+        test(
+            transceiveResult = apduSuccessResponse(responseData)
+        ) {
+            val command = TestTlvApduCommand(response = null)
+            val result = command.transceiveWith(transceiver)
+
+            val error = result.exceptionOrNull()
+            assertThat(error).isInstanceOf<ApduResponseError.Data.Invalid>()
+            assertThat((error as ApduResponseError.Data.Invalid).data.contentEquals(responseData)).isTrue()
+            assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+        }
+    }
+
+    @Test
+    fun `transceiveWith returns Parsing error when tlv data is malformed with Tlv command`() {
         val malformedResponseData = byteArrayOf(0x4F, 0x05, 0x01)
 
         test(
             transceiveResult = apduSuccessResponse(malformedResponseData)
         ) {
-            val command = TestApduCommand(response = "parsed")
+            val command = TestTlvApduCommand(response = "parsed")
             val result = command.transceiveWith(transceiver)
 
             val error = result.exceptionOrNull()
-            assertThat(error).isInstanceOf<ApduResponseError.Parsing>()
+            assertThat(error).isInstanceOf<ApduResponseError.Data.Parsing>()
 
-            val parsingError = error as ApduResponseError.Parsing
+            val parsingError = error as ApduResponseError.Data.Parsing
             assertThat(parsingError.data.contentEquals(malformedResponseData)).isTrue()
             assertThat(parsingError.cause).isInstanceOf<IndexOutOfBoundsException>()
 
@@ -149,8 +166,30 @@ internal class ApduCommandTest {
         override val firstParameterByte: Byte = 0x04,
         override val secondParameterByte: Byte = 0x00,
         override val dataArray: ByteArray? = null,
-        private val response: String?,
+        private val response: String,
     ) : ApduCommand<String>() {
+        override fun responseData(data: ByteArray): ApduDataResult<String> = ApduDataResult.Success(response)
+    }
+
+    private class TestApduCommandWithError(
+        override val classByte: Byte = 0x00,
+        override val instructionByte: Byte = 0xA4.toByte(),
+        override val firstParameterByte: Byte = 0x04,
+        override val secondParameterByte: Byte = 0x00,
+        override val dataArray: ByteArray? = null,
+    ) : ApduCommand<String>() {
+        override fun responseData(data: ByteArray): ApduDataResult<String> =
+            ApduDataResult.Error(ApduResponseError.Data.Invalid(data))
+    }
+
+    private class TestTlvApduCommand(
+        override val classByte: Byte = 0x00,
+        override val instructionByte: Byte = 0xA4.toByte(),
+        override val firstParameterByte: Byte = 0x04,
+        override val secondParameterByte: Byte = 0x00,
+        override val dataArray: ByteArray? = null,
+        private val response: String?,
+    ) : ApduCommand.Tlv<String>() {
         override fun responseData(tlv: Map<String, ByteArray>): String? = response
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
@@ -61,7 +61,7 @@ internal class ApduErrorCreatorTest {
     @Test
     fun `create returns unsupported card error for invalid PPSE response`() {
         val result = errorMapper.create(
-            ApduResponseError.Invalid(data = byteArrayOf(0x01)),
+            ApduResponseError.Data.Invalid(data = byteArrayOf(0x01)),
         )
 
         assertThat(result.errorCode).isEqualTo("cardUnsupportedByNfc")
@@ -125,7 +125,7 @@ internal class ApduErrorCreatorTest {
     @Test
     fun `create returns parsing error for ApduResponseError Parsing`() {
         val result = errorMapper.create(
-            ApduResponseError.Parsing(
+            ApduResponseError.Data.Parsing(
                 data = byteArrayOf(0x01, 0x02),
                 cause = IllegalArgumentException("invalid tlv"),
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommandTest.kt
@@ -52,7 +52,7 @@ internal class SelectPpseCommandTest {
         transceiveResult = apduSuccessResponse(tlv(tag = 0x50, value = byteArrayOf(0x56, 0x49, 0x53, 0x41))),
     ) {
         val result = SelectPpseCommand.transceiveWith(transceiver)
-        assertThat(result.exceptionOrNull()).isInstanceOf<ApduResponseError.Invalid>()
+        assertThat(result.exceptionOrNull()).isInstanceOf<ApduResponseError.Data.Invalid>()
         assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
     }
 


### PR DESCRIPTION
# Summary
Refactor `ApduCommand` to support non-TLV responses.

# Motivation
The `GetProcessingOptions` command has two formats for responses:
- **Tag '77'**: TLV response that can be parsed out into a map of tags.
- **Tag '80'**: Compact response containing only two data points.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified