### PR TITLE
Add CustomerSheet keyboard visibility test harness

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -11,6 +13,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.espresso.Espresso
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG
@@ -69,11 +72,25 @@ internal class CustomerSheetPage(
 
     fun fillOutCardDetails(
         cardNumber: String = CARD_NUMBER,
+        fillOutZipCode: Boolean = true,
     ) {
         replaceText("Card number", cardNumber)
         fillExpirationDate("$EXPIRY_MONTH/$${EXPIRY_YEAR.substring(startIndex = 2)}")
         replaceText("CVC", CVC)
-        replaceText("ZIP Code", ZIP_CODE)
+        if (fillOutZipCode) {
+            replaceText("ZIP Code", ZIP_CODE)
+        }
+    }
+
+    fun focusZipCode() {
+        composeTestRule.onNode(hasText("ZIP Code"))
+            .performScrollTo()
+            .performClick()
+    }
+
+    fun enterZipCode() {
+        composeTestRule.onNode(hasText("ZIP Code"))
+            .performTextInput(ZIP_CODE)
     }
 
     fun changeCardBrandChoice() {
@@ -92,6 +109,16 @@ internal class CustomerSheetPage(
 
     fun clickSaveButton() {
         clickPrimaryButton(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
+    }
+
+    fun assertSaveButtonEnabled() {
+        composeTestRule.onNode(hasTestTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG))
+            .assertIsEnabled()
+    }
+
+    fun assertSaveButtonDisabled() {
+        composeTestRule.onNode(hasTestTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG))
+            .assertIsNotEnabled()
     }
 
     fun clickConfirmButton() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -19,13 +19,13 @@ internal class CustomerSheetTestRunnerContext(
     private val customerSheet: CustomerSheet,
     private val countDownLatch: CountDownLatch,
 ) {
-    fun presentCustomerSheet(): CustomerSheetActivity {
+    fun presentCustomerSheet() {
         val activityLaunchObserver = ActivityLaunchObserver(CustomerSheetActivity::class.java)
         scenario.onActivity {
             activityLaunchObserver.prepareForLaunch(it)
             customerSheet.present()
         }
-        return activityLaunchObserver.awaitLaunch() as CustomerSheetActivity
+        activityLaunchObserver.awaitLaunch()
     }
 
     fun markTestSucceeded() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -19,18 +19,54 @@ internal class CustomerSheetTestRunnerContext(
     private val customerSheet: CustomerSheet,
     private val countDownLatch: CountDownLatch,
 ) {
-    fun presentCustomerSheet() {
+    fun presentCustomerSheet(): CustomerSheetActivity {
         val activityLaunchObserver = ActivityLaunchObserver(CustomerSheetActivity::class.java)
         scenario.onActivity {
             activityLaunchObserver.prepareForLaunch(it)
             customerSheet.present()
         }
-        activityLaunchObserver.awaitLaunch()
+        return activityLaunchObserver.awaitLaunch() as CustomerSheetActivity
     }
 
     fun markTestSucceeded() {
         countDownLatch.countDown()
     }
+}
+
+/**
+ * Runs CustomerSheet against an activity that is already owned by an Android Compose test rule.
+ *
+ * Keeping the SDK host and Compose rule in the same activity is required for tests that observe
+ * window state, such as IME insets.
+ */
+internal fun runCustomerSheetTest(
+    scenario: ActivityScenario<MainActivity>,
+    networkRule: NetworkRule,
+    integrationType: IntegrationType,
+    customerSheetTestType: CustomerSheetTestType,
+    configuration: CustomerSheet.Configuration,
+    resultCallback: CustomerSheetResultCallback,
+    block: (CustomerSheetTestRunnerContext) -> Unit,
+) {
+    val countDownLatch = CountDownLatch(1)
+
+    val factory = CustomerSheetTestFactory(
+        integrationType = integrationType,
+        customerSheetTestType = customerSheetTestType,
+        configuration = configuration,
+        resultCallback = {
+            resultCallback.onCustomerSheetResult(it)
+            countDownLatch.countDown()
+        },
+    )
+
+    runCustomerSheetTest(
+        scenario = scenario,
+        networkRule = networkRule,
+        countDownLatch = countDownLatch,
+        makeCustomerSheet = factory::make,
+        block = block,
+    )
 }
 
 internal fun runCustomerSheetTest(
@@ -70,32 +106,48 @@ private fun runCustomerSheetTest(
     block: (CustomerSheetTestRunnerContext) -> Unit,
 ) {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-        scenario.moveToState(Lifecycle.State.CREATED)
-
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            DefaultLinkStore(it.applicationContext).clear()
-        }
-
-        var customerSheet: CustomerSheet? = null
-
-        scenario.onActivity { activity ->
-            customerSheet = makeCustomerSheet(activity)
-        }
-
-        scenario.moveToState(Lifecycle.State.RESUMED)
-
-        val testContext = CustomerSheetTestRunnerContext(
+        runCustomerSheetTest(
             scenario = scenario,
-            customerSheet = customerSheet ?: throw IllegalStateException(
-                "CustomerSheet should have been created!"
-            ),
+            networkRule = networkRule,
             countDownLatch = countDownLatch,
+            makeCustomerSheet = makeCustomerSheet,
+            block = block,
         )
-        block(testContext)
-
-        val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
-        networkRule.validate()
-        assertThat(didCompleteSuccessfully).isTrue()
     }
+}
+
+private fun runCustomerSheetTest(
+    scenario: ActivityScenario<MainActivity>,
+    networkRule: NetworkRule,
+    countDownLatch: CountDownLatch,
+    makeCustomerSheet: (ComponentActivity) -> CustomerSheet,
+    block: (CustomerSheetTestRunnerContext) -> Unit,
+) {
+    scenario.moveToState(Lifecycle.State.CREATED)
+
+    scenario.onActivity {
+        PaymentConfiguration.init(it, "pk_test_123")
+        DefaultLinkStore(it.applicationContext).clear()
+    }
+
+    var customerSheet: CustomerSheet? = null
+
+    scenario.onActivity { activity ->
+        customerSheet = makeCustomerSheet(activity)
+    }
+
+    scenario.moveToState(Lifecycle.State.RESUMED)
+
+    val testContext = CustomerSheetTestRunnerContext(
+        scenario = scenario,
+        customerSheet = customerSheet ?: throw IllegalStateException(
+            "CustomerSheet should have been created!"
+        ),
+        countDownLatch = countDownLatch,
+    )
+    block(testContext)
+
+    val didCompleteSuccessfully = countDownLatch.await(5, TimeUnit.SECONDS)
+    networkRule.validate()
+    assertThat(didCompleteSuccessfully).isTrue()
 }


### PR DESCRIPTION
## Summary
- let CustomerSheet tests reuse an AndroidComposeRule-owned ActivityScenario
- await CustomerSheet launch without exposing CustomerSheetActivity from the test harness
- add CustomerSheet page helpers for incomplete-card, focused-ZIP, enabled-state, and ZIP-entry assertions
- leave the actual keyboard regression tests to the downstream coverage PR

Reusing the Compose-rule-owned host avoids CustomerSheet keyboard resize re-entering Compose test measurement.

## Stack
- base: #13673
- downstream: CustomerSheet and Address Element keyboard coverage

## Validation
- ./gradlew :paymentsheet:compileDebugAndroidTestKotlin
- ./gradlew :paymentsheet:detekt :paymentsheet:apiCheck