### PR TITLE
 Show required field errors when Save address is tapped with incomplete form in shipping address

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -53,6 +53,7 @@ class InputAddressScreenTest {
                     primaryButtonText = "Save Address",
                     title = "Address",
                     onPrimaryButtonClick = primaryButtonCallback,
+                    onDisabledButtonClick = {},
                     onCloseClick = onCloseCallback,
                     topContent = {},
                     formContent = {},

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -36,6 +36,7 @@ internal fun InputAddressScreen(
     primaryButtonText: String,
     title: String,
     onPrimaryButtonClick: () -> Unit,
+    onDisabledButtonClick: () -> Unit,
     onCloseClick: () -> Unit,
     topContent: @Composable ColumnScope.() -> Unit,
     formContent: @Composable ColumnScope.() -> Unit,
@@ -78,6 +79,11 @@ internal fun InputAddressScreen(
                         focusManager.clearFocus()
                         onPrimaryButtonClick()
                     },
+                    canClickWhileDisabled = true,
+                    onDisabledButtonClick = {
+                        focusManager.clearFocus()
+                        onDisabledButtonClick()
+                    },
                     modifier = Modifier.padding(vertical = 16.dp),
                 )
             }
@@ -108,13 +114,19 @@ internal fun InputAddressScreen(
     val billingSameAsShippingState by viewModel.shippingSameAsBillingState.collectAsState()
 
     InputAddressScreen(
-        primaryButtonEnabled = completeValues != null,
+        primaryButtonEnabled = completeValues != null && formEnabled,
         primaryButtonText = buttonText,
         title = titleText,
         onPrimaryButtonClick = {
             viewModel.clickPrimaryButton(
                 completeValues,
                 checkboxChecked
+            )
+        },
+        onDisabledButtonClick = {
+            viewModel.clickPrimaryButton(
+                completedFormValues = null,
+                checkboxChecked = checkboxChecked
             )
         },
         onCloseClick = { viewModel.navigator.dismiss() },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -114,7 +114,7 @@ internal fun InputAddressScreen(
     val billingSameAsShippingState by viewModel.shippingSameAsBillingState.collectAsState()
 
     InputAddressScreen(
-        primaryButtonEnabled = completeValues != null && formEnabled,
+        primaryButtonEnabled = completeValues != null,
         primaryButtonText = buttonText,
         title = titleText,
         onPrimaryButtonClick = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -202,19 +202,23 @@ internal class InputAddressViewModel @Inject constructor(
         completedFormValues: Map<IdentifierSpec, FormFieldEntry>?,
         checkboxChecked: Boolean
     ) {
+        if (completedFormValues == null) {
+            addressFormController.elements.forEach { it.onValidationStateChanged(true) }
+            return
+        }
         _formEnabled.value = false
         dismissWithAddress(
             AddressDetails(
-                name = completedFormValues?.get(IdentifierSpec.Name)?.value,
+                name = completedFormValues[IdentifierSpec.Name]?.value,
                 address = PaymentSheet.Address(
-                    city = completedFormValues?.get(IdentifierSpec.City)?.value,
-                    country = completedFormValues?.get(IdentifierSpec.Country)?.value,
-                    line1 = completedFormValues?.get(IdentifierSpec.Line1)?.value,
-                    line2 = completedFormValues?.get(IdentifierSpec.Line2)?.value,
-                    postalCode = completedFormValues?.get(IdentifierSpec.PostalCode)?.value,
-                    state = completedFormValues?.get(IdentifierSpec.State)?.value
+                    city = completedFormValues[IdentifierSpec.City]?.value,
+                    country = completedFormValues[IdentifierSpec.Country]?.value,
+                    line1 = completedFormValues[IdentifierSpec.Line1]?.value,
+                    line2 = completedFormValues[IdentifierSpec.Line2]?.value,
+                    postalCode = completedFormValues[IdentifierSpec.PostalCode]?.value,
+                    state = completedFormValues[IdentifierSpec.State]?.value
                 ),
-                phoneNumber = completedFormValues?.get(IdentifierSpec.Phone)?.value,
+                phoneNumber = completedFormValues[IdentifierSpec.Phone]?.value,
                 isCheckboxSelected = checkboxChecked
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -209,16 +209,16 @@ internal class InputAddressViewModel @Inject constructor(
         _formEnabled.value = false
         dismissWithAddress(
             AddressDetails(
-                name = completedFormValues[IdentifierSpec.Name]?.value,
+                name = completedFormValues?.get(IdentifierSpec.Name)?.value,
                 address = PaymentSheet.Address(
-                    city = completedFormValues[IdentifierSpec.City]?.value,
-                    country = completedFormValues[IdentifierSpec.Country]?.value,
-                    line1 = completedFormValues[IdentifierSpec.Line1]?.value,
-                    line2 = completedFormValues[IdentifierSpec.Line2]?.value,
-                    postalCode = completedFormValues[IdentifierSpec.PostalCode]?.value,
-                    state = completedFormValues[IdentifierSpec.State]?.value
+                    city = completedFormValues?.get(IdentifierSpec.City)?.value,
+                    country = completedFormValues?.get(IdentifierSpec.Country)?.value,
+                    line1 = completedFormValues?.get(IdentifierSpec.Line1)?.value,
+                    line2 = completedFormValues?.get(IdentifierSpec.Line2)?.value,
+                    postalCode = completedFormValues?.get(IdentifierSpec.PostalCode)?.value,
+                    state = completedFormValues?.get(IdentifierSpec.State)?.value
                 ),
-                phoneNumber = completedFormValues[IdentifierSpec.Phone]?.value,
+                phoneNumber = completedFormValues?.get(IdentifierSpec.Phone)?.value,
                 isCheckboxSelected = checkboxChecked
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -947,43 +947,21 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `clickPrimaryButton with null triggers validation on form elements`() = runTest {
+    fun `clickPrimaryButton with null triggers validation errors without dismissing`() = runTest {
         val viewModel = createViewModel()
+
+        val sectionElement = viewModel.addressFormController.elements[0] as SectionElement
+        val autocompleteElement = sectionElement.fields[0] as AutocompleteAddressElement
+        val controller = autocompleteElement.sectionFieldErrorController()
+
+        assertThat(controller.validationMessage.value).isNull()
 
         viewModel.clickPrimaryButton(
             completedFormValues = null,
             checkboxChecked = false
         )
 
-        val sectionElement = viewModel.addressFormController.elements[0] as SectionElement
-        val autocompleteElement = sectionElement.fields[0] as AutocompleteAddressElement
-        val addressController = autocompleteElement.sectionFieldErrorController()
-            .addressElementFlow
-            .value
-            .addressController
-            .value
-        val fields = addressController.fieldsFlowable.value
-        fields.forEach { field ->
-            field.getFormFieldValueFlow().value.forEach { (_, entry) ->
-                if (!entry.isComplete) {
-                    assertThat(entry.isComplete).isFalse()
-                }
-            }
-        }
-
-        assertThat(viewModel.formEnabled.value).isTrue()
-        verify(navigator, never()).dismiss(any())
-    }
-
-    @Test
-    fun `clickPrimaryButton with null does not disable form or dismiss`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.clickPrimaryButton(
-            completedFormValues = null,
-            checkboxChecked = true
-        )
-
+        assertThat(controller.validationMessage.value).isNotNull()
         assertThat(viewModel.formEnabled.value).isTrue()
         verify(navigator, never()).dismiss(any())
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -943,6 +944,48 @@ class InputAddressViewModelTest {
         addressFields.forEach {
             it.setRawValue(values)
         }
+    }
+
+    @Test
+    fun `clickPrimaryButton with null triggers validation on form elements`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.clickPrimaryButton(
+            completedFormValues = null,
+            checkboxChecked = false
+        )
+
+        val sectionElement = viewModel.addressFormController.elements[0] as SectionElement
+        val autocompleteElement = sectionElement.fields[0] as AutocompleteAddressElement
+        val addressController = autocompleteElement.sectionFieldErrorController()
+            .addressElementFlow
+            .value
+            .addressController
+            .value
+        val fields = addressController.fieldsFlowable.value
+        fields.forEach { field ->
+            field.getFormFieldValueFlow().value.forEach { (_, entry) ->
+                if (!entry.isComplete) {
+                    assertThat(entry.isComplete).isFalse()
+                }
+            }
+        }
+
+        assertThat(viewModel.formEnabled.value).isTrue()
+        verify(navigator, never()).dismiss(any())
+    }
+
+    @Test
+    fun `clickPrimaryButton with null does not disable form or dismiss`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.clickPrimaryButton(
+            completedFormValues = null,
+            checkboxChecked = true
+        )
+
+        assertThat(viewModel.formEnabled.value).isTrue()
+        verify(navigator, never()).dismiss(any())
     }
 
     @Test


### PR DESCRIPTION

# Summary
<!-- Simple summary of what was changed. -->
Show required field validation errors when "Save address" is tapped with an incomplete form in the standalone/shipping address element.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
 In the billing address form (PaymentSheet), tapping "Pay" with empty required fields shows red underlines and "this field is required" messages. However, in the shipping/standalone address element, the "Save address" button was unresponsive when fields were missing, giving users no feedback about what needs to be filled in. This inconsistency made the standalone address form harder to use.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Verified that:
    - The "Save address" button remains visually grayed out when required fields are empty (unchanged appearance)
    - Tapping the grayed-out button now triggers red "required" underlines on incomplete fields
    - Once all required fields are filled, the button becomes active and dismisses with the address as before

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img width="318" alt="Before" src="https://github.com/user-attachments/assets/084cef15-9560-404a-8acb-b3732c61783e" /> | <img width="303" alt="After" src="https://github.com/user-attachments/assets/91268ba9-cb7e-4ee0-84a6-f2bce0252c1c" /> |



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
Address Element
[ADDED] Standalone/shipping address element now shows required field validation errors when "Save address" is tapped with incomplete fields.
