### PR TITLE
Add additional GPO PDOL producers

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/AmountAuthorizedProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/AmountAuthorizedProducer.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+
+/*
+ * Indicates the amount authorized for purchase to the card. If no amount (such as `SetupIntent`), set to 0 by default.
+ * Amount is encoded into binary-coded decimal format first.
+ */
+internal object AmountAuthorizedProducer : TagValueProducer {
+    override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
+        val amount = paymentMethodMetadata.amount()?.value ?: 0L
+
+        return TagValueProducer.Result(
+            tag = TAG_AMOUNT_AUTHORIZED,
+            value = BcdEncoding.encode(amount, AMOUNT_LENGTH),
+        )
+    }
+
+    private const val TAG_AMOUNT_AUTHORIZED = "9F02"
+    private const val AMOUNT_LENGTH = 6
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/BcdEncoding.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/BcdEncoding.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+internal object BcdEncoding {
+    /**
+     * Converts the receiving [Long] integer into a **packed Binary-Coded Decimal (BCD) byte array**.
+     *
+     * In packed BCD, two decimal digits (0-99) are stored per byte: one digit in the upper nibble
+     * and one in the lower nibble. The conversion is performed from right to left (least significant digits first).
+     *
+     * @param length The required length of the resulting BCD byte array. Must be sufficient
+     * to hold the number (e.g., length 3 can hold up to 6 digits, or 999,999).
+     * @return A [ByteArray] of size [length] containing the packed BCD representation.
+     */
+    fun encode(value: Long, length: Int): ByteArray {
+        val bcdArray = ByteArray(length)
+
+        var num = value
+        for (i in length - 1 downTo 0) {
+            // Get the last two digits (0-99).
+            val pair = num % TWO_DIGIT_DIVISOR
+
+            val tens = pair / FIRST_DIGIT_DIVISOR
+            val ones = pair % FIRST_DIGIT_DIVISOR
+
+            // Pack: (tens digit << 4) OR (ones digit).
+            bcdArray[i] = (tens shl NIBBLE_SHIFT or ones).toByte()
+
+            // Move to the next pair of digits.
+            num /= TWO_DIGIT_DIVISOR
+        }
+
+        return bcdArray
+    }
+
+    private const val TWO_DIGIT_DIVISOR = 100
+    private const val NIBBLE_SHIFT = 4
+    private const val FIRST_DIGIT_DIVISOR = 10
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/EnhancedContactlessReaderCapabilitiesProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/EnhancedContactlessReaderCapabilitiesProducer.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+
+/*
+ * Enhanced Contactless Reader Capabilities (tag `9F6E`) is an American Express (Expresspay) specific field that tells
+ * the card which contactless modes and features the reader supports. Amex cards request this tag in their PDOL and
+ * reject `GetProcessingOptions` with `6985` ("conditions of use not satisfied") when it is all-zero, because that
+ * advertises a reader that supports nothing.
+ *
+ * The value below matches the EMVCo Kernel C-4 mPOS-C/CSP profile for an online-only terminal on a
+ * cardholder-controlled device (see [TerminalTypeProducer] `0x34`):
+ * - Byte 1 `0x18`: contactless EMV partial online + mobile supported; no contact or magstripe.
+ * - Byte 2 `0x80`: mobile CVM only (no online PIN, signature, or offline PIN on the phone reader).
+ * - Byte 3 `0x00`: online-only (not offline-only); CVM-not-required at transaction start.
+ * - Byte 4 `0x03`: C-4 kernel version 2.7+.
+ */
+internal object EnhancedContactlessReaderCapabilitiesProducer : TagValueProducer {
+    override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
+        return TagValueProducer.Result(
+            tag = TAG_ENHANCED_CONTACTLESS_READER_CAPABILITIES,
+            value = ENHANCED_CONTACTLESS_READER_CAPABILITIES,
+        )
+    }
+
+    private const val TAG_ENHANCED_CONTACTLESS_READER_CAPABILITIES = "9F6E"
+
+    private val ENHANCED_CONTACTLESS_READER_CAPABILITIES =
+        byteArrayOf(0x18, 0x80.toByte(), 0x00, 0x03)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/PdolModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/PdolModule.kt
@@ -12,8 +12,14 @@ internal interface PdolModule {
     companion object {
         @Provides
         fun providesProducers(): Set<TagValueProducer> = setOf(
+            AmountAuthorizedProducer,
+            TransactionCurrencyCodeProducer,
+            TerminalCountryCodeProducer,
+            TerminalTypeProducer,
+            TransactionDateProducer,
+            EnhancedContactlessReaderCapabilitiesProducer,
             TerminalTransactionQualifiersProducer,
-            UnpredictableNumberProducer
+            UnpredictableNumberProducer,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalCountryCodeProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalCountryCodeProducer.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import java.util.Locale
+
+/*
+ * Tells the card where the Terminal is located. For the NFC scanning use case, passing the locale is
+ * sufficient.
+ */
+internal object TerminalCountryCodeProducer : TagValueProducer {
+    override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
+        return TagValueProducer.Result(
+            tag = TAG_TERMINAL_COUNTRY,
+            value = BcdEncoding.encode(
+                numericCountryCode().toLong(),
+                NUMERIC_CODE_LENGTH,
+            ),
+        )
+    }
+
+    private fun numericCountryCode(): Int {
+        return COUNTRY_NUMERIC_CODES[Locale.getDefault().country] ?: US_NUMERIC_CODE
+    }
+
+    private const val TAG_TERMINAL_COUNTRY = "9F1A"
+    private const val NUMERIC_CODE_LENGTH = 2
+    private const val US_NUMERIC_CODE = 840
+
+    private val COUNTRY_NUMERIC_CODES = mapOf(
+        "AT" to 40,
+        "AU" to 36,
+        "BE" to 56,
+        "BR" to 76,
+        "CA" to 124,
+        "CH" to 756,
+        "CZ" to 203,
+        "DE" to 276,
+        "DK" to 208,
+        "ES" to 724,
+        "FI" to 246,
+        "FR" to 250,
+        "GB" to 826,
+        "HK" to 344,
+        "IE" to 372,
+        "IN" to 356,
+        "IT" to 380,
+        "JP" to 392,
+        "MX" to 484,
+        "NL" to 528,
+        "NO" to 578,
+        "NZ" to 554,
+        "PL" to 616,
+        "PT" to 620,
+        "SE" to 752,
+        "SG" to 702,
+        "US" to US_NUMERIC_CODE,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalTransactionQualifiersProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalTransactionQualifiersProducer.kt
@@ -2,14 +2,26 @@ package com.stripe.android.common.nfcscan.scanner.apdu.pdol
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 
+/*
+ * Terminal Transaction Qualifiers (tag `9F66`) is a Visa payWave-specific field that tells the card the reader's
+ * contactless capabilities and requirements. Visa cards request this tag in their PDOL.
+ *
+ * The value below matches an online-only terminal on a cardholder-controlled device:
+ * - Byte 1 `0x20`: qVSDC supported; online-capable; no contact chip, magstripe, offline-only, PIN, signature, or ODA.
+ * - Byte 2 `0x00`: online cryptogram not required and CVM not required at transaction start (transient bits).
+ * - Byte 3 `0x40`: mobile functionality / consumer device CVM supported.
+ * - Byte 4 `0x00`: RFU.
+ */
 internal object TerminalTransactionQualifiersProducer : TagValueProducer {
     override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
         return TagValueProducer.Result(
             tag = TAG_TERMINAL_TRANSACTION_QUALIFIERS,
-            value = TERMINAL_TRANSACTION_QUALIFIERS
+            value = TERMINAL_TRANSACTION_QUALIFIERS,
         )
     }
 
     private const val TAG_TERMINAL_TRANSACTION_QUALIFIERS = "9F66"
-    private val TERMINAL_TRANSACTION_QUALIFIERS = byteArrayOf(0x26, 0x00, 0x00, 0x00)
+
+    private val TERMINAL_TRANSACTION_QUALIFIERS =
+        byteArrayOf(0x20, 0x00, 0x40, 0x00)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalTypeProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalTypeProducer.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+
+/*
+ * Terminal Type (tag `9F35`) indicates the environment of the terminal, its communications capability, and its
+ * operational control. Some card applications (notably American Express) request this tag in their PDOL and reject
+ * `GetProcessingOptions` with `6985` ("conditions of use not satisfied") if it is zero/invalid.
+ *
+ * `0x34` = cardholder-controlled, unattended, online-only terminal.
+ */
+internal object TerminalTypeProducer : TagValueProducer {
+    override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
+        return TagValueProducer.Result(
+            tag = TAG_TERMINAL_TYPE,
+            value = TERMINAL_TYPE,
+        )
+    }
+
+    private const val TAG_TERMINAL_TYPE = "9F35"
+    private val TERMINAL_TYPE = byteArrayOf(0x34)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionCurrencyCodeProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionCurrencyCodeProducer.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import android.os.Build
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import java.util.Currency
+import java.util.Locale
+
+/*
+ * Tells the card the currency code of the transaction taking place if the card asks for it. Provides `PaymentIntent`
+ * currency code as a numeric code, otherwise just pass USD. Encodes the currency code as a binary-code decimal.
+ */
+internal object TransactionCurrencyCodeProducer : TagValueProducer {
+    override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
+        val currencyCode = paymentMethodMetadata.amount()?.currencyCode
+
+        return TagValueProducer.Result(
+            tag = TAG_TRANSACTION_CURRENCY,
+            value = BcdEncoding.encode(
+                numericCurrencyCode(currencyCode).toLong(),
+                NUMERIC_CODE_LENGTH,
+            ),
+        )
+    }
+
+    private fun numericCurrencyCode(currencyCode: String?): Int {
+        if (currencyCode == null) {
+            return DEFAULT_US_NUMERIC_CODE
+        }
+
+        val normalizedCode = currencyCode.uppercase(Locale.US)
+        return currencyNumericCodeFromPlatform(normalizedCode)
+            ?: CURRENCY_NUMERIC_CODES[normalizedCode]
+            ?: DEFAULT_US_NUMERIC_CODE
+    }
+
+    private fun currencyNumericCodeFromPlatform(currencyCode: String): Int? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return null
+        }
+
+        return runCatching {
+            Currency.getInstance(currencyCode).numericCode
+        }.getOrNull()
+    }
+
+    private const val TAG_TRANSACTION_CURRENCY = "5F2A"
+    private const val NUMERIC_CODE_LENGTH = 2
+
+    private const val DEFAULT_US_NUMERIC_CODE = 840
+
+    private val CURRENCY_NUMERIC_CODES = mapOf(
+        "USD" to DEFAULT_US_NUMERIC_CODE,
+        "EUR" to 978,
+        "GBP" to 826,
+        "CAD" to 124,
+        "AUD" to 36,
+        "JPY" to 392,
+        "CHF" to 756,
+        "SEK" to 752,
+        "NOK" to 578,
+        "DKK" to 208,
+        "NZD" to 554,
+        "SGD" to 702,
+        "HKD" to 344,
+        "MXN" to 484,
+        "BRL" to 986,
+        "INR" to 356,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionDateProducer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionDateProducer.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import java.util.Calendar
+import java.util.TimeZone
+
+/*
+ * Tells the
+ */
+internal object TransactionDateProducer : TagValueProducer {
+    override fun produce(paymentMethodMetadata: PaymentMethodMetadata): TagValueProducer.Result {
+        val calendar = Calendar.getInstance(UTC_TIME_ZONE).apply {
+            timeInMillis = paymentMethodMetadata.stripeIntent.created * MILLIS_PER_SECOND
+        }
+
+        val year = calendar.get(Calendar.YEAR) % YEARS_IN_CENTURY
+        val month = calendar.get(Calendar.MONTH) + 1
+        val day = calendar.get(Calendar.DAY_OF_MONTH)
+
+        val transactionDate = year * MONTH_AND_DAY_MULTIPLIER + month * DAY_MULTIPLIER + day
+
+        return TagValueProducer.Result(
+            tag = TAG_TRANSACTION_DATE,
+            value = BcdEncoding.encode(transactionDate.toLong(), TRANSACTION_DATE_LENGTH),
+        )
+    }
+
+    private const val TAG_TRANSACTION_DATE = "9A"
+    private const val TRANSACTION_DATE_LENGTH = 3
+
+    private const val YEARS_IN_CENTURY = 100
+    private const val MILLIS_PER_SECOND = 1_000L
+
+    private const val MONTH_AND_DAY_MULTIPLIER = 10_000
+    private const val DAY_MULTIPLIER = 100
+
+    private val UTC_TIME_ZONE: TimeZone = TimeZone.getTimeZone("UTC")
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/DefaultPdolBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/DefaultPdolBuilderTest.kt
@@ -40,7 +40,7 @@ internal class DefaultPdolBuilderTest {
             template = template,
         )
 
-        assertThat(result).isEqualTo(byteArrayOf(0x83.toByte(), 0x04, 0x26, 0x00, 0x00, 0x00))
+        assertThat(result).isEqualTo(byteArrayOf(0x83.toByte(), 0x04, 0x20, 0x00, 0x40, 0x00))
     }
 
     @Test
@@ -107,7 +107,7 @@ internal class DefaultPdolBuilderTest {
         )
 
         assertThat(result)
-            .isEqualTo(byteArrayOf(0x83.toByte(), 0x08, 0x26, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04))
+            .isEqualTo(byteArrayOf(0x83.toByte(), 0x08, 0x20, 0x00, 0x40, 0x00, 0x01, 0x02, 0x03, 0x04))
     }
 
     @Test
@@ -159,7 +159,7 @@ internal class DefaultPdolBuilderTest {
     )
 
     private companion object {
-        val TERMINAL_TRANSACTION_QUALIFIERS = byteArrayOf(0x26, 0x00, 0x00, 0x00)
+        val TERMINAL_TRANSACTION_QUALIFIERS = byteArrayOf(0x20, 0x00, 0x40, 0x00)
         val UNPREDICTABLE_NUMBER = byteArrayOf(0x01, 0x02, 0x03, 0x04)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/AmountAuthorizedProducerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/AmountAuthorizedProducerTest.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.SetupIntentFixtures
+import org.junit.Test
+
+internal class AmountAuthorizedProducerTest {
+    @Test
+    fun `produce returns amount authorized tag & bcd encoded payment intent amount`() {
+        val result = AmountAuthorizedProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        )
+
+        assertThat(result.tag).isEqualTo("9F02")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x00, 0x00, 0x00, 0x00, 0x10, 0x99.toByte()),
+        )
+    }
+
+    @Test
+    fun `produce returns zero amount when payment intent amount is unavailable`() {
+        val result = AmountAuthorizedProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            ),
+        )
+
+        assertThat(result.tag).isEqualTo("9F02")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/EnhancedContactlessReaderCapabilitiesProducerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/EnhancedContactlessReaderCapabilitiesProducerTest.kt
@@ -4,16 +4,16 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import org.junit.Test
 
-internal class TerminalTransactionQualifiersProducerTest {
+internal class EnhancedContactlessReaderCapabilitiesProducerTest {
     @Test
-    fun `produce returns terminal transaction qualifiers for online-only mobile reader`() {
-        val result = TerminalTransactionQualifiersProducer.produce(
+    fun `produce returns enhanced contactless reader capabilities for online-only mobile reader`() {
+        val result = EnhancedContactlessReaderCapabilitiesProducer.produce(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         )
 
-        assertThat(result.tag).isEqualTo("9F66")
+        assertThat(result.tag).isEqualTo("9F6E")
         assertThat(result.value).isEqualTo(
-            byteArrayOf(0x20, 0x00, 0x40, 0x00),
+            byteArrayOf(0x18, 0x80.toByte(), 0x00, 0x03),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalCountryCodeProducerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalCountryCodeProducerTest.kt
@@ -1,0 +1,64 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+internal class TerminalCountryCodeProducerTest {
+    private lateinit var originalLocale: Locale
+
+    @Before
+    fun setUp() {
+        originalLocale = Locale.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+    }
+
+    @Test
+    fun `produce returns terminal country tag for device locale`() {
+        Locale.setDefault(Locale.CANADA)
+
+        val result = TerminalCountryCodeProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        )
+
+        assertThat(result.tag).isEqualTo("9F1A")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x01, 0x24),
+        )
+    }
+
+    @Test
+    fun `produce returns US terminal country tag for US device locale`() {
+        Locale.setDefault(Locale.US)
+
+        val result = TerminalCountryCodeProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        )
+
+        assertThat(result.tag).isEqualTo("9F1A")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x08, 0x40),
+        )
+    }
+
+    @Test
+    fun `produce returns US terminal country tag when device locale country is unmapped`() {
+        Locale.setDefault(Locale.Builder().setLanguage("en").setRegion("JO").build())
+
+        val result = TerminalCountryCodeProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        )
+
+        assertThat(result.tag).isEqualTo("9F1A")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x08, 0x40),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalTypeProducerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TerminalTypeProducerTest.kt
@@ -4,16 +4,16 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import org.junit.Test
 
-internal class TerminalTransactionQualifiersProducerTest {
+internal class TerminalTypeProducerTest {
     @Test
-    fun `produce returns terminal transaction qualifiers for online-only mobile reader`() {
-        val result = TerminalTransactionQualifiersProducer.produce(
+    fun `produce returns terminal type for online-only cardholder-controlled device`() {
+        val result = TerminalTypeProducer.produce(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         )
 
-        assertThat(result.tag).isEqualTo("9F66")
+        assertThat(result.tag).isEqualTo("9F35")
         assertThat(result.value).isEqualTo(
-            byteArrayOf(0x20, 0x00, 0x40, 0x00),
+            byteArrayOf(0x34),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionCurrencyCodeProducerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionCurrencyCodeProducerTest.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Test
+
+internal class TransactionCurrencyCodeProducerTest {
+    @Test
+    fun `produce returns transaction currency tag & bcd encoded numeric currency code`() {
+        val result = TransactionCurrencyCodeProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        )
+
+        assertThat(result.tag).isEqualTo("5F2A")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x08, 0x40),
+        )
+    }
+
+    @Test
+    fun `produce returns default US currency code when payment intent currency is unavailable`() {
+        val result = TransactionCurrencyCodeProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            ),
+        )
+
+        assertThat(result.tag).isEqualTo("5F2A")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x08, 0x40),
+        )
+    }
+
+    @Test
+    fun `produce returns default US currency code when currency code is unknown`() {
+        val result = TransactionCurrencyCodeProducer.produce(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    currency = "xyz",
+                ),
+            ),
+        )
+
+        assertThat(result.tag).isEqualTo("5F2A")
+        assertThat(result.value).isEqualTo(
+            byteArrayOf(0x08, 0x40),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionDateProducerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/TransactionDateProducerTest.kt
@@ -1,0 +1,68 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Test
+
+internal class TransactionDateProducerTest {
+    @Test
+    fun `produce encodes date in UTC not local timezone`() {
+        // 2020-01-01 00:30:00 UTC is still 2019-12-31 in US Pacific time.
+        val result = TransactionDateProducer.produce(
+            paymentMethodMetadata = paymentMethodMetadataWithCreated(CREATED_2020_01_01_0030_UTC),
+        )
+
+        assertThat(result.tag).isEqualTo("9A")
+        assertThat(result.value).isEqualTo(byteArrayOf(0x20, 0x01, 0x01))
+    }
+
+    @Test
+    fun `produce encodes century boundary date`() {
+        val result = TransactionDateProducer.produce(
+            paymentMethodMetadata = paymentMethodMetadataWithCreated(CREATED_2000_01_01_0000_UTC),
+        )
+
+        assertThat(result.tag).isEqualTo("9A")
+        assertThat(result.value).isEqualTo(byteArrayOf(0x00, 0x01, 0x01))
+    }
+
+    @Test
+    fun `produce encodes pre century boundary date`() {
+        val result = TransactionDateProducer.produce(
+            paymentMethodMetadata = paymentMethodMetadataWithCreated(CREATED_1999_12_31_2359_UTC),
+        )
+
+        assertThat(result.tag).isEqualTo("9A")
+        assertThat(result.value).isEqualTo(byteArrayOf(0x99.toByte(), 0x12, 0x31))
+    }
+
+    @Test
+    fun `produce encodes leap day date`() {
+        val result = TransactionDateProducer.produce(
+            paymentMethodMetadata = paymentMethodMetadataWithCreated(CREATED_2020_02_29_1200_UTC),
+        )
+
+        assertThat(result.tag).isEqualTo("9A")
+        assertThat(result.value).isEqualTo(byteArrayOf(0x20, 0x02, 0x29))
+    }
+
+    private fun paymentMethodMetadataWithCreated(created: Long) =
+        PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFactory.create().copy(created = created),
+        )
+
+    private companion object {
+        // 2020-01-01 00:30:00 UTC
+        const val CREATED_2020_01_01_0030_UTC = 1577838600L
+
+        // 2000-01-01 00:00:00 UTC
+        const val CREATED_2000_01_01_0000_UTC = 946684800L
+
+        // 1999-12-31 23:59:59 UTC
+        const val CREATED_1999_12_31_2359_UTC = 946684799L
+
+        // 2020-02-29 12:00:00 UTC
+        const val CREATED_2020_02_29_1200_UTC = 1582977600L
+    }
+}


### PR DESCRIPTION
# Summary
Add additional GPO PDOL producers for handling country code, currency code, amount authorized, and transaction date.

# Motivation
Accept more cards that require more transaction data.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified