### PR TITLE
Make PMM linkBrand field private

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -74,7 +74,7 @@ internal data class PaymentMethodMetadata(
     val isGooglePayReady: Boolean,
     val linkConfiguration: PaymentSheet.LinkConfiguration,
     val linkMode: LinkMode?,
-    val linkBrand: LinkBrand,
+    private val linkBrand: LinkBrand,
     val linkStateResult: LinkStateResult?,
     val paymentMethodIncentive: PaymentMethodIncentive?,
     val financialConnectionsAvailability: FinancialConnectionsAvailability?,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make PMM linkBrand field private

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Callers should always prefer `effectiveLinkBrand` which will get the right brand for a logged in Link consumer. `linkBrand` is based just on the configuration and could be incorrect for a logged in consumer. We keep a reference to the field in PaymentMethodMetadata to use when there is no logged in consumer.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified