### PR TITLE
Add CheckoutController.Configuration.defaults prefill

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -31,6 +31,8 @@ internal fun CheckoutCollectedDetails.toBillingDetails(
     checkoutSessionResponse: CheckoutSessionResponse,
 ): PaymentSheet.BillingDetails = PaymentSheet.BillingDetails(
     address = billingAddress?.asPaymentSheet(),
+    // The merchant-provided default email is set on the session during configure, so it arrives here
+    // as the session's customer email.
     email = checkoutSessionResponse.customerEmail,
     name = billingName,
     phone = billingPhoneNumber,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -104,12 +104,22 @@ class CheckoutController @Inject internal constructor(
                 sessionId = sessionId,
                 adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
             ).mapCatching { response ->
-                if (configurationState.defaultBillingAddress != null &&
+                val defaultBillingAddress = configurationState.defaults.billingDetails?.address
+                if (defaultBillingAddress != null &&
                     response.automaticTaxEnabled &&
                     response.taxAddressSource == CheckoutSessionResponse.TaxAddressSource.BILLING
                 ) {
-                    checkoutSessionRepository.updateTaxRegion(sessionId, configurationState.defaultBillingAddress)
+                    checkoutSessionRepository.updateTaxRegion(sessionId, defaultBillingAddress)
                         .getOrThrow()
+                } else {
+                    response
+                }
+            }.mapCatching { response ->
+                // Push the merchant-provided default email to the Checkout Session so it's set
+                // server-side (mirrors updateEmail), rather than only prefilling local billing details.
+                val defaultEmail = configurationState.defaults.email
+                if (defaultEmail != null) {
+                    checkoutSessionRepository.updateEmail(sessionId, defaultEmail).getOrThrow()
                 } else {
                     response
                 }
@@ -804,9 +814,9 @@ class CheckoutController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
         private var adaptivePricingAllowed: Boolean = false
-        private var defaultBillingAddress: Address? = null
         private var merchantDisplayName: String? = null
         private var googlePayConfiguration: GooglePayConfiguration? = null
+        private var defaults: Defaults = Defaults()
         private var paymentElementConfiguration: PaymentElement.Configuration = PaymentElement.Configuration()
         private var currencySelectorElementConfiguration: CurrencySelectorElement.Configuration =
             CurrencySelectorElement.Configuration()
@@ -822,18 +832,6 @@ class CheckoutController @Inject internal constructor(
             adaptivePricingAllowed: Boolean
         ): Configuration = apply {
             this.adaptivePricingAllowed = adaptivePricingAllowed
-        }
-
-        /**
-         * Sets the customer's known billing address.
-         *
-         * The address is used to prefill payment method forms. When automatic tax uses the billing
-         * address, Checkout can also use it to calculate an initial tax estimate.
-         */
-        fun defaultBillingAddress(
-            defaultBillingAddress: Address,
-        ): Configuration = apply {
-            this.defaultBillingAddress = defaultBillingAddress
         }
 
         /**
@@ -892,12 +890,22 @@ class CheckoutController @Inject internal constructor(
             this.googlePayConfiguration = configuration
         }
 
+        /**
+         * Prefill values for the customer's details. If known up front, these prepopulate the
+         * elements (and the Checkout Session) so the customer doesn't re-enter them.
+         */
+        fun defaults(
+            defaults: Defaults
+        ): Configuration = apply {
+            this.defaults = defaults
+        }
+
         @Parcelize
         internal data class State(
             val adaptivePricingAllowed: Boolean,
-            val defaultBillingAddress: Address.State?,
             val merchantDisplayName: String?,
             val googlePayConfiguration: GooglePayConfiguration.State?,
+            val defaults: Defaults.State,
             val paymentElementConfiguration: PaymentElement.Configuration.State,
             val currencySelectorElementConfiguration: CurrencySelectorElement.Configuration.State,
             val shippingAddressElementConfiguration: ShippingAddressElement.Configuration.State,
@@ -906,14 +914,92 @@ class CheckoutController @Inject internal constructor(
 
         internal fun build(): State = State(
             adaptivePricingAllowed = adaptivePricingAllowed,
-            defaultBillingAddress = defaultBillingAddress?.build(),
             merchantDisplayName = merchantDisplayName,
             paymentElementConfiguration = paymentElementConfiguration.build(),
             currencySelectorElementConfiguration = currencySelectorElementConfiguration.build(),
             shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),
             expressCheckoutElementConfiguration = expressCheckoutElementConfiguration.build(),
             googlePayConfiguration = googlePayConfiguration?.build(),
+            defaults = defaults.build(),
         )
+
+        /**
+         * Prefill values for the customer's billing/shipping details and email.
+         */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Defaults {
+            private var billingDetails: ContactDetails? = null
+            private var shippingDetails: ContactDetails? = null
+            private var email: String? = null
+
+            /**
+             * The customer's known billing contact details.
+             */
+            fun billingDetails(billingDetails: ContactDetails): Defaults = apply {
+                this.billingDetails = billingDetails
+            }
+
+            /**
+             * The customer's known shipping contact details.
+             */
+            fun shippingDetails(shippingDetails: ContactDetails): Defaults = apply {
+                this.shippingDetails = shippingDetails
+            }
+
+            /**
+             * The customer's known email address.
+             */
+            fun email(email: String?): Defaults = apply {
+                this.email = email
+            }
+
+            @Parcelize
+            internal data class State(
+                val billingDetails: ContactDetails.State?,
+                val shippingDetails: ContactDetails.State?,
+                val email: String?,
+            ) : Parcelable
+
+            internal fun build(): State = State(
+                billingDetails = billingDetails?.build(),
+                shippingDetails = shippingDetails?.build(),
+                // Normalize a blank email to null so downstream code treats "not provided" uniformly.
+                email = email?.trim()?.takeIf { it.isNotEmpty() },
+            )
+
+            /**
+             * A name, phone number, and postal address for a customer.
+             */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class ContactDetails {
+                private var name: String? = null
+                private var phoneNumber: String? = null
+                private var address: Address? = null
+
+                fun name(name: String?): ContactDetails = apply { this.name = name }
+
+                fun phoneNumber(phoneNumber: String?): ContactDetails = apply {
+                    this.phoneNumber = phoneNumber
+                }
+
+                fun address(address: Address): ContactDetails = apply { this.address = address }
+
+                @Parcelize
+                internal data class State(
+                    val name: String?,
+                    val phoneNumber: String?,
+                    val address: Address.State?,
+                ) : Parcelable
+
+                internal fun build(): State = State(
+                    name = name,
+                    phoneNumber = phoneNumber,
+                    address = address?.build(),
+                )
+            }
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -103,12 +103,20 @@ class CheckoutController @Inject internal constructor(
                 sessionId = sessionId,
                 adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
             ).mapCatching { response ->
-                if (configurationState.defaultBillingAddress != null &&
+                val defaultBillingAddress = configurationState.defaults.billingDetails?.address
+                if (defaultBillingAddress != null &&
                     response.automaticTaxEnabled &&
                     response.taxAddressSource == CheckoutSessionResponse.TaxAddressSource.BILLING
                 ) {
-                    checkoutSessionRepository.updateTaxRegion(sessionId, configurationState.defaultBillingAddress)
+                    checkoutSessionRepository.updateTaxRegion(sessionId, defaultBillingAddress)
                         .getOrThrow()
+                } else {
+                    response
+                }
+            }.mapCatching { response ->
+                val defaultEmail = configurationState.defaults.email
+                if (defaultEmail != null) {
+                    checkoutSessionRepository.updateEmail(sessionId, defaultEmail).getOrThrow()
                 } else {
                     response
                 }
@@ -876,9 +884,6 @@ class CheckoutController @Inject internal constructor(
         internal data class State(
             val adaptivePricingAllowed: Boolean,
             val apiConfiguration: ApiConfiguration.State?,
-            // Compatibility field for the existing billing-address consumers. The implementation
-            // layer removes this after migrating them to [defaults].
-            val defaultBillingAddress: Address.State?,
             val merchantDisplayName: String?,
             val googlePayConfiguration: GooglePayConfiguration.State?,
             val defaults: Defaults.State,
@@ -893,7 +898,6 @@ class CheckoutController @Inject internal constructor(
             return State(
                 adaptivePricingAllowed = adaptivePricingAllowed,
                 apiConfiguration = apiConfiguration?.build(),
-                defaultBillingAddress = defaultsState.billingDetails?.address,
                 merchantDisplayName = merchantDisplayName,
                 paymentElementConfiguration = paymentElementConfiguration.build(),
                 currencySelectorElementConfiguration = currencySelectorElementConfiguration.build(),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -27,9 +27,7 @@ internal class CheckoutStateLoader @Inject constructor(
         commit(
             configuration = configuration,
             response = checkoutSessionResponse,
-            collectedDetails = CheckoutCollectedDetails(
-                billingAddress = configuration.defaultBillingAddress,
-            ),
+            collectedDetails = configuration.asInitialCollectedDetails(),
             carryForward = CarryForward.initial(),
         )
     }
@@ -135,4 +133,22 @@ internal class CheckoutStateLoader @Inject constructor(
             )
         }
     }
+}
+
+/**
+ * Seeds the initial locally-collected details from the merchant-provided prefill defaults, so the
+ * elements (and the Checkout Session) start prepopulated. `email` is not part of the collected
+ * details here — [CheckoutController.configure] pushes it to the Checkout Session, so it flows back
+ * as the session's customer email.
+ */
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutController.Configuration.State.asInitialCollectedDetails(): CheckoutCollectedDetails {
+    return CheckoutCollectedDetails(
+        shippingName = defaults.shippingDetails?.name,
+        billingName = defaults.billingDetails?.name,
+        shippingPhoneNumber = defaults.shippingDetails?.phoneNumber,
+        billingPhoneNumber = defaults.billingDetails?.phoneNumber,
+        shippingAddress = defaults.shippingDetails?.address,
+        billingAddress = defaults.billingDetails?.address,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -27,9 +27,7 @@ internal class CheckoutStateLoader @Inject constructor(
         commit(
             configuration = configuration,
             response = checkoutSessionResponse,
-            collectedDetails = CheckoutCollectedDetails(
-                billingAddress = configuration.defaultBillingAddress,
-            ),
+            collectedDetails = configuration.asInitialCollectedDetails(),
             carryForward = CarryForward.initial(),
         )
     }
@@ -136,4 +134,16 @@ internal class CheckoutStateLoader @Inject constructor(
             )
         }
     }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutController.Configuration.State.asInitialCollectedDetails(): CheckoutCollectedDetails {
+    return CheckoutCollectedDetails(
+        shippingName = defaults.shippingDetails?.name,
+        billingName = defaults.billingDetails?.name,
+        shippingPhoneNumber = defaults.shippingDetails?.phoneNumber,
+        billingPhoneNumber = defaults.billingDetails?.phoneNumber,
+        shippingAddress = defaults.shippingDetails?.address,
+        billingAddress = defaults.billingDetails?.address,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -145,13 +145,17 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `configure prefills the default billing address`() = runConfigureScenario(
-        configuration = CheckoutController.Configuration().defaultBillingAddress(
-            CheckoutController.Address()
-                .city(" San Francisco ")
-                .country(" US ")
-                .line1(" 510 Townsend St ")
-                .postalCode(" 94103 ")
-                .state(" CA ")
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().billingDetails(
+                CheckoutController.Configuration.Defaults.ContactDetails().address(
+                    CheckoutController.Address()
+                        .city(" San Francisco ")
+                        .country(" US ")
+                        .line1(" 510 Townsend St ")
+                        .postalCode(" 94103 ")
+                        .state(" CA ")
+                )
+            )
         ),
     ) {
         result.getOrThrow()
@@ -166,14 +170,18 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `configure sends default billing address when automatic tax targets billing`() = runConfigureScenario(
-        configuration = CheckoutController.Configuration().defaultBillingAddress(
-            CheckoutController.Address()
-                .city("San Francisco")
-                .country("US")
-                .line1("510 Townsend St")
-                .line2("Suite 100")
-                .postalCode("94103")
-                .state("CA")
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().billingDetails(
+                CheckoutController.Configuration.Defaults.ContactDetails().address(
+                    CheckoutController.Address()
+                        .city("San Francisco")
+                        .country("US")
+                        .line1("510 Townsend St")
+                        .line2("Suite 100")
+                        .postalCode("94103")
+                        .state("CA")
+                )
+            )
         ),
         networkSetup = {
             networkRule.checkoutInit(
@@ -191,6 +199,40 @@ internal class CheckoutControllerTest {
             )
         },
     ) {
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `configure sends the trimmed default email to the checkout session`() = runConfigureScenario(
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().email("  prefill@example.com  ")
+        ),
+        networkSetup = {
+            networkRule.checkoutInit(responseFactory = ::successResponse)
+            networkRule.checkoutUpdate(
+                bodyPart("customer_email", "prefill@example.com"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+                responseFactory = successResponseFactory { json ->
+                    json.put("customer_email", "prefill@example.com")
+                },
+            )
+        },
+    ) {
+        result.getOrThrow()
+        // The updated session email flows back through to the exposed session and the billing email.
+        assertThat(controller.session.value?.email).isEqualTo("prefill@example.com")
+        assertThat(committedState?.embeddedConfiguration?.defaultBillingDetails?.email)
+            .isEqualTo("prefill@example.com")
+    }
+
+    @Test
+    fun `configure does not send an email update when the default email is blank`() = runConfigureScenario(
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().email("   ")
+        ),
+    ) {
+        // A blank default email normalizes to null, so no update request fires. Only checkoutInit is
+        // enqueued by the default networkSetup; NetworkRule fails the test on any unmatched request.
         assertThat(result.isSuccess).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -204,6 +204,37 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `configure sends the trimmed default email to the checkout session`() = runConfigureScenario(
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().email("  prefill@example.com  ")
+        ),
+        networkSetup = {
+            networkRule.checkoutInit(responseFactory = ::successResponse)
+            networkRule.checkoutUpdate(
+                bodyPart("customer_email", "prefill@example.com"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+                responseFactory = successResponseFactory { json ->
+                    json.put("customer_email", "prefill@example.com")
+                },
+            )
+        },
+    ) {
+        result.getOrThrow()
+        assertThat(controller.session.value?.email).isEqualTo("prefill@example.com")
+        assertThat(committedState?.embeddedConfiguration?.defaultBillingDetails?.email)
+            .isEqualTo("prefill@example.com")
+    }
+
+    @Test
+    fun `configure does not send an email update when the default email is blank`() = runConfigureScenario(
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().email("   ")
+        ),
+    ) {
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
     fun `configure defaults merchant display name to the checkout session business name`() =
         runConfigureScenario {
             result.getOrThrow()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -70,7 +70,7 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
-    fun `loadInitial seeds collected details with default billing address`() = runScenario {
+    fun `loadInitial seeds collected details with the defaults billing address`() = runScenario {
         val address = CheckoutController.Address()
             .city(" San Francisco ")
             .country(" US ")
@@ -98,6 +98,33 @@ internal class CheckoutStateLoaderTest {
         assertThat(billingAddress.state).isEqualTo("CA")
         assertThat(stateHolder.state?.embeddedConfiguration?.defaultBillingDetails?.address?.postalCode)
             .isEqualTo("94103")
+    }
+
+    @Test
+    fun `loadInitial seeds collected details from configuration defaults`() = runScenario {
+        val configuration = CheckoutController.Configuration()
+            .defaults(
+                CheckoutController.Configuration.Defaults()
+                    .billingDetails(
+                        CheckoutController.Configuration.Defaults.ContactDetails()
+                            .name("Jane Billing")
+                            .phoneNumber("5559876543")
+                            .address(CheckoutController.Address().country("US").city("Denver")),
+                    )
+                    .shippingDetails(
+                        CheckoutController.Configuration.Defaults.ContactDetails().name("John Shipping"),
+                    ),
+            )
+            .build()
+
+        loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+
+        val collected = requireNotNull(stateHolder.state).collectedDetails
+        assertThat(collected.billingName).isEqualTo("Jane Billing")
+        assertThat(collected.billingPhoneNumber).isEqualTo("5559876543")
+        assertThat(collected.billingAddress?.country).isEqualTo("US")
+        assertThat(collected.billingAddress?.city).isEqualTo("Denver")
+        assertThat(collected.shippingName).isEqualTo("John Shipping")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -70,7 +70,7 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
-    fun `loadInitial seeds collected details with default billing address`() = runScenario {
+    fun `loadInitial seeds collected details with the defaults billing address`() = runScenario {
         val address = CheckoutController.Address()
             .city(" San Francisco ")
             .country(" US ")
@@ -80,7 +80,12 @@ internal class CheckoutStateLoaderTest {
 
         loader.loadInitial(
             configuration = CheckoutController.Configuration()
-                .defaultBillingAddress(address)
+                .defaults(
+                    CheckoutController.Configuration.Defaults()
+                        .billingDetails(
+                            CheckoutController.Configuration.Defaults.ContactDetails().address(address),
+                        ),
+                )
                 .build(),
             checkoutSessionResponse = response(),
         )
@@ -93,6 +98,33 @@ internal class CheckoutStateLoaderTest {
         assertThat(billingAddress.state).isEqualTo("CA")
         assertThat(stateHolder.state?.embeddedConfiguration?.defaultBillingDetails?.address?.postalCode)
             .isEqualTo("94103")
+    }
+
+    @Test
+    fun `loadInitial seeds collected details from configuration defaults`() = runScenario {
+        val configuration = CheckoutController.Configuration()
+            .defaults(
+                CheckoutController.Configuration.Defaults()
+                    .billingDetails(
+                        CheckoutController.Configuration.Defaults.ContactDetails()
+                            .name("Jane Billing")
+                            .phoneNumber("5559876543")
+                            .address(CheckoutController.Address().country("US").city("Denver")),
+                    )
+                    .shippingDetails(
+                        CheckoutController.Configuration.Defaults.ContactDetails().name("John Shipping"),
+                    ),
+            )
+            .build()
+
+        loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+
+        val collected = requireNotNull(stateHolder.state).collectedDetails
+        assertThat(collected.billingName).isEqualTo("Jane Billing")
+        assertThat(collected.billingPhoneNumber).isEqualTo("5559876543")
+        assertThat(collected.billingAddress?.country).isEqualTo("US")
+        assertThat(collected.billingAddress?.city).isEqualTo("Denver")
+        assertThat(collected.shippingName).isEqualTo("John Shipping")
     }
 
     @Test


### PR DESCRIPTION
# Summary

Second PR in a two-PR stack, dependent on `checkout-parity/configuration-defaults-api`. Wires `CheckoutController.Configuration.defaults` into Checkout prefill behavior.

- Seeds billing and shipping names, phone numbers, and addresses into the initially collected details.
- Sends a trimmed default email to the Checkout Session and skips the update when the value is blank.
- Preserves the existing automatic-tax billing-address update through `defaults.billingDetails.address`.

# Motivation

The API introduced by the first PR needs to prepopulate payment elements and the Checkout Session so customers do not re-enter details merchants already know. Keeping this behavior separate makes the runtime and network effects independently reviewable.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

No tests were ignored.

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutControllerTest" --tests "*CheckoutStateLoaderTest" --tests "*CheckoutEmbeddedConfigurationFactoryTest"`
- `./gradlew :paymentsheet:apiCheck :paymentsheet:detekt`

# Screenshots

Not applicable: this changes prefill data flow and has no visual UI changes.

# Changelog

Not applicable: `CheckoutController` is a preview, `LIBRARY_GROUP`-restricted API and is not part of the published API surface.
