### PR TITLE
Retrigger autocomplete in expanded mode

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
@@ -55,8 +55,13 @@ class AddressTextFieldUITest {
                     controller = AddressTextFieldController(
                         label = resolvableString(UiCoreR.string.stripe_address_label_address),
                         addressInputMode = AddressInputMode.NoAutocomplete(),
+                        inlineAutocompleteHandler = null,
+                        reportsFormValue = false,
+                        initialQuery = "",
+                        showEnterManually = true,
                     ),
                     enabled = enabled,
+                    onSearchActivated = null,
                     onClick = onClick
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -56,6 +56,10 @@ internal class BillingInlineAutocompleteAddressInteractor(
     val autocompleteFilledAddress: Address?
         get() = inlineController.autocompleteFilledAddress
 
+    override fun onSearchActivated() {
+        inlineController.onSearchActivated()
+    }
+
     fun dispose() {
         inlineController.dispose()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -26,13 +26,32 @@ internal class InlineAutocompleteController(
     private val coroutineScope: CoroutineScope,
     private val eventListenerProvider: () -> ((AutocompleteAddressInteractor.Event) -> Unit)?,
 ) {
-    private var lastPredictionLine1: String? = null
+    private enum class ActivationState {
+        ActiveByQuery, ActiveBySearch, Inactive
+    }
+
+    private sealed class ActiveWork {
+        open fun cancel() {}
+        object None : ActiveWork()
+        class Predicting(val job: Job, val query: Pair<String, String>) : ActiveWork() {
+            override fun cancel() { job.cancel() }
+        }
+        class Selecting(val job: Job) : ActiveWork() {
+            override fun cancel() { job.cancel() }
+        }
+    }
+
+    private var activationState: ActivationState = ActivationState.ActiveByQuery
     private var lastObservedCountry: String? = null
     private var predictionsPaused = false
     private var queryFlow: StateFlow<String>? = null
     private var countryFlow: StateFlow<String?>? = null
     private var observeJob: Job? = null
-    private var selectionJob: Job? = null
+    private var activeWork: ActiveWork = ActiveWork.None
+        set(value) {
+            field.cancel()
+            field = value
+        }
     var autocompleteFilledAddress: Address? = null
         private set
 
@@ -45,6 +64,7 @@ internal class InlineAutocompleteController(
     @OptIn(FlowPreview::class)
     fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
         observeJob?.cancel()
+        cancelPredictionWork()
         queryFlow = query
         countryFlow = country
         lastObservedCountry = country.value ?: ""
@@ -53,22 +73,30 @@ internal class InlineAutocompleteController(
             combine(query, country) { q, c -> q to (c ?: "") }
                 .debounce(AutocompleteViewModel.SEARCH_DEBOUNCE_MS)
                 .collectLatest { (q, c) ->
-                    if (q == lastPredictionLine1) {
-                        lastPredictionLine1 = null
-                        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                        return@collectLatest
-                    }
+                    val countrySupported = isCountrySupported(c)
                     val countryChanged = c != lastObservedCountry
                     if (countryChanged) {
                         lastObservedCountry = c
+                        if (!countrySupported) {
+                            cancelPredictionWork()
+                            _inlinePredictionsState.value =
+                                AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                            eventListenerProvider()?.invoke(
+                                AutocompleteAddressInteractor.Event.OnValues(
+                                    mapOf(IdentifierSpec.Country to c)
+                                )
+                            )
+                            return@collectLatest
+                        }
                     }
-                    if (predictionsPaused ||
-                        !isCountrySupported(c) ||
-                        q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE
-                    ) {
-                        lastPredictionLine1 = null
-                        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-                        if (countryChanged) {
+                    if ((activeWork as? ActiveWork.Predicting)?.query == (q to c)) {
+                        return@collectLatest
+                    }
+                    cancelPredictionWork()
+                    if (!isQueryEligible(q, c)) {
+                        _inlinePredictionsState.value =
+                            AutocompleteAddressInteractor.InlinePredictionsState.Idle
+                        if (countryChanged && activationState != ActivationState.Inactive) {
                             eventListenerProvider()?.invoke(
                                 AutocompleteAddressInteractor.Event.OnValues(
                                     mapOf(IdentifierSpec.Country to c)
@@ -82,26 +110,34 @@ internal class InlineAutocompleteController(
         }
     }
 
+    fun onSearchActivated() {
+        activationState = ActivationState.ActiveBySearch
+        val q = queryFlow?.value ?: return
+        val c = countryFlow?.value ?: ""
+        if (!isQueryEligible(q, c)) return
+        val job = coroutineScope.launch { fetchPredictions(q, c) }
+        activeWork = ActiveWork.Predicting(job, q to c)
+    }
+
     fun onPredictionSelected(predictionId: String) {
-        selectionJob?.cancel()
-        val queryAtSelection = queryFlow?.value
-        selectionJob = coroutineScope.launch {
+        val job = coroutineScope.launch {
             val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
             try {
                 val result = placesClient.fetchPlace(predictionId, locale)
                 ensureActive()
                 result.fold(
                     onSuccess = { handleFetchPlaceSuccess(it) },
-                    onFailure = { handleFailure(queryAtSelection) }
+                    onFailure = { handleFailure(queryFlow?.value, countryFlow?.value) }
                 )
             } finally {
                 placesClient.resetSession()
             }
         }
+        activeWork = ActiveWork.Selecting(job)
     }
 
     private fun handleFetchPlaceSuccess(address: Address) {
-        lastPredictionLine1 = address.line1
+        activationState = ActivationState.Inactive
         autocompleteFilledAddress = address
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         eventListenerProvider()?.invoke(
@@ -119,9 +155,11 @@ internal class InlineAutocompleteController(
     }
 
     fun onDismissed() {
-        selectionJob?.cancel()
-        lastPredictionLine1 = null
+        activeWork = ActiveWork.None
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+        if (activationState == ActivationState.ActiveBySearch) {
+            activationState = ActivationState.Inactive
+        }
     }
 
     fun onFocusLost() {
@@ -141,6 +179,9 @@ internal class InlineAutocompleteController(
     }
 
     fun expandFormFromInline() {
+        activationState = ActivationState.Inactive
+        activeWork = ActiveWork.None
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         emitExpandForm(
             query = queryFlow?.value,
             country = countryFlow?.value,
@@ -149,7 +190,21 @@ internal class InlineAutocompleteController(
 
     fun dispose() {
         observeJob?.cancel()
-        selectionJob?.cancel()
+        activeWork = ActiveWork.None
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
+    }
+
+    private fun cancelPredictionWork() {
+        if (activeWork is ActiveWork.Predicting) {
+            activeWork = ActiveWork.None
+        }
+    }
+
+    private fun isQueryEligible(query: String, country: String): Boolean {
+        return !predictionsPaused &&
+            activationState != ActivationState.Inactive &&
+            isCountrySupported(country) &&
+            query.length >= AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE
     }
 
     private fun isCountrySupported(country: String): Boolean {
@@ -169,6 +224,8 @@ internal class InlineAutocompleteController(
         )
         currentCoroutineContext().ensureActive()
         if (_inlinePredictionsState.value == AutocompleteAddressInteractor.InlinePredictionsState.Idle) return
+        if (queryFlow?.value != query) return
+        if ((countryFlow?.value ?: "") != country) return
         result.fold(
             onSuccess = { handleFindPredictionsSuccess(query, it) },
             onFailure = {
@@ -196,12 +253,15 @@ internal class InlineAutocompleteController(
         )
     }
 
-    private fun handleFailure(query: String?) {
-        lastPredictionLine1 = null
+    private fun handleFailure(query: String?, country: String?) {
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Results(
             query = query ?: "",
             predictions = emptyList(),
         )
+        if (config.shouldUseStripeHostedAutocomplete) {
+            activationState = ActivationState.Inactive
+            emitExpandForm(query = query, country = country)
+        }
     }
 
     private fun emitExpandForm(query: String?, country: String?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -311,6 +311,10 @@ internal class InputAddressViewModel @Inject constructor(
         }
     }
 
+    override fun onSearchActivated() {
+        inlineAutocompleteController?.onSearchActivated()
+    }
+
     override fun observeQueryChanges(query: StateFlow<String>, country: StateFlow<String?>) {
         inlineAutocompleteController?.observeQueryChanges(query, country)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -41,11 +41,12 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `query at minimum chars triggers fetch`() = runScenario {
+    fun `query at minimum chars triggers fetch when active`() = runScenario {
         fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(emptyList())
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "abc"
         advanceTimeBy(500)
@@ -65,6 +66,21 @@ class InlineAutocompleteControllerTest {
         advanceTimeBy(500)
 
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+    }
+
+    @Test
+    fun `onSearchActivated with unsupported country does not fetch`() = runScenario(
+        autocompleteCountries = setOf("US")
+    ) {
+        countryFlow.value = "CA"
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+        queryFlow.value = "123 Main"
+
+        delegate.onSearchActivated()
+        advanceTimeBy(500)
+
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+        fakePlacesClient.findPredictionsCalls.expectNoEvents()
     }
 
     @Test
@@ -95,6 +111,7 @@ class InlineAutocompleteControllerTest {
         )
         countryFlow.value = "JP"
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "Tokyo"
         advanceTimeBy(500)
@@ -111,6 +128,7 @@ class InlineAutocompleteControllerTest {
         )
         countryFlow.value = "us"
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -124,6 +142,7 @@ class InlineAutocompleteControllerTest {
             FindAutocompletePredictionsResponse(emptyList())
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "12"
         advanceTimeBy(100)
@@ -154,6 +173,7 @@ class InlineAutocompleteControllerTest {
             FindAutocompletePredictionsResponse(predictions)
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "Main"
         advanceTimeBy(500)
@@ -175,6 +195,7 @@ class InlineAutocompleteControllerTest {
     fun `failed fetch keeps dropdown open with empty results`() = runScenario {
         fakePlacesClient.findPredictionsResult = Result.failure(RuntimeException("Network error"))
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -195,6 +216,7 @@ class InlineAutocompleteControllerTest {
             stateBeforeFetch = delegate.inlinePredictionsState.value
         }
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -209,6 +231,7 @@ class InlineAutocompleteControllerTest {
             FindAutocompletePredictionsResponse(emptyList())
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123"
         advanceTimeBy(500)
@@ -270,7 +293,7 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `onPredictionSelected with failed fetch resets to Idle without emitting event`() =
+    fun `onPredictionSelected with failed fetch shows empty results without emitting event`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult =
                 Result.failure(RuntimeException("Network error"))
@@ -332,13 +355,10 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `onPredictionSelected suppresses next query matching predicted line1`() =
+    fun `onPredictionSelected deactivates — typing afterward does not trigger fetch`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
                 Address(line1 = "123 Main Street", country = "US")
-            )
-            fakePlacesClient.findPredictionsResult = Result.success(
-                FindAutocompletePredictionsResponse(emptyList())
             )
             delegate.observeQueryChanges(queryFlow, countryFlow)
 
@@ -349,6 +369,7 @@ class InlineAutocompleteControllerTest {
             fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
+            // After selection isActive = false; typing must not trigger a fetch.
             queryFlow.value = "123 Main Street"
             advanceTimeBy(500)
 
@@ -357,7 +378,7 @@ class InlineAutocompleteControllerTest {
         }
 
     @Test
-    fun `suppression only applies once - second matching query fetches normally`() =
+    fun `onSearchActivated after selection re-activates fetch`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
                 Address(line1 = "123 Main Street", country = "US")
@@ -374,18 +395,14 @@ class InlineAutocompleteControllerTest {
             fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
-            // First matching query is suppressed
+            // Tapping the magnifying glass re-activates the search.
             queryFlow.value = "123 Main Street"
-            advanceTimeBy(500)
-
-            // Second matching query fetches normally
-            queryFlow.value = "123 Main Street "
-            advanceTimeBy(500)
+            delegate.onSearchActivated()
+            advanceTimeBy(100)
             fakePlacesClient.findPredictionsCalls.awaitItem()
 
-            queryFlow.value = "123 Main Street"
-            advanceTimeBy(500)
-            fakePlacesClient.findPredictionsCalls.awaitItem()
+            assertThat(delegate.inlinePredictionsState.value)
+                .isInstanceOf<InlinePredictionsState.Results>()
         }
 
     @Test
@@ -441,12 +458,13 @@ class InlineAutocompleteControllerTest {
             FindAutocompletePredictionsResponse(emptyList())
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         delegate.onFocusLost()
         advanceTimeBy(500)
 
-        // Re-focus re-enables observation
+        // Re-focus re-enables observation; isActive remains true
         delegate.onFocusGained()
         queryFlow.value = "123 Main S"
         advanceTimeBy(500)
@@ -456,7 +474,7 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `onDismissed clears suppression - typing previously-selected address fetches normally`() =
+    fun `onDismissed after selection allows re-activation with same query`() =
         runScenario {
             fakePlacesClient.fetchPlaceResult = Result.success(
                 Address(line1 = "123 Main Street", country = "US")
@@ -473,100 +491,11 @@ class InlineAutocompleteControllerTest {
             fakePlacesClient.resetSessionCalls.awaitItem()
             eventCalls.awaitItem()
 
+            // After selection, isActive=false. Dismiss then re-activate.
+            queryFlow.value = "123 Main Street"
             delegate.onDismissed()
-
-            queryFlow.value = "123 Main Street"
-            advanceTimeBy(500)
-
-            fakePlacesClient.findPredictionsCalls.awaitItem()
-        }
-
-    @Test
-    fun `query dropping below minimum chars clears suppression - re-typing fetches normally`() =
-        runScenario {
-            fakePlacesClient.fetchPlaceResult = Result.success(
-                Address(line1 = "123 Main Street", country = "US")
-            )
-            fakePlacesClient.findPredictionsResult = Result.success(
-                FindAutocompletePredictionsResponse(emptyList())
-            )
-            delegate.observeQueryChanges(queryFlow, countryFlow)
-
-            delegate.onPredictionSelected("place_1")
+            delegate.onSearchActivated()
             advanceTimeBy(100)
-
-            fakePlacesClient.fetchPlaceCalls.awaitItem()
-            fakePlacesClient.resetSessionCalls.awaitItem()
-            eventCalls.awaitItem()
-
-            // Query drops below the minimum — suppression guard should be cleared.
-            queryFlow.value = "1"
-            advanceTimeBy(500)
-
-            queryFlow.value = "123 Main Street"
-            advanceTimeBy(500)
-
-            fakePlacesClient.findPredictionsCalls.awaitItem()
-        }
-
-    @Test
-    fun `prediction selected with null line1 does not block subsequent fetches`() =
-        runScenario {
-            // Place with no street components produces null line1 — no suppression is set.
-            fakePlacesClient.fetchPlaceResult = Result.success(Address())
-            fakePlacesClient.findPredictionsResult = Result.success(
-                FindAutocompletePredictionsResponse(emptyList())
-            )
-            delegate.observeQueryChanges(queryFlow, countryFlow)
-
-            delegate.onPredictionSelected("place_1")
-            advanceTimeBy(100)
-
-            fakePlacesClient.fetchPlaceCalls.awaitItem()
-            fakePlacesClient.resetSessionCalls.awaitItem()
-            eventCalls.awaitItem()
-
-            // lastPredictionLine1 was not set, so the next query must still fetch predictions.
-            queryFlow.value = "123 Main"
-            advanceTimeBy(500)
-
-            fakePlacesClient.findPredictionsCalls.awaitItem()
-        }
-
-    @Test
-    fun `null line1 after prior non-null selection does not leave stale suppression`() =
-        runScenario {
-            // First selection: place with line1="123 Main St" — sets lastPredictionLine1.
-            fakePlacesClient.fetchPlaceResult = Result.success(
-                Address(line1 = "123 Main Street", country = "US")
-            )
-            fakePlacesClient.findPredictionsResult = Result.success(
-                FindAutocompletePredictionsResponse(emptyList())
-            )
-            delegate.observeQueryChanges(queryFlow, countryFlow)
-
-            delegate.onPredictionSelected("place_1")
-            advanceTimeBy(100)
-
-            fakePlacesClient.fetchPlaceCalls.awaitItem()
-            fakePlacesClient.resetSessionCalls.awaitItem()
-            eventCalls.awaitItem()
-
-            // Second selection: place with no street components → line1 is null.
-            // This must clear lastPredictionLine1 so the previous value doesn't
-            // suppress a future fetch for "123 Main St".
-            fakePlacesClient.fetchPlaceResult = Result.success(Address())
-
-            delegate.onPredictionSelected("place_2")
-            advanceTimeBy(100)
-
-            fakePlacesClient.fetchPlaceCalls.awaitItem()
-            fakePlacesClient.resetSessionCalls.awaitItem()
-            eventCalls.awaitItem()
-
-            // Typing "123 Main St" must now fetch predictions — not be suppressed.
-            queryFlow.value = "123 Main St"
-            advanceTimeBy(500)
 
             fakePlacesClient.findPredictionsCalls.awaitItem()
         }
@@ -585,6 +514,7 @@ class InlineAutocompleteControllerTest {
             )
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
         fakePlacesClient.findPredictionsCalls.awaitItem()
@@ -598,21 +528,20 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `country change triggers re-evaluation`() = runScenario(
-        autocompleteCountries = setOf("US")
-    ) {
+    fun `while active, country change triggers re-evaluation`() = runScenario {
         fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(emptyList())
         )
-        countryFlow.value = "CA"
         delegate.observeQueryChanges(queryFlow, countryFlow)
-
         queryFlow.value = "123 Main"
-        advanceTimeBy(500)
-
-        countryFlow.value = "US"
-        advanceTimeBy(500)
+        delegate.onSearchActivated()
+        advanceTimeBy(100)
         fakePlacesClient.findPredictionsCalls.awaitItem()
+
+        countryFlow.value = "CA"
+        advanceTimeBy(500)
+        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+        assertThat(call.country).isEqualTo("CA")
     }
 
     @Test
@@ -651,6 +580,7 @@ class InlineAutocompleteControllerTest {
 
             delegate.observeQueryChanges(queryFlow, countryFlow)
             delegate.observeQueryChanges(secondQueryFlow, secondCountryFlow)
+            delegate.onSearchActivated()
 
             queryFlow.value = "first query"
             advanceTimeBy(500)
@@ -667,6 +597,7 @@ class InlineAutocompleteControllerTest {
             FindAutocompletePredictionsResponse(emptyList())
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         delegate.dispose()
 
@@ -685,6 +616,7 @@ class InlineAutocompleteControllerTest {
         )
         countryFlow.value = null
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -701,6 +633,7 @@ class InlineAutocompleteControllerTest {
             RuntimeException("Hosted proxy unavailable")
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -722,6 +655,7 @@ class InlineAutocompleteControllerTest {
             FindAutocompletePredictionsResponse(emptyList())
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123"
         advanceTimeBy(500)
@@ -755,6 +689,8 @@ class InlineAutocompleteControllerTest {
         fakePlacesClient.resetSessionCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value)
             .isEqualTo(InlinePredictionsState.Results(query = "", predictions = emptyList()))
+        assertThat(eventCalls.awaitItem())
+            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
     }
 
     @Test
@@ -776,6 +712,7 @@ class InlineAutocompleteControllerTest {
             RuntimeException("Hosted proxy unavailable")
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -788,6 +725,48 @@ class InlineAutocompleteControllerTest {
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(
             InlinePredictionsState.Results(query = "123 Main", predictions = emptyList())
         )
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "123 Main",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `stripe-hosted fetchPlace failure expands with edits made while fetch in flight`() = runScenario(
+        shouldUseStripeHostedAutocomplete = true,
+    ) {
+        val fetchGate = CompletableDeferred<Unit>()
+        fakePlacesClient.fetchPlaceResult = Result.failure(
+            RuntimeException("Hosted proxy unavailable")
+        )
+        fakePlacesClient.onBeforeFetchPlace = { fetchGate.await() }
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+        queryFlow.value = "123 Main"
+
+        delegate.onPredictionSelected("place-id-abc")
+        advanceTimeBy(100)
+
+        // User keeps editing the field while fetchPlace is still in flight.
+        queryFlow.value = "456 Oak Ave"
+
+        // Release the gate — the fallback expansion must use the edited query, not the stale one.
+        fetchGate.complete(Unit)
+        advanceTimeBy(100)
+
+        fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnExpandForm(
+                values = mapOf(
+                    IdentifierSpec.Line1 to "456 Oak Ave",
+                    IdentifierSpec.Country to "US",
+                )
+            )
+        )
     }
 
     @Test
@@ -799,6 +778,7 @@ class InlineAutocompleteControllerTest {
         )
         countryFlow.value = null
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -811,32 +791,78 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `no proxy calls Google Places for predictions`() = runScenario {
-        fakePlacesClient.findPredictionsResult = Result.success(
-            FindAutocompletePredictionsResponse(emptyList())
-        )
-        delegate.observeQueryChanges(queryFlow, countryFlow)
+    fun `onSearchActivated triggers immediate fetch bypassing debounce`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+            queryFlow.value = "123 Main St"
 
-        queryFlow.value = "123 Main"
-        advanceTimeBy(500)
+            delegate.onSearchActivated()
+            advanceTimeBy(100)
 
-        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
-        assertThat(call.query).isEqualTo("123 Main")
-    }
+            val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+            assertThat(call.query).isEqualTo("123 Main St")
+        }
 
     @Test
-    fun `no proxy calls Google Places for place selection`() = runScenario {
-        fakePlacesClient.fetchPlaceResult = Result.success(
-            Address(line1 = "123 Main Street", country = "US")
-        )
+    fun `onSearchActivated does not double-fetch when debounce catches up`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+            queryFlow.value = "123 Main St"
 
-        delegate.onPredictionSelected("place-id-123")
+            delegate.onSearchActivated()
+            // Advance past the debounce window: the pending debounced emission for the
+            // just-typed query must not fire a second request for the same query.
+            advanceTimeBy(500)
 
-        val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
-        fakePlacesClient.resetSessionCalls.awaitItem()
-        assertThat(call.placeId).isEqualTo("place-id-123")
-        eventCalls.awaitItem()
-    }
+            val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+            assertThat(call.query).isEqualTo("123 Main St")
+            fakePlacesClient.findPredictionsCalls.expectNoEvents()
+        }
+
+    @Test
+    fun `onSearchActivated with short query stays Idle but activates for typing`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            // query = "" — too short for immediate fetch, but activates for subsequent typing
+            delegate.onSearchActivated()
+
+            queryFlow.value = "123 Main"
+            advanceTimeBy(500)
+
+            val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+            assertThat(call.query).isEqualTo("123 Main")
+        }
+
+    @Test
+    fun `after search-activated dismiss, country change does not auto-trigger`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+            queryFlow.value = "123 Main"
+            delegate.onSearchActivated()
+            advanceTimeBy(100)
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+
+            delegate.onDismissed()
+
+            countryFlow.value = "CA"
+            advanceTimeBy(500)
+
+            assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+            fakePlacesClient.findPredictionsCalls.expectNoEvents()
+        }
 
     @Test
     fun `expandFormFromInline emits OnExpandForm with null values when query is empty`() = runScenario {
@@ -864,10 +890,8 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `fetchPlace failure clears lastPredictionLine1 so next query fetches normally`() = runScenario {
-        fakePlacesClient.fetchPlaceResult = Result.success(
-            Address(line1 = "123 Main Street", country = "US")
-        )
+    fun `fetchPlace failure deactivates - re-activation after failure allows fetch`() = runScenario {
+        fakePlacesClient.fetchPlaceResult = Result.failure(RuntimeException("network error"))
         fakePlacesClient.findPredictionsResult = Result.success(
             FindAutocompletePredictionsResponse(emptyList())
         )
@@ -878,19 +902,11 @@ class InlineAutocompleteControllerTest {
 
         fakePlacesClient.fetchPlaceCalls.awaitItem()
         fakePlacesClient.resetSessionCalls.awaitItem()
-        eventCalls.awaitItem()
 
-        // fetchPlace failure must clear lastPredictionLine1
-        fakePlacesClient.fetchPlaceResult = Result.failure(RuntimeException("network error"))
-        delegate.onPredictionSelected("place_2")
-        advanceTimeBy(100)
-
-        fakePlacesClient.fetchPlaceCalls.awaitItem()
-        fakePlacesClient.resetSessionCalls.awaitItem()
-
-        // Typing the first selection's line1 must trigger a fresh fetch, not be suppressed
+        // After failure, isActive=false. Re-activate and verify fetch works.
         queryFlow.value = "123 Main Street"
-        advanceTimeBy(500)
+        delegate.onSearchActivated()
+        advanceTimeBy(100)
 
         fakePlacesClient.findPredictionsCalls.awaitItem()
     }
@@ -942,6 +958,7 @@ class InlineAutocompleteControllerTest {
         val fetchGate = CompletableDeferred<Unit>()
         fakePlacesClient.onBeforeFindPredictions = { fetchGate.await() }
         delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
 
         queryFlow.value = "123 Main"
         advanceTimeBy(500)
@@ -960,6 +977,99 @@ class InlineAutocompleteControllerTest {
         fakePlacesClient.findPredictionsCalls.awaitItem()
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
     }
+
+    @Test
+    fun `query change during in-flight fetch discards stale result`() = runScenario {
+        val fetchGate = CompletableDeferred<Unit>()
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(
+                listOf(
+                    AutocompletePrediction(
+                        SpannableString("123 Main St"),
+                        SpannableString("City, ST"),
+                        "place_1",
+                    )
+                )
+            )
+        )
+        fakePlacesClient.onBeforeFindPredictions = { fetchGate.await() }
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+        delegate.onSearchActivated()
+
+        queryFlow.value = "123 Main"
+        advanceTimeBy(500)
+
+        // Fetch is suspended at the gate
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Loading)
+
+        // User types more — query changes while fetch is in-flight
+        queryFlow.value = "123 Main St"
+
+        // Release the gate — stale result for "123 Main" must be discarded
+        fetchGate.complete(Unit)
+        advanceTimeBy(100)
+
+        fakePlacesClient.findPredictionsCalls.awaitItem()
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Loading)
+
+        // The debounced fetch for the new query should fire
+        fakePlacesClient.onBeforeFindPredictions = {}
+        advanceTimeBy(500)
+        val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+        assertThat(call.query).isEqualTo("123 Main St")
+    }
+
+    @Test
+    fun `expanded mode - typing does not trigger predictions after expandFormFromInline`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            delegate.expandFormFromInline()
+            eventCalls.awaitItem()
+
+            queryFlow.value = "123 Main"
+            advanceTimeBy(500)
+
+            assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
+            fakePlacesClient.findPredictionsCalls.expectNoEvents()
+        }
+
+    @Test
+    fun `expanded mode - search enables autocomplete, dismiss disables it`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+
+            delegate.expandFormFromInline()
+            eventCalls.awaitItem()
+
+            queryFlow.value = "123 Main"
+            delegate.onSearchActivated()
+            advanceTimeBy(100)
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+
+            // Typing while search is active continues to trigger predictions
+            queryFlow.value = "123 Main St"
+            advanceTimeBy(500)
+            val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+            assertThat(call.query).isEqualTo("123 Main St")
+
+            // Dismiss (X button) deactivates — typing no longer triggers
+            delegate.onDismissed()
+            queryFlow.value = "123 Main Street"
+            advanceTimeBy(500)
+            fakePlacesClient.findPredictionsCalls.expectNoEvents()
+
+            // Must click search again to re-enable
+            delegate.onSearchActivated()
+            advanceTimeBy(100)
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+        }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun runScenario(

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -69,6 +69,12 @@ public final class com/stripe/android/uicore/elements/AddressFieldConfiguration$
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/uicore/elements/ComposableSingletons$AddressTextFieldUIKt {
+	public static final field INSTANCE Lcom/stripe/android/uicore/elements/ComposableSingletons$AddressTextFieldUIKt;
+	public fun <init> ()V
+	public final fun getLambda$-704858027$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/uicore/elements/ComposableSingletons$OTPElementUIKt {
 	public static final field INSTANCE Lcom/stripe/android/uicore/elements/ComposableSingletons$OTPElementUIKt;
 	public fun <init> ()V

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -60,9 +60,28 @@ class AddressElement(
         label = resolvableString(R.string.stripe_address_label_address),
         addressInputMode = addressInputMode,
         inlineAutocompleteHandler = inlineAutocompleteHandler,
+        reportsFormValue = false,
+        initialQuery = "",
+        showEnterManually = true,
     )
 
-    val inlineQuery: StateFlow<String> get() = addressAutoCompleteElement.inlineQuery
+    private val expandedAutoCompleteElement: AddressTextFieldElement? =
+        if (inlineAutocompleteHandler != null && addressInputMode is AddressInputMode.NoAutocomplete) {
+            AddressTextFieldElement(
+                identifier = IdentifierSpec.Line1,
+                label = resolvableString(R.string.stripe_address_label_address),
+                addressInputMode = addressInputMode,
+                inlineAutocompleteHandler = inlineAutocompleteHandler,
+                reportsFormValue = true,
+                initialQuery = rawValuesMap[IdentifierSpec.Line1] ?: "",
+                showEnterManually = false,
+            )
+        } else {
+            null
+        }
+
+    val inlineQuery: StateFlow<String>
+        get() = expandedAutoCompleteElement?.inlineQuery ?: addressAutoCompleteElement.inlineQuery
 
     @VisibleForTesting
     val phoneNumberElement = PhoneNumberElement(
@@ -131,6 +150,7 @@ class AddressElement(
             allFields.forEach { field ->
                 field.setRawValue(values)
             }
+            syncExpandedLine1(values)
         }
     }
 
@@ -146,8 +166,9 @@ class AddressElement(
                 ) {
                     it.toList().flatten()
                 }
-            }
-        ) { country, values ->
+            },
+            expandedAutoCompleteElement?.inlineQuery ?: stateFlowOf(""),
+        ) { country, values, expandedLine1 ->
             country?.let {
                 currentValuesMap[IdentifierSpec.Country] = it
             }
@@ -156,6 +177,9 @@ class AddressElement(
                     Pair(it.first, it.second.value)
                 }
             )
+            if (expandedAutoCompleteElement != null) {
+                currentValuesMap[IdentifierSpec.Line1] = expandedLine1
+            }
             val same = currentValuesMap.all {
                 (shippingValuesMap?.get(it.key) ?: "") == it.value
             }
@@ -173,16 +197,13 @@ class AddressElement(
         isValidating,
     ) { country, otherFields, _, _, isValidating ->
         val hideName = addressInputMode.nameConfig == AddressFieldConfiguration.HIDDEN
-
-        val condensed = listOfNotNull(
+        val headerElements = listOfNotNull(
             nameElement.takeUnless { hideName },
             countryElement.takeUnless { hideCountry },
-            addressAutoCompleteElement,
         )
-        val expanded = listOfNotNull(
-            nameElement.takeUnless { hideName },
-            countryElement.takeUnless { hideCountry },
-        ).plus(otherFields)
+
+        val condensed = headerElements.plus(addressAutoCompleteElement)
+        val expanded = headerElements.plus(otherFields)
         val baseElements = when (addressInputMode) {
             is AddressInputMode.AutocompleteInline -> condensed
             is AddressInputMode.AutocompleteCondensed -> {
@@ -198,10 +219,10 @@ class AddressElement(
                 expanded
             }
             else -> {
-                listOfNotNull(
-                    nameElement.takeUnless { hideName },
-                    countryElement.takeUnless { hideCountry }
-                ).plus(otherFields)
+                val bodyFields = otherFields.map { field ->
+                    expandedAutoCompleteElement?.takeIf { field.identifier == IdentifierSpec.Line1 } ?: field
+                }
+                headerElements.plus(bodyFields)
             }
         }
 
@@ -246,6 +267,11 @@ class AddressElement(
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         this.rawValuesMap = rawValuesMap
+        syncExpandedLine1(rawValuesMap)
+    }
+
+    private fun syncExpandedLine1(values: Map<IdentifierSpec, String?>) {
+        expandedAutoCompleteElement?.controller?.onRawValueChange(values[IdentifierSpec.Line1] ?: "")
     }
 
     override fun onValidationStateChanged(isValidating: Boolean) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -22,24 +22,32 @@ import kotlinx.coroutines.flow.asStateFlow
 class AddressTextFieldController(
     label: ResolvableString,
     addressInputMode: AddressInputMode,
-    private val inlineAutocompleteHandler: InlineAutocompleteHandler? = null,
+    private val inlineAutocompleteHandler: InlineAutocompleteHandler?,
+    private val reportsFormValue: Boolean,
+    initialQuery: String,
+    private val showEnterManually: Boolean,
 ) : InputController, SectionFieldValidationController, SectionFieldComposable {
     private val _isValidating = MutableStateFlow(false)
-    private val _inlineQuery = MutableStateFlow("")
+    private val _inlineQuery = MutableStateFlow(initialQuery)
     private val onNavigation = (addressInputMode as? AddressInputMode.AutocompleteCondensed)?.onNavigation
 
-    val isEditable = addressInputMode is AddressInputMode.AutocompleteInline
+    val isEditable = inlineAutocompleteHandler != null
     val inlineQuery: StateFlow<String> = _inlineQuery.asStateFlow()
 
     override val showOptionalLabel: Boolean = false
     override val label = stateFlowOf(label)
-    override val fieldValue: StateFlow<String> = stateFlowOf("")
-    override val rawFieldValue: StateFlow<String> = stateFlowOf("")
-    override val isComplete: StateFlow<Boolean> = stateFlowOf(false)
+    override val fieldValue: StateFlow<String> =
+        if (reportsFormValue) inlineQuery else stateFlowOf("")
+    override val rawFieldValue: StateFlow<String> = fieldValue
+    override val isComplete: StateFlow<Boolean> =
+        if (reportsFormValue) _inlineQuery.mapAsStateFlow { it.isNotBlank() } else stateFlowOf(false)
 
-    override val validationMessage: StateFlow<FieldValidationMessage?> = _isValidating.mapAsStateFlow { isValidating ->
-        FieldValidationMessage.Error(R.string.stripe_blank_and_required).takeIf { isValidating }
-    }
+    override val validationMessage: StateFlow<FieldValidationMessage?> =
+        combineAsStateFlow(_isValidating, _inlineQuery) { isValidating, query ->
+            FieldValidationMessage.Error(R.string.stripe_blank_and_required).takeIf {
+                isValidating && (!reportsFormValue || query.isBlank())
+            }
+        }
 
     override val formFieldValue: StateFlow<FormFieldEntry> =
         combineAsStateFlow(isComplete, rawFieldValue) { complete, value ->
@@ -47,7 +55,9 @@ class AddressTextFieldController(
         }
 
     override fun onRawValueChange(rawValue: String) {
-        // No-op, this field does not support direct input manipulation
+        if (reportsFormValue) {
+            _inlineQuery.value = rawValue
+        }
     }
 
     fun onInlineQueryChanged(query: String) {
@@ -60,6 +70,15 @@ class AddressTextFieldController(
         _isValidating.value = isValidating
     }
 
+    private fun onPredictionsDismissed() {
+        // Inline mode clears the field on dismiss; expanded mode keeps the typed
+        // text so the user doesn't lose their in-progress input.
+        if (!reportsFormValue) {
+            _inlineQuery.value = ""
+        }
+        inlineAutocompleteHandler?.onDismissed()
+    }
+
     @Composable
     override fun ComposeUI(
         enabled: Boolean,
@@ -69,12 +88,22 @@ class AddressTextFieldController(
         lastTextFieldIdentifier: IdentifierSpec?
     ) {
         if (inlineAutocompleteHandler != null) {
-            val onClear = {
-                _inlineQuery.value = ""
-                inlineAutocompleteHandler.onDismissed()
-            }
             val predictionsState by inlineAutocompleteHandler.predictionsState.collectAsState()
             val isDarkTheme = isSystemInDarkTheme()
+
+            val predictions = @Composable {
+                InlineAddressPredictionsUI(
+                    state = predictionsState,
+                    attributionDrawable = inlineAutocompleteHandler.getAttributionDrawable(isDarkTheme),
+                    onPredictionSelected = inlineAutocompleteHandler::onPredictionSelected,
+                    onClear = ::onPredictionsDismissed,
+                    onEnterManually = if (showEnterManually) {
+                        inlineAutocompleteHandler::onEnterManually
+                    } else {
+                        null
+                    },
+                )
+            }
 
             Column(
                 modifier = modifier.onFocusChanged { state ->
@@ -88,17 +117,12 @@ class AddressTextFieldController(
                 AddressTextFieldUI(
                     controller = this@AddressTextFieldController,
                     enabled = enabled,
+                    onSearchActivated = if (reportsFormValue) inlineAutocompleteHandler::onSearchActivated else null,
                 )
-                InlineAddressPredictionsUI(
-                    state = predictionsState,
-                    attributionDrawable = inlineAutocompleteHandler.getAttributionDrawable(isDarkTheme),
-                    onPredictionSelected = inlineAutocompleteHandler::onPredictionSelected,
-                    onClear = onClear,
-                    onEnterManually = inlineAutocompleteHandler::onEnterManually,
-                )
+                predictions()
             }
         } else {
-            AddressTextFieldUI(controller = this, enabled = enabled, modifier = modifier)
+            AddressTextFieldUI(controller = this, enabled = enabled, onSearchActivated = null, modifier = modifier)
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -10,7 +10,10 @@ class AddressTextFieldElement(
     override val identifier: IdentifierSpec,
     label: ResolvableString,
     addressInputMode: AddressInputMode,
-    inlineAutocompleteHandler: InlineAutocompleteHandler? = null,
+    inlineAutocompleteHandler: InlineAutocompleteHandler?,
+    reportsFormValue: Boolean,
+    initialQuery: String,
+    showEnterManually: Boolean,
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
@@ -20,6 +23,9 @@ class AddressTextFieldElement(
             label = label,
             addressInputMode = addressInputMode,
             inlineAutocompleteHandler = inlineAutocompleteHandler,
+            reportsFormValue = reportsFormValue,
+            initialQuery = initialQuery,
+            showEnterManually = showEnterManually,
         )
 
     val inlineQuery: StateFlow<String> get() = controller.inlineQuery

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
@@ -3,15 +3,30 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import com.stripe.android.uicore.LocalTextFieldInsets
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.compat.CompatTextField
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
+
+@Composable
+private fun SearchIconButton(onClick: () -> Unit, enabled: Boolean) {
+    IconButton(onClick = onClick, enabled = enabled) {
+        Icon(
+            painter = painterResource(R.drawable.stripe_ic_search),
+            contentDescription = stringResource(R.string.stripe_address_search_content_description),
+        )
+    }
+}
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -19,6 +34,7 @@ fun AddressTextFieldUI(
     controller: AddressTextFieldController,
     modifier: Modifier = Modifier,
     enabled: Boolean,
+    onSearchActivated: (() -> Unit)?,
     onClick: () -> Unit = {
         controller.launchAutocompleteScreen()
     }
@@ -45,7 +61,16 @@ fun AddressTextFieldUI(
             FormLabel(label.resolve())
         },
         placeholder = null,
-        trailingIcon = null,
+        trailingIcon = if (onSearchActivated != null) {
+            {
+                SearchIconButton(
+                    onClick = onSearchActivated,
+                    enabled = enabled,
+                )
+            }
+        } else {
+            null
+        },
         singleLine = true,
         contentPadding = textFieldInsets.asPaddingValues(),
         colors = TextFieldColors(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -66,6 +66,10 @@ class AutocompleteAddressController(
                 override fun getAttributionDrawable(isDarkTheme: Boolean): Int? {
                     return R.drawable.stripe_google_maps_logo
                 }
+
+                override fun onSearchActivated() {
+                    interactor.onSearchActivated()
+                }
             }
         } else {
             null
@@ -153,6 +157,11 @@ class AutocompleteAddressController(
         values: Map<IdentifierSpec, String?>,
         addressInputMode: AddressInputMode,
     ): AddressElement {
+        val handler = if (isCountrySupported(values[IdentifierSpec.Country])) {
+            inlineAutocompleteHandler
+        } else {
+            null
+        }
         return AddressElement(
             _identifier = identifier,
             rawValuesMap = values,
@@ -162,7 +171,7 @@ class AutocompleteAddressController(
             shippingValuesMap = shippingValuesMap,
             isPlacesAvailable = config.isPlacesAvailable,
             hideCountry = hideCountry,
-            inlineAutocompleteHandler = inlineAutocompleteHandler,
+            inlineAutocompleteHandler = handler,
         )
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
@@ -30,6 +30,8 @@ interface AutocompleteAddressInteractor {
 
     fun onEnterManuallyFromInline() = Unit
 
+    fun onSearchActivated() = Unit
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Config(
         val googlePlacesApiKey: String?,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InlineAutocompleteHandler.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InlineAutocompleteHandler.kt
@@ -18,4 +18,6 @@ interface InlineAutocompleteHandler {
     fun onEnterManually()
 
     fun getAttributionDrawable(isDarkTheme: Boolean): Int?
+
+    fun onSearchActivated()
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldControllerTest.kt
@@ -4,12 +4,14 @@ import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
 class AddressTextFieldControllerTest {
     @Test
-    fun `on raw field change, should not update value or field value states`() = runTest {
+    fun `on raw field change, should not update value when reportsFormValue is false`() = runTest {
         val controller = createAddressController()
 
         turbineScope {
@@ -26,6 +28,26 @@ class AddressTextFieldControllerTest {
 
             rawFieldValueTurbine.cancelAndIgnoreRemainingEvents()
             fieldValueTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `on raw field change, should update value when reportsFormValue is true`() = runTest {
+        val controller = createAddressController(
+            inlineAutocompleteHandler = FakeInlineAutocompleteHandler(),
+            reportsFormValue = true,
+        )
+
+        turbineScope {
+            val rawFieldValueTurbine = controller.rawFieldValue.testIn(this)
+
+            assertThat(rawFieldValueTurbine.awaitItem()).isEqualTo("")
+
+            controller.onRawValueChange("123 Main St")
+
+            assertThat(rawFieldValueTurbine.awaitItem()).isEqualTo("123 Main St")
+
+            rawFieldValueTurbine.cancelAndIgnoreRemainingEvents()
         }
     }
 
@@ -47,15 +69,38 @@ class AddressTextFieldControllerTest {
     }
 
     @Test
+    fun `reportsFormValue mode - no error when query is not blank`() = runTest {
+        val controller = createAddressController(
+            inlineAutocompleteHandler = FakeInlineAutocompleteHandler(),
+            reportsFormValue = true,
+            initialQuery = "123 Main St",
+        )
+
+        turbineScope {
+            val errorTurbine = controller.validationMessage.testIn(this)
+
+            assertThat(errorTurbine.awaitItem()).isNull()
+
+            controller.onValidationStateChanged(true)
+
+            errorTurbine.expectNoEvents()
+
+            errorTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `non-inline mode - is not editable`() = runTest {
-        val controller = createAddressController(isInlineAutocompleteEnabled = false)
+        val controller = createAddressController(inlineAutocompleteHandler = null)
 
         assertThat(controller.isEditable).isFalse()
     }
 
     @Test
     fun `inline mode - is editable and tracks query`() = runTest {
-        val controller = createAddressController(isInlineAutocompleteEnabled = true)
+        val controller = createAddressController(
+            inlineAutocompleteHandler = FakeInlineAutocompleteHandler(),
+        )
 
         assertThat(controller.isEditable).isTrue()
 
@@ -73,8 +118,8 @@ class AddressTextFieldControllerTest {
     }
 
     @Test
-    fun `non-inline mode - query ignored when inline is disabled`() = runTest {
-        val controller = createAddressController(isInlineAutocompleteEnabled = false)
+    fun `non-inline mode - query ignored when handler is null`() = runTest {
+        val controller = createAddressController(inlineAutocompleteHandler = null)
 
         turbineScope {
             val queryTurbine = controller.inlineQuery.testIn(this)
@@ -86,6 +131,46 @@ class AddressTextFieldControllerTest {
             queryTurbine.expectNoEvents()
 
             queryTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `initialQuery sets the starting value`() = runTest {
+        val controller = createAddressController(
+            inlineAutocompleteHandler = FakeInlineAutocompleteHandler(),
+            initialQuery = "pre-filled value",
+        )
+
+        turbineScope {
+            val queryTurbine = controller.inlineQuery.testIn(this)
+
+            assertThat(queryTurbine.awaitItem()).isEqualTo("pre-filled value")
+
+            queryTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `isComplete reflects query state when reportsFormValue is true`() = runTest {
+        val controller = createAddressController(
+            inlineAutocompleteHandler = FakeInlineAutocompleteHandler(),
+            reportsFormValue = true,
+        )
+
+        turbineScope {
+            val completeTurbine = controller.isComplete.testIn(this)
+
+            assertThat(completeTurbine.awaitItem()).isFalse()
+
+            controller.onInlineQueryChanged("123 Main")
+
+            assertThat(completeTurbine.awaitItem()).isTrue()
+
+            controller.onInlineQueryChanged("")
+
+            assertThat(completeTurbine.awaitItem()).isFalse()
+
+            completeTurbine.cancelAndIgnoreRemainingEvents()
         }
     }
 
@@ -110,20 +195,31 @@ class AddressTextFieldControllerTest {
         ).isTrue()
     }
 
-    private fun createAddressController(isInlineAutocompleteEnabled: Boolean = false): AddressTextFieldController {
+    private fun createAddressController(
+        inlineAutocompleteHandler: InlineAutocompleteHandler? = null,
+        reportsFormValue: Boolean = false,
+        initialQuery: String = "",
+    ): AddressTextFieldController {
         return AddressTextFieldController(
             label = resolvableString(value = "Name"),
-            addressInputMode = if (isInlineAutocompleteEnabled) {
-                AddressInputMode.AutocompleteInline(
-                    googleApiKey = "test-key",
-                    autocompleteCountries = emptySet(),
-                    phoneNumberConfig = AddressFieldConfiguration.HIDDEN,
-                    nameConfig = AddressFieldConfiguration.HIDDEN,
-                    emailConfig = AddressFieldConfiguration.HIDDEN,
-                )
-            } else {
-                AddressInputMode.NoAutocomplete()
-            },
+            addressInputMode = AddressInputMode.NoAutocomplete(),
+            inlineAutocompleteHandler = inlineAutocompleteHandler,
+            reportsFormValue = reportsFormValue,
+            initialQuery = initialQuery,
+            showEnterManually = true,
         )
+    }
+
+    private class FakeInlineAutocompleteHandler : InlineAutocompleteHandler {
+        override val predictionsState: StateFlow<AutocompleteAddressInteractor.InlinePredictionsState> =
+            MutableStateFlow(AutocompleteAddressInteractor.InlinePredictionsState.Idle)
+
+        override fun onPredictionSelected(predictionId: String) = Unit
+        override fun onDismissed() = Unit
+        override fun onFocusLost() = Unit
+        override fun onFocusGained() = Unit
+        override fun onEnterManually() = Unit
+        override fun getAttributionDrawable(isDarkTheme: Boolean): Int? = null
+        override fun onSearchActivated() = Unit
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
@@ -13,6 +13,10 @@ class AddressTextFieldElementTest {
             identifier = IdentifierSpec.OneLineAddress,
             label = "Address".resolvableString,
             addressInputMode = AddressInputMode.NoAutocomplete(),
+            inlineAutocompleteHandler = null,
+            reportsFormValue = false,
+            initialQuery = "",
+            showEnterManually = true,
         )
 
         element.getTextFieldIdentifiers().test {


### PR DESCRIPTION

# Summary
<!-- Simple summary of what was changed. -->
Re-trigger inline autocomplete predictions when users type in Line1 in expanded mode. Dismissing predictions (clicking outside) keeps the typed text without requiring a selection.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
When a user clicks "enter address manually" from the inline autocomplete flow and lands in expanded mode, typing in Line1 should still show autocomplete predictions to help them complete the address faster. Previously, predictions were only available in the condensed/inline mode. This change adds a second autocomplete-enabled Line1 field that replaces the regular Line1 in expanded mode, with proper suppression logic to avoid unwanted prediction triggers from pre-filled values, dismissed queries, and programmatic changes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A, Behind feature flag currently.