### PR TITLE
Pass elements session ID to intent_token param as fallback

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -88,7 +88,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             val linkAccount = requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
             linkRepository.createLinkAccountSession(
                 consumerSessionClientSecret = linkAccount.clientSecret,
-                stripeIntent = config.stripeIntent,
+                intentToken = config.stripeIntent.clientSecret ?: config.elementsSessionId,
                 linkMode = config.linkMode,
             ).getOrThrow()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -507,12 +507,12 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun createLinkAccountSession(
         consumerSessionClientSecret: String,
-        stripeIntent: StripeIntent,
+        intentToken: String?,
         linkMode: LinkMode?,
     ): Result<LinkAccountSession> {
         return consumersApiService.createLinkAccountSession(
             consumerSessionClientSecret = consumerSessionClientSecret,
-            intentToken = stripeIntent.clientSecret,
+            intentToken = intentToken,
             linkMode = linkMode,
             requestSurface = requestSurface.value,
             requestOptions = apiRequestOptions,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -217,7 +217,7 @@ internal interface LinkRepository {
 
     suspend fun createLinkAccountSession(
         consumerSessionClientSecret: String,
-        stripeIntent: StripeIntent,
+        intentToken: String?,
         linkMode: LinkMode?,
     ): Result<LinkAccountSession>
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -1027,7 +1027,8 @@ class DefaultLinkAccountManagerTest {
     }
 
     @Test
-    fun `createLinkAccountSession falls back to elements session ID when intent client secret is null`() = runSuspendTest {
+    fun `createLinkAccountSession falls back to elements session ID when intent client secret is null`() =
+        runSuspendTest {
         var capturedIntentToken: String? = null
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -961,7 +961,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
                 consumerSessionClientSecret: String,
-                stripeIntent: StripeIntent,
+                intentToken: String?,
                 linkMode: LinkMode?,
             ): Result<LinkAccountSession> {
                 return Result.success(TestFactory.LINK_ACCOUNT_SESSION)
@@ -996,6 +996,62 @@ class DefaultLinkAccountManagerTest {
         val result = accountManager.createLinkAccountSession()
 
         assertThat(result.exceptionOrNull()).isEqualTo(error)
+    }
+
+    @Test
+    fun `createLinkAccountSession passes intent client secret as intent token`() = runSuspendTest {
+        var capturedIntentToken: String? = null
+        val linkRepository = object : FakeLinkRepository() {
+            override suspend fun createLinkAccountSession(
+                consumerSessionClientSecret: String,
+                intentToken: String?,
+                linkMode: LinkMode?,
+            ): Result<LinkAccountSession> {
+                capturedIntentToken = intentToken
+                return Result.success(TestFactory.LINK_ACCOUNT_SESSION)
+            }
+        }
+        val accountManager = accountManager(
+            stripeIntent = PaymentIntentFactory.create(clientSecret = "pi_123_secret_abc"),
+            linkRepository = linkRepository,
+        )
+        accountManager.setLinkAccountFromLookupResult(
+            lookup = TestFactory.CONSUMER_SESSION_LOOKUP,
+            startSession = true,
+            linkAuthIntentId = null,
+        )
+
+        accountManager.createLinkAccountSession()
+
+        assertThat(capturedIntentToken).isEqualTo("pi_123_secret_abc")
+    }
+
+    @Test
+    fun `createLinkAccountSession falls back to elements session ID when intent client secret is null`() = runSuspendTest {
+        var capturedIntentToken: String? = null
+        val linkRepository = object : FakeLinkRepository() {
+            override suspend fun createLinkAccountSession(
+                consumerSessionClientSecret: String,
+                intentToken: String?,
+                linkMode: LinkMode?,
+            ): Result<LinkAccountSession> {
+                capturedIntentToken = intentToken
+                return Result.success(TestFactory.LINK_ACCOUNT_SESSION)
+            }
+        }
+        val accountManager = accountManager(
+            stripeIntent = PaymentIntentFactory.create(clientSecret = null),
+            linkRepository = linkRepository,
+        )
+        accountManager.setLinkAccountFromLookupResult(
+            lookup = TestFactory.CONSUMER_SESSION_LOOKUP,
+            startSession = true,
+            linkAuthIntentId = null,
+        )
+
+        accountManager.createLinkAccountSession()
+
+        assertThat(capturedIntentToken).isEqualTo(TestFactory.LINK_CONFIGURATION.elementsSessionId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -250,7 +250,7 @@ internal open class FakeLinkRepository : LinkRepository {
 
     override suspend fun createLinkAccountSession(
         consumerSessionClientSecret: String,
-        stripeIntent: StripeIntent,
+        intentToken: String?,
         linkMode: LinkMode?,
     ): Result<LinkAccountSession> = createLinkAccountSessionResult
 


### PR DESCRIPTION
# Summary

When creating a Link Account Session for the Link wallet -> Add bank flow, we should pass up the elements session ID in the `intent_token` param when a payment or setup intent ID isn't available. This is what the web flow does, and allows the LAS be associated with the elements session.

The `intent_token` name is misnamed, IMO, but here is the backend code showing an elements session ID is accepted: https://stripe.sourcegraphcloud.com/r/stripe-internal/mint@e201794d72c39cfda6c93c299faa11dc1dbcf75f/-/blob/pay-server/lib/consumer/api/methods/payment_details/bank_account/create_connections_link_account_session_method.rb?L117-126

# Motivation

https://stripe.enterprise.slack.com/archives/C07TB59Q4HJ/p1784839402103419?thread_ts=1784748231.848969&channel=C07TB59Q4HJ&message_ts=1784839402.103419

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Working request from the Android demo app: https://admin.corp.stripe.com/request-log/req_3tigtyffFPQMEr

# Changelog

N/a