### PR TITLE
[RUN_MOBILESDK-5542] Restores standalone US Bank Account coverage

### DIFF
--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -76,6 +77,14 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        if (::webView.isInitialized) {
+            (webView.parent as? ViewGroup)?.removeView(webView)
+            webView.destroy()
+        }
+        super.onDestroy()
     }
 
     private fun handleEdgeToEdge() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -31,13 +31,11 @@ import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.test.core.ui.PaymentSelection
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@Ignore("#ir-implore-chord")
 internal class TestUSBankAccount : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "us_bank_account",


### PR DESCRIPTION
## Summary

Restores standalone US Bank Account coverage and releases the app-owned Financial Connections Lite WebView when its activity is destroyed.

## Evidence

The Chrome GMD run exercised all nine TestUSBankAccount cases. Two Lite-only cases initially failed LeakCanary with the same retained path:

native GC root -> WindowAndroid -> PhoneWindow -> FinancialConnectionsSheetLiteActivity

The activity owns the layout WebView, so onDestroy now removes it from its parent and calls destroy(). No LeakCanary matcher or suppression was added. The Chrome GMD rerun passes.

## Scope

- Unignores only TestUSBankAccount.
- Leaves TestEmbedded.testUsBankAccount ignored. It uses the full Financial Connections flow and has a separate Compose timeout before leak detection.
- Does not include or stack on #13612.

## Verification

- :financial-connections-lite:testDebugUnitTest
- :financial-connections-lite:apiCheck
- :financial-connections-lite:detekt
- Chrome GMD PaymentSheet E2E rerun
