### PR TITLE
Add link + merchantDisplayName options to CheckoutController.Configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -20,6 +20,7 @@ import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.validateShippingCountry
@@ -711,6 +712,8 @@ class CheckoutController @Inject internal constructor(
     class Configuration {
         private var adaptivePricingAllowed: Boolean = false
         private var googlePayConfiguration: GooglePayConfiguration? = null
+        private var linkConfiguration: PaymentSheet.LinkConfiguration = PaymentSheet.LinkConfiguration()
+        private var merchantDisplayName: String? = null
         private var paymentElementConfiguration: PaymentElement.Configuration = PaymentElement.Configuration()
         private var currencySelectorElementConfiguration: CurrencySelectorElement.Configuration =
             CurrencySelectorElement.Configuration()
@@ -723,6 +726,27 @@ class CheckoutController @Inject internal constructor(
             adaptivePricingAllowed: Boolean
         ): Configuration = apply {
             this.adaptivePricingAllowed = adaptivePricingAllowed
+        }
+
+        /**
+         * Configuration for Link.
+         */
+        fun linkConfiguration(
+            configuration: PaymentSheet.LinkConfiguration
+        ): Configuration = apply {
+            this.linkConfiguration = configuration
+        }
+
+        /**
+         * The customer-facing business name.
+         *
+         * If not set, this defaults to the application's label. Set this to override the name shown to the
+         * customer while paying.
+         */
+        fun merchantDisplayName(
+            merchantDisplayName: String
+        ): Configuration = apply {
+            this.merchantDisplayName = merchantDisplayName
         }
 
         fun paymentElement(
@@ -759,6 +783,8 @@ class CheckoutController @Inject internal constructor(
         internal data class State(
             val adaptivePricingAllowed: Boolean,
             val googlePayConfiguration: GooglePayConfiguration.State?,
+            val linkConfiguration: PaymentSheet.LinkConfiguration,
+            val merchantDisplayName: String?,
             val paymentElementConfiguration: PaymentElement.Configuration.State,
             val currencySelectorElementConfiguration: CurrencySelectorElement.Configuration.State,
             val shippingAddressElementConfiguration: ShippingAddressElement.Configuration.State,
@@ -772,6 +798,8 @@ class CheckoutController @Inject internal constructor(
             shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),
             expressCheckoutElementConfiguration = expressCheckoutElementConfiguration.build(),
             googlePayConfiguration = googlePayConfiguration?.build(),
+            linkConfiguration = linkConfiguration,
+            merchantDisplayName = merchantDisplayName,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -24,11 +24,14 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .asPaymentSheet()
             .copy(attachDefaultsToPaymentMethod = true)
 
-        return EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
+        return EmbeddedPaymentElement.Configuration.Builder(
+            configuration.merchantDisplayName ?: merchantDisplayName
+        )
             .embeddedViewDisplaysMandateText(
                 configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
             )
             .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
+            .link(configuration.linkConfiguration)
             .googlePay(
                 googlePay = checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
                     configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -204,6 +204,43 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
+    fun `propagates the link configuration`() {
+        val linkConfiguration = PaymentSheet.LinkConfiguration(
+            display = PaymentSheet.LinkConfiguration.Display.Never,
+        )
+
+        val result = factory().create(
+            configuration = controllerConfiguration(linkConfiguration = linkConfiguration),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.link.display).isEqualTo(PaymentSheet.LinkConfiguration.Display.Never)
+    }
+
+    @Test
+    fun `merchant display name override takes precedence over the injected default`() {
+        val result = factory(merchantDisplayName = "Injected Default").create(
+            configuration = controllerConfiguration(merchantDisplayName = "Merchant Override"),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("Merchant Override")
+    }
+
+    @Test
+    fun `falls back to the injected merchant display name when the configuration has none`() {
+        val result = factory(merchantDisplayName = "Injected Default").create(
+            configuration = controllerConfiguration(merchantDisplayName = null),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("Injected Default")
+    }
+
+    @Test
     fun `sets attachDefaultsToPaymentMethod to true`() {
         val result = factory().create(
             configuration = controllerConfiguration(),
@@ -222,6 +259,8 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         embeddedViewDisplaysMandateText: Boolean = true,
         billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
         googlePayConfiguration: GooglePayConfiguration? = null,
+        linkConfiguration: PaymentSheet.LinkConfiguration? = null,
+        merchantDisplayName: String? = null,
     ): CheckoutController.Configuration.State {
         val builder = CheckoutController.Configuration()
             .paymentElement(
@@ -234,6 +273,8 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         if (googlePayConfiguration != null) {
             builder.googlePayConfiguration(googlePayConfiguration)
         }
+        linkConfiguration?.let { builder.linkConfiguration(it) }
+        merchantDisplayName?.let { builder.merchantDisplayName(it) }
         return builder.build()
     }
 


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE).

iOS's `CheckoutController.Configuration` exposes `linkConfiguration` and `merchantDisplayName`; Android's exposed neither.

- **`linkConfiguration(PaymentSheet.LinkConfiguration)`** — routed into the embedded configuration via `.link(...)`.
- **`merchantDisplayName(String)`** — overrides the injected default (the application label) when set; `CheckoutEmbeddedConfigurationFactory` falls back to the injected `@MerchantDisplayName` value when it's `null`.

### Deferred

The iOS `Configuration.defaults` prefill (`billingDetails`/`shippingDetails`/`phone`/`email`) is intentionally **not** in this PR — its top-level `email`/`phone` don't map cleanly onto Android's `CheckoutCollectedDetails`, and the API review itself flags an `attachDefaults` edge case. It warrants its own design pass and will be a follow-up.

## Scope

Isolated change (`CheckoutController.Configuration` + `CheckoutEmbeddedConfigurationFactory`). All checkout APIs are `@CheckoutSessionPreview` + `@RestrictTo(LIBRARY_GROUP)`, so `paymentsheet.api` is unaffected.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutEmbeddedConfigurationFactoryTest"` — added link propagation + merchantDisplayName override/fallback tests ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)