### PR TITLE
Use different message for internal errors in NFC scanning

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -104,6 +104,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_network_error_message">An error occurred. Check your connection and try again.</string>
   <!-- Error message with user action shown in NFC scanning flow when the card is expired. -->
   <string name="stripe_nfc_expired_error">Card expired. Try another card.</string>
+  <!-- Error with action to take shown in the NFC scanning flow if an internal SDK error occurs -->
+  <string name="stripe_nfc_scan_internal_error_message">Something went wrong. Try again later</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card was declined -->
   <string name="stripe_nfc_scan_error_declined_card">Card declined. Try another card.</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card is expired -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -105,7 +105,7 @@ to be saved and used in future checkout sessions. -->
   <!-- Error message with user action shown in NFC scanning flow when the card is expired. -->
   <string name="stripe_nfc_expired_error">Card expired. Try another card.</string>
   <!-- Error with action to take shown in the NFC scanning flow if an internal SDK error occurs -->
-  <string name="stripe_nfc_scan_internal_error_message">Something went wrong. Try again later</string>
+  <string name="stripe_nfc_scan_internal_error_message">Something went wrong. Try another card.</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card was declined -->
   <string name="stripe_nfc_scan_error_declined_card">Card declined. Try another card.</string>
   <!-- Error with action to take shown in the NFC scanning flow if the scanned card is expired -->

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreator.kt
@@ -21,11 +21,11 @@ internal class ApduErrorCreator @Inject constructor() : NfcCardReader.ErrorCreat
             )
             is ApduResponseError.TooShort -> NfcCardReader.Result.Error(
                 errorCode = APDU_RESPONSE_TOO_SHORT_ERROR_CODE,
-                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+                userMessage = R.string.stripe_nfc_scan_internal_error_message.resolvableString,
             )
             is ApduResponseError.Parsing -> NfcCardReader.Result.Error(
                 errorCode = APDU_RESPONSE_PARSING_ERROR_CODE,
-                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+                userMessage = R.string.stripe_nfc_scan_internal_error_message.resolvableString,
             )
             is ApduResponseError.Invalid -> unsupportedCard()
             is ApduResponseError.Command -> mapCommandError(error)

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduErrorCreatorTest.kt
@@ -117,7 +117,7 @@ internal class ApduErrorCreatorTest {
         assertThat(result).isEqualTo(
             NfcCardReader.Result.Error(
                 errorCode = "apduResponseTooShort",
-                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+                userMessage = R.string.stripe_nfc_scan_internal_error_message.resolvableString,
             ),
         )
     }
@@ -134,7 +134,7 @@ internal class ApduErrorCreatorTest {
         assertThat(result).isEqualTo(
             NfcCardReader.Result.Error(
                 errorCode = "apduParsingCode",
-                userMessage = R.string.stripe_something_went_wrong.resolvableString,
+                userMessage = R.string.stripe_nfc_scan_internal_error_message.resolvableString,
             ),
         )
     }


### PR DESCRIPTION
# Summary
Use different message for internal errors in NFC scanning.

# Motivation
Have both an error message and action for the user to perform like other messages in NFC scanning.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified