### PR TITLE
Add Session.orderSummaryItems (iOS order-summary shape)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -429,6 +429,10 @@ class CheckoutController @Inject internal constructor(
          */
         val lineItems: List<LineItem>,
         /**
+         * The items the customer is purchasing, in the iOS-aligned order-summary shape.
+         */
+        val orderSummaryItems: List<OrderSummaryItem>,
+        /**
          * Available shipping options for this checkout session.
          */
         val shippingOptions: List<ShippingRate>,
@@ -794,6 +798,85 @@ class CheckoutController @Inject internal constructor(
              */
             val total: Amount,
         )
+
+        /**
+         * An item (or group of items) the customer is purchasing, mirroring the iOS
+         * `OrderSummaryItem` shape.
+         */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        sealed interface OrderSummaryItem {
+            /**
+             * A group of one-time-priced items with their subtotal and total.
+             */
+            @Poko
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class OneTimePrice internal constructor(
+                /**
+                 * The individual items in this group.
+                 */
+                val items: List<Item>,
+                /**
+                 * The subtotal for this group, if available.
+                 */
+                val subtotal: Amount?,
+                /**
+                 * The total for this group, if available.
+                 */
+                val total: Amount?,
+            ) : OrderSummaryItem {
+                /**
+                 * A single line in a [OneTimePrice] group.
+                 */
+                @Poko
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                class Item internal constructor(
+                    /**
+                     * The display name of the item.
+                     */
+                    val displayName: String,
+                    /**
+                     * Image URLs for the item. May be empty.
+                     */
+                    val images: List<String>,
+                    /**
+                     * The unit price, if available.
+                     */
+                    val unitAmount: Amount?,
+                    /**
+                     * A label describing the unit (e.g. "per seat"), if any.
+                     */
+                    val unitLabel: String?,
+                    /**
+                     * The quantity of this item.
+                     */
+                    val quantity: Int,
+                    /**
+                     * The quantity adjustment bounds, if the quantity is adjustable.
+                     */
+                    val adjustableQuantity: AdjustableQuantity?,
+                )
+
+                /**
+                 * The bounds within which an item's quantity may be adjusted.
+                 */
+                @Poko
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                class AdjustableQuantity internal constructor(
+                    /**
+                     * The minimum allowed quantity.
+                     */
+                    val minimum: Int,
+                    /**
+                     * The maximum allowed quantity.
+                     */
+                    val maximum: Int,
+                )
+            }
+        }
 
         /**
          * Display data for the customer's currently selected payment option.

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -39,6 +39,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         totalSummary = totalSummary?.asTotalSummary(currency),
         totals = totalSummary?.asTotal(currency),
         lineItems = lineItems.map { it.asLineItem(currency) },
+        orderSummaryItems = asOrderSummaryItems(currency),
         shippingOptions = shippingOptions.map { it.asShippingRate(currency) },
         paymentOptionDisplayData = paymentOptionDisplayData,
         lastPaymentError = lastPaymentError(),
@@ -245,5 +246,33 @@ private fun CheckoutSessionResponse.LineItem.asLineItem(currency: String): Sessi
         unitAmount = unitAmount?.asAmount(currency),
         subtotal = subtotal.asAmount(currency),
         total = total.asAmount(currency),
+    )
+}
+
+/**
+ * Projects the flat line items into the iOS-aligned [Session.OrderSummaryItem] shape as a single
+ * [Session.OrderSummaryItem.OneTimePrice] group. Best guess: mobile_elements only offers one-time
+ * pricing today, and the `/init` line items don't yet carry images, unit labels, per-item taxes, or
+ * adjustable-quantity bounds, so those are empty/null until the contract provides them.
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.asOrderSummaryItems(currency: String): List<Session.OrderSummaryItem> {
+    if (lineItems.isEmpty()) return emptyList()
+    val items = lineItems.map { lineItem ->
+        Session.OrderSummaryItem.OneTimePrice.Item(
+            displayName = lineItem.name,
+            images = emptyList(),
+            unitAmount = lineItem.unitAmount?.asAmount(currency),
+            unitLabel = null,
+            quantity = lineItem.quantity,
+            adjustableQuantity = null,
+        )
+    }
+    return listOf(
+        Session.OrderSummaryItem.OneTimePrice(
+            items = items,
+            subtotal = totalSummary?.subtotal?.asAmount(currency),
+            total = totalSummary?.totalAmountDue?.asAmount(currency),
+        )
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -434,6 +434,37 @@ class CheckoutSessionMappersTest {
     }
 
     @Test
+    fun `maps lineItems into a single orderSummaryItems group`() {
+        val session = createSession(
+            lineItems = listOf(
+                CheckoutSessionResponse.LineItem(
+                    id = "li_1",
+                    name = "Llama Figure",
+                    quantity = 2,
+                    unitAmount = 999L,
+                    subtotal = 1998L,
+                    total = 1998L,
+                ),
+            ),
+            totalSummary = TotalSummaryResponseFactory.create(subtotal = 1998L, totalAmountDue = 2100L),
+        )
+
+        val group = session.orderSummaryItems.single() as Session.OrderSummaryItem.OneTimePrice
+        assertThat(group.subtotal?.minorUnitsAmount).isEqualTo(1998L)
+        assertThat(group.total?.minorUnitsAmount).isEqualTo(2100L)
+        val item = group.items.single()
+        assertThat(item.displayName).isEqualTo("Llama Figure")
+        assertThat(item.quantity).isEqualTo(2)
+        assertThat(item.unitAmount?.minorUnitsAmount).isEqualTo(999L)
+    }
+
+    @Test
+    fun `empty lineItems maps orderSummaryItems to empty list`() {
+        val session = createSession(lineItems = emptyList())
+        assertThat(session.orderSummaryItems).isEmpty()
+    }
+
+    @Test
     fun `maps shippingOptions`() {
         val session = createSession(
             shippingOptions = listOf(


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE). iOS exposes purchases as `orderSummaryItems` (an enum whose one-time-price case groups items with a subtotal/total).

- Add **`Session.orderSummaryItems: List<OrderSummaryItem>`** with a `OneTimePrice` group containing `Item`s and an `AdjustableQuantity`.
- Map the flat line items into a single `OneTimePrice` group.

## ⚠️ Best-guess decisions (need confirmation)

1. **The doc itself flags this shape as unresolved** (stripe.js vs API-review discrepancy). This models the API-review structure; expect it to change.
2. The `/init` line items don't yet carry `images`, `unitLabel`, per-item taxes, or `adjustableQuantity` bounds, so those are **empty/null**. Per-item tax fields are intentionally **omitted** rather than shipped as always-zero (which would mislead).
3. **Additive**: `lineItems` is retained alongside `orderSummaryItems`; a future strict-parity pass can remove `lineItems` once the shape is confirmed.

## Stack

Stacked on **#13663** → #13662 → #13661 → #13660 → #13659 → `master`.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutSessionMappersTest"` — added group-mapping + empty-list tests ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)