### PR TITLE
Update autocomplete countries for address autocomplete

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
@@ -1,5 +1,10 @@
 package com.stripe.android.paymentsheet.addresselement
 
+/**
+ * Countries where autocomplete results have been validated for quality.
+ * Merchants can override this with their own list if they want autocomplete
+ * in additional countries, accepting responsibility for the experience there.
+ */
 internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "AU",
     "BE",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
@@ -22,3 +22,11 @@ internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
     "US",
     "ZA"
 )
+
+/**
+ * Extended list used when using Stripe-hosted autocomplete proxy endpoints.
+ * These countries are enabled only for the Stripe-hosted endpoint to avoid exposing
+ * merchant-owned API keys to broader usage.
+ */
+internal val AUTOCOMPLETE_STRIPE_HOSTED_DEFAULT_COUNTRIES: Set<String> =
+    AUTOCOMPLETE_DEFAULT_COUNTRIES + setOf("IN", "JP", "MY", "NZ", "PH", "SG")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -74,7 +74,19 @@ internal class InputAddressViewModel @Inject constructor(
 
     override val autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,
-        autocompleteCountries = args.config?.autocompleteCountries ?: emptySet(),
+        // If merchant is opting into Stripe-hosted autocomplete and the caller did not
+        // override the launcher default countries, use the extended Stripe-hosted list.
+        // Otherwise, honor the caller-provided set (or empty set if explicitly set).
+        autocompleteCountries = run {
+            val provided = args.config?.autocompleteCountries
+            if (args.config?.useStripeHostedAutocomplete == true &&
+                provided == AUTOCOMPLETE_DEFAULT_COUNTRIES
+            ) {
+                AUTOCOMPLETE_STRIPE_HOSTED_DEFAULT_COUNTRIES
+            } else {
+                provided ?: emptySet()
+            }
+        },
         isInlineAutocompleteEnabled = isInlineAutocompleteEnabled,
         shouldUseStripeHostedAutocomplete = args.config?.useStripeHostedAutocomplete == true,
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update default countries for which autocomplete is enabled. Uses the same list that web uses.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Aligning with https://github.com/stripe/stripe-ios/pull/6594 and web autocomplete country list


<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A: Behind feature flag for inline autocomplete