### PR TITLE
Switch to expanded mode for unsupported countries

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -61,11 +61,13 @@ internal class InlineAutocompleteController(
                     if (!isCountrySupported(c)) {
                         lastPredictionLine1 = null
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                        eventListenerProvider()?.invoke(
-                            AutocompleteAddressInteractor.Event.OnValues(
-                                mapOf(IdentifierSpec.Country to c)
+                        if (countryChanged) {
+                            eventListenerProvider()?.invoke(
+                                AutocompleteAddressInteractor.Event.OnValues(
+                                    mapOf(IdentifierSpec.Country to c)
+                                )
                             )
-                        )
+                        }
                         return@collectLatest
                     }
                     if (q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -58,19 +58,7 @@ internal class InlineAutocompleteController(
                     if (countryChanged) {
                         lastObservedCountry = c
                     }
-                    if (!isCountrySupported(c)) {
-                        lastPredictionLine1 = null
-                        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                        if (countryChanged) {
-                            eventListenerProvider()?.invoke(
-                                AutocompleteAddressInteractor.Event.OnValues(
-                                    mapOf(IdentifierSpec.Country to c)
-                                )
-                            )
-                        }
-                        return@collectLatest
-                    }
-                    if (q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE) {
+                    if (!isCountrySupported(c) || q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE) {
                         lastPredictionLine1 = null
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                         if (countryChanged) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -27,6 +27,7 @@ internal class InlineAutocompleteController(
     private val eventListenerProvider: () -> ((AutocompleteAddressInteractor.Event) -> Unit)?,
 ) {
     private var lastPredictionLine1: String? = null
+    private var lastObservedCountry: String? = null
     private var queryFlow: StateFlow<String>? = null
     private var countryFlow: StateFlow<String?>? = null
     private var observeJob: Job? = null
@@ -43,6 +44,7 @@ internal class InlineAutocompleteController(
         observeJob?.cancel()
         queryFlow = query
         countryFlow = country
+        lastObservedCountry = country.value ?: ""
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
                 .debounce(AutocompleteViewModel.SEARCH_DEBOUNCE_MS)
@@ -52,9 +54,30 @@ internal class InlineAutocompleteController(
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                         return@collectLatest
                     }
-                    if (q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE || !isCountrySupported(c)) {
+                    val countryChanged = c != lastObservedCountry
+                    if (countryChanged) {
+                        lastObservedCountry = c
+                    }
+                    if (!isCountrySupported(c)) {
                         lastPredictionLine1 = null
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                        eventListenerProvider()?.invoke(
+                            AutocompleteAddressInteractor.Event.OnValues(
+                                mapOf(IdentifierSpec.Country to c)
+                            )
+                        )
+                        return@collectLatest
+                    }
+                    if (q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE) {
+                        lastPredictionLine1 = null
+                        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                        if (countryChanged) {
+                            eventListenerProvider()?.invoke(
+                                AutocompleteAddressInteractor.Event.OnValues(
+                                    mapOf(IdentifierSpec.Country to c)
+                                )
+                            )
+                        }
                         return@collectLatest
                     }
                     fetchPredictions(q, c)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -65,8 +65,25 @@ class InlineAutocompleteControllerTest {
         advanceTimeBy(500)
 
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+    }
+
+    @Test
+    fun `switching to unsupported country emits OnValues event`() = runScenario(
+        autocompleteCountries = setOf("US")
+    ) {
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        queryFlow.value = "123 Main"
+        countryFlow.value = "CA"
+        advanceTimeBy(500)
+
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
         val event = eventCalls.awaitItem()
-        assertThat(event).isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
+        assertThat(event).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnValues(
+                mapOf(IdentifierSpec.Country to "CA")
+            )
+        )
     }
 
     @Test
@@ -474,7 +491,6 @@ class InlineAutocompleteControllerTest {
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
-        eventCalls.awaitItem()
 
         countryFlow.value = "US"
         advanceTimeBy(500)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -65,6 +65,8 @@ class InlineAutocompleteControllerTest {
         advanceTimeBy(500)
 
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        val event = eventCalls.awaitItem()
+        assertThat(event).isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
     }
 
     @Test
@@ -472,6 +474,7 @@ class InlineAutocompleteControllerTest {
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
+        eventCalls.awaitItem()
 
         countryFlow.value = "US"
         advanceTimeBy(500)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -172,7 +172,7 @@ class AutocompleteAddressController(
         val countrySupported = isCountrySupported(values[IdentifierSpec.Country])
 
         val showInline = inlineAutocompleteActive && !expandForm &&
-            countrySupported && values[IdentifierSpec.Line1] == null
+            countrySupported && values[IdentifierSpec.Line1].isNullOrEmpty()
         return if (showInline) {
             AddressInputMode.AutocompleteInline(
                 googleApiKey = googlePlacesApiKey,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -158,13 +158,22 @@ class AutocompleteAddressController(
         )
     }
 
+    private fun isCountrySupported(country: String?): Boolean {
+        if (country.isNullOrBlank()) return true
+        val supported = config.autocompleteCountries
+        return supported.isEmpty() || supported.any { it.equals(country, ignoreCase = true) }
+    }
+
     private fun toAddressInputMode(
         expandForm: Boolean,
         values: Map<IdentifierSpec, String?>
     ): AddressInputMode {
         val googlePlacesApiKey = config.googlePlacesApiKey
+        val countrySupported = isCountrySupported(values[IdentifierSpec.Country])
 
-        return if (inlineAutocompleteActive && !expandForm && values[IdentifierSpec.Line1] == null) {
+        val showInline = inlineAutocompleteActive && !expandForm &&
+            countrySupported && values[IdentifierSpec.Line1] == null
+        return if (showInline) {
             AddressInputMode.AutocompleteInline(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -196,6 +196,105 @@ class AutocompleteAddressControllerTest {
             assertThat(elements.any { it.identifier == IdentifierSpec.Line1 }).isFalse()
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `Inline autocomplete switches to expanded when country changes to unsupported`() =
+        runTest(UnconfinedTestDispatcher()) {
+            TestAutocompleteAddressInteractor.test(
+                autocompleteConfig = AutocompleteAddressInteractor.Config(
+                    googlePlacesApiKey = null,
+                    autocompleteCountries = setOf("US"),
+                    isPlacesAvailable = false,
+                    isInlineAutocompleteEnabled = true,
+                    shouldUseStripeHostedAutocomplete = true,
+                ),
+            ) {
+                val controller = createAutocompleteAddressController(
+                    interactor = interactor,
+                )
+
+                val registerCall = registerCalls.awaitItem()
+
+                controller.addressElementFlow.test {
+                    val firstElement = awaitItem()
+                    val firstFields = firstElement.fields.value
+
+                    assertThat(
+                        firstFields.any { it is AddressTextFieldElement }
+                    ).isTrue()
+                    assertThat(
+                        firstFields.any { it.identifier == IdentifierSpec.Line1 }
+                    ).isFalse()
+
+                    registerCall.onEvent(
+                        AutocompleteAddressInteractor.Event.OnValues(
+                            values = mapOf(IdentifierSpec.Country to "JP")
+                        )
+                    )
+
+                    val secondElement = awaitItem()
+                    val secondFields = secondElement.fields.value
+
+                    assertThat(
+                        secondFields.any { it is AddressTextFieldElement }
+                    ).isFalse()
+                    assertThat(
+                        secondFields.any { it.identifier == IdentifierSpec.Line1 }
+                    ).isTrue()
+                }
+            }
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `Inline autocomplete resumes when country changes back to supported`() =
+        runTest(UnconfinedTestDispatcher()) {
+            TestAutocompleteAddressInteractor.test(
+                autocompleteConfig = AutocompleteAddressInteractor.Config(
+                    googlePlacesApiKey = null,
+                    autocompleteCountries = setOf("US"),
+                    isPlacesAvailable = false,
+                    isInlineAutocompleteEnabled = true,
+                    shouldUseStripeHostedAutocomplete = true,
+                ),
+            ) {
+                val controller = createAutocompleteAddressController(
+                    interactor = interactor,
+                )
+
+                val registerCall = registerCalls.awaitItem()
+
+                controller.addressElementFlow.test {
+                    awaitItem()
+
+                    registerCall.onEvent(
+                        AutocompleteAddressInteractor.Event.OnValues(
+                            values = mapOf(IdentifierSpec.Country to "JP")
+                        )
+                    )
+
+                    val expandedElement = awaitItem()
+                    assertThat(
+                        expandedElement.fields.value.any { it.identifier == IdentifierSpec.Line1 }
+                    ).isTrue()
+
+                    registerCall.onEvent(
+                        AutocompleteAddressInteractor.Event.OnValues(
+                            values = mapOf(IdentifierSpec.Country to "US")
+                        )
+                    )
+
+                    val inlineElement = awaitItem()
+                    assertThat(
+                        inlineElement.fields.value.any { it is AddressTextFieldElement }
+                    ).isTrue()
+                    assertThat(
+                        inlineElement.fields.value.any { it.identifier == IdentifierSpec.Line1 }
+                    ).isFalse()
+                }
+            }
+        }
+
     @Test
     fun `Element does not use full-screen autocomplete when stripe-hosted is enabled without inline autocomplete`() =
         noAutocompleteTest(


### PR DESCRIPTION


# Summary
<!-- Simple summary of what was changed. -->

When the user switches to a country not supported by inline autocomplete, the address form now switches to expanded mode. When they switch back to a supported country, the form returns to inline autocomplete mode.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Previously, switching to an unsupported country while in inline autocomplete mode left the form in an inconsistent state, the controller stopped fetching predictions but the UI didn't expand to show manual address fields. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A behind feature flag