### PR TITLE
Add Session.totals (iOS Total breakdown) and enrich discount amounts

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -415,8 +415,15 @@ class CheckoutController @Inject internal constructor(
         val tax: Tax,
         /**
          * Summary of totals including subtotal, discounts, taxes, and shipping.
+         *
+         * @see totals for the iOS-aligned tax/discount breakdown.
          */
         val totalSummary: TotalSummary?,
+        /**
+         * The tax and discount breakdown for the computed session total. `null` until totals are
+         * available.
+         */
+        val totals: Total?,
         /**
          * The products or services being purchased in this checkout session.
          */
@@ -652,6 +659,35 @@ class CheckoutController @Inject internal constructor(
         )
 
         /**
+         * Tax and discount breakdown for the computed session total, mirroring the iOS `Total` shape.
+         */
+        @Poko
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Total internal constructor(
+            /**
+             * The subtotal before discounts and taxes.
+             */
+            val subtotal: Amount,
+            /**
+             * The total of tax that is added on top of the subtotal (exclusive tax).
+             */
+            val taxExclusive: Amount,
+            /**
+             * The total of tax that is already included in the subtotal (inclusive tax).
+             */
+            val taxInclusive: Amount,
+            /**
+             * The total of all discounts applied.
+             */
+            val discount: Amount,
+            /**
+             * The grand total for the session.
+             */
+            val total: Amount,
+        )
+
+        /**
          * A discount applied to the checkout session.
          */
         @Poko
@@ -666,6 +702,14 @@ class CheckoutController @Inject internal constructor(
              * The display name of the discount.
              */
             val displayName: String,
+            /**
+             * The promotion code that produced this discount, if any.
+             */
+            val promotionCode: String?,
+            /**
+             * The percentage off applied by this discount, if the discount is percentage-based.
+             */
+            val percentOff: Int?,
         )
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -37,6 +37,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         shippingAddress = collectedDetails.asShippingAddress(),
         tax = taxStatus.asTax(),
         totalSummary = totalSummary?.asTotalSummary(currency),
+        totals = totalSummary?.asTotal(currency),
         lineItems = lineItems.map { it.asLineItem(currency) },
         shippingOptions = shippingOptions.map { it.asShippingRate(currency) },
         paymentOptionDisplayData = paymentOptionDisplayData,
@@ -185,11 +186,33 @@ private fun CheckoutSessionResponse.TotalSummaryResponse.asTotalSummary(currency
     )
 }
 
+/**
+ * Derives the iOS-aligned [Session.Total] breakdown from the server total summary. Best guess (the
+ * `/init` contract doesn't send these split out): tax is split into inclusive/exclusive by summing
+ * the per-rate [taxAmounts], `discount` sums the [discountAmounts], and `total` is the total amount
+ * due.
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.TotalSummaryResponse.asTotal(currency: String): Session.Total {
+    val taxExclusive = taxAmounts.filterNot { it.inclusive }.sumOf { it.amount }
+    val taxInclusive = taxAmounts.filter { it.inclusive }.sumOf { it.amount }
+    val discount = discountAmounts.sumOf { it.amount }
+    return Session.Total(
+        subtotal = subtotal.asAmount(currency),
+        taxExclusive = taxExclusive.asAmount(currency),
+        taxInclusive = taxInclusive.asAmount(currency),
+        discount = discount.asAmount(currency),
+        total = totalAmountDue.asAmount(currency),
+    )
+}
+
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.DiscountAmount.asDiscountAmount(currency: String): Session.DiscountAmount {
     return Session.DiscountAmount(
         amount = amount.asAmount(currency),
         displayName = displayName,
+        promotionCode = promotionCode,
+        percentOff = percentOff,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -75,6 +75,8 @@ internal data class CheckoutSessionResponse(
     data class DiscountAmount(
         val amount: Long,
         val displayName: String,
+        val promotionCode: String? = null,
+        val percentOff: Int? = null,
     ) : StripeModel
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -366,9 +366,18 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         return (0 until array.length()).mapNotNull { i ->
             val obj = array.optJSONObject(i) ?: return@mapNotNull null
             val amount = obj.optLong(FIELD_AMOUNT, -1).takeIf { it >= 0 } ?: return@mapNotNull null
-            val displayName = obj.optJSONObject(FIELD_COUPON)?.optString(FIELD_NAME)
+            val coupon = obj.optJSONObject(FIELD_COUPON)
+            val displayName = coupon?.optString(FIELD_NAME)
                 ?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-            CheckoutSessionResponse.DiscountAmount(amount = amount, displayName = displayName)
+            // Best-guess keys: the /init contract for promotion code / percent off is unconfirmed.
+            val promotionCode = StripeJsonUtils.optString(obj, FIELD_PROMOTION_CODE)
+            val percentOff = coupon.optInt(FIELD_PERCENT_OFF, -1).takeIf { it >= 0 }
+            CheckoutSessionResponse.DiscountAmount(
+                amount = amount,
+                displayName = displayName,
+                promotionCode = promotionCode,
+                percentOff = percentOff,
+            )
         }
     }
 
@@ -572,6 +581,8 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_APPLIED_BALANCE = "applied_balance"
     private const val FIELD_DISCOUNT_AMOUNTS = "discount_amounts"
     private const val FIELD_COUPON = "coupon"
+    private const val FIELD_PROMOTION_CODE = "promotion_code"
+    private const val FIELD_PERCENT_OFF = "percent_off"
     private const val FIELD_NAME = "name"
     private const val FIELD_TAX_AMOUNTS = "tax_amounts"
     private const val FIELD_INCLUSIVE = "inclusive"

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -222,6 +222,59 @@ class CheckoutSessionMappersTest {
     }
 
     @Test
+    fun `null totalSummary maps totals to null`() {
+        val session = createSession(totalSummary = null)
+        assertThat(session.totals).isNull()
+    }
+
+    @Test
+    fun `derives totals breakdown from the total summary`() {
+        val session = createSession(
+            totalSummary = TotalSummaryResponseFactory.create(
+                subtotal = 5000L,
+                totalAmountDue = 5400L,
+                discountAmounts = listOf(
+                    CheckoutSessionResponse.DiscountAmount(amount = 200L, displayName = "SUMMER10"),
+                ),
+                taxAmounts = listOf(
+                    CheckoutSessionResponse.TaxAmount(
+                        amount = 400L, inclusive = false, displayName = "Sales Tax", percentage = 8.0,
+                    ),
+                    CheckoutSessionResponse.TaxAmount(
+                        amount = 100L, inclusive = true, displayName = "VAT", percentage = 2.0,
+                    ),
+                ),
+            ),
+        )
+
+        val totals = requireNotNull(session.totals)
+        assertThat(totals.subtotal.minorUnitsAmount).isEqualTo(5000L)
+        assertThat(totals.taxExclusive.minorUnitsAmount).isEqualTo(400L)
+        assertThat(totals.taxInclusive.minorUnitsAmount).isEqualTo(100L)
+        assertThat(totals.discount.minorUnitsAmount).isEqualTo(200L)
+        assertThat(totals.total.minorUnitsAmount).isEqualTo(5400L)
+    }
+
+    @Test
+    fun `maps discount promotion code and percent off`() {
+        val session = createSession(
+            totalSummary = TotalSummaryResponseFactory.create(
+                discountAmounts = listOf(
+                    CheckoutSessionResponse.DiscountAmount(
+                        amount = 500L,
+                        displayName = "SUMMER10",
+                        promotionCode = "SUMMER",
+                        percentOff = 10,
+                    ),
+                ),
+            ),
+        )
+        val discount = session.totalSummary!!.discountAmounts.single()
+        assertThat(discount.promotionCode).isEqualTo("SUMMER")
+        assertThat(discount.percentOff).isEqualTo(10)
+    }
+
+    @Test
     fun `maps totalSummary subtotal`() {
         val session = createSession(
             totalSummary = TotalSummaryResponseFactory.create(subtotal = 5000L),


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE). iOS exposes `Session.totals: Total` and discount amounts that carry a promotion code + percent off.

- Add **`Session.totals: Total?`** = `{ subtotal, taxExclusive, taxInclusive, discount, total }`.
- Add **`promotionCode`/`percentOff`** to `Session.DiscountAmount` (+ response model + parser).

## ⚠️ Best-guess decisions (need confirmation)

1. **`Total` is derived client-side** — the `/init` contract doesn't send the tax split, so: `taxExclusive`/`taxInclusive` sum the per-rate `taxAmounts` by inclusivity; `discount` sums the `discountAmounts`; `total` = total amount due; `subtotal` = subtotal.
2. **`promotionCode`/`percentOff`** parsed from **guessed** keys (`promotion_code`, `coupon.percent_off`), degrading to `null` if absent.
3. **Additive, not a destructive reshape.** iOS strictly *replaces* the summary with `Total`, but Android's `TotalSummary` carries `totalDueToday`, `appliedBalance`, and the selected `shippingRate` — real EwCS data with **no** iOS `Total` equivalent. Rather than drop them, this PR adds `totals` alongside `totalSummary`. A future strict-parity pass can consolidate once the contract + product intent are confirmed. (Flagging for review since the original direction was strict parity.)

## Stack

Stacked on **#13662** → #13661 → #13660 → #13659 → `master`.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutSessionMappersTest"` — added totals-derivation (incl. inclusive/exclusive tax split) + promotionCode/percentOff tests ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)