### PR TITLE
Add configurable payment method layout for PaymentElement.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
@@ -18,17 +19,19 @@ import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.state.CustomerState
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Provider
 
+@OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
+    private val paymentElementConfigurationProvider: Provider<PaymentElement.Configuration.State>,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
@@ -142,7 +145,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                paymentMethodLayout = paymentElementConfigurationProvider.get().paymentMethodLayout.asPaymentSheet(),
             ),
         )
         activityLauncher.launch(args)
@@ -200,7 +203,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                paymentMethodLayout = paymentElementConfigurationProvider.get().paymentMethodLayout.asPaymentSheet(),
             ),
         )
         activityLauncher.launch(args)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -32,6 +32,7 @@ class PaymentElement @Inject internal constructor(
         private var embeddedViewDisplaysMandateText: Boolean = true
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
+        private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
 
         fun embeddedViewDisplaysMandateText(
             embeddedViewDisplaysMandateText: Boolean
@@ -45,15 +46,54 @@ class PaymentElement @Inject internal constructor(
             this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
         }
 
+        /**
+         * The layout of payment methods in the sheet. Defaults to [PaymentMethodLayout.Automatic].
+         *
+         * Note: Only used if you call `presentPaymentOptions`.
+         *
+         * @see [PaymentMethodLayout] for the list of available layouts.
+         */
+        fun paymentMethodLayout(
+            paymentMethodLayout: PaymentMethodLayout
+        ): Configuration = apply {
+            this.paymentMethodLayout = paymentMethodLayout
+        }
+
         @Parcelize
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
+            val paymentMethodLayout: PaymentMethodLayout,
         ) : Parcelable
 
         internal fun build(): State = State(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
+            paymentMethodLayout = paymentMethodLayout,
         )
+    }
+
+    /**
+     * The layout of payment methods.
+     */
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class PaymentMethodLayout {
+        /**
+         * Payment methods are arranged horizontally.
+         * Users can swipe left or right to navigate through different payment methods.
+         */
+        Horizontal,
+
+        /**
+         * Payment methods are arranged vertically.
+         * Users can scroll up or down to navigate through different payment methods.
+         */
+        Vertical,
+
+        /**
+         * This lets Stripe choose the best layout for payment methods.
+         */
+        Automatic
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentMethodLayoutMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentMethodLayoutMapper.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun PaymentElement.PaymentMethodLayout.asPaymentSheet(): PaymentSheet.PaymentMethodLayout {
+    return when (this) {
+        PaymentElement.PaymentMethodLayout.Horizontal -> PaymentSheet.PaymentMethodLayout.Horizontal
+        PaymentElement.PaymentMethodLayout.Vertical -> PaymentSheet.PaymentMethodLayout.Vertical
+        PaymentElement.PaymentMethodLayout.Automatic -> PaymentSheet.PaymentMethodLayout.Automatic
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -2,6 +2,8 @@ package com.stripe.android.checkout.injection
 
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutSheetLauncher
+import com.stripe.android.checkout.PaymentElement
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
@@ -44,7 +46,15 @@ internal interface PaymentElementModule {
     @Binds
     fun bindsSheetLauncher(launcher: CheckoutSheetLauncher): EmbeddedSheetLauncher
 
+    @OptIn(CheckoutSessionPreview::class)
     companion object {
+        @Provides
+        fun providePaymentElementConfiguration(
+            stateHolder: CheckoutControllerStateHolder,
+        ): PaymentElement.Configuration.State {
+            return requireNotNull(stateHolder.state).configuration.paymentElementConfiguration
+        }
+
         @Provides
         fun provideEmbeddedContentState(
             stateHolder: CheckoutControllerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -41,6 +42,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutSheetLauncherTest {
 
@@ -73,7 +75,7 @@ internal class CheckoutSheetLauncherTest {
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
             ),
         )
 
@@ -90,6 +92,29 @@ internal class CheckoutSheetLauncherTest {
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
         assertThat(selectionHolder.temporarySelection.value).isEqualTo(code)
+    }
+
+    @Test
+    fun `launchForm uses configured payment method layout`() = testScenario(
+        paymentElementConfiguration = PaymentElement.Configuration()
+            .paymentMethodLayout(PaymentElement.PaymentMethodLayout.Horizontal)
+            .build()
+    ) {
+        sheetLauncher.launchForm(
+            code = "test_code",
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            configuration = EmbeddedConfigurationFactory.create(),
+            customerState = createCustomerState(),
+            promotion = null,
+        )
+
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(launchCall.launchMode).isEqualTo(
+            EmbeddedLaunchMode.Form(
+                selectedPaymentMethodCode = "test_code",
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            )
+        )
     }
 
     @Test
@@ -393,7 +418,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             promotion = null,
             launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
             ),
         )
 
@@ -407,6 +432,27 @@ internal class CheckoutSheetLauncherTest {
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchPaymentOptions uses configured payment method layout`() = testScenario(
+        paymentElementConfiguration = PaymentElement.Configuration()
+            .paymentMethodLayout(PaymentElement.PaymentMethodLayout.Horizontal)
+            .build()
+    ) {
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            selection = PaymentSelection.GooglePay,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(launchCall.launchMode).isEqualTo(
+            EmbeddedLaunchMode.PaymentOptions(
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            )
+        )
     }
 
     @Test
@@ -566,6 +612,7 @@ internal class CheckoutSheetLauncherTest {
     }
 
     private fun testScenario(
+        paymentElementConfiguration: PaymentElement.Configuration.State = PaymentElement.Configuration().build(),
         block: suspend Scenario.() -> Unit
     ) = runTest {
         val lifecycleOwner = TestLifecycleOwner()
@@ -586,6 +633,7 @@ internal class CheckoutSheetLauncherTest {
                 activityResultCaller = activityResultCaller,
                 lifecycleOwner = lifecycleOwner,
                 selectionHolder = selectionHolder,
+                paymentElementConfigurationProvider = { paymentElementConfiguration },
                 customerStateHolder = customerStateHolder,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,


### PR DESCRIPTION
# Summary
This PR introduces the ability to configure the layout (horizontal, vertical, automatic) of payment methods in the PaymentElement. The layout is now passed via configuration and respected in launcher logic.

A follow up will actually wire up the functionality to display horizontal mode.

# Motivation
Allow SDK users to customize how payment methods are displayed in checkout, improving flexibility and potential UI adaptations in merchant flows.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
