### PR TITLE
Properly parse out AIP & AFL tags from the `GetProcessingCommand`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
@@ -21,16 +21,27 @@ internal class GetProcessingOptionsCommand(
             return null
         }
 
+        val records = tlv.toMutableMap()
+
+        parseFromRecords(records)
+
         return ProcessingOptionsInfo(
-            aflEntries = extractAfl(tlv)?.let(::parseAflEntries).orEmpty(),
-            records = tlv,
+            aflEntries = tlv[TAG_AFL]?.let(::parseAflEntries).orEmpty(),
+            records = records.toMap(),
         )
     }
 
-    private fun extractAfl(tlv: Map<String, ByteArray>): ByteArray? {
-        return tlv[TAG_AFL] ?: tlv[TAG_RESPONSE_TEMPLATE_FORMAT_1]?.let { format1Value ->
-            format1Value.takeIf { it.size > AIP_LENGTH }
-                ?.copyOfRange(AIP_LENGTH, format1Value.size)
+    private fun parseFromRecords(records: MutableMap<String, ByteArray>) {
+        val format1Value = records[TAG_RESPONSE_TEMPLATE_FORMAT_1] ?: return
+
+        if (records.containsKey(TAG_AIP) && records.containsKey(TAG_AFL)) {
+            return
+        }
+
+        records[TAG_AIP] = format1Value.copyOfRange(0, AIP_LENGTH)
+
+        if (format1Value.size > AIP_LENGTH) {
+            records[TAG_AFL] = format1Value.copyOfRange(AIP_LENGTH, format1Value.size)
         }
     }
 
@@ -48,6 +59,7 @@ internal class GetProcessingOptionsCommand(
 
     private companion object {
         const val TAG_RESPONSE_TEMPLATE_FORMAT_1 = "80"
+        const val TAG_AIP = "82"
         const val TAG_AFL = "94"
         const val AIP_LENGTH = 2
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommandTest.kt
@@ -78,7 +78,7 @@ internal class GetProcessingOptionsCommandTest {
     }
 
     @Test
-    fun `transceiveWith parses AFL from response template format 1`() = test(
+    fun `transceiveWith extracts AIP and AFL from response template format 1 into records`() = test(
         transceiveResult = apduSuccessResponse(
             tlv(
                 tag = 0x80.toByte(),
@@ -96,13 +96,58 @@ internal class GetProcessingOptionsCommandTest {
         val result = GetProcessingOptionsCommand(pdolData = byteArrayOf()).transceiveWith(transceiver)
 
         assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrNull()?.aflEntries).containsExactly(
+
+        val processingOptionsInfo = result.getOrNull()
+
+        assertThat(processingOptionsInfo?.aflEntries).isEmpty()
+
+        val records = processingOptionsInfo?.records
+
+        assertThat(records?.getValue("82")?.contentEquals(byteArrayOf(0x00, 0x00))).isTrue()
+        assertThat(records?.getValue("94")?.contentEquals(byteArrayOf(0x08, 0x01, 0x01, 0x00)))
+            .isTrue()
+
+        assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `transceiveWith does not overwrite AIP and AFL when both are already present`() = test(
+        transceiveResult = apduSuccessResponse(
+            tlv(
+                tag = 0x80.toByte(),
+                value = byteArrayOf(
+                    0x00,
+                    0x00,
+                    0x08,
+                    0x01,
+                    0x01,
+                    0x00,
+                ),
+            ) +
+                tlv(tag = 0x82.toByte(), value = byteArrayOf(0x01, 0x02)) +
+                tlv(tag = 0x94.toByte(), value = byteArrayOf(0x10, 0x02, 0x02, 0x01)),
+        ),
+    ) {
+        val result = GetProcessingOptionsCommand(pdolData = byteArrayOf()).transceiveWith(transceiver)
+
+        assertThat(result.isSuccess).isTrue()
+
+        val processingOptionsInfo = result.getOrNull()
+
+        assertThat(processingOptionsInfo?.aflEntries).containsExactly(
             ProcessingOptionsInfo.AflEntry(
-                shortFileIdentifier = 1,
-                firstRecord = 1,
-                lastRecord = 1,
+                shortFileIdentifier = 2,
+                firstRecord = 2,
+                lastRecord = 2,
             ),
         )
+
+        val records = processingOptionsInfo?.records
+
+        assertThat(records?.getValue("82")?.contentEquals(byteArrayOf(0x01, 0x02))).isTrue()
+        assertThat(records?.getValue("94")?.contentEquals(byteArrayOf(0x10, 0x02, 0x02, 0x01)))
+            .isTrue()
+
         assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
     }
 


### PR DESCRIPTION
# Summary
Properly parse out AIP & AFL tags from the `GetProcessingCommand` when tag 80 is present.

# Motivation
Ensure both the AFL & AIP tags are present in both formats of `GetProcessingCommand`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified