### PR TITLE
Use parsed records to produce AFL entries in `GetProcessingOptionsCommand`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
@@ -26,7 +26,7 @@ internal class GetProcessingOptionsCommand(
         parseFromRecords(records)
 
         return ProcessingOptionsInfo(
-            aflEntries = tlv[TAG_AFL]?.let(::parseAflEntries).orEmpty(),
+            aflEntries = records[TAG_AFL]?.let(::parseAflEntries).orEmpty(),
             records = records.toMap(),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommandTest.kt
@@ -99,7 +99,13 @@ internal class GetProcessingOptionsCommandTest {
 
         val processingOptionsInfo = result.getOrNull()
 
-        assertThat(processingOptionsInfo?.aflEntries).isEmpty()
+        assertThat(processingOptionsInfo?.aflEntries).containsExactly(
+            ProcessingOptionsInfo.AflEntry(
+                shortFileIdentifier = 1,
+                firstRecord = 1,
+                lastRecord = 1,
+            ),
+        )
 
         val records = processingOptionsInfo?.records
 


### PR DESCRIPTION
# Summary
Use parsed records to produce AFL entries in `GetProcessingOptionsCommand` rather than the original `TLV` to ensure both the AFL from tag 80 is used to produce the entries

# Motivation
Fix an issue where no AFL entries are returned.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified