### PR TITLE
Introduce Session.Amount value type for Checkout money fields

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -35,7 +35,6 @@ import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.checkout.CheckoutController.Session.PaymentOptionDisplayData
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
-import com.stripe.android.uicore.format.CurrencyFormatter
 import kotlinx.coroutines.launch
 
 internal class CheckoutControllerExampleActivity : AppCompatActivity() {
@@ -175,7 +174,7 @@ private fun LineItemsSection(session: Session) {
                     style = MaterialTheme.typography.body2,
                 )
                 Text(
-                    text = formatAmount(item.total, session.currency),
+                    text = item.total.formatted,
                     style = MaterialTheme.typography.body2,
                 )
             }
@@ -190,23 +189,23 @@ private fun TotalSummarySection(session: Session) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Divider(modifier = Modifier.padding(vertical = 12.dp))
 
-        SummaryRow(label = "Subtotal", amount = formatAmount(summary.subtotal, session.currency))
+        SummaryRow(label = "Subtotal", amount = summary.subtotal.formatted)
 
         for (discount in summary.discountAmounts) {
             SummaryRow(
                 label = discount.displayName,
-                amount = "-${formatAmount(discount.amount, session.currency)}",
+                amount = "-${discount.amount.formatted}",
             )
         }
 
         summary.shippingRate?.let { shipping ->
-            val amountText = if (shipping.amount == 0L) "Free" else formatAmount(shipping.amount, session.currency)
+            val amountText = if (shipping.amount.minorUnitsAmount == 0L) "Free" else shipping.amount.formatted
             SummaryRow(label = "Shipping", amount = amountText)
         }
 
         for (tax in summary.taxAmounts) {
             val label = if (tax.inclusive) "${tax.displayName} (included)" else tax.displayName
-            SummaryRow(label = label, amount = formatAmount(tax.amount, session.currency))
+            SummaryRow(label = label, amount = tax.amount.formatted)
         }
 
         Divider(modifier = Modifier.padding(vertical = 8.dp))
@@ -217,7 +216,7 @@ private fun TotalSummarySection(session: Session) {
         ) {
             Text(text = "Total", style = MaterialTheme.typography.subtitle1)
             Text(
-                text = formatAmount(summary.totalDueToday, session.currency),
+                text = summary.totalDueToday.formatted,
                 style = MaterialTheme.typography.subtitle1,
             )
         }
@@ -233,8 +232,4 @@ private fun SummaryRow(label: String, amount: String) {
         Text(text = label, style = MaterialTheme.typography.body2)
         Text(text = amount, style = MaterialTheme.typography.body2)
     }
-}
-
-private fun formatAmount(amount: Long, currency: String): String {
-    return CurrencyFormatter.format(amount, currency)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -386,6 +386,11 @@ class CheckoutController @Inject internal constructor(
          */
         val currency: String,
         /**
+         * The factor used to convert amounts in the smallest currency unit to the major currency unit
+         * (e.g., `100` for USD, `1` for JPY). `null` if the currency is not recognized.
+         */
+        val minorUnitsAmountDivisor: Int?,
+        /**
          * The customer's email address from the checkout session.
          */
         val customerEmail: String?,
@@ -486,6 +491,23 @@ class CheckoutController @Inject internal constructor(
         }
 
         /**
+         * A monetary amount, expressed both in the smallest currency unit and as a display string.
+         */
+        @Poko
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Amount internal constructor(
+            /**
+             * The amount in the smallest currency unit (e.g., cents for USD).
+             */
+            val minorUnitsAmount: Long,
+            /**
+             * A localized, currency-formatted string representing the amount (e.g., "$9.99").
+             */
+            val formatted: String,
+        )
+
+        /**
          * Summary of all totals for the checkout session.
          */
         @Poko
@@ -495,15 +517,15 @@ class CheckoutController @Inject internal constructor(
             /**
              * The subtotal before discounts, taxes, and shipping.
              */
-            val subtotal: Long,
+            val subtotal: Amount,
             /**
              * The amount due today, accounting for applied balances.
              */
-            val totalDueToday: Long,
+            val totalDueToday: Amount,
             /**
              * The total amount due including all charges.
              */
-            val totalAmountDue: Long,
+            val totalAmountDue: Amount,
             /**
              * Discounts applied to the checkout session.
              */
@@ -519,7 +541,7 @@ class CheckoutController @Inject internal constructor(
             /**
              * The customer's account balance applied to this session, if any.
              */
-            val appliedBalance: Long?,
+            val appliedBalance: Amount?,
         )
 
         /**
@@ -530,9 +552,9 @@ class CheckoutController @Inject internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class DiscountAmount internal constructor(
             /**
-             * The discount amount in the smallest currency unit.
+             * The discount amount.
              */
-            val amount: Long,
+            val amount: Amount,
             /**
              * The display name of the discount.
              */
@@ -547,9 +569,9 @@ class CheckoutController @Inject internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class TaxAmount internal constructor(
             /**
-             * The tax amount in the smallest currency unit.
+             * The tax amount.
              */
-            val amount: Long,
+            val amount: Amount,
             /**
              * Whether this tax is inclusive (already included in the price).
              */
@@ -576,9 +598,9 @@ class CheckoutController @Inject internal constructor(
              */
             val id: String,
             /**
-             * The shipping amount in the smallest currency unit.
+             * The shipping amount.
              */
-            val amount: Long,
+            val amount: Amount,
             /**
              * The display name of the shipping option (e.g., "Standard Shipping").
              */
@@ -609,17 +631,17 @@ class CheckoutController @Inject internal constructor(
              */
             val quantity: Int,
             /**
-             * The unit price in the smallest currency unit, if available.
+             * The unit price, if available.
              */
-            val unitAmount: Long?,
+            val unitAmount: Amount?,
             /**
              * The subtotal before discounts and taxes.
              */
-            val subtotal: Long,
+            val subtotal: Amount,
             /**
              * The total after discounts and taxes.
              */
-            val total: Long,
+            val total: Amount,
         )
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -7,6 +7,11 @@ import com.stripe.android.checkout.ece.ExpressButtonType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptionsFactory
+import com.stripe.android.uicore.format.CurrencyFormatter
+import java.util.Currency
+import kotlin.math.pow
+
+private const val MAJOR_UNIT_BASE = 10.0
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutSessionResponse.asCheckoutSession(
@@ -19,11 +24,12 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         status = status.asStatus(),
         liveMode = liveMode,
         currency = currency,
+        minorUnitsAmountDivisor = minorUnitsAmountDivisor(currency),
         customerEmail = customerEmail,
         tax = taxStatus.asTax(),
-        totalSummary = totalSummary?.asTotalSummary(),
-        lineItems = lineItems.map { it.asLineItem() },
-        shippingOptions = shippingOptions.map { it.asShippingRate() },
+        totalSummary = totalSummary?.asTotalSummary(currency),
+        lineItems = lineItems.map { it.asLineItem(currency) },
+        shippingOptions = shippingOptions.map { it.asShippingRate(currency) },
         paymentOptionDisplayData = paymentOptionDisplayData,
         currencySelectorOptions = CurrencySelectorOptionsFactory.create(
             adaptivePricingInfo = adaptivePricingInfo,
@@ -32,6 +38,26 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         availableExpressButtonTypes = availableExpressButtonTypes,
     )
 }
+
+/**
+ * Wraps a raw minor-units [Long] in a [Session.Amount], attaching a localized, currency-formatted
+ * display string produced by the shared [CurrencyFormatter].
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun Long.asAmount(currency: String): Session.Amount = Session.Amount(
+    minorUnitsAmount = this,
+    formatted = CurrencyFormatter.format(amount = this, amountCurrencyCode = currency),
+)
+
+/**
+ * The factor to convert amounts in the smallest currency unit to the major unit (e.g. 100 for USD,
+ * 1 for JPY), derived from the same decimal-digit logic [CurrencyFormatter] uses. `null` when the
+ * currency code isn't recognized.
+ */
+private fun minorUnitsAmountDivisor(currency: String): Int? = runCatching {
+    val decimalDigits = CurrencyFormatter.getDefaultDecimalDigits(Currency.getInstance(currency.uppercase()))
+    MAJOR_UNIT_BASE.pow(decimalDigits).toInt()
+}.getOrNull()
 
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.Status.asStatus(): Session.Status {
@@ -63,30 +89,30 @@ private fun CheckoutSessionResponse.TaxStatus.asTax(): Session.Tax {
 }
 
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.TotalSummaryResponse.asTotalSummary(): Session.TotalSummary {
+private fun CheckoutSessionResponse.TotalSummaryResponse.asTotalSummary(currency: String): Session.TotalSummary {
     return Session.TotalSummary(
-        subtotal = subtotal,
-        totalDueToday = totalDueToday,
-        totalAmountDue = totalAmountDue,
-        discountAmounts = discountAmounts.map { it.asDiscountAmount() },
-        taxAmounts = taxAmounts.map { it.asTaxAmount() },
-        shippingRate = shippingRate?.asShippingRate(),
-        appliedBalance = appliedBalance,
+        subtotal = subtotal.asAmount(currency),
+        totalDueToday = totalDueToday.asAmount(currency),
+        totalAmountDue = totalAmountDue.asAmount(currency),
+        discountAmounts = discountAmounts.map { it.asDiscountAmount(currency) },
+        taxAmounts = taxAmounts.map { it.asTaxAmount(currency) },
+        shippingRate = shippingRate?.asShippingRate(currency),
+        appliedBalance = appliedBalance?.asAmount(currency),
     )
 }
 
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.DiscountAmount.asDiscountAmount(): Session.DiscountAmount {
+private fun CheckoutSessionResponse.DiscountAmount.asDiscountAmount(currency: String): Session.DiscountAmount {
     return Session.DiscountAmount(
-        amount = amount,
+        amount = amount.asAmount(currency),
         displayName = displayName,
     )
 }
 
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.TaxAmount.asTaxAmount(): Session.TaxAmount {
+private fun CheckoutSessionResponse.TaxAmount.asTaxAmount(currency: String): Session.TaxAmount {
     return Session.TaxAmount(
-        amount = amount,
+        amount = amount.asAmount(currency),
         inclusive = inclusive,
         displayName = displayName,
         percentage = percentage,
@@ -94,23 +120,23 @@ private fun CheckoutSessionResponse.TaxAmount.asTaxAmount(): Session.TaxAmount {
 }
 
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.ShippingRate.asShippingRate(): Session.ShippingRate {
+private fun CheckoutSessionResponse.ShippingRate.asShippingRate(currency: String): Session.ShippingRate {
     return Session.ShippingRate(
         id = id,
-        amount = amount,
+        amount = amount.asAmount(currency),
         displayName = displayName,
         deliveryEstimate = deliveryEstimate,
     )
 }
 
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.LineItem.asLineItem(): Session.LineItem {
+private fun CheckoutSessionResponse.LineItem.asLineItem(currency: String): Session.LineItem {
     return Session.LineItem(
         id = id,
         name = name,
         quantity = quantity,
-        unitAmount = unitAmount,
-        subtotal = subtotal,
-        total = total,
+        unitAmount = unitAmount?.asAmount(currency),
+        subtotal = subtotal.asAmount(currency),
+        total = total.asAmount(currency),
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -451,7 +451,8 @@ internal class CheckoutControllerTest {
         val result = controller.updateLineItemQuantity("li_1", 3)
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(7000)
+        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday?.minorUnitsAmount)
+            .isEqualTo(7000)
     }
 
     @Test
@@ -480,7 +481,8 @@ internal class CheckoutControllerTest {
         val result = controller.updateCurrency("usd")
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(5099)
+        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday?.minorUnitsAmount)
+            .isEqualTo(5099)
     }
 
     @Test
@@ -714,7 +716,8 @@ internal class CheckoutControllerTest {
         val result = controller.runServerUpdate { Result.success(Unit) }
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(8000)
+        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday?.minorUnitsAmount)
+            .isEqualTo(8000)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -111,7 +111,17 @@ class CheckoutSessionMappersTest {
         val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(subtotal = 5000L),
         )
-        assertThat(session.totalSummary?.subtotal).isEqualTo(5000L)
+        assertThat(session.totalSummary?.subtotal?.minorUnitsAmount).isEqualTo(5000L)
+    }
+
+    @Test
+    fun `formats totalSummary subtotal`() {
+        val session = createSession(
+            currency = "usd",
+            totalSummary = TotalSummaryResponseFactory.create(subtotal = 5000L),
+        )
+        // The formatted string is locale-dependent, but the major-unit value is always present.
+        assertThat(session.totalSummary?.subtotal?.formatted).contains("50")
     }
 
     @Test
@@ -119,7 +129,7 @@ class CheckoutSessionMappersTest {
         val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(totalDueToday = 4044L),
         )
-        assertThat(session.totalSummary?.totalDueToday).isEqualTo(4044L)
+        assertThat(session.totalSummary?.totalDueToday?.minorUnitsAmount).isEqualTo(4044L)
     }
 
     @Test
@@ -127,7 +137,19 @@ class CheckoutSessionMappersTest {
         val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(totalAmountDue = 3000L),
         )
-        assertThat(session.totalSummary?.totalAmountDue).isEqualTo(3000L)
+        assertThat(session.totalSummary?.totalAmountDue?.minorUnitsAmount).isEqualTo(3000L)
+    }
+
+    @Test
+    fun `maps minorUnitsAmountDivisor for a two-decimal currency`() {
+        val session = createSession(currency = "usd")
+        assertThat(session.minorUnitsAmountDivisor).isEqualTo(100)
+    }
+
+    @Test
+    fun `maps minorUnitsAmountDivisor for a zero-decimal currency`() {
+        val session = createSession(currency = "jpy")
+        assertThat(session.minorUnitsAmountDivisor).isEqualTo(1)
     }
 
     @Test
@@ -142,9 +164,9 @@ class CheckoutSessionMappersTest {
         )
         val discounts = session.totalSummary!!.discountAmounts
         assertThat(discounts).hasSize(2)
-        assertThat(discounts[0].amount).isEqualTo(500L)
+        assertThat(discounts[0].amount.minorUnitsAmount).isEqualTo(500L)
         assertThat(discounts[0].displayName).isEqualTo("SUMMER10")
-        assertThat(discounts[1].amount).isEqualTo(250L)
+        assertThat(discounts[1].amount.minorUnitsAmount).isEqualTo(250L)
         assertThat(discounts[1].displayName).isEqualTo("LOYALTY5")
     }
 
@@ -164,7 +186,7 @@ class CheckoutSessionMappersTest {
         )
         val taxes = session.totalSummary!!.taxAmounts
         assertThat(taxes).hasSize(1)
-        assertThat(taxes[0].amount).isEqualTo(294L)
+        assertThat(taxes[0].amount.minorUnitsAmount).isEqualTo(294L)
         assertThat(taxes[0].inclusive).isFalse()
         assertThat(taxes[0].displayName).isEqualTo("Sales Tax")
         assertThat(taxes[0].percentage).isEqualTo(6.875)
@@ -184,7 +206,7 @@ class CheckoutSessionMappersTest {
         )
         val shipping = session.totalSummary!!.shippingRate!!
         assertThat(shipping.id).isEqualTo("shr_standard")
-        assertThat(shipping.amount).isEqualTo(500L)
+        assertThat(shipping.amount.minorUnitsAmount).isEqualTo(500L)
         assertThat(shipping.displayName).isEqualTo("Standard Shipping")
         assertThat(shipping.deliveryEstimate).isEqualTo("5-7 business days")
     }
@@ -202,7 +224,7 @@ class CheckoutSessionMappersTest {
         val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(appliedBalance = -200L),
         )
-        assertThat(session.totalSummary!!.appliedBalance).isEqualTo(-200L)
+        assertThat(session.totalSummary!!.appliedBalance?.minorUnitsAmount).isEqualTo(-200L)
     }
 
     @Test
@@ -232,9 +254,9 @@ class CheckoutSessionMappersTest {
         assertThat(items[0].id).isEqualTo("li_1")
         assertThat(items[0].name).isEqualTo("Llama Figure")
         assertThat(items[0].quantity).isEqualTo(2)
-        assertThat(items[0].unitAmount).isEqualTo(999L)
-        assertThat(items[0].subtotal).isEqualTo(1998L)
-        assertThat(items[0].total).isEqualTo(1998L)
+        assertThat(items[0].unitAmount?.minorUnitsAmount).isEqualTo(999L)
+        assertThat(items[0].subtotal.minorUnitsAmount).isEqualTo(1998L)
+        assertThat(items[0].total.minorUnitsAmount).isEqualTo(1998L)
     }
 
     @Test
@@ -264,11 +286,11 @@ class CheckoutSessionMappersTest {
         val options = session.shippingOptions
         assertThat(options).hasSize(2)
         assertThat(options[0].id).isEqualTo("shr_standard")
-        assertThat(options[0].amount).isEqualTo(500L)
+        assertThat(options[0].amount.minorUnitsAmount).isEqualTo(500L)
         assertThat(options[0].displayName).isEqualTo("Standard Shipping")
         assertThat(options[0].deliveryEstimate).isNull()
         assertThat(options[1].id).isEqualTo("shr_express")
-        assertThat(options[1].amount).isEqualTo(1500L)
+        assertThat(options[1].amount.minorUnitsAmount).isEqualTo(1500L)
         assertThat(options[1].displayName).isEqualTo("Express Shipping")
         assertThat(options[1].deliveryEstimate).isEqualTo("1-3 business days")
     }


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE).

iOS wraps every money value in an `Amount` (a pre-formatted display string + a minor-units value) and exposes `minorUnitsAmountDivisor` on the `Session`, so merchants can render totals directly. Android exposed raw `Long`s with no formatting and no divisor.

- Add **`Session.Amount(minorUnitsAmount: Long, formatted: String)`**.
- Add **`Session.minorUnitsAmountDivisor: Int?`**, derived from the same decimal-digit logic the shared `CurrencyFormatter` uses (100 for USD, 1 for JPY; `null` if the currency is unrecognized).
- Convert every `Session` money field (`TotalSummary` subtotal/totalDueToday/totalAmountDue/appliedBalance, `DiscountAmount`, `TaxAmount`, `ShippingRate`, `LineItem`) from `Long` to `Amount`, formatting via the existing `CurrencyFormatter`.

## Stack

This is the **foundational** PR of the Session-shape parity stack (base `master`). Subsequent stacked PRs (status/enum alignment, new Session properties, confirm PaymentStatus) build on the `Amount` type. Later, backend-dependent PRs will restructure `TotalSummary` → `Total` and `lineItems` → `orderSummaryItems`.

## Scope

All checkout APIs are `@CheckoutSessionPreview` + `@RestrictTo(LIBRARY_GROUP)`, so `paymentsheet.api` is unaffected. Reuses `com.stripe.android.uicore.format.CurrencyFormatter` — no cross-module change.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutSessionMappersTest"` — updated money assertions to the `Amount` shape; added divisor (USD/JPY) and formatted-string tests ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)