### PR TITLE
Add NFC activity test for validating card brand filtering

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -170,6 +170,20 @@ internal class NfcScanningActivityTest {
     }
 
     @Test
+    fun `merchant card brand filter rejects visa and keeps activity open`() {
+        test(
+            paymentMethodMetadata = NfcScanningActivityTestFixtures.paymentMethodMetadataWithVisaDisallowed(),
+        ) {
+            dispatchCardRead(NfcScanningActivityTestFixtures.successResponses())
+            assertErrorIsDisplayed(errorText = "Card not supported. Try another card.")
+
+            isoDep.assertSuccess()
+
+            assertThat(isActivityDestroyed()).isFalse()
+        }
+    }
+
+    @Test
     fun `expired card shows error and keeps activity open`() = test {
         dispatchCardRead(NfcScanningActivityTestFixtures.expiredCardResponses())
         assertErrorIsDisplayed(errorText = "Card expired. Try another card.")

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -4,6 +4,8 @@ import com.stripe.android.common.nfcscan.scanner.apdu.apduSuccessResponse
 import com.stripe.android.common.nfcscan.scanner.apdu.tlv
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.PaymentIntentFactory
 
 internal object NfcScanningActivityTestFixtures {
@@ -103,6 +105,16 @@ internal object NfcScanningActivityTestFixtures {
                 amount = FULL_PDOL_AMOUNT,
                 currency = FULL_PDOL_CURRENCY,
             ).copy(created = FULL_PDOL_CREATED),
+        )
+    }
+
+    fun paymentMethodMetadataWithVisaDisallowed(): PaymentMethodMetadata {
+        return PaymentMethodMetadataFactory.create(
+            cardBrandFilter = PaymentSheetCardBrandFilter(
+                PaymentSheet.CardBrandAcceptance.disallowed(
+                    listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Visa),
+                ),
+            ),
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
 Add NFC activity test for validating card brand filtering error that should occur if card brand is disallowed

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
NFC scanning testing coverage

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>