### PR TITLE
Log number of attempts taken in the NFC scanning flow

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModel.kt
@@ -48,6 +48,7 @@ internal class NfcScanningViewModel @Inject constructor(
     private var pendingValidCardData: ScannedCardData? = null
     private var successShownDispatched = false
     private var isFlowClosed = false
+    private var numberOfAttempts = 0
 
     init {
         eventReporter.onNfcScanStarted()
@@ -66,6 +67,7 @@ internal class NfcScanningViewModel @Inject constructor(
                             )
                         )
 
+                        numberOfAttempts++
                         eventReporter.onNfcScanAttemptStarted()
                     }
                     is NfcCardScanner.State.Failed -> {
@@ -132,7 +134,7 @@ internal class NfcScanningViewModel @Inject constructor(
                     return
                 }
                 successShownDispatched = true
-                eventReporter.onNfcScanSucceeded()
+                eventReporter.onNfcScanSucceeded(numberOfAttempts)
                 viewModelScope.launch {
                     pendingValidCardData?.let { cardData ->
                         _event.emit(
@@ -163,7 +165,10 @@ internal class NfcScanningViewModel @Inject constructor(
 
         isFlowClosed = true
         timeoutManager.cancel()
-        eventReporter.onNfcScanCancelled(reason)
+        eventReporter.onNfcScanCancelled(
+            reason = reason,
+            numberOfAttempts = numberOfAttempts,
+        )
         _event.emit(NfcScanningEvent.CloseWithResult(NfcScanningContract.Result.Canceled))
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
@@ -41,15 +41,21 @@ internal interface NfcScanningEventReporter {
     /**
      * NFC scan flow completed successfully meaning the user is being returned to the calling payment flow after
      * being shown that they successfully scanned valid card details.
+     *
+     * @param numberOfAttempts number of times the user attempted to scan their card with NFC
      */
-    fun onNfcScanSucceeded()
+    fun onNfcScanSucceeded(numberOfAttempts: Int)
 
     /**
      * The user has chosen to exit the NFC scanning flow without scanning valid card details.
      *
      * @param reason why there was an NFC flow cancellation
+     * @param numberOfAttempts number of times the user attempted to scan their card with NFC
      */
-    fun onNfcScanCancelled(reason: NfcScanCancellationReason)
+    fun onNfcScanCancelled(
+        reason: NfcScanCancellationReason,
+        numberOfAttempts: Int,
+    )
 }
 
 internal class DefaultNfcScanningEventReporter @Inject constructor(
@@ -63,9 +69,13 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
         fireEvent(eventName = SCAN_STARTED_EVENT_NAME)
     }
 
-    override fun onNfcScanSucceeded() {
+    override fun onNfcScanSucceeded(numberOfAttempts: Int) {
         val duration = durationProvider.end(DurationProvider.Key.NfcScan)
-        fireEvent(eventName = SCAN_SUCCESS_EVENT_NAME, additionalParams = duration.mapOfDurationInSeconds())
+        fireEvent(
+            eventName = SCAN_SUCCESS_EVENT_NAME,
+            additionalParams = duration.mapOfDurationInSeconds() +
+                mapOf(FIELD_NUMBER_OF_ATTEMPTS to numberOfAttempts),
+        )
     }
 
     override fun onNfcScanAttemptStarted() {
@@ -91,12 +101,18 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
         )
     }
 
-    override fun onNfcScanCancelled(reason: NfcScanCancellationReason) {
+    override fun onNfcScanCancelled(
+        reason: NfcScanCancellationReason,
+        numberOfAttempts: Int,
+    ) {
         val duration = durationProvider.end(DurationProvider.Key.NfcScan)
         fireEvent(
             eventName = SCAN_CANCELED_EVENT_NAME,
             additionalParams = duration.mapOfDurationInSeconds() +
-                mapOf(FIELD_CANCELLATION_REASON to reason.analyticsValue)
+                mapOf(
+                    FIELD_CANCELLATION_REASON to reason.analyticsValue,
+                    FIELD_NUMBER_OF_ATTEMPTS to numberOfAttempts,
+                )
         )
     }
 
@@ -118,6 +134,7 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
     private companion object {
         const val FIELD_ERROR_CODE = "error_code"
         const val FIELD_CANCELLATION_REASON = "cancellation_reason"
+        const val FIELD_NUMBER_OF_ATTEMPTS = "number_of_attempts"
 
         const val SCAN_STARTED_EVENT_NAME = "nfc_scan_started"
         const val SCAN_SUCCESS_EVENT_NAME = "nfc_scan_success"

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningViewModelTest.kt
@@ -68,8 +68,12 @@ internal class NfcScanningViewModelTest {
             assertThat(resultEvent.result).isEqualTo(NfcScanningContract.Result.Canceled)
         }
 
-        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem())
-            .isEqualTo(NfcScanCancellationReason.UserInitiated)
+        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem()).isEqualTo(
+            FakeNfcScanningEventReporter.NfcScanCancelledCall(
+                reason = NfcScanCancellationReason.UserInitiated,
+                numberOfAttempts = 0,
+            ),
+        )
 
         assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
     }
@@ -219,6 +223,10 @@ internal class NfcScanningViewModelTest {
 
     @Test
     fun `card scanner Complete state emits Complete result after success animation`() = runScenario {
+        scannerState.emit(NfcCardScanner.State.Scanning)
+
+        assertThat(fakeEventReporter.onNfcScanAttemptStartedCalls.awaitItem()).isNotNull()
+
         viewModel.event.test {
             scannerState.emit(
                 NfcCardScanner.State.Complete(
@@ -252,7 +260,7 @@ internal class NfcScanningViewModelTest {
         }
 
         assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
-        assertThat(fakeEventReporter.onNfcScanSucceededCalls.awaitItem()).isNotNull()
+        assertThat(fakeEventReporter.onNfcScanSucceededCalls.awaitItem()).isEqualTo(1)
     }
 
     @Test
@@ -315,8 +323,12 @@ internal class NfcScanningViewModelTest {
             assertThat(resultEvent.result).isEqualTo(NfcScanningContract.Result.Canceled)
         }
 
-        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem())
-            .isEqualTo(NfcScanCancellationReason.Timeout)
+        assertThat(fakeEventReporter.onNfcScanCancelledCalls.awaitItem()).isEqualTo(
+            FakeNfcScanningEventReporter.NfcScanCancelledCall(
+                reason = NfcScanCancellationReason.Timeout,
+                numberOfAttempts = 0,
+            ),
+        )
         assertThat(fakeTimeoutManager.cancelCalls.awaitItem()).isNotNull()
     }
 
@@ -339,6 +351,66 @@ internal class NfcScanningViewModelTest {
             fakeTimeoutManager.emitTimeout()
             expectNoEvents()
         }
+    }
+
+    @Test
+    fun `A successful scan reports number of attempts`() = runScenario {
+        scannerState.emit(NfcCardScanner.State.Scanning)
+        assertThat(fakeEventReporter.onNfcScanAttemptStartedCalls.awaitItem()).isNotNull()
+
+        scannerState.emit(
+            NfcCardScanner.State.Failed(
+                error = NfcCardScanner.Error(
+                    code = "expiredCard",
+                    userMessage = R.string.stripe_nfc_expired_error.resolvableString,
+                ),
+            ),
+        )
+        assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isNotNull()
+
+        scannerState.emit(NfcCardScanner.State.Scanning)
+        assertThat(fakeEventReporter.onNfcScanAttemptStartedCalls.awaitItem()).isNotNull()
+
+        scannerState.emit(
+            NfcCardScanner.State.Complete(
+                ScannedCardData(
+                    cardNumber = "4242424242424242",
+                    expirationMonth = 12,
+                    expirationYear = 2030,
+                ),
+            ),
+        )
+        assertThat(fakeEventReporter.onNfcScanAttemptSucceededCalls.awaitItem()).isNotNull()
+
+        viewModel.handleViewAction(NfcScanningViewAction.SuccessShown)
+
+        assertThat(fakeEventReporter.onNfcScanSucceededCalls.awaitItem()).isEqualTo(2)
+    }
+
+    @Test
+    fun `Cancellation reports number of attempts`() = runScenario {
+        repeat(5) {
+            scannerState.emit(NfcCardScanner.State.Scanning)
+            assertThat(fakeEventReporter.onNfcScanAttemptStartedCalls.awaitItem()).isNotNull()
+
+            scannerState.emit(
+                NfcCardScanner.State.Failed(
+                    error = NfcCardScanner.Error(
+                        code = "expiredCard",
+                        userMessage = R.string.stripe_nfc_expired_error.resolvableString,
+                    ),
+                ),
+            )
+
+            assertThat(fakeEventReporter.onNfcScanAttemptFailedCalls.awaitItem()).isNotNull()
+        }
+
+        viewModel.handleViewAction(NfcScanningViewAction.Close)
+
+        val cancelledEventCall = fakeEventReporter.onNfcScanCancelledCalls.awaitItem()
+
+        assertThat(cancelledEventCall.reason).isEqualTo(NfcScanCancellationReason.UserInitiated)
+        assertThat(cancelledEventCall.numberOfAttempts).isEqualTo(5)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/DefaultNfcScanningEventReporterTest.kt
@@ -24,10 +24,10 @@ internal class DefaultNfcScanningEventReporterTest {
     }
 
     @Test
-    fun `onNfcScanSucceeded ends duration and fires event with duration`() = runScenario {
+    fun `onNfcScanSucceeded ends duration and fires event with duration and number of attempts`() = runScenario {
         durationProvider.start(DurationProvider.Key.NfcScan)
 
-        reporter.onNfcScanSucceeded()
+        reporter.onNfcScanSucceeded(numberOfAttempts = 2)
 
         assertThat(
             durationProvider.has(
@@ -38,6 +38,7 @@ internal class DefaultNfcScanningEventReporterTest {
         val loggedParams = executor.getExecutedRequests().single().params
         assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_success")
         assertThat(loggedParams).containsEntry("duration", 1.0f)
+        assertThat(loggedParams).containsEntry("number_of_attempts", 2)
     }
 
     @Test
@@ -103,18 +104,23 @@ internal class DefaultNfcScanningEventReporterTest {
     }
 
     @Test
-    fun `onNfcScanCancelled ends duration and fires event with cancellation reason`() = runScenario {
-        reporter.onNfcScanCancelled(NfcScanCancellationReason.Timeout)
+    fun `onNfcScanCancelled ends duration and fires event with cancellation reason and number of attempts`() =
+        runScenario {
+            reporter.onNfcScanCancelled(
+                reason = NfcScanCancellationReason.Timeout,
+                numberOfAttempts = 3,
+            )
 
-        assertThat(
-            durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScan))
-        ).isTrue()
+            assertThat(
+                durationProvider.has(FakeDurationProvider.Call.End(DurationProvider.Key.NfcScan))
+            ).isTrue()
 
-        val loggedParams = executor.getExecutedRequests().single().params
-        assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_canceled")
-        assertThat(loggedParams).containsEntry("duration", 1.0f)
-        assertThat(loggedParams).containsEntry("cancellation_reason", "scanning_timeout")
-    }
+            val loggedParams = executor.getExecutedRequests().single().params
+            assertThat(loggedParams).containsEntry("event", "mc_nfc_scan_canceled")
+            assertThat(loggedParams).containsEntry("duration", 1.0f)
+            assertThat(loggedParams).containsEntry("cancellation_reason", "scanning_timeout")
+            assertThat(loggedParams).containsEntry("number_of_attempts", 3)
+        }
 
     private class Scenario(
         val reporter: NfcScanningEventReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/analytics/FakeNfcScanningEventReporter.kt
@@ -7,8 +7,13 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
     val onNfcScanAttemptStartedCalls = Turbine<Unit>()
     val onNfcScanAttemptSucceededCalls = Turbine<Unit>()
     val onNfcScanAttemptFailedCalls = Turbine<NfcScanAttemptFailedCall>()
-    val onNfcScanSucceededCalls = Turbine<Unit>()
-    val onNfcScanCancelledCalls = Turbine<NfcScanCancellationReason>()
+    val onNfcScanSucceededCalls = Turbine<Int>()
+    val onNfcScanCancelledCalls = Turbine<NfcScanCancelledCall>()
+
+    data class NfcScanCancelledCall(
+        val reason: NfcScanCancellationReason,
+        val numberOfAttempts: Int,
+    )
 
     data class NfcScanAttemptFailedCall(
         val errorCode: String,
@@ -39,12 +44,20 @@ internal class FakeNfcScanningEventReporter : NfcScanningEventReporter {
         )
     }
 
-    override fun onNfcScanSucceeded() {
-        onNfcScanSucceededCalls.add(Unit)
+    override fun onNfcScanSucceeded(numberOfAttempts: Int) {
+        onNfcScanSucceededCalls.add(numberOfAttempts)
     }
 
-    override fun onNfcScanCancelled(reason: NfcScanCancellationReason) {
-        onNfcScanCancelledCalls.add(reason)
+    override fun onNfcScanCancelled(
+        reason: NfcScanCancellationReason,
+        numberOfAttempts: Int,
+    ) {
+        onNfcScanCancelledCalls.add(
+            NfcScanCancelledCall(
+                reason = reason,
+                numberOfAttempts = numberOfAttempts,
+            ),
+        )
     }
 
     fun ensureAllEventsConsumed() {


### PR DESCRIPTION
# Summary
Log number of attempts taken in the NFC scanning flow during success and cancellation of the NFC scanning flow.

# Motivation
See how many attempts users actually take during the NFC scanning flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified