### PR TITLE
Add presentmentDetails/shippingAddress + rename Session.customerEmail to email

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -391,9 +391,18 @@ class CheckoutController @Inject internal constructor(
          */
         val minorUnitsAmountDivisor: Int?,
         /**
+         * Details about the currency presented to the customer, or `null` if the session is not using
+         * adaptive pricing.
+         */
+        val presentmentDetails: PresentmentDetails?,
+        /**
          * The customer's email address from the checkout session.
          */
-        val customerEmail: String?,
+        val email: String?,
+        /**
+         * The customer's shipping contact details and postal address, if one has been collected.
+         */
+        val shippingAddress: ShippingAddress?,
         /**
          * The tax computation status for this checkout session.
          */
@@ -505,6 +514,69 @@ class CheckoutController @Inject internal constructor(
              * A localized, currency-formatted string representing the amount (e.g., "$9.99").
              */
             val formatted: String,
+        )
+
+        /**
+         * Information about the currency presented to the customer during payment.
+         */
+        @Poko
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class PresentmentDetails internal constructor(
+            /**
+             * The three-letter ISO currency code presented to the customer (e.g., "eur").
+             */
+            val presentmentCurrency: String,
+        )
+
+        /**
+         * The customer's shipping contact details and postal address.
+         */
+        @Poko
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class ShippingAddress internal constructor(
+            /**
+             * The recipient's name, if collected.
+             */
+            val name: String?,
+            /**
+             * The shipping postal address.
+             */
+            val address: Address,
+        )
+
+        /**
+         * A postal address on the checkout session.
+         */
+        @Poko
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Address internal constructor(
+            /**
+             * The two-letter ISO country code (e.g., "US").
+             */
+            val country: String,
+            /**
+             * The first line of the address (e.g., street, PO box).
+             */
+            val line1: String?,
+            /**
+             * The second line of the address (e.g., apartment, suite, unit).
+             */
+            val line2: String?,
+            /**
+             * The city, district, suburb, town, or village.
+             */
+            val city: String?,
+            /**
+             * The postal or ZIP code.
+             */
+            val postalCode: String?,
+            /**
+             * The state, county, province, or region.
+             */
+            val state: String?,
         )
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -43,6 +43,7 @@ internal data class CheckoutControllerState(
     ): Session {
         return checkoutSessionResponse.asCheckoutSession(
             flagImages = flagImages,
+            collectedDetails = collectedDetails,
             paymentOptionDisplayData = paymentOptionFactory.create(
                 selection = paymentSelection,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -16,6 +16,7 @@ private const val MAJOR_UNIT_BASE = 10.0
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutSessionResponse.asCheckoutSession(
     flagImages: Map<String, Bitmap>?,
+    collectedDetails: CheckoutCollectedDetails,
     paymentOptionDisplayData: PaymentOptionDisplayData?,
     availableExpressButtonTypes: List<ExpressButtonType>,
 ): Session {
@@ -25,7 +26,11 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         liveMode = liveMode,
         currency = currency,
         minorUnitsAmountDivisor = minorUnitsAmountDivisor(currency),
-        customerEmail = customerEmail,
+        presentmentDetails = adaptivePricingInfo?.let {
+            Session.PresentmentDetails(presentmentCurrency = it.activePresentmentCurrency)
+        },
+        email = customerEmail,
+        shippingAddress = collectedDetails.asShippingAddress(),
         tax = taxStatus.asTax(),
         totalSummary = totalSummary?.asTotalSummary(currency),
         lineItems = lineItems.map { it.asLineItem(currency) },
@@ -58,6 +63,26 @@ private fun minorUnitsAmountDivisor(currency: String): Int? = runCatching {
     val decimalDigits = CurrencyFormatter.getDefaultDecimalDigits(Currency.getInstance(currency.uppercase()))
     MAJOR_UNIT_BASE.pow(decimalDigits).toInt()
 }.getOrNull()
+
+/**
+ * Projects the locally collected shipping details onto the public [Session.ShippingAddress]. Returns
+ * `null` until a shipping address has been collected (a name alone isn't enough to form an address).
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutCollectedDetails.asShippingAddress(): Session.ShippingAddress? {
+    val address = shippingAddress ?: return null
+    return Session.ShippingAddress(
+        name = shippingName,
+        address = Session.Address(
+            country = address.country,
+            line1 = address.line1,
+            line2 = address.line2,
+            city = address.city,
+            postalCode = address.postalCode,
+            state = address.state,
+        ),
+    )
+}
 
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.Status.asStatus(): Session.Status {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -61,15 +61,66 @@ class CheckoutSessionMappersTest {
     }
 
     @Test
-    fun `maps customerEmail`() {
+    fun `maps email`() {
         val session = createSession(customerEmail = "test@example.com")
-        assertThat(session.customerEmail).isEqualTo("test@example.com")
+        assertThat(session.email).isEqualTo("test@example.com")
     }
 
     @Test
-    fun `null customerEmail maps to null`() {
+    fun `null email maps to null`() {
         val session = createSession(customerEmail = null)
-        assertThat(session.customerEmail).isNull()
+        assertThat(session.email).isNull()
+    }
+
+    @Test
+    fun `maps presentmentDetails from adaptive pricing info`() {
+        val session = createSession(
+            adaptivePricingInfo = CheckoutSessionResponse.AdaptivePricingInfo(
+                activePresentmentCurrency = "eur",
+                integrationAmount = 1000L,
+                integrationCurrency = "usd",
+                localCurrencyOptions = emptyList(),
+            ),
+        )
+        assertThat(session.presentmentDetails?.presentmentCurrency).isEqualTo("eur")
+    }
+
+    @Test
+    fun `null adaptive pricing info maps presentmentDetails to null`() {
+        val session = createSession(adaptivePricingInfo = null)
+        assertThat(session.presentmentDetails).isNull()
+    }
+
+    @Test
+    fun `maps shippingAddress from collected details`() {
+        val session = createSession(
+            collectedDetails = CheckoutCollectedDetails(
+                shippingName = "Jane Doe",
+                shippingAddress = CheckoutController.Address.State(
+                    city = "Denver",
+                    country = "US",
+                    line1 = "123 Main St",
+                    line2 = "Apt 4",
+                    postalCode = "80202",
+                    state = "CO",
+                ),
+            ),
+        )
+
+        val shippingAddress = requireNotNull(session.shippingAddress)
+        assertThat(shippingAddress.name).isEqualTo("Jane Doe")
+        assertThat(shippingAddress.address.country).isEqualTo("US")
+        assertThat(shippingAddress.address.line1).isEqualTo("123 Main St")
+        assertThat(shippingAddress.address.line2).isEqualTo("Apt 4")
+        assertThat(shippingAddress.address.city).isEqualTo("Denver")
+        assertThat(shippingAddress.address.postalCode).isEqualTo("80202")
+        assertThat(shippingAddress.address.state).isEqualTo("CO")
+    }
+
+    @Test
+    fun `no collected shipping address maps shippingAddress to null`() {
+        val session = createSession(collectedDetails = CheckoutCollectedDetails())
+        assertThat(session.shippingAddress).isNull()
     }
 
     @Test
@@ -301,6 +352,7 @@ class CheckoutSessionMappersTest {
         assertThat(session.shippingOptions).isEmpty()
     }
 
+    @Suppress("LongParameterList")
     private fun createSession(
         id: String = DEFAULT_CHECKOUT_SESSION_ID,
         status: CheckoutSessionResponse.Status = CheckoutSessionResponse.Status.OPEN,
@@ -311,6 +363,8 @@ class CheckoutSessionMappersTest {
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
+        adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
+        collectedDetails: CheckoutCollectedDetails = CheckoutCollectedDetails(),
     ): Session {
         return CheckoutSessionResponseFactory.create(
             id = id,
@@ -322,8 +376,10 @@ class CheckoutSessionMappersTest {
             totalSummary = totalSummary,
             lineItems = lineItems,
             shippingOptions = shippingOptions,
+            adaptivePricingInfo = adaptivePricingInfo,
         ).asCheckoutSession(
             flagImages = null,
+            collectedDetails = collectedDetails,
             paymentOptionDisplayData = null,
             availableExpressButtonTypes = emptyList(),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
@@ -86,6 +86,7 @@ internal class CurrencySelectorViewModelTest {
             checkoutSessionFlow.value = CheckoutSessionResponseFactory.create(currency = "eur")
                 .asCheckoutSession(
                     flagImages = null,
+                    collectedDetails = CheckoutCollectedDetails(),
                     paymentOptionDisplayData = null,
                     availableExpressButtonTypes = emptyList(),
                 )
@@ -128,6 +129,7 @@ internal class CurrencySelectorViewModelTest {
         val checkoutSessionFlow = MutableStateFlow(
             CheckoutSessionResponseFactory.create().asCheckoutSession(
                 flagImages = null,
+                collectedDetails = CheckoutCollectedDetails(),
                 paymentOptionDisplayData = null,
                 availableExpressButtonTypes = emptyList(),
             )


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE). Adds the cleanly-derivable `Session` properties from the iOS `Session` object:

- **`presentmentDetails: PresentmentDetails { presentmentCurrency: String }`** — mapped from `adaptivePricingInfo.activePresentmentCurrency`.
- **`shippingAddress: ShippingAddress { name: String?, address: Address }`** — projected from the locally collected shipping details (threads `collectedDetails` into the response→Session mapper); adds a read-only `Session.Address` type (distinct from the existing write-builder `CheckoutController.Address`).
- Rename **`Session.customerEmail` → `email`** to match iOS.

### Deferred (no clean client-side source yet)

- `businessName` — `ElementsSession` has no business-name field, and the injected `@MerchantDisplayName` is the *app label*, not the Stripe "Business Public Details" name. Needs a defined source.
- `lastPaymentError` — needs a defined mapping from `paymentIntent`/`setupIntent`.

## Stack

Stacked on **#13659** (`checkout-parity/session/amount`). Base is that branch, not `master`.

## Scope

All checkout APIs are `@CheckoutSessionPreview` + `@RestrictTo(LIBRARY_GROUP)`, so `paymentsheet.api` is unaffected.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutSessionMappersTest" --tests "*CurrencySelectorViewModelTest"` — added presentmentDetails (present/null) and shippingAddress (present/null) tests; updated email assertions ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)