### PR TITLE
[RUN_MOBILESDK-5542] Restore embedded US bank account coverage

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestEmbedded.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestEmbedded.kt
@@ -22,7 +22,6 @@ import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaym
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -88,7 +87,6 @@ internal class TestEmbedded : BasePlaygroundTest() {
     }
 
     @Test
-    @Ignore("#ir-implore-chord")
     fun testUsBankAccount() {
         testDriver.confirmEmbeddedUsBankAccount(
             testParameters = parameters.copy(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1624,7 +1624,7 @@ internal class PlaygroundTestDriver(
 
         // Verifies bank in web view so Compose hierarchy can detach. Button should be available
         // after web view verification.
-        clickButtonWithTag("connect_account_button", composeCanDetach = true)
+        clickButtonWithTagAfterDismissingChromeFirstRun("connect_account_button")
 
         clickButtonWithTag("skip_cta")
         clickButtonWithTag("done_button")
@@ -1722,7 +1722,22 @@ internal class PlaygroundTestDriver(
     }
 
     private fun clickButtonWithTag(tag: String, composeCanDetach: Boolean = false) {
+        clickButtonWithTag(tag, composeCanDetach) {}
+    }
+
+    private fun clickButtonWithTagAfterDismissingChromeFirstRun(tag: String) {
+        clickButtonWithTag(tag, composeCanDetach = true) {
+            selectors.dismissChromeFirstRunIfPresent()
+        }
+    }
+
+    private fun clickButtonWithTag(
+        tag: String,
+        composeCanDetach: Boolean,
+        beforeCheckingTag: () -> Unit,
+    ) {
         composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            beforeCheckingTag()
             composeTestRule
                 .onAllNodesWithTag(tag)
                 .fetchSemanticsNodes(atLeastOneRootRequired = !composeCanDetach)

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -189,8 +189,8 @@ internal class Selectors(
         )
         repeat(8) {
             val clicked = freButtonIds.any { id ->
-                val button = device.findObject(UiSelector().resourceId("$chrome:id/$id"))
-                if (button.exists()) {
+                val button = device.findObject(By.res("$chrome:id/$id"))
+                if (button != null) {
                     runCatching { button.click() }
                     device.waitForIdle()
                     true


### PR DESCRIPTION
## Summary
- remove the sole ignore from `TestEmbedded.testUsBankAccount`

## Verification
- `:paymentsheet-example:detekt` (pre-push hook)
- Chrome GMD PaymentSheet E2E diagnostic CI pending

This is intentionally a narrow diagnostic PR based directly on current `master`; it is not stacked on #13612 or #13649.