### PR TITLE
Verify `IsoDep` interactions & add test for full PDOL template in `NfcScanningActivityTest`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeIsoDep.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeIsoDep.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.nfcscan
 
 import android.nfc.Tag
 import android.nfc.tech.IsoDep
+import app.cash.turbine.Turbine
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
@@ -10,13 +11,19 @@ import org.mockito.kotlin.whenever
 internal class FakeIsoDep(
     val tag: Tag = mock(),
 ) {
+    val connectCalls = Turbine<Unit>()
+    val transceiveCalls = Turbine<ByteArray>()
+    val closeCalls = Turbine<Unit>()
+
     private var transceiveResults: List<ByteArray> = emptyList()
     private var transceiveResultIndex = 0
 
     val wrappedInstance: IsoDep = mock()
 
     init {
-        whenever(wrappedInstance.transceive(any())).thenAnswer {
+        whenever(wrappedInstance.transceive(any())).thenAnswer { invocation ->
+            val command = invocation.arguments[0] as ByteArray
+            transceiveCalls.add(command)
             if (transceiveResultIndex < transceiveResults.size) {
                 transceiveResults[transceiveResultIndex++]
             } else {
@@ -24,8 +31,15 @@ internal class FakeIsoDep(
             }
         }
 
-        doAnswer { null }.whenever(wrappedInstance).connect()
-        doAnswer { null }.whenever(wrappedInstance).close()
+        doAnswer {
+            connectCalls.add(Unit)
+            null
+        }.whenever(wrappedInstance).connect()
+
+        doAnswer {
+            closeCalls.add(Unit)
+            null
+        }.whenever(wrappedInstance).close()
     }
 
     fun setTransceiveResponses(
@@ -33,5 +47,11 @@ internal class FakeIsoDep(
     ) {
         this.transceiveResults = transceiveResults
         this.transceiveResultIndex = 0
+    }
+
+    fun ensureAllEventsConsumed() {
+        connectCalls.ensureAllEventsConsumed()
+        transceiveCalls.ensureAllEventsConsumed()
+        closeCalls.ensureAllEventsConsumed()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeIsoDep.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/FakeIsoDep.kt
@@ -3,6 +3,7 @@ package com.stripe.android.common.nfcscan
 import android.nfc.Tag
 import android.nfc.tech.IsoDep
 import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
@@ -47,6 +48,18 @@ internal class FakeIsoDep(
     ) {
         this.transceiveResults = transceiveResults
         this.transceiveResultIndex = 0
+    }
+
+    suspend fun assertConnect() {
+        assertThat(connectCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    suspend fun assertCommand(command: ByteArray) {
+        assertThat(transceiveCalls.awaitItem()).isEqualTo(command)
+    }
+
+    suspend fun assertClose() {
+        assertThat(closeCalls.awaitItem()).isEqualTo(Unit)
     }
 
     fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTest.kt
@@ -71,6 +71,7 @@ internal class NfcScanningActivityAnalyticsTest {
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.successResponses())
             waitForCompleteUi()
+            isoDep.assertSuccess()
             waitForIdle()
         }
     }
@@ -84,6 +85,7 @@ internal class NfcScanningActivityAnalyticsTest {
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.declinedCardResponses())
             assertErrorIsDisplayed(errorText = "Card declined. Try another card.")
+            isoDep.assertUntilPpseSelectionCommand()
         }
     }
 
@@ -96,6 +98,7 @@ internal class NfcScanningActivityAnalyticsTest {
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.unsupportedCardResponses())
             assertErrorIsDisplayed(errorText = "Card not supported. Try another card.")
+            isoDep.assertUntilPpseSelectionCommand()
         }
     }
 
@@ -108,6 +111,7 @@ internal class NfcScanningActivityAnalyticsTest {
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.expiredCardResponses())
             assertErrorIsDisplayed(errorText = "Card expired. Try another card.")
+            isoDep.assertSuccess()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityIsoDepAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityIsoDepAssertions.kt
@@ -6,36 +6,15 @@ internal suspend fun FakeIsoDep.assertSuccess(
     gpoCommand: ByteArray = NfcScanningActivityTestFixtures.ApduCommands.GPO_EMPTY_PDOL,
 ) {
     assertConnect()
-    assertPpseSelection()
-    assertSelectApplication()
-    assertGetProcessingOptionsCommand(gpoCommand)
+    assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_PPSE)
+    assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_VISA_APPLICATION)
+    assertCommand(gpoCommand)
+    assertThat(transceiveCalls.awaitItem()).isEqualTo(gpoCommand)
     assertClose()
 }
 
 internal suspend fun FakeIsoDep.assertUntilPpseSelectionCommand() {
     assertConnect()
-    assertPpseSelection()
+    assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_PPSE)
     assertClose()
-}
-
-private suspend fun FakeIsoDep.assertConnect() {
-    assertThat(connectCalls.awaitItem()).isEqualTo(Unit)
-}
-
-private suspend fun FakeIsoDep.assertClose() {
-    assertThat(closeCalls.awaitItem()).isEqualTo(Unit)
-}
-
-private suspend fun FakeIsoDep.assertPpseSelection() {
-    assertThat(transceiveCalls.awaitItem())
-        .isEqualTo(NfcScanningActivityTestFixtures.ApduCommands.SELECT_PPSE)
-}
-
-private suspend fun FakeIsoDep.assertSelectApplication() {
-    assertThat(transceiveCalls.awaitItem())
-        .isEqualTo(NfcScanningActivityTestFixtures.ApduCommands.SELECT_VISA_APPLICATION)
-}
-
-private suspend fun FakeIsoDep.assertGetProcessingOptionsCommand(expectedCommand: ByteArray) {
-    assertThat(transceiveCalls.awaitItem()).isEqualTo(expectedCommand)
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityIsoDepAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityIsoDepAssertions.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.common.nfcscan
 
-import com.google.common.truth.Truth.assertThat
-
 internal suspend fun FakeIsoDep.assertSuccess(
     gpoCommand: ByteArray = NfcScanningActivityTestFixtures.ApduCommands.GPO_EMPTY_PDOL,
 ) {
@@ -9,7 +7,6 @@ internal suspend fun FakeIsoDep.assertSuccess(
     assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_PPSE)
     assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_VISA_APPLICATION)
     assertCommand(gpoCommand)
-    assertThat(transceiveCalls.awaitItem()).isEqualTo(gpoCommand)
     assertClose()
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityIsoDepAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityIsoDepAssertions.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.common.nfcscan
+
+import com.google.common.truth.Truth.assertThat
+
+internal suspend fun FakeIsoDep.assertSuccess(
+    gpoCommand: ByteArray = NfcScanningActivityTestFixtures.ApduCommands.GPO_EMPTY_PDOL,
+) {
+    assertConnect()
+    assertPpseSelection()
+    assertSelectApplication()
+    assertGetProcessingOptionsCommand(gpoCommand)
+    assertClose()
+}
+
+internal suspend fun FakeIsoDep.assertUntilPpseSelectionCommand() {
+    assertConnect()
+    assertPpseSelection()
+    assertClose()
+}
+
+private suspend fun FakeIsoDep.assertConnect() {
+    assertThat(connectCalls.awaitItem()).isEqualTo(Unit)
+}
+
+private suspend fun FakeIsoDep.assertClose() {
+    assertThat(closeCalls.awaitItem()).isEqualTo(Unit)
+}
+
+private suspend fun FakeIsoDep.assertPpseSelection() {
+    assertThat(transceiveCalls.awaitItem())
+        .isEqualTo(NfcScanningActivityTestFixtures.ApduCommands.SELECT_PPSE)
+}
+
+private suspend fun FakeIsoDep.assertSelectApplication() {
+    assertThat(transceiveCalls.awaitItem())
+        .isEqualTo(NfcScanningActivityTestFixtures.ApduCommands.SELECT_VISA_APPLICATION)
+}
+
+private suspend fun FakeIsoDep.assertGetProcessingOptionsCommand(expectedCommand: ByteArray) {
+    assertThat(transceiveCalls.awaitItem()).isEqualTo(expectedCommand)
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityScenario.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityScenario.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowNfcAdapter
 
@@ -16,6 +17,7 @@ internal class NfcScanningActivityScenario(
     val composeRule: ComposeTestRule,
     val isoDep: FakeIsoDep,
     val nfcAdapter: ShadowNfcAdapter?,
+    val paymentMethodMetadata: PaymentMethodMetadata,
 ) {
     fun waitForIdle() {
         shadowOf(Looper.getMainLooper()).idle()

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -14,7 +14,9 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.utils.AnimationConstants
 import org.junit.Rule
@@ -28,6 +30,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowActivity
 import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.shadows.ShadowVibrator
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlin.use
@@ -44,6 +47,7 @@ internal class NfcScanningActivityTest {
     val ruleChain: RuleChain = RuleChain
         .outerRule(composeCleanupRule)
         .around(composeRule)
+        .around(LocaleTestRule(Locale.US))
 
     @Test
     fun `close button returns canceled result`() = test {
@@ -104,6 +108,8 @@ internal class NfcScanningActivityTest {
         dispatchCardRead(NfcScanningActivityTestFixtures.successResponses())
         waitForCompleteUi()
 
+        isoDep.assertSuccess()
+
         assertThat(getShadowVibrator(context).effectId).isEqualTo(VibrationEffect.EFFECT_CLICK)
 
         waitForIdle()
@@ -118,9 +124,35 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
+    fun `successful card scan with full PDOL template returns proper values in GPO command`() {
+        test(
+            paymentMethodMetadata = NfcScanningActivityTestFixtures.paymentMethodMetadataWithPdolData(),
+        ) {
+            dispatchCardRead(NfcScanningActivityTestFixtures.fullPdolSuccessResponses())
+            waitForCompleteUi()
+
+            isoDep.assertSuccess(
+                gpoCommand = NfcScanningActivityTestFixtures.ApduCommands.GPO_FULL_PDOL,
+            )
+
+            waitForIdle()
+
+            assertThat(getResult()).isEqualTo(
+                NfcScanningContract.Result.Complete(
+                    cardNumber = "4242424242424242",
+                    expirationMonth = 12,
+                    expirationYear = 2030,
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `declined card shows error, performs haptic feedback, and keeps activity open`() = test {
         dispatchCardRead(NfcScanningActivityTestFixtures.declinedCardResponses())
         assertErrorIsDisplayed(errorText = "Card declined. Try another card.")
+
+        isoDep.assertUntilPpseSelectionCommand()
 
         assertThat(getShadowVibrator(context).effectId).isEqualTo(VibrationEffect.EFFECT_HEAVY_CLICK)
 
@@ -132,6 +164,8 @@ internal class NfcScanningActivityTest {
         dispatchCardRead(NfcScanningActivityTestFixtures.unsupportedCardResponses())
         assertErrorIsDisplayed(errorText = "Card not supported. Try another card.")
 
+        isoDep.assertUntilPpseSelectionCommand()
+
         assertThat(isActivityDestroyed()).isFalse()
     }
 
@@ -139,6 +173,8 @@ internal class NfcScanningActivityTest {
     fun `expired card shows error and keeps activity open`() = test {
         dispatchCardRead(NfcScanningActivityTestFixtures.expiredCardResponses())
         assertErrorIsDisplayed(errorText = "Card expired. Try another card.")
+
+        isoDep.assertSuccess()
 
         assertThat(isActivityDestroyed()).isFalse()
     }
@@ -175,11 +211,13 @@ internal class NfcScanningActivityTest {
     }
 
     private fun test(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         block: suspend NfcScanningActivityScenario.() -> Unit,
     ) {
         NfcScanningActivityTestHelpers.launchScenario(
             context = context,
             composeRule = composeRule,
+            paymentMethodMetadata = paymentMethodMetadata,
             block = block,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -52,13 +52,26 @@ internal object NfcScanningActivityTestFixtures {
 
     val EMPTY_PDOL_TEMPLATE = tlv(tag = 0x9F.toByte(), tagContinuation = 0x38, value = byteArrayOf())
 
+    /**
+     * PDOL template (tag `9F38`) returned during application selection. Each entry is a
+     * tag plus the byte length the terminal must supply — values are omitted from the template.
+     *
+     * See [com.stripe.android.common.nfcscan.scanner.apdu.pdol.PdolBuilder].
+     */
     val FULL_PDOL_TEMPLATE = byteArrayOf(
+        // 9F02 (Amount, Authorized) — 6 bytes
         0x9F.toByte(), 0x02, 0x06,
+        // 5F2A (Transaction Currency Code) — 2 bytes
         0x5F.toByte(), 0x2A, 0x02,
+        // 9F1A (Terminal Country Code) — 2 bytes
         0x9F.toByte(), 0x1A, 0x02,
+        // 9F35 (Terminal Type) — 1 byte
         0x9F.toByte(), 0x35, 0x01,
+        // 9A (Transaction Date) — 3 bytes
         0x9A.toByte(), 0x03,
+        // 9F6E (Enhanced Contactless Reader Capabilities) — 4 bytes
         0x9F.toByte(), 0x6E, 0x04,
+        // 9F66 (Terminal Transaction Qualifiers) — 4 bytes
         0x9F.toByte(), 0x66, 0x04,
     )
 
@@ -109,13 +122,22 @@ internal object NfcScanningActivityTestFixtures {
         ),
     )
 
+    /*
+     * Expected APDU command bytes sent to the card during NFC scanning.
+     * Format: CLA | INS | P1 | P2 | Lc | command data | Le
+     */
     object ApduCommands {
+        /*
+         * SELECT PPSE — locates the contactless payment application directory.
+         * CLA=0x00, INS=SELECT (0xA4), P1=select by name (0x04), P2=first occurrence (0x00)
+         */
         val SELECT_PPSE = byteArrayOf(
-            0x00,
-            0xA4.toByte(),
-            0x04,
-            0x00,
-            0x0E,
+            0x00, // CLA
+            0xA4.toByte(), // INS (SELECT)
+            0x04, // P1 (select by name)
+            0x00, // P2 (first or only occurrence)
+            0x0E, // Lc (data length)
+            // "2PAY.SYS.DDF01" (PPSE directory name)
             0x32,
             0x50,
             0x41,
@@ -133,12 +155,17 @@ internal object NfcScanningActivityTestFixtures {
             0x00,
         )
 
+        /*
+         * SELECT application — selects the Visa payment application by AID.
+         * CLA=0x00, INS=SELECT (0xA4), P1=select by name (0x04), P2=first occurrence (0x00)
+         */
         val SELECT_VISA_APPLICATION = byteArrayOf(
-            0x00,
-            0xA4.toByte(),
-            0x04,
-            0x00,
-            0x07,
+            0x00, // CLA
+            0xA4.toByte(), // INS (SELECT)
+            0x04, // P1 (select by name)
+            0x00, // P2 (first or only occurrence)
+            0x07, // Lc (AID length)
+            // Visa AID (Application Identifier)
             0xA0.toByte(),
             0x00,
             0x00,
@@ -149,43 +176,60 @@ internal object NfcScanningActivityTestFixtures {
             0x00,
         )
 
+        /*
+         * GET PROCESSING OPTIONS — card returned an empty PDOL template, so no terminal data is sent.
+         * CLA=0x80, INS=GET PROCESSING OPTIONS (0xA8)
+         */
         val GPO_EMPTY_PDOL = byteArrayOf(
-            0x80.toByte(),
-            0xA8.toByte(),
-            0x00,
-            0x00,
-            0x02,
-            0x83.toByte(),
-            0x00,
+            0x80.toByte(), // CLA
+            0xA8.toByte(), // INS (GET PROCESSING OPTIONS)
+            0x00, // P1
+            0x00, // P2
+            0x02, // Lc (command data length)
+            0x83.toByte(), // tag 83 (command template)
+            0x00, // length (empty PDOL — card requested no terminal data)
             0x00,
         )
 
+        /*
+         * GET PROCESSING OPTIONS with populated PDOL data built from [FULL_PDOL_TEMPLATE] and
+         * [paymentMethodMetadataWithPdolData]. Command data is tag `83` followed by terminal
+         * values concatenated in PDOL order.
+         * CLA=0x80, INS=GET PROCESSING OPTIONS (0xA8)
+         */
         val GPO_FULL_PDOL = byteArrayOf(
-            0x80.toByte(),
-            0xA8.toByte(),
-            0x00,
-            0x00,
-            0x18,
-            0x83.toByte(),
-            0x16,
+            0x80.toByte(), // CLA
+            0xA8.toByte(), // INS (GET PROCESSING OPTIONS)
+            0x00, // P1
+            0x00, // P2
+            0x18, // Lc (command data length)
+            0x83.toByte(), // tag 83 (command template)
+            0x16, // length (22 bytes of PDOL response)
+            // 9F02 — Amount, Authorized (€55.02 = 5502 minor units, BCD)
             0x00,
             0x00,
             0x00,
             0x00,
             0x55,
             0x02,
+            // 5F2A — Transaction Currency Code (EUR = 978, BCD)
             0x09,
             0x78,
+            // 9F1A — Terminal Country Code (US = 840, BCD; from default locale in tests)
             0x08,
             0x40,
+            // 9F35 — Terminal Type (0x34 = cardholder-controlled, unattended, online-only)
             0x34,
+            // 9A — Transaction Date (2020-01-01, BCD YYMMDD; from [FULL_PDOL_CREATED])
             0x20,
             0x01,
             0x01,
+            // 9F6E — Enhanced Contactless Reader Capabilities (Amex Expresspay)
             0x18,
             0x80.toByte(),
             0x00,
             0x03,
+            // 9F66 — Terminal Transaction Qualifiers (Visa payWave)
             0x20,
             0x00,
             0x40,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -2,6 +2,9 @@ package com.stripe.android.common.nfcscan
 
 import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
 import com.stripe.android.common.nfcscan.scanner.apdu.tlv
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.testing.PaymentIntentFactory
 
 internal object NfcScanningActivityTestFixtures {
     val VISA_AID = byteArrayOf(
@@ -49,6 +52,22 @@ internal object NfcScanningActivityTestFixtures {
 
     val EMPTY_PDOL_TEMPLATE = tlv(tag = 0x9F.toByte(), tagContinuation = 0x38, value = byteArrayOf())
 
+    val FULL_PDOL_TEMPLATE = byteArrayOf(
+        0x9F.toByte(), 0x02, 0x06,
+        0x5F.toByte(), 0x2A, 0x02,
+        0x9F.toByte(), 0x1A, 0x02,
+        0x9F.toByte(), 0x35, 0x01,
+        0x9A.toByte(), 0x03,
+        0x9F.toByte(), 0x6E, 0x04,
+        0x9F.toByte(), 0x66, 0x04,
+    )
+
+    val FULL_PDOL_SELECT_RESPONSE = tlv(
+        tag = 0x9F.toByte(),
+        tagContinuation = 0x38,
+        value = FULL_PDOL_TEMPLATE,
+    )
+
     fun successResponses(): List<ByteArray> = listOf(
         apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
         apduSuccessResponse(EMPTY_PDOL_TEMPLATE),
@@ -56,6 +75,23 @@ internal object NfcScanningActivityTestFixtures {
             tlv(tag = 0x77, value = tlv(tag = 0x57, value = VALID_TRACK_2_DATA)),
         ),
     )
+
+    fun fullPdolSuccessResponses(): List<ByteArray> = listOf(
+        apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+        apduSuccessResponse(FULL_PDOL_SELECT_RESPONSE),
+        apduSuccessResponse(
+            tlv(tag = 0x77, value = tlv(tag = 0x57, value = VALID_TRACK_2_DATA)),
+        ),
+    )
+
+    fun paymentMethodMetadataWithPdolData(): PaymentMethodMetadata {
+        return PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFactory.create(
+                amount = FULL_PDOL_AMOUNT,
+                currency = FULL_PDOL_CURRENCY,
+            ).copy(created = FULL_PDOL_CREATED),
+        )
+    }
 
     fun declinedCardResponses(): List<ByteArray> = listOf(
         CARD_DECLINED_RESPONSE,
@@ -72,4 +108,93 @@ internal object NfcScanningActivityTestFixtures {
             tlv(tag = 0x77, value = tlv(tag = 0x57, value = EXPIRED_TRACK_2_DATA)),
         ),
     )
+
+    object ApduCommands {
+        val SELECT_PPSE = byteArrayOf(
+            0x00,
+            0xA4.toByte(),
+            0x04,
+            0x00,
+            0x0E,
+            0x32,
+            0x50,
+            0x41,
+            0x59,
+            0x2E,
+            0x53,
+            0x59,
+            0x53,
+            0x2E,
+            0x44,
+            0x44,
+            0x46,
+            0x30,
+            0x31,
+            0x00,
+        )
+
+        val SELECT_VISA_APPLICATION = byteArrayOf(
+            0x00,
+            0xA4.toByte(),
+            0x04,
+            0x00,
+            0x07,
+            0xA0.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x03,
+            0x10,
+            0x10,
+            0x00,
+        )
+
+        val GPO_EMPTY_PDOL = byteArrayOf(
+            0x80.toByte(),
+            0xA8.toByte(),
+            0x00,
+            0x00,
+            0x02,
+            0x83.toByte(),
+            0x00,
+            0x00,
+        )
+
+        val GPO_FULL_PDOL = byteArrayOf(
+            0x80.toByte(),
+            0xA8.toByte(),
+            0x00,
+            0x00,
+            0x18,
+            0x83.toByte(),
+            0x16,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x55,
+            0x02,
+            0x09,
+            0x78,
+            0x08,
+            0x40,
+            0x34,
+            0x20,
+            0x01,
+            0x01,
+            0x18,
+            0x80.toByte(),
+            0x00,
+            0x03,
+            0x20,
+            0x00,
+            0x40,
+            0x00,
+            0x00,
+        )
+    }
+
+    private const val FULL_PDOL_AMOUNT = 5502L
+    private const val FULL_PDOL_CURRENCY = "eur"
+    private const val FULL_PDOL_CREATED = 1577838600L
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestHelpers.kt
@@ -46,6 +46,7 @@ internal object NfcScanningActivityTestHelpers {
                                 activityScenario = scenario,
                                 isoDep = fakeIsoDep,
                                 nfcAdapter = nfcAdapter,
+                                paymentMethodMetadata = paymentMethodMetadata,
                             ).apply {
                                 waitForUi()
                             }
@@ -53,6 +54,8 @@ internal object NfcScanningActivityTestHelpers {
                     }
                 }
             }
+
+            fakeIsoDep.ensureAllEventsConsumed()
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
 Verify `IsoDep` interactions by adding `Turbine` events to `FakeIsoDep` and validating that all the calls were checked. Also add a test for full PDOL template & response verification in `NfcScanningActivityTest`.   

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improved testing for NFC scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>