### PR TITLE
Add additional error insights into NFC scanning

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
@@ -82,7 +82,10 @@ internal class NfcScanningViewModel @Inject constructor(
                             )
                         )
 
-                        eventReporter.onNfcScanAttemptFailed(errorCode = error.code)
+                        eventReporter.onNfcScanAttemptFailed(
+                            errorCode = error.code,
+                            parameters = error.parameters,
+                        )
                     }
                     is NfcCardScanner.State.Complete -> {
                         timeoutManager.cancel()

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
@@ -31,8 +31,12 @@ internal interface NfcScanningEventReporter {
      * details from the NFC card held against the device.
      *
      * @param errorCode code generated from NFC scanning flow indicating the error
+     * @param parameters additional context about the failure, such as APDU status words
      */
-    fun onNfcScanAttemptFailed(errorCode: String)
+    fun onNfcScanAttemptFailed(
+        errorCode: String,
+        parameters: Map<String, String> = emptyMap(),
+    )
 
     /**
      * NFC scan flow completed successfully meaning the user is being returned to the calling payment flow after
@@ -74,12 +78,16 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
         fireEvent(eventName = SCAN_ATTEMPT_SUCCEEDED_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
     }
 
-    override fun onNfcScanAttemptFailed(errorCode: String) {
+    override fun onNfcScanAttemptFailed(
+        errorCode: String,
+        parameters: Map<String, String>,
+    ) {
         val duration = durationProvider.end(DurationProvider.Key.NfcScanAttempt)
         fireEvent(
             eventName = SCAN_ATTEMPT_FAILED_EVENT_NAME,
             additionalParams = duration.mapOfDurationInSeconds() +
-                mapOf(FIELD_ERROR_CODE to errorCode)
+                mapOf(FIELD_ERROR_CODE to errorCode) +
+                parameters
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -25,6 +25,7 @@ internal interface NfcCardReader {
         data class Error(
             val errorCode: String,
             val userMessage: ResolvableString,
+            val parameters: Map<String, String> = emptyMap(),
         ) : Result
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardScanner.kt
@@ -23,6 +23,7 @@ internal interface NfcCardScanner {
     data class Error(
         val code: String,
         val userMessage: ResolvableString,
+        val parameters: Map<String, String> = emptyMap(),
     )
 
     val state: Flow<State>
@@ -61,6 +62,7 @@ internal class DefaultNfcCardScanner @Inject constructor(
                                 error = NfcCardScanner.Error(
                                     code = readerResult.errorCode,
                                     userMessage = readerResult.userMessage,
+                                    parameters = readerResult.parameters,
                                 )
                             )
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.nfcscan.scanner.apdu
 
 import com.stripe.android.common.nfcscan.scanner.NfcCardReader
+import com.stripe.android.common.nfcscan.scanner.apdu.pdol.PdolParsingException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import java.io.IOException
@@ -29,6 +30,10 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
             )
             is ApduResponseError.Invalid -> unsupportedCard()
             is ApduResponseError.Command -> mapCommandError(error)
+            is PdolParsingException -> NfcCardReader.Result.Error(
+                errorCode = PDOL_PARSING_ERROR_CODE,
+                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+            )
             is IllegalStateException -> generalFailure()
             else -> NfcCardReader.Result.Error(
                 errorCode = UNKNOWN_ERROR_CODE,
@@ -38,11 +43,24 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
     }
 
     private fun mapCommandError(error: ApduResponseError.Command): NfcCardReader.Result.Error {
+        val parameters = commandErrorParameters(error)
+
         return when {
-            isDeclined(error) -> declined()
-            isUnsupported(error) -> unsupportedCard()
-            else -> generalFailure()
+            isDeclined(error) -> declined(parameters)
+            isUnsupported(error) -> unsupportedCard(parameters)
+            else -> generalFailure(parameters)
         }
+    }
+
+    private fun commandErrorParameters(error: ApduResponseError.Command): Map<String, String> {
+        return mapOf(
+            SW1_PARAMETER to formatStatusWord(error.sw1),
+            SW2_PARAMETER to formatStatusWord(error.sw2),
+        )
+    }
+
+    private fun formatStatusWord(statusWord: Byte): String {
+        return String.format(STATUS_WORD_FORMAT, statusWord.toInt() and STATUS_WORD_MASK)
     }
 
     private fun isDeclined(error: ApduResponseError.Command): Boolean {
@@ -59,24 +77,33 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
         }
     }
 
-    private fun unsupportedCard(): NfcCardReader.Result.Error {
+    private fun unsupportedCard(
+        parameters: Map<String, String> = emptyMap(),
+    ): NfcCardReader.Result.Error {
         return NfcCardReader.Result.Error(
             errorCode = UNSUPPORTED_CARD_ERROR_CODE,
             userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+            parameters = parameters,
         )
     }
 
-    private fun declined(): NfcCardReader.Result.Error {
+    private fun declined(
+        parameters: Map<String, String> = emptyMap(),
+    ): NfcCardReader.Result.Error {
         return NfcCardReader.Result.Error(
             errorCode = CARD_DECLINED_ERROR_CODE,
             userMessage = R.string.stripe_nfc_scan_error_declined_card.resolvableString,
+            parameters = parameters,
         )
     }
 
-    private fun generalFailure(): NfcCardReader.Result.Error {
+    private fun generalFailure(
+        parameters: Map<String, String> = emptyMap(),
+    ): NfcCardReader.Result.Error {
         return NfcCardReader.Result.Error(
             errorCode = GENERAL_READ_ERROR_CODE,
             userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+            parameters = parameters,
         )
     }
 
@@ -87,6 +114,12 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
 
         const val APDU_RESPONSE_TOO_SHORT_ERROR_CODE = "apduResponseTooShort"
         const val APDU_RESPONSE_PARSING_ERROR_CODE = "apduParsingCode"
+        const val PDOL_PARSING_ERROR_CODE = "pdolParsingError"
+
+        const val SW1_PARAMETER = "sw1"
+        const val SW2_PARAMETER = "sw2"
+        const val STATUS_WORD_FORMAT = "%02X"
+        const val STATUS_WORD_MASK = 0xFF
 
         const val UNSUPPORTED_CARD_ERROR_CODE = "cardUnsupportedByNfc"
         const val CARD_DECLINED_ERROR_CODE = "cardDeclinedByNfc"

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/PdolBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/PdolBuilder.kt
@@ -29,6 +29,20 @@ internal class DefaultPdolBuilder @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
         template: ByteArray,
     ): ByteArray {
+        return runCatching {
+            buildFromTemplate(
+                paymentMethodMetadata = paymentMethodMetadata,
+                template = template,
+            )
+        }.getOrElse { cause ->
+            throw PdolParsingException(cause)
+        }
+    }
+
+    private fun buildFromTemplate(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        template: ByteArray,
+    ): ByteArray {
         if (template.isEmpty()) {
             return byteArrayOf()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/PdolParsingException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/pdol/PdolParsingException.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.common.nfcscan.scanner.apdu.pdol
+
+internal class PdolParsingException(
+    override val cause: Throwable,
+) : Exception("Failed to parse PDOL template", cause)

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -84,7 +84,38 @@ internal class NfcScanningViewModelTest {
                 ),
             ),
         )
-        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("expiredCard")
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo(
+            FakeNfcScanningEventReporter.NfcScanAttemptFailedCall(
+                errorCode = "expiredCard",
+                parameters = emptyMap(),
+            ),
+        )
+    }
+
+    @Test
+    fun `card scanner failed reports attempt failed with error parameters`() = runScenario {
+        scannerState.emit(
+            NfcCardScanner.State.Failed(
+                error = NfcCardScanner.Error(
+                    code = "nfcCardReadFailed",
+                    userMessage = R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+                    parameters = mapOf(
+                        "sw1" to "64",
+                        "sw2" to "00",
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo(
+            FakeNfcScanningEventReporter.NfcScanAttemptFailedCall(
+                errorCode = "nfcCardReadFailed",
+                parameters = mapOf(
+                    "sw1" to "64",
+                    "sw2" to "00",
+                ),
+            ),
+        )
     }
 
     @Test
@@ -147,7 +178,12 @@ internal class NfcScanningViewModelTest {
             )
 
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Idle(error = errorMessage))
-            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("unknown")
+            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo(
+                FakeNfcScanningEventReporter.NfcScanAttemptFailedCall(
+                    errorCode = "unknown",
+                    parameters = emptyMap(),
+                ),
+            )
             assertThat(fakeTimeoutManager.resetCalls.awaitItem()).isNotNull()
         }
     }
@@ -168,7 +204,12 @@ internal class NfcScanningViewModelTest {
                 ),
             )
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Idle(error = errorMessage))
-            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("unknown")
+            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo(
+                FakeNfcScanningEventReporter.NfcScanAttemptFailedCall(
+                    errorCode = "unknown",
+                    parameters = emptyMap(),
+                ),
+            )
 
             scannerState.emit(NfcCardScanner.State.Scanning)
             assertThat(awaitItem().status).isEqualTo(NfcScanningStatus.Scanning)
@@ -231,7 +272,12 @@ internal class NfcScanningViewModelTest {
             )
         }
 
-        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo("expiredCard")
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isEqualTo(
+            FakeNfcScanningEventReporter.NfcScanAttemptFailedCall(
+                errorCode = "expiredCard",
+                parameters = emptyMap(),
+            ),
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
@@ -85,6 +85,24 @@ internal class DefaultNfcScanningEventReporterTest {
     }
 
     @Test
+    fun `onNfcScanAttemptFailed includes parameters in analytics event`() = runScenario {
+        durationProvider.start(DurationProvider.Key.NfcScanAttempt)
+
+        reporter.onNfcScanAttemptFailed(
+            errorCode = "nfcCardReadFailed",
+            parameters = mapOf(
+                "sw1" to "64",
+                "sw2" to "00",
+            ),
+        )
+
+        val loggedParams = executor.getExecutedRequests().single().params
+        assertThat(loggedParams).containsEntry("error_code", "nfcCardReadFailed")
+        assertThat(loggedParams).containsEntry("sw1", "64")
+        assertThat(loggedParams).containsEntry("sw2", "00")
+    }
+
+    @Test
     fun `onNfcScanCancelled ends duration and fires event with cancellation reason`() = runScenario {
         reporter.onNfcScanCancelled(NfcScanCancellationReason.Timeout)
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
@@ -6,9 +6,14 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
     val onNfcScanStartedCalls = Turbine<Unit>()
     val onNfcScanAttemptStartedCalls = Turbine<Unit>()
     val onNfcScanAttemptSucceededCalls = Turbine<Unit>()
-    val onNfcScanAttemptFailedCalls = Turbine<String>()
+    val onNfcScanAttemptFailedCalls = Turbine<NfcScanAttemptFailedCall>()
     val onNfcScanSucceededCalls = Turbine<Unit>()
     val onNfcScanCancelledCalls = Turbine<NfcScanCancellationReason>()
+
+    data class NfcScanAttemptFailedCall(
+        val errorCode: String,
+        val parameters: Map<String, String>,
+    )
 
     override fun onNfcScanStarted() {
         onNfcScanStartedCalls.add(Unit)
@@ -22,8 +27,16 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
         onNfcScanAttemptSucceededCalls.add(Unit)
     }
 
-    override fun onNfcScanAttemptFailed(errorCode: String) {
-        onNfcScanAttemptFailedCalls.add(errorCode)
+    override fun onNfcScanAttemptFailed(
+        errorCode: String,
+        parameters: Map<String, String>,
+    ) {
+        onNfcScanAttemptFailedCalls.add(
+            NfcScanAttemptFailedCall(
+                errorCode = errorCode,
+                parameters = parameters,
+            ),
+        )
     }
 
     override fun onNfcScanSucceeded() {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.nfcscan.scanner.apdu
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.scanner.NfcCardReader
+import com.stripe.android.common.nfcscan.scanner.apdu.pdol.PdolParsingException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import org.junit.Test
@@ -23,6 +24,12 @@ internal class ApduErrorCreatorTest {
         assertThat(result.errorCode).isEqualTo("cardUnsupportedByNfc")
         assertThat(result.userMessage).isEqualTo(
             R.string.stripe_nfc_scan_unsupported_card.resolvableString,
+        )
+        assertThat(result.parameters).isEqualTo(
+            mapOf(
+                "sw1" to "6A",
+                "sw2" to "82",
+            ),
         )
     }
 
@@ -83,6 +90,26 @@ internal class ApduErrorCreatorTest {
         assertThat(result.errorCode).isEqualTo("nfcCardReadFailed")
         assertThat(result.userMessage).isEqualTo(
             R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
+        )
+        assertThat(result.parameters).isEqualTo(
+            mapOf(
+                "sw1" to "64",
+                "sw2" to "00",
+            ),
+        )
+    }
+
+    @Test
+    fun `create returns pdol parsing error for PdolParsingException`() {
+        val result = errorMapper.create(
+            PdolParsingException(cause = IndexOutOfBoundsException("invalid template")),
+        )
+
+        assertThat(result).isEqualTo(
+            NfcCardReader.Result.Error(
+                errorCode = "pdolParsingError",
+                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+            ),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/DefaultPdolBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/DefaultPdolBuilderTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.common.nfcscan.scanner.apdu
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.nfcscan.scanner.apdu.pdol.DefaultPdolBuilder
 import com.stripe.android.common.nfcscan.scanner.apdu.pdol.FakeTagValueProducer
+import com.stripe.android.common.nfcscan.scanner.apdu.pdol.PdolParsingException
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.testing.PaymentIntentFactory
@@ -10,6 +11,22 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 internal class DefaultPdolBuilderTest {
+    @Test
+    fun `fromTemplate throws PdolParsingException for malformed template`() = runScenario(
+        tagValueProducers = emptySet(),
+    ) {
+        val malformedTemplate = byteArrayOf(0x9F.toByte())
+
+        val exception = runCatching {
+            builder.fromTemplate(
+                paymentMethodMetadata = paymentMethodMetadata,
+                template = malformedTemplate,
+            )
+        }.exceptionOrNull()
+
+        assertThat(exception).isInstanceOf(PdolParsingException::class.java)
+    }
+
     @Test
     fun `fromTemplate returns empty payload when template is empty`() = runScenario(
         tagValueProducers = emptySet(),


### PR DESCRIPTION
# Summary
Add additional error insights into NFC scanning by allowing the `NfcCardScanner` and `NfcCardReader` to return parameters that can be sent while reporting a failed NFC attempt. Currently reports any status codes received from any of the APDU commands sent to the card chip. Also better reported errors that come failed attempts at parsing the PDOL due to malformed data.

# Motivation
Better insight into NFC failures.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified