### PR TITLE
Make primary-button test tags expose enabled state

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -2,8 +2,11 @@ package com.stripe.android.paymentsheet.addresselement
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.DefaultStripeTheme
@@ -21,6 +24,7 @@ class InputAddressScreenTest {
     fun clicking_primary_button_triggers_callback_when_enabled() {
         var counter = 0
         setContent(primaryButtonEnabled = true, primaryButtonCallback = { counter++ })
+        composeTestRule.onNodeWithTag(ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
         composeTestRule.onNodeWithText("Save Address").performClick()
         assertThat(counter).isEqualTo(1)
     }
@@ -29,6 +33,7 @@ class InputAddressScreenTest {
     fun clicking_primary_button_does_not_trigger_callback_when_not_enabled() {
         var counter = 0
         setContent(primaryButtonEnabled = false, primaryButtonCallback = { counter++ })
+        composeTestRule.onNodeWithTag(ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG).assertIsNotEnabled()
         composeTestRule.onNodeWithText("Save Address").performClick()
         assertThat(counter).isEqualTo(0)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/PrimaryButton.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -39,6 +40,7 @@ internal fun PrimaryButton(
     label: String,
     isEnabled: Boolean,
     onButtonClick: () -> Unit,
+    testTag: String? = null,
     modifier: Modifier = Modifier,
     canClickWhileDisabled: Boolean = false,
     isLoading: Boolean = false,
@@ -68,7 +70,7 @@ internal fun PrimaryButton(
         ) {
             TextButton(
                 onClick = onButtonClick,
-                modifier = Modifier
+                modifier = (if (testTag != null) Modifier.testTag(testTag) else Modifier)
                     .fillMaxWidth()
                     .defaultMinSize(
                         minHeight = StripeTheme.primaryButtonStyle.shape.height.dp

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.nfcscan.LocalNfcScanEventShownReporter
@@ -190,9 +189,9 @@ internal fun SelectPaymentMethod(
                     viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
                 },
                 modifier = Modifier
-                    .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
                     .padding(top = 20.dp)
                     .padding(horizontalPadding),
+                testTag = CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG,
             )
         }
 
@@ -317,9 +316,9 @@ internal fun AddPaymentMethod(
             viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
         },
         modifier = Modifier
-            .testTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
             .padding(top = 10.dp)
             .padding(horizontalPadding),
+        testTag = CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG,
     )
 
     if (!viewState.showMandateAbovePrimaryButton) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -85,11 +85,14 @@ internal fun InputAddressScreen(
                         onDisabledButtonClick()
                     },
                     modifier = Modifier.padding(vertical = 16.dp),
+                    testTag = ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG,
                 )
             }
         }
     }
 }
+
+internal const val ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG = "ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG"
 
 @Composable
 internal fun InputAddressScreen(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateButton.kt
@@ -18,7 +18,7 @@ internal fun BacsMandateButton(type: BacsMandateButtonType, label: String, onCli
         BacsMandateButtonType.Primary -> PrimaryButton(
             label = label,
             isEnabled = true,
-            onButtonClick = onClick
+            onButtonClick = onClick,
         )
         BacsMandateButtonType.Secondary -> {
             // Use the same text style as the primary button but a different color.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -293,8 +293,8 @@ private fun UpdatePaymentMethodUi(interactor: UpdatePaymentMethodInteractor) {
             interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.DisabledSaveButtonPressed)
         },
         modifier = Modifier
-            .testTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG)
-            .testMetadata("isLoading=$isLoading")
+            .testMetadata("isLoading=$isLoading"),
+        testTag = UPDATE_PM_SAVE_BUTTON_TEST_TAG,
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/ui/PrimaryButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/ui/PrimaryButtonScreenshotTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.ui
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule

--- a/paymentsheet/src/test/java/com/stripe/android/common/ui/PrimaryButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/ui/PrimaryButtonScreenshotTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.common.ui
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -29,14 +28,22 @@ class PrimaryButtonScreenshotTest {
     @Test
     fun testEnabled() {
         paparazziRule.snapshot {
-            PrimaryButton(isEnabled = true, label = BUTTON_TEXT, onButtonClick = {})
+            PrimaryButton(
+                isEnabled = true,
+                label = BUTTON_TEXT,
+                onButtonClick = {},
+            )
         }
     }
 
     @Test
     fun testDisabled() {
         paparazziRule.snapshot {
-            PrimaryButton(isEnabled = false, label = BUTTON_TEXT, onButtonClick = {})
+            PrimaryButton(
+                isEnabled = false,
+                label = BUTTON_TEXT,
+                onButtonClick = {},
+            )
         }
     }
 
@@ -47,7 +54,7 @@ class PrimaryButtonScreenshotTest {
                 isEnabled = true,
                 label = BUTTON_TEXT,
                 onButtonClick = {},
-                displayLockIcon = true
+                displayLockIcon = true,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -3,15 +3,11 @@ package com.stripe.android.paymentsheet.ui
 import android.os.Build
 import android.os.Parcel
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.isEnabled
-import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
@@ -101,7 +97,7 @@ class UpdatePaymentMethodUITest {
         isSaveButtonEnabled = true,
     ) {
         composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).onChildren().assertAll(isEnabled())
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsEnabled()
     }
 
     @Test
@@ -110,7 +106,7 @@ class UpdatePaymentMethodUITest {
         isSaveButtonEnabled = false,
     ) {
         composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).onChildren().assertAll(isNotEnabled())
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsNotEnabled()
     }
 
     @Test


### PR DESCRIPTION
Moves CustomerSheet, Address Element, and update-payment primary-button test tags from layout wrappers onto the actual Material TextButton. This makes enabled-state and geometry assertions reliable for keyboard-layout integration coverage.\n\nValidation:\n- Address Element instrumentation tests\n- Targeted UpdatePM test\n- :paymentsheet:apiCheck\n- :paymentsheet:detekt