### PR TITLE
Align Session status/tax enums with iOS + add businessName and lastPaymentError

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -50,7 +50,7 @@ internal class CheckoutControllerExampleViewModel(
         viewModelScope.launch {
             controller.checkoutSession.collect { session ->
                 updateConfiguredState { it.copy(checkoutSession = session) }
-                if (session?.status == Session.Status.Complete) {
+                if (session?.status is Session.Status.Complete) {
                     _sessionComplete.tryEmit(Unit)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -382,6 +382,11 @@ class CheckoutController @Inject internal constructor(
          */
         val liveMode: Boolean,
         /**
+         * The business name configured in the Business Public Details settings of your Stripe account,
+         * or `null` if unavailable.
+         */
+        val businessName: String?,
+        /**
          * The three-letter ISO currency code (e.g., "usd").
          */
         val currency: String,
@@ -423,6 +428,10 @@ class CheckoutController @Inject internal constructor(
          * The customer's currently selected payment option, or `null` if none has been selected yet.
          */
         val paymentOptionDisplayData: PaymentOptionDisplayData?,
+        /**
+         * The error encountered the last time this checkout session was confirmed, or `null` if none.
+         */
+        val lastPaymentError: Throwable?,
         internal val currencySelectorOptions: CurrencySelectorOptions?,
         internal val availableExpressButtonTypes: List<ExpressButtonType>,
     ) {
@@ -433,30 +442,60 @@ class CheckoutController @Inject internal constructor(
         val isExpressCheckoutElementAvailable: Boolean = availableExpressButtonTypes.isNotEmpty()
 
         /**
-         * The status of a checkout session.
+         * The lifecycle status of a checkout session.
          */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        enum class Status {
+        sealed interface Status {
             /**
              * The checkout session is still in progress. Payment processing has not started.
              */
-            Open,
-
-            /**
-             * The checkout session is complete. Payment processing may still be in progress.
-             */
-            Complete,
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            data object Open : Status
 
             /**
              * The checkout session has expired. No further processing will occur.
              */
-            Expired,
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            data object Expired : Status
 
             /**
-             * A status not recognized by this version of the SDK.
+             * The checkout session is complete. Payment processing may still be in progress; inspect
+             * [paymentStatus] to determine whether the payment has been collected.
              */
-            Unknown,
+            @Poko
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class Complete internal constructor(
+                /**
+                 * Whether the payment for this completed session has been collected.
+                 */
+                val paymentStatus: PaymentStatus,
+            ) : Status
+
+            /**
+             * Whether the payment for a completed checkout session has been collected.
+             */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class PaymentStatus {
+                /**
+                 * The payment has been collected.
+                 */
+                Paid,
+
+                /**
+                 * The payment has not been collected (it may still be processing or may have failed).
+                 */
+                Unpaid,
+
+                /**
+                 * No payment was required for this session (e.g. a setup-mode session or a zero-amount order).
+                 */
+                NoPaymentRequired,
+            }
         }
 
         /**
@@ -491,11 +530,6 @@ class CheckoutController @Inject internal constructor(
                  * A billing address must be provided to calculate tax.
                  */
                 RequiresBillingAddress,
-
-                /**
-                 * A tax status not recognized by this version of the SDK.
-                 */
-                Unknown,
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -4,6 +4,8 @@ import android.graphics.Bitmap
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.checkout.CheckoutController.Session.PaymentOptionDisplayData
 import com.stripe.android.checkout.ece.ExpressButtonType
+import com.stripe.android.core.exception.LocalStripeException
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptionsFactory
@@ -12,6 +14,7 @@ import java.util.Currency
 import kotlin.math.pow
 
 private const val MAJOR_UNIT_BASE = 10.0
+private const val LAST_PAYMENT_ERROR_ANALYTICS_VALUE = "checkoutSessionLastPaymentError"
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutSessionResponse.asCheckoutSession(
@@ -22,8 +25,9 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
 ): Session {
     return Session(
         id = id,
-        status = status.asStatus(),
+        status = asStatus(),
         liveMode = liveMode,
+        businessName = businessName,
         currency = currency,
         minorUnitsAmountDivisor = minorUnitsAmountDivisor(currency),
         presentmentDetails = adaptivePricingInfo?.let {
@@ -36,6 +40,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         lineItems = lineItems.map { it.asLineItem(currency) },
         shippingOptions = shippingOptions.map { it.asShippingRate(currency) },
         paymentOptionDisplayData = paymentOptionDisplayData,
+        lastPaymentError = lastPaymentError(),
         currencySelectorOptions = CurrencySelectorOptionsFactory.create(
             adaptivePricingInfo = adaptivePricingInfo,
             flagImages = flagImages,
@@ -84,16 +89,70 @@ private fun CheckoutCollectedDetails.asShippingAddress(): Session.ShippingAddres
     )
 }
 
+/**
+ * Maps the session lifecycle status. The public [Session.Status] intentionally has no `Unknown` case
+ * (per the API design), so an unrecognized server status is treated as [Session.Status.Open] — the
+ * conservative, non-terminal state. When the session is complete, the payment status is derived from
+ * [paymentStatus].
+ */
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutSessionResponse.Status.asStatus(): Session.Status {
-    return when (this) {
+private fun CheckoutSessionResponse.asStatus(): Session.Status {
+    return when (status) {
         CheckoutSessionResponse.Status.OPEN -> Session.Status.Open
-        CheckoutSessionResponse.Status.COMPLETE -> Session.Status.Complete
         CheckoutSessionResponse.Status.EXPIRED -> Session.Status.Expired
-        CheckoutSessionResponse.Status.UNKNOWN -> Session.Status.Unknown
+        CheckoutSessionResponse.Status.COMPLETE -> Session.Status.Complete(paymentStatus())
+        CheckoutSessionResponse.Status.UNKNOWN -> Session.Status.Open
     }
 }
 
+/**
+ * Best-guess derivation of the payment status for a completed session (the `/init` contract doesn't
+ * expose it directly): setup-mode sessions and zero-amount orders require no payment; otherwise the
+ * payment is considered collected only when the PaymentIntent has succeeded or is awaiting capture.
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.paymentStatus(): Session.Status.PaymentStatus {
+    return when {
+        mode == CheckoutSessionResponse.Mode.SETUP -> Session.Status.PaymentStatus.NoPaymentRequired
+        amount == 0L -> Session.Status.PaymentStatus.NoPaymentRequired
+        paymentIntent?.status == StripeIntent.Status.Succeeded ||
+            paymentIntent?.status == StripeIntent.Status.RequiresCapture ->
+            Session.Status.PaymentStatus.Paid
+        else -> Session.Status.PaymentStatus.Unpaid
+    }
+}
+
+/**
+ * Surfaces the error from the last confirmation attempt, wrapped as a [Throwable]. Best guess: the
+ * `/init` contract doesn't confirm which intent carries it, so we prefer the PaymentIntent's error
+ * and fall back to the SetupIntent's.
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.lastPaymentError(): Throwable? {
+    paymentIntent?.lastPaymentError?.let { error ->
+        return LocalStripeException(
+            displayMessage = error.message,
+            analyticsValue = LAST_PAYMENT_ERROR_ANALYTICS_VALUE,
+            errorCode = error.code,
+            declineCode = error.declineCode,
+        )
+    }
+    setupIntent?.lastSetupError?.let { error ->
+        return LocalStripeException(
+            displayMessage = error.message,
+            analyticsValue = LAST_PAYMENT_ERROR_ANALYTICS_VALUE,
+            errorCode = error.code,
+            declineCode = error.declineCode,
+        )
+    }
+    return null
+}
+
+/**
+ * Maps the tax computation status. The public [Session.Tax.Status] intentionally has no `Unknown`
+ * case, so an unrecognized server status is treated as [Session.Tax.Status.RequiresShippingAddress]
+ * — the conservative "not ready to confirm" state.
+ */
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.TaxStatus.asTax(): Session.Tax {
     val status = when (this) {
@@ -107,7 +166,7 @@ private fun CheckoutSessionResponse.TaxStatus.asTax(): Session.Tax {
             Session.Tax.Status.RequiresBillingAddress
         }
         CheckoutSessionResponse.TaxStatus.UNKNOWN -> {
-            Session.Tax.Status.Unknown
+            Session.Tax.Status.RequiresShippingAddress
         }
     }
     return Session.Tax(status = status)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -31,6 +31,7 @@ internal data class CheckoutSessionResponse(
     val allowedShippingCountries: List<String>?,
     val requiresBillingAddress: Boolean,
     val merchantCountry: String?,
+    val businessName: String?,
 ) : StripeModel {
 
     val shouldDisableWalletsForAutomaticTaxBilling: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -41,6 +41,11 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         val merchantCountry = accountSettings?.let {
             StripeJsonUtils.optCountryCode(it, FIELD_ACCOUNT_SETTINGS_COUNTRY)
         }
+        // Best-guess key: the /init contract for the business name is unconfirmed. Reads
+        // account_settings.business_name and degrades to null if the key is absent or renamed.
+        val businessName = accountSettings?.let {
+            StripeJsonUtils.optString(it, FIELD_ACCOUNT_SETTINGS_BUSINESS_NAME)
+        }
         val mode = parseMode(json.optString(FIELD_MODE))
         val status = parseStatus(json.optString(FIELD_STATUS))
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
@@ -112,6 +117,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
             merchantCountry = merchantCountry,
+            businessName = businessName,
         )
     }
 
@@ -533,6 +539,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_SESSION_ID = "session_id"
     private const val FIELD_ACCOUNT_SETTINGS = "account_settings"
     private const val FIELD_ACCOUNT_SETTINGS_COUNTRY = "country"
+    private const val FIELD_ACCOUNT_SETTINGS_BUSINESS_NAME = "business_name"
     private const val FIELD_UI_MODE = "ui_mode"
     private const val UI_MODE_CUSTOM = "custom"
     private const val FIELD_MODE = "mode"

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.checkout
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -27,7 +29,7 @@ class CheckoutSessionMappersTest {
     @Test
     fun `maps status complete`() {
         val session = createSession(status = CheckoutSessionResponse.Status.COMPLETE)
-        assertThat(session.status).isEqualTo(Session.Status.Complete)
+        assertThat(session.status).isInstanceOf(Session.Status.Complete::class.java)
     }
 
     @Test
@@ -37,9 +39,71 @@ class CheckoutSessionMappersTest {
     }
 
     @Test
-    fun `maps status unknown`() {
+    fun `unknown status maps to open`() {
         val session = createSession(status = CheckoutSessionResponse.Status.UNKNOWN)
-        assertThat(session.status).isEqualTo(Session.Status.Unknown)
+        assertThat(session.status).isEqualTo(Session.Status.Open)
+    }
+
+    @Test
+    fun `complete setup-mode session has NoPaymentRequired payment status`() {
+        val session = createSession(
+            status = CheckoutSessionResponse.Status.COMPLETE,
+            mode = CheckoutSessionResponse.Mode.SETUP,
+        )
+        val complete = session.status as Session.Status.Complete
+        assertThat(complete.paymentStatus).isEqualTo(Session.Status.PaymentStatus.NoPaymentRequired)
+    }
+
+    @Test
+    fun `complete zero-amount session has NoPaymentRequired payment status`() {
+        val session = createSession(status = CheckoutSessionResponse.Status.COMPLETE, amount = 0L)
+        val complete = session.status as Session.Status.Complete
+        assertThat(complete.paymentStatus).isEqualTo(Session.Status.PaymentStatus.NoPaymentRequired)
+    }
+
+    @Test
+    fun `complete session with a succeeded PaymentIntent has Paid payment status`() {
+        val session = createSession(
+            status = CheckoutSessionResponse.Status.COMPLETE,
+            paymentIntent = PaymentIntentFixtures.PI_SUCCEEDED,
+        )
+        val complete = session.status as Session.Status.Complete
+        assertThat(complete.paymentStatus).isEqualTo(Session.Status.PaymentStatus.Paid)
+    }
+
+    @Test
+    fun `complete session without a collected payment has Unpaid payment status`() {
+        val session = createSession(
+            status = CheckoutSessionResponse.Status.COMPLETE,
+            paymentIntent = null,
+        )
+        val complete = session.status as Session.Status.Complete
+        assertThat(complete.paymentStatus).isEqualTo(Session.Status.PaymentStatus.Unpaid)
+    }
+
+    @Test
+    fun `maps businessName`() {
+        val session = createSession(businessName = "Example, Inc.")
+        assertThat(session.businessName).isEqualTo("Example, Inc.")
+    }
+
+    @Test
+    fun `null businessName maps to null`() {
+        val session = createSession(businessName = null)
+        assertThat(session.businessName).isNull()
+    }
+
+    @Test
+    fun `maps lastPaymentError from the PaymentIntent`() {
+        val session = createSession(paymentIntent = PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR)
+        assertThat(session.lastPaymentError?.message)
+            .isEqualTo(PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR?.lastPaymentError?.message)
+    }
+
+    @Test
+    fun `no last payment error maps to null`() {
+        val session = createSession(paymentIntent = PaymentIntentFixtures.PI_SUCCEEDED)
+        assertThat(session.lastPaymentError).isNull()
     }
 
     @Test
@@ -146,9 +210,9 @@ class CheckoutSessionMappersTest {
     }
 
     @Test
-    fun `maps tax status unknown`() {
+    fun `unknown tax status maps to requires shipping address`() {
         val session = createSession(taxStatus = CheckoutSessionResponse.TaxStatus.UNKNOWN)
-        assertThat(session.tax.status).isEqualTo(Session.Tax.Status.Unknown)
+        assertThat(session.tax.status).isEqualTo(Session.Tax.Status.RequiresShippingAddress)
     }
 
     @Test
@@ -365,6 +429,10 @@ class CheckoutSessionMappersTest {
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
         adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
         collectedDetails: CheckoutCollectedDetails = CheckoutCollectedDetails(),
+        mode: CheckoutSessionResponse.Mode = CheckoutSessionResponse.Mode.PAYMENT,
+        amount: Long = 1000L,
+        paymentIntent: PaymentIntent? = null,
+        businessName: String? = null,
     ): Session {
         return CheckoutSessionResponseFactory.create(
             id = id,
@@ -377,6 +445,10 @@ class CheckoutSessionMappersTest {
             lineItems = lineItems,
             shippingOptions = shippingOptions,
             adaptivePricingInfo = adaptivePricingInfo,
+            mode = mode,
+            amount = amount,
+            paymentIntent = paymentIntent,
+            businessName = businessName,
         ).asCheckoutSession(
             flagImages = null,
             collectedDetails = collectedDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -30,6 +30,7 @@ internal object CheckoutSessionResponseFactory {
         allowedShippingCountries: List<String>? = null,
         requiresBillingAddress: Boolean = false,
         merchantCountry: String? = "US",
+        businessName: String? = null,
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -54,6 +55,7 @@ internal object CheckoutSessionResponseFactory {
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
             merchantCountry = merchantCountry,
+            businessName = businessName,
         )
     }
 }


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE). iOS forbids `unknown` enum cases and models a completed session's payment status, a business name, and the last payment error.

- **`Session.Status`** becomes a sealed hierarchy `Open | Expired | Complete(paymentStatus)` with `PaymentStatus { Paid, Unpaid, NoPaymentRequired }`. The public `Unknown` case is removed.
- Remove `Unknown` from **`Session.Tax.Status`**.
- Add **`Session.businessName: String?`** and **`Session.lastPaymentError: Throwable?`**.

## ⚠️ Best-guess decisions (need confirmation)

Per direction to ship best guesses and document them, these were decided without a confirmed backend contract:

1. **Unknown-value handling** (public enums no longer have `Unknown`): an unrecognized server *session* status maps to `Open` (conservative, non-terminal); an unrecognized *tax* status maps to `RequiresShippingAddress` (conservative "not ready to confirm").
2. **`PaymentStatus` derivation** (the `/init` response doesn't expose it directly): `SETUP` mode **or** zero `amount` → `NoPaymentRequired`; `PAYMENT` mode with a `Succeeded`/`RequiresCapture` PaymentIntent → `Paid`; otherwise → `Unpaid`.
3. **`businessName` source**: `ElementsSession` has no business-name field, so this is parsed from a **guessed** `account_settings.business_name` key and degrades to `null` if the key is absent/renamed.
4. **`lastPaymentError`**: wraps the PaymentIntent's `lastPaymentError` (falling back to the SetupIntent's `lastSetupError`) as a `LocalStripeException` carrying message/code/declineCode.

All four are called out in code comments too. Please confirm/correct against the `mobile_elements` `/init` contract.

## Stack

Stacked on **#13660** → #13659 → `master`. Base is `checkout-parity/session/properties`.

## Scope

All checkout APIs are `@CheckoutSessionPreview` + `@RestrictTo(LIBRARY_GROUP)`, so `paymentsheet.api` is unaffected.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutSessionMappersTest"` — added tests for the 4 PaymentStatus paths, unknown→Open / unknown-tax→RequiresShippingAddress, businessName, and lastPaymentError ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)