### PR TITLE
Add appearance/network config options to Checkout PaymentElement.Configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -24,11 +24,18 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .asPaymentSheet()
             .copy(attachDefaultsToPaymentMethod = true)
 
+        val paymentElementConfiguration = configuration.paymentElementConfiguration
+
         return EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
             .embeddedViewDisplaysMandateText(
-                configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
+                paymentElementConfiguration.embeddedViewDisplaysMandateText
             )
             .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
+            .appearance(paymentElementConfiguration.appearance)
+            .preferredNetworks(paymentElementConfiguration.preferredNetworks)
+            .paymentMethodOrder(paymentElementConfiguration.paymentMethodOrder)
+            .cardBrandAcceptance(paymentElementConfiguration.cardBrandAcceptance)
+            .opensCardScannerAutomatically(paymentElementConfiguration.opensCardScannerAutomatically)
             .googlePay(
                 googlePay = checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
                     configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -4,8 +4,11 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import com.stripe.android.common.configuration.ConfigurationDefaults
+import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -32,6 +35,13 @@ class PaymentElement @Inject internal constructor(
         private var embeddedViewDisplaysMandateText: Boolean = true
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
+        private var appearance: PaymentSheet.Appearance = ConfigurationDefaults.appearance
+        private var preferredNetworks: List<CardBrand> = ConfigurationDefaults.preferredNetworks
+        private var paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder
+        private var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance =
+            ConfigurationDefaults.cardBrandAcceptance
+        private var opensCardScannerAutomatically: Boolean =
+            ConfigurationDefaults.opensCardScannerAutomatically
 
         fun embeddedViewDisplaysMandateText(
             embeddedViewDisplaysMandateText: Boolean
@@ -45,15 +55,85 @@ class PaymentElement @Inject internal constructor(
             this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
         }
 
+        /**
+         * Describes the appearance of the Payment Element.
+         */
+        fun appearance(
+            appearance: PaymentSheet.Appearance
+        ): Configuration = apply {
+            this.appearance = appearance
+        }
+
+        /**
+         * A list of preferred networks that should be used to process payments made with a co-branded card if
+         * your user hasn't selected a network themselves.
+         *
+         * The first preferred network that matches any available network will be used. If no preferred network
+         * is applicable, Stripe will select the network.
+         */
+        fun preferredNetworks(
+            preferredNetworks: List<CardBrand>
+        ): Configuration = apply {
+            this.preferredNetworks = preferredNetworks
+        }
+
+        /**
+         * By default, Stripe will use a dynamic ordering that optimizes payment method display for the customer.
+         * You can override the default order in which payment methods are displayed with a list of payment
+         * method types.
+         *
+         * See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of
+         * valid types. Example: `listOf("card", "klarna")`. Payment methods omitted from this list are ordered
+         * by Stripe after the ones you provide; invalid payment methods are ignored.
+         */
+        fun paymentMethodOrder(
+            paymentMethodOrder: List<String>
+        ): Configuration = apply {
+            this.paymentMethodOrder = paymentMethodOrder
+        }
+
+        /**
+         * By default, the Payment Element will accept all card brands supported by Stripe. You can specify card
+         * brands to block or allow by providing a [PaymentSheet.CardBrandAcceptance].
+         *
+         * **Note**: This is only a client-side solution.
+         * **Note**: Card brand filtering is not currently supported in Link.
+         */
+        fun cardBrandAcceptance(
+            cardBrandAcceptance: PaymentSheet.CardBrandAcceptance
+        ): Configuration = apply {
+            this.cardBrandAcceptance = cardBrandAcceptance
+        }
+
+        /**
+         * By default, the Payment Element offers a card scan button within the new card entry form. When set to
+         * `true`, the card entry form initializes with the card scanner already open.
+         */
+        fun opensCardScannerAutomatically(
+            opensCardScannerAutomatically: Boolean
+        ): Configuration = apply {
+            this.opensCardScannerAutomatically = opensCardScannerAutomatically
+        }
+
         @Parcelize
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
+            val appearance: PaymentSheet.Appearance,
+            val preferredNetworks: List<CardBrand>,
+            val paymentMethodOrder: List<String>,
+            val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
+            val opensCardScannerAutomatically: Boolean,
         ) : Parcelable
 
         internal fun build(): State = State(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
+            appearance = appearance,
+            preferredNetworks = preferredNetworks,
+            paymentMethodOrder = paymentMethodOrder,
+            cardBrandAcceptance = cardBrandAcceptance,
+            opensCardScannerAutomatically = opensCardScannerAutomatically,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
 import com.stripe.android.checkout.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
 import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -204,6 +205,71 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
+    fun `propagates the payment element appearance`() {
+        val appearance = PaymentSheet.Appearance()
+
+        val result = factory().create(
+            configuration = controllerConfiguration(appearance = appearance),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.appearance).isSameInstanceAs(appearance)
+    }
+
+    @Test
+    fun `propagates preferredNetworks`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(
+                preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa),
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.preferredNetworks)
+            .containsExactly(CardBrand.CartesBancaires, CardBrand.Visa)
+            .inOrder()
+    }
+
+    @Test
+    fun `propagates paymentMethodOrder`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(paymentMethodOrder = listOf("card", "klarna")),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.paymentMethodOrder).containsExactly("card", "klarna").inOrder()
+    }
+
+    @Test
+    fun `propagates cardBrandAcceptance`() {
+        val cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.disallowed(
+            listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Amex),
+        )
+
+        val result = factory().create(
+            configuration = controllerConfiguration(cardBrandAcceptance = cardBrandAcceptance),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.cardBrandAcceptance).isEqualTo(cardBrandAcceptance)
+    }
+
+    @Test
+    fun `propagates opensCardScannerAutomatically`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(opensCardScannerAutomatically = true),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
     fun `sets attachDefaultsToPaymentMethod to true`() {
         val result = factory().create(
             configuration = controllerConfiguration(),
@@ -218,19 +284,29 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         merchantDisplayName: String = "Example, Inc.",
     ) = CheckoutEmbeddedConfigurationFactory(merchantDisplayName = merchantDisplayName)
 
+    @Suppress("LongParameterList")
     private fun controllerConfiguration(
         embeddedViewDisplaysMandateText: Boolean = true,
         billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
         googlePayConfiguration: GooglePayConfiguration? = null,
+        appearance: PaymentSheet.Appearance? = null,
+        preferredNetworks: List<CardBrand>? = null,
+        paymentMethodOrder: List<String>? = null,
+        cardBrandAcceptance: PaymentSheet.CardBrandAcceptance? = null,
+        opensCardScannerAutomatically: Boolean? = null,
     ): CheckoutController.Configuration.State {
-        val builder = CheckoutController.Configuration()
-            .paymentElement(
-                PaymentElement.Configuration()
-                    .embeddedViewDisplaysMandateText(embeddedViewDisplaysMandateText)
-                    .billingDetailsCollectionConfiguration(
-                        BillingDetailsCollectionConfiguration().address(billingDetailsAddress)
-                    )
+        val paymentElement = PaymentElement.Configuration()
+            .embeddedViewDisplaysMandateText(embeddedViewDisplaysMandateText)
+            .billingDetailsCollectionConfiguration(
+                BillingDetailsCollectionConfiguration().address(billingDetailsAddress)
             )
+        appearance?.let { paymentElement.appearance(it) }
+        preferredNetworks?.let { paymentElement.preferredNetworks(it) }
+        paymentMethodOrder?.let { paymentElement.paymentMethodOrder(it) }
+        cardBrandAcceptance?.let { paymentElement.cardBrandAcceptance(it) }
+        opensCardScannerAutomatically?.let { paymentElement.opensCardScannerAutomatically(it) }
+        val builder = CheckoutController.Configuration()
+            .paymentElement(paymentElement)
         if (googlePayConfiguration != null) {
             builder.googlePayConfiguration(googlePayConfiguration)
         }


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE).

The checkout `PaymentElement.Configuration` previously exposed only `embeddedViewDisplaysMandateText` and `billingDetailsCollectionConfiguration`. iOS's `PaymentElement.Configuration` exposes the full Payment Element customization surface. This adds the cleanly-mapped, high-value options that the underlying `EmbeddedPaymentElement.Configuration` already supports:

- `appearance`
- `preferredNetworks`
- `paymentMethodOrder`
- `cardBrandAcceptance`
- `opensCardScannerAutomatically`

These are routed into the embedded configuration in `CheckoutEmbeddedConfigurationFactory`.

Remaining iOS `PaymentElement.Configuration` options (`savePaymentMethodOptInBehavior`, `removeSavedPaymentMethodMessage`, `useAutocompleteEndpoints`, `termsDisplay`, `paymentMethodLayout`, `rowSelectionBehavior`) are deferred — they either don't map cleanly to Android's embedded presentation or need more investigation, and will be follow-ups.

## Scope

Isolated change — touches only `PaymentElement.kt` and `CheckoutEmbeddedConfigurationFactory.kt`; no overlap with the `Session`-shape parity work. All checkout APIs are `@CheckoutSessionPreview` + `@RestrictTo(LIBRARY_GROUP)`, so `paymentsheet.api` is unaffected.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutEmbeddedConfigurationFactoryTest"` — added a test per new option ✓
- `./gradlew :paymentsheet:detekt` ✓
- `./gradlew :paymentsheet:compileDebugKotlin` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)