### PR TITLE
Rename isLoading to isUpdating and add PaymentStatus to confirm Result

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -63,12 +63,13 @@ class CheckoutController @Inject internal constructor(
     private val mutex = Mutex()
     private val pendingMutations = AtomicInteger(0)
 
-    private val _isLoading = MutableStateFlow(false)
+    private val _isUpdating = MutableStateFlow(false)
 
     /**
-     * Whether a mutation is currently in progress.
+     * `true` while the checkout session is being updated. Use this to disable interactive UI (e.g.
+     * your buy button) so the customer can't confirm while an update is in flight.
      */
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    val isUpdating: StateFlow<Boolean> = _isUpdating.asStateFlow()
 
     suspend fun configure(
         checkoutSessionClientSecret: String,
@@ -304,14 +305,14 @@ class CheckoutController @Inject internal constructor(
 
     /**
      * Serializes [block] behind [mutex] so configuration and mutations run in sequence, and toggles
-     * [isLoading] while any serialized work is in flight (tracked via [pendingMutations] so
+     * [isUpdating] while any serialized work is in flight (tracked via [pendingMutations] so
      * concurrent callers share a single loading window).
      */
     private suspend fun <T> runSerialized(
         block: suspend () -> kotlin.Result<T>,
     ): kotlin.Result<T> {
         if (pendingMutations.incrementAndGet() == 1) {
-            _isLoading.value = true
+            _isUpdating.value = true
         }
         return try {
             // Run network requests with a mutex to ensure events are processed in order.
@@ -320,7 +321,7 @@ class CheckoutController @Inject internal constructor(
             }
         } finally {
             if (pendingMutations.decrementAndGet() == 0) {
-                _isLoading.value = false
+                _isUpdating.value = false
             }
         }
     }
@@ -964,9 +965,15 @@ class CheckoutController @Inject internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Result {
+        @Poko
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        class Completed internal constructor() : Result
+        class Completed internal constructor(
+            /**
+             * Whether the payment for the now-completed session was collected.
+             */
+            val paymentStatus: Session.Status.PaymentStatus,
+        ) : Result
 
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
@@ -33,7 +33,7 @@ class CurrencySelectorElement @Inject internal constructor(
         )
         val state by stateHolder.stateFlow.collectAsState()
         val appearanceState = state?.configuration?.currencySelectorElementConfiguration?.appearance ?: return
-        val isLoading by checkoutController.isLoading.collectAsState()
+        val isUpdating by checkoutController.isUpdating.collectAsState()
         val checkoutSession by checkoutController.checkoutSession.collectAsState()
         val currencySelectorOptions = checkoutSession?.currencySelectorOptions ?: return
         val showCurrencyCode = appearanceState.labelContent == Appearance.LabelContent.CURRENCY_CODE
@@ -43,7 +43,7 @@ class CurrencySelectorElement @Inject internal constructor(
             onCurrencySelected = { currencyOption ->
                 viewModel.onCurrencySelected(currencyOption.code)
             },
-            isEnabled = !isLoading,
+            isEnabled = !isUpdating,
             showCurrencyCode = showCurrencyCode,
             errorMessage = errorMessage?.resolve(),
             appearance = appearanceState,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -818,8 +818,8 @@ internal class CheckoutControllerTest {
         runMutationScenario(assertLoadingConsumed = true) {
             markIntegrationLaunched()
 
-            // The guard fast-fails before runSerialized, so isLoading must never flip to true.
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            // The guard fast-fails before runSerialized, so isUpdating must never flip to true.
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
             val result = controller.configure(DEFAULT_CLIENT_SECRET)
 
@@ -827,7 +827,7 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `isLoading transitions to true then false on a successful mutation`() = runMutationScenario(
+    fun `isUpdating transitions to true then false on a successful mutation`() = runMutationScenario(
         assertLoadingConsumed = true,
     ) {
         networkRule.checkoutUpdate(
@@ -835,16 +835,16 @@ internal class CheckoutControllerTest {
             responseFactory = successResponseFactory(),
         )
 
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
         controller.applyPromotionCode("10OFF")
 
-        assertThat(isLoadingTurbine.awaitItem()).isTrue()
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
     }
 
     @Test
-    fun `isLoading stays true while queued mutations are pending`() = runMutationScenario(
+    fun `isUpdating stays true while queued mutations are pending`() = runMutationScenario(
         assertLoadingConsumed = true,
     ) {
         val holdFirstResponse = CountDownLatch(1)
@@ -859,24 +859,24 @@ internal class CheckoutControllerTest {
             responseFactory = successResponseFactory(),
         )
 
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
         val job1 = async { controller.applyPromotionCode("10OFF") }
         val job2 = async { controller.applyPromotionCode("20OFF") }
         testScheduler.advanceUntilIdle()
 
-        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+        assertThat(isUpdatingTurbine.awaitItem()).isTrue()
 
         holdFirstResponse.countDown()
         job1.await()
         job2.await()
 
-        // isLoading should go directly from true to false with no intermediate flicker.
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        // isUpdating should go directly from true to false with no intermediate flicker.
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
     }
 
     @Test
-    fun `isLoading transitions to true then false on a failed mutation`() = runMutationScenario(
+    fun `isUpdating transitions to true then false on a failed mutation`() = runMutationScenario(
         assertLoadingConsumed = true,
     ) {
         networkRule.checkoutUpdate { response ->
@@ -884,17 +884,17 @@ internal class CheckoutControllerTest {
             response.setBody("""{"error": {"message": "Invalid promotion code"}}""")
         }
 
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
         controller.applyPromotionCode("INVALID")
 
         // The failure path must still release the loading window via the finally block.
-        assertThat(isLoadingTurbine.awaitItem()).isTrue()
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
     }
 
     @Test
-    fun `isLoading returns to false when a queued mutation is cancelled`() = runMutationScenario(
+    fun `isUpdating returns to false when a queued mutation is cancelled`() = runMutationScenario(
         assertLoadingConsumed = true,
     ) {
         val holdFirstResponse = CountDownLatch(1)
@@ -907,27 +907,27 @@ internal class CheckoutControllerTest {
         // No mock for "20OFF": NetworkRule fails unmatched requests, so if the cancelled mutation's
         // network call fires, the test fails.
 
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
         val job1 = async { controller.applyPromotionCode("10OFF") }
         val job2 = async { controller.applyPromotionCode("20OFF") }
         testScheduler.advanceUntilIdle()
 
-        assertThat(isLoadingTurbine.awaitItem()).isTrue()
+        assertThat(isUpdatingTurbine.awaitItem()).isTrue()
 
         // Prove job2 has started and is suspended waiting for the mutex, not merely unstarted.
         assertThat(job2.isActive).isTrue()
 
         job2.cancelAndJoin()
 
-        // isLoading stays true because job1 is still in-flight (shared loading window).
-        assertThat(controller.isLoading.value).isTrue()
-        isLoadingTurbine.expectNoEvents()
+        // isUpdating stays true because job1 is still in-flight (shared loading window).
+        assertThat(controller.isUpdating.value).isTrue()
+        isUpdatingTurbine.expectNoEvents()
 
         holdFirstResponse.countDown()
         job1.await()
 
-        assertThat(isLoadingTurbine.awaitItem()).isFalse()
+        assertThat(isUpdatingTurbine.awaitItem()).isFalse()
     }
 
     @Test
@@ -959,24 +959,24 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `configure toggles isLoading true then false`() = runTest {
+    fun `configure toggles isUpdating true then false`() = runTest {
         networkRule.defaultInit()
         val controller = createController()
 
         turbineScope {
-            val isLoadingTurbine = controller.isLoading.testIn(backgroundScope)
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
             controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
 
-            assertThat(isLoadingTurbine.awaitItem()).isTrue()
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
-            isLoadingTurbine.cancelAndIgnoreRemainingEvents()
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+            isUpdatingTurbine.cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `configure resets isLoading to false when the request fails`() = runTest {
+    fun `configure resets isUpdating to false when the request fails`() = runTest {
         networkRule.checkoutInit { response ->
             response.setResponseCode(500)
             response.setBody("""{"error": {"message": "Internal server error"}}""")
@@ -984,14 +984,14 @@ internal class CheckoutControllerTest {
         val controller = createController()
 
         turbineScope {
-            val isLoadingTurbine = controller.isLoading.testIn(backgroundScope)
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
             assertThat(controller.configure(DEFAULT_CLIENT_SECRET).isFailure).isTrue()
 
             // The failure path must still release the loading window via the finally block.
-            assertThat(isLoadingTurbine.awaitItem()).isTrue()
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
         }
     }
 
@@ -1007,13 +1007,13 @@ internal class CheckoutControllerTest {
             }
             networkRule.checkoutInit(responseFactory = successResponseFactory())
 
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
             val mutation = async { controller.applyPromotionCode("10OFF") }
             val configure = async { controller.configure(DEFAULT_CLIENT_SECRET) }
             testScheduler.advanceUntilIdle()
 
-            assertThat(isLoadingTurbine.awaitItem()).isTrue()
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
             // configure cannot complete while the mutation holds the mutex, proving it is serialized.
             assertThat(configure.isCompleted).isFalse()
 
@@ -1022,7 +1022,7 @@ internal class CheckoutControllerTest {
             assertThat(configure.await().isSuccess).isTrue()
 
             // A single loading window spanned both operations, with no flicker to false in between.
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
         }
 
     // region allowedShippingCountries validation
@@ -1057,8 +1057,8 @@ internal class CheckoutControllerTest {
         ) {
             val before = controller.checkoutSession.value
 
-            // Fast-fail returns before runSerialized, so isLoading must never flip to true.
-            assertThat(isLoadingTurbine.awaitItem()).isFalse()
+            // Fast-fail returns before runSerialized, so isUpdating must never flip to true.
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
             val result = controller.updateShippingAddress(
                 name = null,
@@ -1248,10 +1248,10 @@ internal class CheckoutControllerTest {
 
     // Configures a controller from a fresh init, then hands it to [block] alongside the shared
     // SavedStateHandle (used to read committed state and simulate a presented payment flow) and an
-    // isLoading Turbine.
+    // isUpdating Turbine.
     //
     // Set [assertLoadingConsumed] for tests that verify loading behavior: the block must consume
-    // every isLoading emission and this asserts none are left over. Tests that don't care about
+    // every isUpdating emission and this asserts none are left over. Tests that don't care about
     // loading leave it false, and any unconsumed emissions are ignored.
     private fun runMutationScenario(
         initModifier: (JSONObject) -> Unit = {},
@@ -1264,7 +1264,7 @@ internal class CheckoutControllerTest {
         controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
 
         turbineScope {
-            val isLoadingTurbine = controller.isLoading.testIn(backgroundScope)
+            val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
             // Re-derive the controller's own child handle so writes made here (selection, sheet-open)
             // are observed by the controller and vice versa.
             val childHandle = savedStateHandle.checkoutSubHandle(DEFAULT_INTEGRATION_NAME)
@@ -1274,13 +1274,13 @@ internal class CheckoutControllerTest {
                     stateHolder = CheckoutControllerStateFactory.createStateHolder(childHandle),
                     sheetStateHolder = SheetStateHolder(childHandle),
                     testScope = this@runTest,
-                    isLoadingTurbine = isLoadingTurbine,
+                    isUpdatingTurbine = isUpdatingTurbine,
                 )
             )
             if (assertLoadingConsumed) {
-                isLoadingTurbine.ensureAllEventsConsumed()
+                isUpdatingTurbine.ensureAllEventsConsumed()
             } else {
-                isLoadingTurbine.cancelAndIgnoreRemainingEvents()
+                isUpdatingTurbine.cancelAndIgnoreRemainingEvents()
             }
         }
     }
@@ -1290,7 +1290,7 @@ internal class CheckoutControllerTest {
         private val stateHolder: CheckoutControllerStateHolder,
         private val sheetStateHolder: SheetStateHolder,
         private val testScope: TestScope,
-        val isLoadingTurbine: ReceiveTurbine<Boolean>,
+        val isUpdatingTurbine: ReceiveTurbine<Boolean>,
     ) : CoroutineScope by testScope {
         val testScheduler: TestCoroutineScheduler get() = testScope.testScheduler
 


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE).

- Rename **`CheckoutController.isLoading` → `isUpdating`** to match iOS's `isUpdating`; docs updated to reference disabling interactive UI (e.g. the buy button) while an update is in flight.
- Reshape **`Result.Completed`** to carry `paymentStatus: Session.Status.PaymentStatus`, matching iOS's `ConfirmResult.succeeded(paymentStatus:)`.

## ⚠️ Best-guess / follow-up note

The confirm-result **delivery** is not yet wired in the codebase — `resultCallback` is currently a placeholder (nothing observes `ConfirmationHandler` state and invokes it). This PR only aligns the **public API shape**. A follow-up must implement the confirmation-result observation that constructs `Result.Completed(paymentStatus)`. Best-guess derivation for when that lands: a successful payment-mode confirmation → `Paid`; setup-mode → `NoPaymentRequired`. Wiring it now would touch the payment-confirmation path with process-death/lifecycle correctness concerns, so it's intentionally out of scope here.

## Stack

Stacked on **#13661** → #13660 → #13659 → `master`. Base is `checkout-parity/session/status`.

## Scope

All checkout APIs are `@CheckoutSessionPreview` + `@RestrictTo(LIBRARY_GROUP)`, so `paymentsheet.api` is unaffected.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutControllerTest" --tests "*CurrencySelectorElementContentUITest"` (isUpdating rename) ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)