### PR TITLE
Add support for horizontal payment options layout in embedded PaymentSheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -191,4 +191,28 @@ class PaymentElement @Inject internal constructor(
          */
         Automatic
     }
+
+    /**
+     * The layout of payment methods.
+     */
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class PaymentMethodLayout {
+        /**
+         * Payment methods are arranged horizontally.
+         * Users can swipe left or right to navigate through different payment methods.
+         */
+        Horizontal,
+
+        /**
+         * Payment methods are arranged vertically.
+         * Users can scroll up or down to navigate through different payment methods.
+         */
+        Vertical,
+
+        /**
+         * This lets Stripe choose the best layout for payment methods.
+         */
+        Automatic
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -105,6 +105,12 @@ internal data class PaymentMethodMetadata(
 ) : Parcelable {
 
     fun paymentMethodOrientation(): PaymentMethodOrientation {
+        return paymentMethodOrientation(paymentMethodLayout)
+    }
+
+    fun paymentMethodOrientation(
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout
+    ): PaymentMethodOrientation {
         return when (paymentMethodLayout) {
             PaymentSheet.PaymentMethodLayout.Horizontal -> PaymentMethodOrientation.Horizontal
             PaymentSheet.PaymentMethodLayout.Vertical -> PaymentMethodOrientation.Vertical

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -145,7 +145,8 @@ internal interface EmbeddedActivityModule {
             val initialBackStack = when (launchMode) {
                 is EmbeddedLaunchMode.Form -> listOf(formScreenFactory.create(launchMode))
                 is EmbeddedLaunchMode.Manage -> listOf(initialManageScreenFactory.createInitialScreen())
-                is EmbeddedLaunchMode.PaymentOptions -> initialPaymentOptionsScreenFactory.createInitialScreen()
+                is EmbeddedLaunchMode.PaymentOptions ->
+                    initialPaymentOptionsScreenFactory.createInitialScreen(launchMode.paymentMethodLayout)
             }
             return EmbeddedNavigator(
                 coroutineScope = viewModelScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
@@ -1,0 +1,122 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.job
+import javax.inject.Inject
+
+/**
+ * Builds the [AddPaymentMethodInteractor] backing the horizontal payment-options screen. Mirrors
+ * [com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory], constructing the interactor
+ * without a [com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel] by sourcing every dependency from the
+ * embedded holders.
+ */
+internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val embeddedSelectionHolder: EmbeddedSelectionHolder,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+    private val tapToAddHelper: TapToAddHelper,
+    private val eventReporter: EventReporter,
+    private val customerStateHolder: CustomerStateHolder,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+) {
+    fun create(): AddPaymentMethodInteractor {
+        val formScope = CoroutineScope(
+            viewModelScope.coroutineContext + SupervisorJob(viewModelScope.coroutineContext.job)
+        )
+        val initialCode = (embeddedSelectionHolder.selection.value as? PaymentSelection.New)?.paymentMethodType
+            ?: paymentMethodMetadata.supportedPaymentMethodTypes().first()
+        val hasSavedPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty()
+
+        // Horizontal mode renders the form inline, so it uses the full form helper (card scan auto-launch +
+        // tap-to-add), matching the main PaymentSheet's horizontal AddPaymentMethod flow. A single card-scan helper
+        // is built for the initially selected code, as in the main flow.
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = formScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            automaticallyLaunchedCardScanFormDataHelper =
+                embeddedFormHelperFactory.createAutomaticallyLaunchedCardScanFormDataHelper(
+                    selectedPaymentMethodCode = initialCode,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                ),
+            selectionUpdater = { embeddedSelectionHolder.setSelection(it) },
+            tapToAddHelper = tapToAddHelper,
+            setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+        )
+
+        return DefaultAddPaymentMethodInteractor(
+            initiallySelectedPaymentMethodType = initialCode,
+            selection = embeddedSelectionHolder.selection,
+            processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
+            // Embedded does not support validation at the moment. Should update here once it does.
+            validationRequested = MutableSharedFlow(),
+            incentive = PaymentMethodIncentiveInteractor(
+                paymentMethodMetadata.paymentMethodIncentive
+            ).displayedIncentive,
+            supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods(),
+            createFormArguments = formHelper::createFormArguments,
+            formElementsForCode = formHelper::formElementsForCode,
+            clearErrorMessages = { sheetActivityStateHolder.updateError(null) },
+            reportFieldInteraction = eventReporter::onPaymentMethodFormInteraction,
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportPromotionDisplayed = { code ->
+                paymentMethodMessagePromotionsHelper.reportPromotionDisplayed(code, paymentMethodMetadata)
+            },
+            createUSBankAccountFormArguments = { code ->
+                createUsBankAccountFormArguments(code)
+            },
+            coroutineScope = formScope,
+            uiContext = Dispatchers.Main,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = null,
+                    isVerticalLayout = false,
+                )
+            },
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+        )
+    }
+
+    private fun createUsBankAccountFormArguments(code: String): USBankAccountFormArguments {
+        return USBankAccountFormArguments.createForEmbedded(
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectedPaymentMethodCode = code,
+            hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
+            setSelection = embeddedSelectionHolder::setSelection,
+            hasSavedPaymentMethods = customerStateHolder.paymentMethods.value.any { it.type?.code == code },
+            onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
+            onMandateTextChanged = { mandateText, _ ->
+                sheetActivityStateHolder.updateMandate(mandateText)
+            },
+            onUpdatePrimaryButtonUIState = sheetActivityStateHolder::updatePrimaryButton,
+            onError = sheetActivityStateHolder::updateError,
+            onFormCompleted = { eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code) },
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -9,20 +9,27 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
+import com.stripe.android.paymentelement.embedded.form.FormActivityError
 import com.stripe.android.paymentelement.embedded.form.FormActivityPrimaryButton
 import com.stripe.android.paymentelement.embedded.form.FormScreenContent
+import com.stripe.android.paymentelement.embedded.form.USBankAccountMandate
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.navigation.NavigationHandler
+import com.stripe.android.paymentsheet.ui.AddPaymentMethod
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
+import com.stripe.android.paymentsheet.utils.isOnlyOneNonCardPaymentMethod
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenUI
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
@@ -41,6 +48,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.Closeable
 import javax.inject.Inject
+import com.stripe.android.R as PaymentsCoreR
 
 internal class EmbeddedNavigator private constructor(
     private val eventReporter: EventReporter,
@@ -108,7 +116,8 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageAll -> eventReporter.onShowManageSavedPaymentMethods()
             is Screen.ManageUpdate -> eventReporter.onShowEditablePaymentOption()
             is Screen.Form -> Unit
-            is Screen.PaymentOptions -> eventReporter.onShowNewPaymentOptions()
+            is Screen.VerticalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
+            is Screen.HorizontalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
         }
     }
 
@@ -117,7 +126,8 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageAll -> Unit
             is Screen.ManageUpdate -> eventReporter.onHideEditablePaymentOption()
             is Screen.Form -> Unit
-            is Screen.PaymentOptions -> Unit
+            is Screen.VerticalPaymentOptions -> Unit
+            is Screen.HorizontalPaymentOptions -> Unit
         }
     }
 
@@ -271,7 +281,7 @@ internal class EmbeddedNavigator private constructor(
             }
         }
 
-        class PaymentOptions(
+        class VerticalPaymentOptions(
             private val interactor: PaymentMethodVerticalLayoutInteractor,
             private val isLiveMode: Boolean,
             private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
@@ -305,6 +315,56 @@ internal class EmbeddedNavigator private constructor(
                     onClick = onContinueClick,
                 )
                 PaymentSheetContentPadding()
+            }
+
+            override fun close() {
+                interactor.close()
+            }
+        }
+
+        class HorizontalPaymentOptions(
+            private val interactor: AddPaymentMethodInteractor,
+            private val eventReporter: EventReporter,
+            private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
+            private val onContinueClick: () -> Unit,
+        ) : Screen(), Closeable {
+            override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
+                PaymentSheetTopBarState(
+                    showTestModeLabel = !interactor.isLiveMode,
+                    showEditMenu = false,
+                    isEditing = false,
+                    onEditIconPressed = {},
+                )
+            )
+
+            override fun title(): StateFlow<ResolvableString?> {
+                return interactor.state.mapAsStateFlow { state ->
+                    if (state.supportedPaymentMethods.isOnlyOneNonCardPaymentMethod()) {
+                        null
+                    } else if (state.supportedPaymentMethods.singleOrNull()?.code == PaymentMethod.Type.Card.code) {
+                        PaymentsCoreR.string.stripe_title_add_a_card.resolvableString
+                    } else {
+                        R.string.stripe_paymentsheet_choose_payment_method.resolvableString
+                    }
+                }
+            }
+
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> = stateFlowOf(false)
+
+            @Composable
+            override fun Content() {
+                val state by sheetActivityState.collectAsState()
+                EventReporterProvider(eventReporter) {
+                    AddPaymentMethod(interactor = interactor)
+                    USBankAccountMandate(state)
+                    FormActivityError(state)
+                    Spacer(Modifier.height(40.dp))
+                    FormActivityPrimaryButton(
+                        state = state,
+                        onClick = onContinueClick,
+                    )
+                    PaymentSheetContentPadding()
+                }
             }
 
             override fun close() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
@@ -50,27 +51,26 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private val sheetActivityStateHolder: SheetActivityStateHolder,
     private val formScreenFactory: EmbeddedFormScreenFactory,
     private val linkAccountHolder: LinkAccountHolder,
+    private val addPaymentMethodInteractorFactory: EmbeddedAddPaymentMethodInteractorFactory,
 ) {
-    fun createInitialScreen(): List<EmbeddedNavigator.Screen> {
+    fun createInitialScreen(
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout
+    ): List<EmbeddedNavigator.Screen> {
+        return when (paymentMethodMetadata.paymentMethodOrientation(paymentMethodLayout)) {
+            PaymentMethodOrientation.Vertical -> createVerticalInitialScreens(paymentMethodLayout)
+            PaymentMethodOrientation.Horizontal -> listOf(createHorizontalScreen(paymentMethodLayout))
+        }
+    }
+
+    private fun createVerticalInitialScreens(
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout
+    ): List<EmbeddedNavigator.Screen> {
         val formHelper = createFormHelper()
-        val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
+        val paymentOptionsScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = createInteractor(formHelper),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             sheetActivityState = sheetActivityStateHolder.state,
-            onContinueClick = {
-                sheetActivityStateHolder.setResult(
-                    EmbeddedActivityResult.Complete(
-                        selection = selectionHolder.selection.value,
-                        previousNewSelections = selectionHolder.previousNewSelections,
-                        hasBeenConfirmed = false,
-                        customerState = customerStateHolder.customer.value,
-                        shouldInvokeSelectionCallback = false,
-                        launchMode = EmbeddedLaunchMode.PaymentOptions(
-                            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                        ),
-                    )
-                )
-            },
+            onContinueClick = { setPaymentOptionsResult(paymentMethodLayout) },
         )
         return buildList {
             add(paymentOptionsScreen)
@@ -83,6 +83,34 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                 add(formScreenFactory.createFormScreen(selection.paymentMethodType))
             }
         }
+    }
+
+    // Horizontal mode renders the payment method tabs and the selected method's form inline on a single screen, so
+    // there is no separate form screen to pre-push.
+    private fun createHorizontalScreen(
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout
+    ): EmbeddedNavigator.Screen {
+        return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
+            interactor = addPaymentMethodInteractorFactory.create(),
+            eventReporter = eventReporter,
+            sheetActivityState = sheetActivityStateHolder.state,
+            onContinueClick = { setPaymentOptionsResult(paymentMethodLayout) },
+        )
+    }
+
+    private fun setPaymentOptionsResult(paymentMethodLayout: PaymentSheet.PaymentMethodLayout) {
+        sheetActivityStateHolder.setResult(
+            EmbeddedActivityResult.Complete(
+                selection = selectionHolder.selection.value,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = false,
+                customerState = customerStateHolder.customer.value,
+                shouldInvokeSelectionCallback = false,
+                launchMode = EmbeddedLaunchMode.PaymentOptions(
+                    paymentMethodLayout = paymentMethodLayout,
+                ),
+            )
+        )
     }
 
     private fun createFormHelper(): FormHelper {
@@ -158,7 +186,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private fun isCurrentScreen(): StateFlow<Boolean> = flow {
         emitAll(embeddedNavigatorProvider.get().screen)
     }.map { screen ->
-        screen is EmbeddedNavigator.Screen.PaymentOptions
+        screen is EmbeddedNavigator.Screen.VerticalPaymentOptions
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -2384,6 +2384,45 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
+    fun `paymentMethodOrientation(layout) overrides the metadata's own layout`() {
+        // Metadata is built with Vertical (as the embedded flow forces), but the explicit argument wins.
+        val metadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        )
+
+        assertThat(metadata.paymentMethodOrientation(PaymentSheet.PaymentMethodLayout.Horizontal))
+            .isEqualTo(PaymentMethodOrientation.Horizontal)
+        assertThat(metadata.paymentMethodOrientation(PaymentSheet.PaymentMethodLayout.Vertical))
+            .isEqualTo(PaymentMethodOrientation.Vertical)
+    }
+
+    @Test
+    fun `paymentMethodOrientation(layout) resolves Automatic to Vertical with three payment methods`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna", "affirm"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        )
+
+        assertThat(metadata.paymentMethodOrientation(PaymentSheet.PaymentMethodLayout.Automatic))
+            .isEqualTo(PaymentMethodOrientation.Vertical)
+    }
+
+    @Test
+    fun `paymentMethodOrientation(layout) resolves Automatic to Horizontal with two payment methods`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        )
+
+        assertThat(metadata.paymentMethodOrientation(PaymentSheet.PaymentMethodLayout.Automatic))
+            .isEqualTo(PaymentMethodOrientation.Horizontal)
+    }
+
+    @Test
     fun `effectiveLinkBrand returns account linkBrand when account linkBrand is present`() {
         val metadata = PaymentMethodMetadataFactory.create(linkBrand = LinkBrand.Link)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.FakeUpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
@@ -340,11 +341,23 @@ internal class EmbeddedNavigatorTest {
     }
 
     @Test
+    fun `initial screen HorizontalPaymentOptions calls onShowNewPaymentOptions`() = runTest {
+        val eventReporter = FakeEventReporter()
+        EmbeddedNavigator(
+            coroutineScope = this,
+            eventReporter = eventReporter,
+            initialScreen = createHorizontalPaymentOptionsScreen(),
+        )
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+        eventReporter.validate()
+    }
+
+    @Test
     fun `initial back stack with a form on top starts on the form and can go back`() = runTest {
         val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
         val paymentOptionsInteractor = FakePaymentMethodVerticalLayoutInteractor.create()
-        val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
+        val paymentOptionsScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = paymentOptionsInteractor,
             isLiveMode = true,
             sheetActivityState = stateFlowOf(
@@ -593,10 +606,30 @@ internal class EmbeddedNavigatorTest {
 
     private fun createPaymentOptionsScreen(
         isLiveMode: Boolean = true,
-    ): EmbeddedNavigator.Screen.PaymentOptions {
-        return EmbeddedNavigator.Screen.PaymentOptions(
+    ): EmbeddedNavigator.Screen.VerticalPaymentOptions {
+        return EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = FakePaymentMethodVerticalLayoutInteractor.create(),
             isLiveMode = isLiveMode,
+            sheetActivityState = stateFlowOf(
+                SheetActivityStateHolder.State(
+                    primaryButtonLabel = "".resolvableString,
+                    isEnabled = false,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    isProcessing = false,
+                    shouldDisplayLockIcon = true,
+                    savedPaymentSelectionToConfirm = null,
+                )
+            ),
+            onContinueClick = {},
+        )
+    }
+
+    private fun createHorizontalPaymentOptionsScreen(): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
+        return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState(),
+            ),
+            eventReporter = FakeEventReporter(),
             sheetActivityState = stateFlowOf(
                 SheetActivityStateHolder.State(
                     primaryButtonLabel = "".resolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactoryTest.kt
@@ -1,0 +1,125 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.taptoadd.FakeTapToAddHelper
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.FakeIsNfcScanningAvailable
+import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
+import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+internal class EmbeddedAddPaymentMethodInteractorFactoryTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `created interactor exposes the sorted supported payment methods`() = runScenario {
+        val interactor = factory.create()
+
+        assertThat(interactor.state.value.supportedPaymentMethods)
+            .isEqualTo(paymentMethodMetadata.sortedSupportedPaymentMethods())
+    }
+
+    @Test
+    fun `created interactor is not live mode for a test-mode intent`() = runScenario {
+        val interactor = factory.create()
+
+        assertThat(interactor.isLiveMode).isFalse()
+    }
+
+    @Test
+    fun `initially selected code defaults to the first supported payment method`() = runScenario {
+        val interactor = factory.create()
+
+        assertThat(interactor.state.value.selectedPaymentMethodCode)
+            .isEqualTo(paymentMethodMetadata.supportedPaymentMethodTypes().first())
+    }
+
+    @Test
+    fun `initially selected code is seeded from the current new selection`() = runScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+
+        val interactor = factory.create()
+
+        assertThat(interactor.state.value.selectedPaymentMethodCode).isEqualTo("cashapp")
+    }
+
+    @Test
+    fun `selecting a payment method updates the selected code`() = runScenario {
+        val interactor = factory.create()
+        assertThat(interactor.state.value.selectedPaymentMethodCode).isEqualTo("card")
+
+        interactor.handleViewAction(
+            AddPaymentMethodInteractor.ViewAction.OnPaymentMethodSelected("cashapp")
+        )
+
+        assertThat(interactor.state.value.selectedPaymentMethodCode).isEqualTo("cashapp")
+    }
+
+    private fun runScenario(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            ),
+        ),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata),
+            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
+        )
+        // Separate scope so the interactor's long-lived collectors are not awaited by runTest.
+        val testScope = TestScope(UnconfinedTestDispatcher())
+        val formHelperFactory = EmbeddedFormHelperFactory(
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+            embeddedSelectionHolder = selectionHolder,
+            savedStateHandle = savedStateHandle,
+            isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
+        )
+        val factory = EmbeddedAddPaymentMethodInteractorFactory(
+            paymentMethodMetadata = paymentMethodMetadata,
+            embeddedSelectionHolder = selectionHolder,
+            embeddedFormHelperFactory = formHelperFactory,
+            viewModelScope = testScope,
+            sheetActivityStateHolder = FakeSheetActivityStateHolder(),
+            tapToAddHelper = FakeTapToAddHelper.noOp(),
+            eventReporter = FakeEventReporter(),
+            customerStateHolder = customerStateHolder,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+        )
+
+        Scenario(
+            factory = factory,
+            selectionHolder = selectionHolder,
+            paymentMethodMetadata = paymentMethodMetadata,
+        ).block()
+    }
+
+    private class Scenario(
+        val factory: EmbeddedAddPaymentMethodInteractorFactory,
+        val selectionHolder: EmbeddedSelectionHolder,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
@@ -29,6 +29,8 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
 
     val resultTurbine = Turbine<EmbeddedActivityResult>()
 
+    val updateErrorTurbine = Turbine<ResolvableString?>()
+
     override val result: SharedFlow<EmbeddedActivityResult> = MutableSharedFlow<EmbeddedActivityResult>()
 
     override fun updateMandate(mandateText: ResolvableString?) {
@@ -40,7 +42,7 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
     }
 
     override fun updateError(error: ResolvableString?) {
-        error("This should never be called!")
+        updateErrorTurbine.add(error)
     }
 
     override fun setResult(result: EmbeddedActivityResult) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInt
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
@@ -41,48 +42,48 @@ internal class InitialPaymentOptionsScreenFactoryTest {
     fun `creates initial screen successfully with Google Pay ready`() = testScenario(
         isGooglePayReady = true,
     ) {
-        val screens = factory.createInitialScreen()
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical)
         assertThat(screens).hasSize(1)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
     @Test
     fun `creates initial screen successfully without wallets`() = testScenario(
         isGooglePayReady = false,
     ) {
-        val screens = factory.createInitialScreen()
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical)
         assertThat(screens).hasSize(1)
     }
 
     @Test
     fun `screen is created with correct isLiveMode`() = testScenario {
-        val screen = factory.createInitialScreen().first()
+        val screen = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical).first()
         val topBarState = screen.topBarState().value!!
         assertThat(topBarState.showTestModeLabel).isTrue()
     }
 
     @Test
     fun `screen isPerformingNetworkOperation returns false`() = testScenario {
-        val screen = factory.createInitialScreen().first()
+        val screen = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical).first()
         assertThat(screen.isPerformingNetworkOperation().value).isFalse()
     }
 
     @Test
     fun `no payment selection creates a single payment options screen`() = testScenario {
-        val screens = factory.createInitialScreen()
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical)
 
         assertThat(screens).hasSize(1)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
     @Test
     fun `new selection requiring a form starts with the form on top of the back stack`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
-        val screens = factory.createInitialScreen()
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical)
 
         assertThat(screens).hasSize(2)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
         assertThat(screens[1]).isInstanceOf<EmbeddedNavigator.Screen.Form>()
     }
 
@@ -96,10 +97,56 @@ internal class InitialPaymentOptionsScreenFactoryTest {
     ) {
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
-        val screens = factory.createInitialScreen()
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Vertical)
 
         assertThat(screens).hasSize(1)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
+    }
+
+    @Test
+    fun `horizontal layout creates a single horizontal payment options screen`() = testScenario {
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Horizontal)
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.HorizontalPaymentOptions>()
+    }
+
+    @Test
+    fun `horizontal layout with a new selection requiring a form does not add a form screen`() = testScenario {
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Horizontal)
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.HorizontalPaymentOptions>()
+    }
+
+    @Test
+    fun `automatic layout with two payment methods creates a horizontal screen`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna"),
+            ),
+        ),
+    ) {
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Automatic)
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.HorizontalPaymentOptions>()
+    }
+
+    @Test
+    fun `automatic layout with three payment methods creates a vertical screen`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "klarna", "affirm"),
+            ),
+        ),
+    ) {
+        val screens = factory.createInitialScreen(PaymentSheet.PaymentMethodLayout.Automatic)
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
     @Suppress("LongMethod")
@@ -155,7 +202,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
 
         val fakeInteractor =
             com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor.create()
-        val initialScreen = EmbeddedNavigator.Screen.PaymentOptions(
+        val initialScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = fakeInteractor,
             isLiveMode = true,
             sheetActivityState = sheetActivityStateHolder.state,
@@ -167,6 +214,18 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             initialScreen = initialScreen,
         )
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+
+        val addPaymentMethodInteractorFactory = EmbeddedAddPaymentMethodInteractorFactory(
+            paymentMethodMetadata = paymentMethodMetadata,
+            embeddedSelectionHolder = selectionHolder,
+            embeddedFormHelperFactory = formHelperFactory,
+            viewModelScope = testScope,
+            sheetActivityStateHolder = sheetActivityStateHolder,
+            tapToAddHelper = FakeTapToAddHelper.noOp(),
+            eventReporter = FakeEventReporter(),
+            customerStateHolder = customerStateHolder,
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+        )
 
         val factory = InitialPaymentOptionsScreenFactory(
             paymentMethodMetadata = paymentMethodMetadata,
@@ -182,6 +241,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             sheetActivityStateHolder = sheetActivityStateHolder,
             formScreenFactory = formScreenFactory,
             linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+            addPaymentMethodInteractorFactory = addPaymentMethodInteractorFactory,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -126,7 +126,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         scenario.onActivity { activity ->
             assertThat(activity.embeddedNavigator.canGoBack).isFalse()
             assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
         }
     }
 


### PR DESCRIPTION
# Summary
Refactors embedded PaymentSheet to support horizontal payment options layout, alongside vertical layout. Introduces factories and screens to cleanly handle both modes. Updates tests and utility functions for the new configuration.

# Motivation
PaymentSheet embedded flows previously only supported vertical payment options layout. To meet integration requirements and parity with main PaymentSheet, horizontal layout is now supported. This allows for a more streamlined UI in cases with limited payment methods.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Added] Horizontal payment options layout support in embedded PaymentSheet.