### PR TITLE
Refactor `NfcScanningActivityTest` & `NfcScanningActivityAnalyticsTest`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeIsoDep.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeIsoDep.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.common.nfcscan
+
+import android.nfc.Tag
+import android.nfc.tech.IsoDep
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal class FakeIsoDep(
+    val tag: Tag = mock(),
+) {
+    private var transceiveResults: List<ByteArray> = emptyList()
+    private var transceiveResultIndex = 0
+
+    val wrappedInstance: IsoDep = mock()
+
+    init {
+        whenever(wrappedInstance.transceive(any())).thenAnswer {
+            if (transceiveResultIndex < transceiveResults.size) {
+                transceiveResults[transceiveResultIndex++]
+            } else {
+                byteArrayOf(0x69.toByte(), 0x82.toByte())
+            }
+        }
+
+        doAnswer { null }.whenever(wrappedInstance).connect()
+        doAnswer { null }.whenever(wrappedInstance).close()
+    }
+
+    fun setTransceiveResponses(
+        transceiveResults: List<ByteArray>,
+    ) {
+        this.transceiveResults = transceiveResults
+        this.transceiveResultIndex = 0
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import org.junit.Rule
@@ -58,7 +57,7 @@ internal class NfcScanningActivityAnalyticsTest {
         launchScenario {
             composeRule.onNodeWithContentDescription("Cancel").performClick()
 
-            waitForActivityFinish()
+            waitForIdle()
         }
     }
 
@@ -70,12 +69,9 @@ internal class NfcScanningActivityAnalyticsTest {
         networkRule.expectNfcScanSuccess()
 
         launchScenario {
-            NfcScanningActivityTestHelpers.completeSuccessfulScan(
-                scenario = this,
-                responses = NfcScanningActivityTestFixtures.successResponses(),
-            )
-
-            waitForActivityFinish()
+            dispatchCardRead(NfcScanningActivityTestFixtures.successResponses())
+            waitForCompleteUi()
+            waitForIdle()
         }
     }
 
@@ -86,11 +82,8 @@ internal class NfcScanningActivityAnalyticsTest {
         networkRule.expectNfcScanAttemptFailed(errorCode = "cardDeclinedByNfc")
 
         launchScenario {
-            NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
-                scenario = this,
-                responses = NfcScanningActivityTestFixtures.declinedCardResponses(),
-                errorText = context.getString(R.string.stripe_nfc_scan_error_declined_card),
-            )
+            dispatchCardRead(NfcScanningActivityTestFixtures.declinedCardResponses())
+            assertErrorIsDisplayed(errorText = "Card declined. Try another card.")
         }
     }
 
@@ -101,11 +94,8 @@ internal class NfcScanningActivityAnalyticsTest {
         networkRule.expectNfcScanAttemptFailed(errorCode = "cardUnsupportedByNfc")
 
         launchScenario {
-            NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
-                scenario = this,
-                responses = NfcScanningActivityTestFixtures.unsupportedCardResponses(),
-                errorText = context.getString(R.string.stripe_nfc_scan_unsupported_card),
-            )
+            dispatchCardRead(NfcScanningActivityTestFixtures.unsupportedCardResponses())
+            assertErrorIsDisplayed(errorText = "Card not supported. Try another card.")
         }
     }
 
@@ -116,16 +106,13 @@ internal class NfcScanningActivityAnalyticsTest {
         networkRule.expectNfcScanAttemptFailed(errorCode = "expiredCard")
 
         launchScenario {
-            NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
-                scenario = this,
-                responses = NfcScanningActivityTestFixtures.expiredCardResponses(),
-                errorText = context.getString(R.string.stripe_nfc_scan_error_expired_card),
-            )
+            dispatchCardRead(NfcScanningActivityTestFixtures.expiredCardResponses())
+            assertErrorIsDisplayed(errorText = "Card expired. Try another card.")
         }
     }
 
     private fun launchScenario(
-        block: NfcScanningActivityTestHelpers.Scenario.() -> Unit,
+        block: suspend NfcScanningActivityScenario.() -> Unit,
     ) {
         NfcScanningActivityTestHelpers.launchScenario(
             context = context,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityScenario.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityScenario.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.common.nfcscan
+
+import android.os.Looper
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowNfcAdapter
+
+internal class NfcScanningActivityScenario(
+    private val activityScenario: ActivityScenario<NfcScanningActivity>,
+    val composeRule: ComposeTestRule,
+    val isoDep: FakeIsoDep,
+    val nfcAdapter: ShadowNfcAdapter?,
+) {
+    fun waitForIdle() {
+        shadowOf(Looper.getMainLooper()).idle()
+        Espresso.onIdle()
+        composeRule.waitForIdle()
+    }
+
+    fun dispatchCardRead(
+        apduResponses: List<ByteArray>,
+    ) {
+        isoDep.setTransceiveResponses(apduResponses)
+        nfcAdapter?.dispatchTagDiscovered(isoDep.tag)
+        waitForIdle()
+    }
+
+    fun waitForUi() {
+        composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            waitForIdle()
+            composeRule.onAllNodesWithContentDescription("Cancel")
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+    }
+
+    fun waitForCompleteUi() {
+        composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            waitForIdle()
+            composeRule.onAllNodesWithContentDescription("Cancel")
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty()
+        }
+    }
+
+    fun assertErrorIsDisplayed(errorText: String) {
+        composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            waitForIdle()
+            composeRule.onAllNodesWithText(errorText, substring = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+
+        composeRule.onNodeWithText(errorText, substring = true).assertExists()
+    }
+
+    fun getResult(): NfcScanningContract.Result {
+        return NfcScanningContract.parseResult(
+            resultCode = activityScenario.result.resultCode,
+            intent = activityScenario.result.resultData,
+        )
+    }
+
+    fun moveToState(state: Lifecycle.State) {
+        activityScenario.moveToState(state)
+    }
+
+    fun isActivityDestroyed(): Boolean {
+        return activityScenario.state == Lifecycle.State.DESTROYED
+    }
+
+    private companion object {
+        const val UI_TIMEOUT_MS = 5_000L
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Looper
 import android.os.VibrationEffect
+import android.os.Vibrator
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
@@ -13,37 +14,42 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.common.nfcscan.NfcScanningActivityTestHelpers.configureNfc
-import com.stripe.android.common.nfcscan.NfcScanningActivityTestHelpers.getShadowVibrator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.utils.AnimationConstants
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowActivity
+import org.robolectric.shadows.ShadowSystemClock
+import org.robolectric.shadows.ShadowVibrator
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+import kotlin.use
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 internal class NfcScanningActivityTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
-    @get:Rule
-    val composeRule = createEmptyComposeRule()
+    private val composeRule = createEmptyComposeRule()
+    private val composeCleanupRule = createComposeCleanupRule()
 
     @get:Rule
-    val composeCleanupRule = createComposeCleanupRule()
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(composeCleanupRule)
+        .around(composeRule)
 
     @Test
     fun `close button returns canceled result`() = test {
         composeRule.onNodeWithContentDescription("Cancel").performClick()
 
-        waitForActivityFinish()
+        waitForIdle()
 
         assertThat(getResult()).isEqualTo(NfcScanningContract.Result.Canceled)
     }
@@ -52,7 +58,7 @@ internal class NfcScanningActivityTest {
     fun `activity returns canceled result when moved to background`() = test {
         moveToState(Lifecycle.State.CREATED)
 
-        waitForActivityFinish()
+        waitForIdle()
 
         assertThat(getResult()).isEqualTo(NfcScanningContract.Result.Canceled)
     }
@@ -95,14 +101,12 @@ internal class NfcScanningActivityTest {
 
     @Test
     fun `successful card scan perform haptic feedback & returns complete result`() = test {
-        NfcScanningActivityTestHelpers.completeSuccessfulScan(
-            scenario = this,
-            responses = NfcScanningActivityTestFixtures.successResponses(),
-        )
+        dispatchCardRead(NfcScanningActivityTestFixtures.successResponses())
+        waitForCompleteUi()
 
-        assertThat(context.getShadowVibrator().effectId).isEqualTo(VibrationEffect.EFFECT_CLICK)
+        assertThat(getShadowVibrator(context).effectId).isEqualTo(VibrationEffect.EFFECT_CLICK)
 
-        waitForActivityFinish()
+        waitForIdle()
 
         assertThat(getResult()).isEqualTo(
             NfcScanningContract.Result.Complete(
@@ -115,54 +119,40 @@ internal class NfcScanningActivityTest {
 
     @Test
     fun `declined card shows error, performs haptic feedback, and keeps activity open`() = test {
-        NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
-            scenario = this,
-            responses = NfcScanningActivityTestFixtures.declinedCardResponses(),
-            errorText = context.getString(R.string.stripe_nfc_scan_error_declined_card),
-        )
+        dispatchCardRead(NfcScanningActivityTestFixtures.declinedCardResponses())
+        assertErrorIsDisplayed(errorText = "Card declined. Try another card.")
 
-        assertThat(context.getShadowVibrator().effectId).isEqualTo(VibrationEffect.EFFECT_HEAVY_CLICK)
+        assertThat(getShadowVibrator(context).effectId).isEqualTo(VibrationEffect.EFFECT_HEAVY_CLICK)
 
         assertThat(isActivityDestroyed()).isFalse()
     }
 
     @Test
     fun `unsupported card shows error and keeps activity open`() = test {
-        NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
-            scenario = this,
-            responses = NfcScanningActivityTestFixtures.unsupportedCardResponses(),
-            errorText = context.getString(R.string.stripe_nfc_scan_unsupported_card),
-        )
+        dispatchCardRead(NfcScanningActivityTestFixtures.unsupportedCardResponses())
+        assertErrorIsDisplayed(errorText = "Card not supported. Try another card.")
 
         assertThat(isActivityDestroyed()).isFalse()
     }
 
     @Test
     fun `expired card shows error and keeps activity open`() = test {
-        NfcScanningActivityTestHelpers.assertErrorIsDisplayed(
-            scenario = this,
-            responses = NfcScanningActivityTestFixtures.expiredCardResponses(),
-            errorText = context.getString(R.string.stripe_nfc_scan_error_expired_card),
-        )
+        dispatchCardRead(NfcScanningActivityTestFixtures.expiredCardResponses())
+        assertErrorIsDisplayed(errorText = "Card expired. Try another card.")
 
         assertThat(isActivityDestroyed()).isFalse()
     }
 
     @Test
     fun `inactivity timeout returns canceled result`() = test {
-        NfcScanningActivityTestHelpers.waitForInitialScanningUi(this)
-
-        NfcScanningActivityTestHelpers.advanceInactivityTimeout(this)
-
-        waitForActivityFinish()
+        ShadowSystemClock.advanceBy(20.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        waitForIdle()
 
         assertThat(getResult()).isEqualTo(NfcScanningContract.Result.Canceled)
     }
 
     @Test
     fun `finish applies fade out transition`() {
-        configureNfc(context)
-
         val intent = NfcScanningContract.createIntent(
             context = context,
             input = NfcScanningContract.Args(
@@ -185,12 +175,18 @@ internal class NfcScanningActivityTest {
     }
 
     private fun test(
-        block: NfcScanningActivityTestHelpers.Scenario.() -> Unit,
+        block: suspend NfcScanningActivityScenario.() -> Unit,
     ) {
         NfcScanningActivityTestHelpers.launchScenario(
             context = context,
             composeRule = composeRule,
             block = block,
         )
+    }
+
+    private fun getShadowVibrator(context: Context): ShadowVibrator {
+        @Suppress("DEPRECATION")
+        val vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        return shadowOf(vibrator)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -1,14 +1,7 @@
 package com.stripe.android.common.nfcscan
 
-import android.nfc.Tag
-import android.nfc.tech.IsoDep
-import com.stripe.android.common.nfcscan.scanner.FakeNfcTagTransceiver
 import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
 import com.stripe.android.common.nfcscan.scanner.apdu.tlv
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 internal object NfcScanningActivityTestFixtures {
     val VISA_AID = byteArrayOf(
@@ -21,7 +14,6 @@ internal object NfcScanningActivityTestFixtures {
         0x10,
     )
 
-    val RECORD_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x83.toByte())
     val FILE_NOT_FOUND_RESPONSE = byteArrayOf(0x6A.toByte(), 0x82.toByte())
     val CARD_DECLINED_RESPONSE = byteArrayOf(0x69.toByte(), 0x85.toByte())
 
@@ -54,37 +46,6 @@ internal object NfcScanningActivityTestFixtures {
         0x10,
         0x01,
     )
-
-    fun createIsoDepTag(): Tag = mock()
-
-    fun createConfiguredIsoDep(
-        responses: List<ByteArray>,
-    ): Pair<Tag, IsoDep> {
-        val tag = createIsoDepTag()
-
-        val fakeTransceiver = FakeNfcTagTransceiver(
-            transceiveResults = responses,
-            transceiveResult = RECORD_NOT_FOUND_RESPONSE,
-        )
-
-        val isoDep = mock<IsoDep>()
-
-        whenever(isoDep.transceive(any())).thenAnswer { invocation ->
-            fakeTransceiver.transceive(invocation.arguments[0] as ByteArray)
-        }
-
-        doAnswer {
-            fakeTransceiver.open()
-            null
-        }.whenever(isoDep).connect()
-
-        doAnswer {
-            fakeTransceiver.close()
-            null
-        }.whenever(isoDep).close()
-
-        return tag to isoDep
-    }
 
     val EMPTY_PDOL_TEMPLATE = tlv(tag = 0x9F.toByte(), tagContinuation = 0x38, value = byteArrayOf())
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mockStatic
 import org.robolectric.Shadows.shadowOf
-import org.robolectric.shadows.ShadowNfcAdapter
 
 internal object NfcScanningActivityTestHelpers {
     fun launchScenario(
@@ -21,7 +20,11 @@ internal object NfcScanningActivityTestHelpers {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         block: suspend NfcScanningActivityScenario.() -> Unit,
     ) {
-        val nfcAdapter = getEnabledNfcAdapter(context)
+        shadowOf(context.packageManager).setSystemFeature(PackageManager.FEATURE_NFC, true)
+
+        val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+            ?.let { shadowOf(it) }
+            ?.also { it.setEnabled(true) }
 
         val fakeIsoDep = FakeIsoDep()
         val intent = NfcScanningContract.createIntent(
@@ -51,11 +54,5 @@ internal object NfcScanningActivityTestHelpers {
                 }
             }
         }
-    }
-
-    fun getEnabledNfcAdapter(context: Context): ShadowNfcAdapter? {
-        shadowOf(context.packageManager).setSystemFeature(PackageManager.FEATURE_NFC, true)
-
-        return NfcAdapter.getDefaultAdapter(context)?.let { shadowOf(it) }?.also { it.setEnabled(true) }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
@@ -4,37 +4,26 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.nfc.NfcAdapter
 import android.nfc.tech.IsoDep
-import android.os.Looper
-import android.os.Vibrator
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithText
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.Espresso
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import kotlinx.coroutines.runBlocking
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mockStatic
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowNfcAdapter
-import org.robolectric.shadows.ShadowSystemClock
-import org.robolectric.shadows.ShadowVibrator
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.seconds
 
 internal object NfcScanningActivityTestHelpers {
-    private const val UI_TIMEOUT_MS = 5_000L
-
     fun launchScenario(
         context: Context,
         composeRule: ComposeTestRule,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-        block: Scenario.() -> Unit,
+        block: suspend NfcScanningActivityScenario.() -> Unit,
     ) {
-        configureNfc(context)
+        val nfcAdapter = getEnabledNfcAdapter(context)
 
+        val fakeIsoDep = FakeIsoDep()
         val intent = NfcScanningContract.createIntent(
             context = context,
             input = NfcScanningContract.Args(
@@ -42,143 +31,31 @@ internal object NfcScanningActivityTestHelpers {
             ),
         )
 
-        ActivityScenario.launchActivityForResult<NfcScanningActivity>(intent).use { scenario ->
-            scenario.onActivity {
-                block(
-                    createScenario(
-                        context = context,
-                        composeRule = composeRule,
-                        activityScenario = scenario,
-                        readResult = { readActivityResult(scenario) },
-                    ),
-                )
-            }
-        }
-    }
-
-    fun assertErrorIsDisplayed(
-        scenario: Scenario,
-        responses: List<ByteArray>,
-        errorText: String,
-    ) {
-        withDispatchedNfcCard(scenario, responses) {
-            scenario.composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
-                scenario.waitForIdle()
-                scenario.composeRule.onAllNodesWithText(errorText, substring = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-
-            scenario.composeRule.onNodeWithText(errorText, substring = true).assertExists()
-        }
-    }
-
-    fun completeSuccessfulScan(
-        scenario: Scenario,
-        responses: List<ByteArray>,
-    ) {
-        waitForInitialScanningUi(scenario)
-
-        withDispatchedNfcCard(scenario, responses) {
-            waitForScannedState(scenario)
-            scenario.waitForIdle()
-        }
-    }
-
-    fun advanceInactivityTimeout(scenario: Scenario) {
-        ShadowSystemClock.advanceBy(
-            20.seconds.inWholeSeconds,
-            TimeUnit.SECONDS,
-        )
-        scenario.waitForIdle()
-    }
-
-    private fun createScenario(
-        context: Context,
-        composeRule: ComposeTestRule,
-        activityScenario: ActivityScenario<NfcScanningActivity>,
-        readResult: () -> NfcScanningContract.Result,
-    ): Scenario {
-        val waitForIdle = {
-            shadowOf(Looper.getMainLooper()).idle()
-            Espresso.onIdle()
-            composeRule.waitForIdle()
-        }
-
-        return Scenario(
-            composeRule = composeRule,
-            nfcAdapter = getNfcAdapter(context),
-            moveToState = activityScenario::moveToState,
-            waitForIdle = waitForIdle,
-            waitForActivityFinish = waitForIdle,
-            isActivityDestroyed = { activityScenario.state == Lifecycle.State.DESTROYED },
-            getResult = readResult,
-        )
-    }
-
-    private fun readActivityResult(
-        activityScenario: ActivityScenario<NfcScanningActivity>,
-    ): NfcScanningContract.Result {
-        return NfcScanningContract.parseResult(
-            resultCode = activityScenario.result.resultCode,
-            intent = activityScenario.result.resultData,
-        )
-    }
-
-    fun Context.getShadowVibrator(): ShadowVibrator {
-        @Suppress("DEPRECATION")
-        val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-        return shadowOf(vibrator)
-    }
-
-    fun configureNfc(context: Context) {
-        shadowOf(context.packageManager).setSystemFeature(PackageManager.FEATURE_NFC, true)
-        getNfcAdapter(context)?.setEnabled(true)
-    }
-
-    private fun getNfcAdapter(context: Context) =
-        NfcAdapter.getDefaultAdapter(context)?.let { shadowOf(it) }
-
-    internal fun waitForInitialScanningUi(scenario: Scenario) {
-        scenario.composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
-            scenario.waitForIdle()
-            scenario.composeRule.onAllNodesWithContentDescription("Cancel")
-                .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                .isNotEmpty()
-        }
-    }
-
-    private fun waitForScannedState(scenario: Scenario) {
-        scenario.composeRule.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
-            scenario.waitForIdle()
-            scenario.composeRule.onAllNodesWithContentDescription("Cancel")
-                .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                .isEmpty()
-        }
-    }
-
-    private inline fun withDispatchedNfcCard(
-        scenario: Scenario,
-        responses: List<ByteArray>,
-        block: () -> Unit,
-    ) {
-        val (tag, isoDep) = NfcScanningActivityTestFixtures.createConfiguredIsoDep(responses)
-
         mockStatic(IsoDep::class.java).use { mockedIsoDep ->
-            mockedIsoDep.`when`<IsoDep> { IsoDep.get(any()) }.thenReturn(isoDep)
-            scenario.nfcAdapter?.dispatchTagDiscovered(tag)
-            scenario.waitForIdle()
-            block()
+            mockedIsoDep.`when`<IsoDep> { IsoDep.get(any()) }.thenReturn(fakeIsoDep.wrappedInstance)
+
+            ActivityScenario.launchActivityForResult<NfcScanningActivity>(intent).use { scenario ->
+                scenario.onActivity {
+                    runBlocking {
+                        block(
+                            NfcScanningActivityScenario(
+                                composeRule = composeRule,
+                                activityScenario = scenario,
+                                isoDep = fakeIsoDep,
+                                nfcAdapter = nfcAdapter,
+                            ).apply {
+                                waitForUi()
+                            }
+                        )
+                    }
+                }
+            }
         }
     }
 
-    class Scenario(
-        val composeRule: ComposeTestRule,
-        val nfcAdapter: ShadowNfcAdapter?,
-        val moveToState: (Lifecycle.State) -> Unit,
-        val waitForIdle: () -> Unit,
-        val waitForActivityFinish: () -> Unit,
-        val isActivityDestroyed: () -> Boolean,
-        val getResult: () -> NfcScanningContract.Result,
-    )
+    fun getEnabledNfcAdapter(context: Context): ShadowNfcAdapter? {
+        shadowOf(context.packageManager).setSystemFeature(PackageManager.FEATURE_NFC, true)
+
+        return NfcAdapter.getDefaultAdapter(context)?.let { shadowOf(it) }?.also { it.setEnabled(true) }
+    }
 }


### PR DESCRIPTION
# Summary
Refactor `NfcScanningActivityTest` & `NfcScanningActivityAnalyticsTest` to more clear show operations going on during tests while cleaning up various test files.
- Move out the `Scenario` class in `NfcScanningActivityTestHelper` into its own class. Move accompanying functions into the scenario class.
- Make a `FakeIsoDep` that configures the mock and wraps the instance. This will be used in a follow-up PR to verify interactions.

# Motivation
Cleaner test code & setup for `IsoDep` interaction verification.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>