### PR TITLE
Add CheckoutController.updateEmail

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -169,6 +169,18 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
+     * Updates the customer's email address on the checkout session.
+     *
+     * @param email The customer's email address, or `null` to clear it. Leading/trailing whitespace
+     * is trimmed.
+     */
+    suspend fun updateEmail(
+        email: String?,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.updateEmail(sessionId, email?.trim())
+    }
+
+    /**
      * Updates the customer's tax ID.
      *
      * @param type The type of tax ID (e.g. "eu_vat"). Leading/trailing whitespace is trimmed.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -196,6 +196,19 @@ internal class CheckoutSessionRepository @Inject constructor(
         fireEvent(PaymentSheetEvent.AdaptivePricingCurrencyToggledFailed(error = it.safeAnalyticsMessage))
     }
 
+    // Best-guess param key: the /init-family endpoint for updating the customer email is unconfirmed.
+    // Uses `customer_email` to mirror the field the response parser reads back.
+    suspend fun updateEmail(
+        sessionId: String,
+        email: String?,
+    ): Result<CheckoutSessionResponse> = executePost(
+        url = updateUrl(sessionId),
+        params = mapOf(
+            "customer_email" to email.orEmpty(),
+            "elements_session_client[is_aggregation_expected]" to "true",
+        ),
+    )
+
     private fun fireEvent(event: PaymentSheetEvent) {
         analyticsRequestExecutor.executeAsync(
             paymentAnalyticsRequestFactory.createRequest(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -554,6 +554,33 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `updateEmail sends customer_email on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("customer_email", "buyer@example.com"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.updateEmail("  buyer@example.com  ")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateEmail returns failure and preserves session on error`() = runMutationScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid email"}}""")
+        }
+        val before = controller.checkoutSession.value
+
+        val result = controller.updateEmail("not-an-email")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
     fun `updateShippingAddress sends tax_region and stores address when automatic tax targets shipping`() =
         runMutationScenario(initModifier = automaticTaxFor("shipping")) {
             networkRule.checkoutUpdate(


### PR DESCRIPTION
## Summary

Part of the effort to bring Android's **Checkout Elements** (`CheckoutController`) to parity with the [iOS API Review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE). iOS exposes `updateEmail(_:)`; Android had no way to update the customer's email on the session.

- Add **`CheckoutController.updateEmail(email: String?)`** (trims whitespace; `null` clears).
- Add **`CheckoutSessionRepository.updateEmail(...)`**.

## ⚠️ Best-guess decision (needs confirmation)

The update request sends **`customer_email`** — mirroring the field the response parser reads back — but the actual `/init`-family contract for updating email is **unconfirmed**. Flagged in code.

## Stack

Stacked on **#13664** → #13663 → #13662 → #13661 → #13660 → #13659 → `master`.

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutControllerTest"` — added success (with trim) + failure/preservation tests using the existing `NetworkRule` harness ✓
- `./gradlew :paymentsheet:detekt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)