### PR TITLE
Reveal CustomerSheet and Address Element primary buttons above the keyboard

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetKeyboardTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetKeyboardTest.kt
@@ -1,0 +1,76 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
+import com.stripe.android.networktesting.elementsSession
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.CustomerSheetTestType
+import com.stripe.android.paymentsheet.utils.CustomerSheetUtils
+import com.stripe.android.paymentsheet.utils.IntegrationType
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
+import org.junit.Rule
+import org.junit.Test
+
+@RequiresIme
+internal class CustomerSheetKeyboardTest {
+    private val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(composeTestRule = composeTestRule)
+
+    private val networkRule = testRules.networkRule
+    private val page = CustomerSheetPage(composeTestRule)
+
+    @Test
+    fun saveButtonIsVisibleAboveKeyboardWhenCardFormBecomesComplete() = runCustomerSheetTest(
+        scenario = composeTestRule.activityRule.scenario,
+        networkRule = networkRule,
+        integrationType = IntegrationType.Activity,
+        customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,
+        configuration = CustomerSheet.Configuration.builder(merchantDisplayName = "Merchant Inc.")
+            .defaultBillingDetails(defaultBillingDetailsWithoutPostalCode)
+            .billingDetailsCollectionConfiguration(fullAddressCollection)
+            .build(),
+        resultCallback = { error("CustomerSheet should not return a result") },
+    ) { context ->
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = false)
+
+        context.presentCustomerSheet()
+
+        page.fillOutCardDetails(fillOutZipCode = false)
+        page.assertSaveButtonDisabled()
+        page.focusZipCode()
+        composeTestRule.waitForKeyboardToBeVisible()
+        composeTestRule.onNodeWithTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
+            .assertIsNotDisplayed()
+
+        page.enterZipCode()
+        page.assertSaveButtonEnabled()
+        composeTestRule.assertNodeWithTagVisibleAboveKeyboard(
+            testTag = CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG,
+        )
+
+        context.markTestSucceeded()
+    }
+
+    private companion object {
+        val defaultBillingDetailsWithoutPostalCode = PaymentSheet.BillingDetails(
+            address = PaymentSheet.Address(
+                line1 = "123 Main Street",
+                city = "San Francisco",
+                state = "CA",
+                country = "US",
+            ),
+        )
+        val fullAddressCollection = PaymentSheet.BillingDetailsCollectionConfiguration(
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/KeyboardAssertions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/KeyboardAssertions.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.paymentsheet
+
+import android.view.View
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import com.google.common.truth.Truth.assertThat
+import kotlin.math.roundToInt
+
+private const val KEYBOARD_VISIBILITY_TIMEOUT_MS = 5_000L
+
+/** Waits for the IME opened by a real form-field focus action to become visible. */
+internal fun ComposeTestRule.waitForKeyboardToBeVisible() {
+    waitUntil(KEYBOARD_VISIBILITY_TIMEOUT_MS) {
+        currentRootView().imeBottomInset() > 0
+    }
+}
+
+/** Asserts that [testTag]'s bottom is not occluded by the currently visible IME. */
+internal fun ComposeTestRule.assertNodeWithTagVisibleAboveKeyboard(
+    testTag: String,
+) {
+    waitUntil(KEYBOARD_VISIBILITY_TIMEOUT_MS) {
+        nodePositionRelativeToKeyboard(testTag).isAboveKeyboard
+    }
+    val position = nodePositionRelativeToKeyboard(testTag)
+    assertThat(position.imeBottomInset).isGreaterThan(0)
+    assertThat(position.nodeBottom).isAtMost(position.keyboardTop)
+}
+
+private fun ComposeTestRule.nodePositionRelativeToKeyboard(testTag: String): NodePosition {
+    waitForIdle()
+    val node = onNodeWithTag(testTag).fetchSemanticsNode()
+    val rootView = currentRootView()
+    val imeBottomInset = rootView.imeBottomInset()
+    val rootLocation = IntArray(2)
+    rootView.getLocationOnScreen(rootLocation)
+    val keyboardTop = rootLocation[1] + rootView.height - imeBottomInset
+    val nodeBottom = rootLocation[1] + node.boundsInWindow.bottom.roundToInt()
+
+    return NodePosition(
+        imeBottomInset = imeBottomInset,
+        keyboardTop = keyboardTop,
+        nodeBottom = nodeBottom,
+    )
+}
+
+private fun currentRootView(): View {
+    var rootView: View? = null
+    onView(isRoot()).check { view, _ ->
+        rootView = view
+    }
+    return requireNotNull(rootView)
+}
+
+private fun View.imeBottomInset(): Int {
+    return ViewCompat.getRootWindowInsets(this)
+        ?.getInsets(WindowInsetsCompat.Type.ime())
+        ?.bottom
+        ?: 0
+}
+
+private data class NodePosition(
+    val imeBottomInset: Int,
+    val keyboardTop: Int,
+    val nodeBottom: Int,
+) {
+    val isAboveKeyboard: Boolean
+        get() = imeBottomInset > 0 && nodeBottom <= keyboardTop
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -1,14 +1,32 @@
 package com.stripe.android.paymentsheet.addresselement
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.MainActivity
+import com.stripe.android.paymentsheet.RequiresIme
+import com.stripe.android.paymentsheet.assertNodeWithTagVisibleAboveKeyboard
+import com.stripe.android.paymentsheet.waitForKeyboardToBeVisible
 import com.stripe.android.uicore.DefaultStripeTheme
 import org.junit.Rule
 import org.junit.Test
@@ -18,7 +36,7 @@ import org.junit.runner.RunWith
 class InputAddressScreenTest {
 
     @get:Rule
-    val composeTestRule = createComposeRule()
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     @Test
     fun clicking_primary_button_triggers_callback_when_enabled() {
@@ -46,6 +64,53 @@ class InputAddressScreenTest {
         assertThat(counter).isEqualTo(1)
     }
 
+    @RequiresIme
+    @Test
+    fun primaryButtonIsVisibleAboveKeyboardWhenAddressBecomesComplete() {
+        composeTestRule.setContent {
+            var address by remember { mutableStateOf("") }
+
+            DefaultStripeTheme {
+                InputAddressScreen(
+                    primaryButtonEnabled = address.isNotEmpty(),
+                    primaryButtonText = "Save Address",
+                    title = "Address",
+                    onPrimaryButtonClick = {},
+                    onDisabledButtonClick = {},
+                    onCloseClick = {},
+                    topContent = {},
+                    formContent = {
+                        Spacer(modifier = Modifier.height(800.dp))
+                        TextField(
+                            value = address,
+                            onValueChange = { address = it },
+                            label = { Text("Address line 1") },
+                            modifier = Modifier.testTag(ADDRESS_FIELD_TEST_TAG),
+                        )
+                    },
+                    bottomContent = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG)
+            .assertIsNotEnabled()
+        composeTestRule.onNodeWithTag(ADDRESS_FIELD_TEST_TAG)
+            .performScrollTo()
+            .performClick()
+        composeTestRule.waitForKeyboardToBeVisible()
+        composeTestRule.onNodeWithTag(ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG)
+            .assertIsNotDisplayed()
+
+        composeTestRule.onNodeWithTag(ADDRESS_FIELD_TEST_TAG)
+            .performTextInput("510 Townsend St")
+        composeTestRule.onNodeWithTag(ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG)
+            .assertIsEnabled()
+        composeTestRule.assertNodeWithTagVisibleAboveKeyboard(
+            testTag = ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG,
+        )
+    }
+
     private fun setContent(
         primaryButtonEnabled: Boolean = true,
         primaryButtonCallback: () -> Unit = {},
@@ -66,5 +131,9 @@ class InputAddressScreenTest {
                 )
             }
         }
+    }
+
+    private companion object {
+        const val ADDRESS_FIELD_TEST_TAG = "address_field"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -4,13 +4,18 @@ import androidx.annotation.RestrictTo
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.nfcscan.LocalNfcScanEventShownReporter
@@ -34,6 +39,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.PaymentElement
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
+import com.stripe.android.paymentsheet.ui.RevealPrimaryButtonWhenEnabled
 import com.stripe.android.paymentsheet.ui.SavedPaymentMethodTabLayoutUI
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
@@ -214,6 +220,14 @@ internal fun AddPaymentMethod(
     displayForm: Boolean,
 ) {
     val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val primaryButtonBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+
+    RevealPrimaryButtonWhenEnabled(
+        isEnabled = viewState.primaryButtonEnabled,
+        isImeVisible = isImeVisible,
+        bringIntoViewRequester = primaryButtonBringIntoViewRequester,
+    )
 
     if (viewState.displayDismissConfirmationModal) {
         SimpleDialogElementUI(
@@ -317,7 +331,8 @@ internal fun AddPaymentMethod(
         },
         modifier = Modifier
             .padding(top = 10.dp)
-            .padding(horizontalPadding),
+            .padding(horizontalPadding)
+            .bringIntoViewRequester(primaryButtonBringIntoViewRequester),
         testTag = CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -2,9 +2,13 @@ package com.stripe.android.paymentsheet.addresselement
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -12,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -21,6 +26,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
+import com.stripe.android.paymentsheet.ui.RevealPrimaryButtonWhenEnabled
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
@@ -43,6 +49,15 @@ internal fun InputAddressScreen(
     bottomContent: @Composable ColumnScope.() -> Unit
 ) {
     val focusManager = LocalFocusManager.current
+    val primaryButtonBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+
+    RevealPrimaryButtonWhenEnabled(
+        isEnabled = primaryButtonEnabled,
+        isImeVisible = isImeVisible,
+        bringIntoViewRequester = primaryButtonBringIntoViewRequester,
+    )
+
     Scaffold(
         modifier = Modifier
             .fillMaxHeight()
@@ -84,7 +99,9 @@ internal fun InputAddressScreen(
                         focusManager.clearFocus()
                         onDisabledButtonClick()
                     },
-                    modifier = Modifier.padding(vertical = 16.dp),
+                    modifier = Modifier
+                        .padding(vertical = 16.dp)
+                        .bringIntoViewRequester(primaryButtonBringIntoViewRequester),
                     testTag = ADDRESS_ELEMENT_PRIMARY_BUTTON_TEST_TAG,
                 )
             }


### PR DESCRIPTION
## Summary
- reveal the CustomerSheet Save button and Address Element primary button when form completion enables them while the keyboard is visible
- reuse the primary-button reveal behavior introduced by #13671
- derive IME geometry from the currently focused Espresso root without exposing CustomerSheetActivity from the test harness
- cover real off-screen-to-visible transitions for CustomerSheet and Address Element under RequiresIme
- use full address collection in the CustomerSheet test so ZIP remains the final enablement step

## Stack
- base: #13676
- test semantics: #13673
- PaymentSheet reveal behavior: #13671
- IME routing: #13674

## Validation
- ./gradlew :paymentsheet:compileDebugAndroidTestKotlin
- focused CustomerSheetKeyboardTest managed-device test
- focused InputAddressScreenTest managed-device test
- path-aware pre-push hook: full detekt and apiCheck