### PR TITLE
Fix pre-fill for manual entry on address autocomplete

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -41,7 +41,7 @@ internal class BillingInlineAutocompleteAddressInteractor(
     }
 
     override fun onEnterManuallyFromInline() {
-        eventListener?.invoke(AutocompleteAddressInteractor.Event.OnExpandForm(null))
+        inlineController.expandFormFromInline()
     }
 
     fun dispose() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -158,12 +158,13 @@ internal class InlineAutocompleteController(
     }
 
     private fun emitExpandForm(query: String?, country: String?) {
-        val listener = eventListenerProvider() ?: return
         val values = buildMap<IdentifierSpec, String?> {
             query?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Line1, it) }
             country?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Country, it) }
         }.takeIf { it.isNotEmpty() }
 
-        listener(AutocompleteAddressInteractor.Event.OnExpandForm(values))
+        eventListenerProvider()?.invoke(
+            AutocompleteAddressInteractor.Event.OnExpandForm(values)
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -27,13 +27,9 @@ internal class InlineAutocompleteController(
     private val eventListenerProvider: () -> ((AutocompleteAddressInteractor.Event) -> Unit)?,
 ) {
     private var lastPredictionLine1: String? = null
-    private var latestQuery: String? = null
-    private var latestCountry: String? = null
+    private var queryFlow: StateFlow<String>? = null
+    private var countryFlow: StateFlow<String?>? = null
     private var observeJob: Job? = null
-    private var pendingQueryJob: Job? = null
-    private var pendingCountryJob: Job? = null
-    private var pendingQueryForManualEntry: String? = null
-    private var pendingCountryForManualEntry: String? = null
     private var selectionJob: Job? = null
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
@@ -45,19 +41,8 @@ internal class InlineAutocompleteController(
     @OptIn(FlowPreview::class)
     fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
         observeJob?.cancel()
-        pendingQueryJob?.cancel()
-        pendingCountryJob?.cancel()
-        // keep a non-debounced copy of the latest typing so manual expansion can use it immediately
-        pendingQueryJob = coroutineScope.launch {
-            query.collect { q ->
-                pendingQueryForManualEntry = q
-            }
-        }
-        pendingCountryJob = coroutineScope.launch {
-            country.collect { c ->
-                pendingCountryForManualEntry = c ?: ""
-            }
-        }
+        queryFlow = query
+        countryFlow = country
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
                 .debounce(AutocompleteViewModel.SEARCH_DEBOUNCE_MS)
@@ -72,8 +57,6 @@ internal class InlineAutocompleteController(
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                         return@collectLatest
                     }
-                    latestQuery = q
-                    latestCountry = c
                     fetchPredictions(q, c)
                 }
         }
@@ -116,35 +99,18 @@ internal class InlineAutocompleteController(
     fun onDismissed() {
         selectionJob?.cancel()
         lastPredictionLine1 = null
-        latestQuery = null
-        pendingQueryForManualEntry = null
-        latestCountry = null
-        pendingCountryForManualEntry = null
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
     }
 
-    /**
-     * When the user chooses "Enter address manually" from the inline predictions UI,
-     * pre-populate the expanded form with the current inline query/country if present.
-     */
     fun expandFormFromInline() {
-        val queryToUse = pendingQueryForManualEntry?.takeIf { it.isNotBlank() } ?: latestQuery
-        val countryToUse = pendingCountryForManualEntry?.takeIf { it.isNotBlank() } ?: latestCountry
-
-        val values = buildMap<IdentifierSpec, String?> {
-            queryToUse?.let { put(IdentifierSpec.Line1, it) }
-            countryToUse?.let { put(IdentifierSpec.Country, it) }
-        }.takeIf { it.isNotEmpty() }
-
-        eventListenerProvider()?.invoke(
-            AutocompleteAddressInteractor.Event.OnExpandForm(values)
+        emitExpandForm(
+            query = queryFlow?.value,
+            country = countryFlow?.value,
         )
     }
 
     fun dispose() {
         observeJob?.cancel()
-        pendingQueryJob?.cancel()
-        pendingCountryJob?.cancel()
         selectionJob?.cancel()
     }
 
@@ -187,14 +153,14 @@ internal class InlineAutocompleteController(
     private fun handleFailure() {
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         if (config.shouldUseStripeHostedAutocomplete) {
-            expandFormForHostedFailure()
+            expandFormFromInline()
         }
     }
 
-    private fun expandFormForHostedFailure() {
+    private fun emitExpandForm(query: String?, country: String?) {
         val values = buildMap<IdentifierSpec, String?> {
-            latestQuery?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Line1, it) }
-            latestCountry?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Country, it) }
+            query?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Line1, it) }
+            country?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Country, it) }
         }.takeIf { it.isNotEmpty() }
 
         eventListenerProvider()?.invoke(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -30,6 +30,10 @@ internal class InlineAutocompleteController(
     private var latestQuery: String? = null
     private var latestCountry: String? = null
     private var observeJob: Job? = null
+    private var pendingQueryJob: Job? = null
+    private var pendingCountryJob: Job? = null
+    private var pendingQueryForManualEntry: String? = null
+    private var pendingCountryForManualEntry: String? = null
     private var selectionJob: Job? = null
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
@@ -41,6 +45,19 @@ internal class InlineAutocompleteController(
     @OptIn(FlowPreview::class)
     fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
         observeJob?.cancel()
+        pendingQueryJob?.cancel()
+        pendingCountryJob?.cancel()
+        // keep a non-debounced copy of the latest typing so manual expansion can use it immediately
+        pendingQueryJob = coroutineScope.launch {
+            query.collect { q ->
+                pendingQueryForManualEntry = q
+            }
+        }
+        pendingCountryJob = coroutineScope.launch {
+            country.collect { c ->
+                pendingCountryForManualEntry = c ?: ""
+            }
+        }
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
                 .debounce(AutocompleteViewModel.SEARCH_DEBOUNCE_MS)
@@ -100,12 +117,34 @@ internal class InlineAutocompleteController(
         selectionJob?.cancel()
         lastPredictionLine1 = null
         latestQuery = null
+        pendingQueryForManualEntry = null
         latestCountry = null
+        pendingCountryForManualEntry = null
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+    }
+
+    /**
+     * When the user chooses "Enter address manually" from the inline predictions UI,
+     * pre-populate the expanded form with the current inline query/country if present.
+     */
+    fun expandFormFromInline() {
+        val queryToUse = pendingQueryForManualEntry?.takeIf { it.isNotBlank() } ?: latestQuery
+        val countryToUse = pendingCountryForManualEntry?.takeIf { it.isNotBlank() } ?: latestCountry
+
+        val values = buildMap<IdentifierSpec, String?> {
+            queryToUse?.let { put(IdentifierSpec.Line1, it) }
+            countryToUse?.let { put(IdentifierSpec.Country, it) }
+        }.takeIf { it.isNotEmpty() }
+
+        eventListenerProvider()?.invoke(
+            AutocompleteAddressInteractor.Event.OnExpandForm(values)
+        )
     }
 
     fun dispose() {
         observeJob?.cancel()
+        pendingQueryJob?.cancel()
+        pendingCountryJob?.cancel()
         selectionJob?.cancel()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -71,7 +71,7 @@ internal class InlineAutocompleteController(
                 ensureActive()
                 result.fold(
                     onSuccess = { handleFetchPlaceSuccess(it) },
-                    onFailure = { handleFailure() }
+                    onFailure = { handleFailure(queryFlow?.value, countryFlow?.value) }
                 )
             } finally {
                 placesClient.resetSession()
@@ -130,7 +130,7 @@ internal class InlineAutocompleteController(
         currentCoroutineContext().ensureActive()
         result.fold(
             onSuccess = { handleFindPredictionsSuccess(query, it) },
-            onFailure = { handleFailure() }
+            onFailure = { handleFailure(query, country) }
         )
     }
 
@@ -150,21 +150,20 @@ internal class InlineAutocompleteController(
         )
     }
 
-    private fun handleFailure() {
+    private fun handleFailure(query: String?, country: String?) {
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         if (config.shouldUseStripeHostedAutocomplete) {
-            expandFormFromInline()
+            emitExpandForm(query = query, country = country)
         }
     }
 
     private fun emitExpandForm(query: String?, country: String?) {
+        val listener = eventListenerProvider() ?: return
         val values = buildMap<IdentifierSpec, String?> {
             query?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Line1, it) }
             country?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Country, it) }
         }.takeIf { it.isNotEmpty() }
 
-        eventListenerProvider()?.invoke(
-            AutocompleteAddressInteractor.Event.OnExpandForm(values)
-        )
+        listener(AutocompleteAddressInteractor.Event.OnExpandForm(values))
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -250,7 +250,7 @@ internal class InputAddressViewModel @Inject constructor(
     }
 
     override fun onEnterManuallyFromInline() {
-        onEnterManually()
+        inlineAutocompleteController?.expandFormFromInline() ?: onEnterManually()
     }
 
     private fun canUseShippingSameAsBilling(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -214,7 +214,7 @@ internal class InputAddressViewModel @Inject constructor(
             eventReporter.onCompleted(
                 country = country,
                 autocompleteResultSelected = collectedAddress.value?.address?.line1 != null,
-                editDistance = addressDetails.editDistance(collectedAddress.value),
+                editDistance = addressDetails.editDistance(collectedAddress.value)
             )
         }
         navigator.dismiss(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -5,8 +5,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -32,25 +30,6 @@ class BillingInlineAutocompleteAddressInteractorTest {
 
         assertThat(eventCalls.awaitItem())
             .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
-    }
-
-    @Test
-    fun `onEnterManuallyFromInline pre-fills Line1 with typed inline query`() = runScenario {
-        val queryFlow = MutableStateFlow("")
-        val countryFlow = MutableStateFlow<String?>("US")
-        interactor.observeQueryChanges(queryFlow, countryFlow)
-
-        queryFlow.value = "123 Main St"
-        interactor.onEnterManuallyFromInline()
-
-        assertThat(eventCalls.awaitItem()).isEqualTo(
-            AutocompleteAddressInteractor.Event.OnExpandForm(
-                values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main St",
-                    IdentifierSpec.Country to "US",
-                )
-            )
-        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractorTest.kt
@@ -5,6 +5,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -25,11 +27,30 @@ class BillingInlineAutocompleteAddressInteractorTest {
     }
 
     @Test
-    fun `onEnterManuallyFromInline emits OnExpandForm with null values`() = runScenario {
+    fun `onEnterManuallyFromInline emits OnExpandForm with null values when query is empty`() = runScenario {
         interactor.onEnterManuallyFromInline()
 
         assertThat(eventCalls.awaitItem())
             .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `onEnterManuallyFromInline pre-fills Line1 with typed inline query`() = runScenario {
+        val queryFlow = MutableStateFlow("")
+        val countryFlow = MutableStateFlow<String?>("US")
+        interactor.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main St"
+        interactor.onEnterManuallyFromInline()
+
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main St",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -690,7 +690,6 @@ class InlineAutocompleteControllerTest {
         )
     }
 
-
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -665,6 +665,32 @@ class InlineAutocompleteControllerTest {
         eventCalls.awaitItem()
     }
 
+    @Test
+    fun `expandFormFromInline emits OnExpandForm with null values when query is empty`() = runScenario {
+        delegate.expandFormFromInline()
+
+        assertThat(eventCalls.awaitItem())
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `expandFormFromInline pre-fills Line1 from current query before debounce completes`() = runScenario {
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main St"
+        delegate.expandFormFromInline()
+
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main St",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
+    }
+
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(
         autocompleteCountries: Set<String> = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -5,13 +5,14 @@ import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.Address
 import com.stripe.android.paymentelement.AddressElementSameAsBillingPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
-import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -958,8 +959,6 @@ class InputAddressViewModelTest {
     // Core controller logic (predictions, debouncing, selection, suppression, dismissal)
     // is tested in InlineAutocompleteControllerTest.
 
-    private val mockPlacesClient = mock<PlacesClientProxy>()
-
     private fun createInlineViewModel(
         googlePlacesApiKey: String = "test_key",
         autocompleteCountries: Set<String> = emptySet(),
@@ -975,19 +974,46 @@ class InputAddressViewModelTest {
             ),
             navigator,
             eventReporter,
-            placesClient = mockPlacesClient,
+            placesClient = FakePlacesClientProxy(
+                findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+                fetchPlaceResult = Result.success(Address()),
+            ),
         ).also { viewModelStoreRule.track(it) }
     }
 
     @Test
-    fun `onEnterManuallyFromInline emits OnExpandForm event`() = runTest {
+    fun `onEnterManuallyFromInline emits OnExpandForm with null values when query is empty`() = runTest {
         val viewModel = createInlineViewModel()
         var emittedEvent: AutocompleteAddressInteractor.Event? = null
         viewModel.register { emittedEvent = it }
 
         viewModel.onEnterManuallyFromInline()
 
-        assertThat(emittedEvent).isInstanceOf<AutocompleteAddressInteractor.Event.OnExpandForm>()
+        assertThat(emittedEvent)
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+    }
+
+    @Test
+    fun `onEnterManuallyFromInline pre-fills Line1 with typed inline query`() = runTest(UnconfinedTestDispatcher()) {
+        val viewModel = createInlineViewModel()
+        var emittedEvent: AutocompleteAddressInteractor.Event? = null
+        viewModel.register { emittedEvent = it }
+
+        val queryFlow = MutableStateFlow("")
+        val countryFlow = MutableStateFlow<String?>("US")
+        viewModel.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main St"
+        viewModel.onEnterManuallyFromInline()
+
+        assertThat(emittedEvent).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main St",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
     }
 
     private fun createShowState(isChecked: Boolean) =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Address
 import com.stripe.android.paymentelement.AddressElementSameAsBillingPreview
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -25,14 +25,16 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class InputAddressViewModelTest {
     private val navigator = mock<AddressElementNavigator>()
-    private val eventReporter = FakeAddressLauncherEventReporter()
+    private val eventReporter = mock<AddressLauncherEventReporter>()
 
     private fun createViewModel(
         address: AddressDetails? = null,
@@ -160,10 +162,11 @@ class InputAddressViewModelTest {
                 )
             )
         )
-        val completedCall = eventReporter.completedCalls.awaitItem()
-        assertThat(completedCall.country).isEqualTo("US")
-        assertThat(completedCall.autocompleteResultSelected).isTrue()
-        assertThat(completedCall.editDistance).isEqualTo(0)
+        verify(eventReporter).onCompleted(
+            country = eq("US"),
+            autocompleteResultSelected = eq(true),
+            editDistance = eq(0)
+        )
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Preserves the user's previously typed address string when they switch to manual address entry via the inline popup menu.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
When a user begins typing an address into the inline address field and then selects "Enter address manually" from the autocomplete popup, the resulting manual entry sheet previously opened with an empty address field. This bug forced users to retype what they had already entered.

This fix ensures that the string already in the input field is passed directly to the manual entry form to match the expected behavior and improve UX flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A (Behind feature flag for inline autocomplete)