### PR TITLE
Move release tag creation to deploy flow

### DIFF
--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -7,6 +7,6 @@ Use:
   `./scripts/deploy/propose_release.rb`
   `./scripts/deploy/deploy_release.rb`
 
-`propose release` creates the version bump branch, signed tag, and PR handoff.
-`deploy release` publishes from the existing signed tag after the version bump PR is merged.
+`propose release` creates the version bump branch and PR handoff.
+`deploy release` creates the signed tag from the merged version bump PR and publishes it.
 EOS

--- a/scripts/deploy/deploy_release.rb
+++ b/scripts/deploy/deploy_release.rb
@@ -10,13 +10,15 @@ require_relative 'version_bump_pr_steps'
 
 def cleanup_deploy_release(success:)
     delete_github_release if @is_dry_run
-    execute("git checkout #{@deploy_branch}") if success && @checked_out_release_tag
+    delete_release_tag if @is_dry_run && @created_local_release_tag
+    execute("git checkout #{@deploy_branch}") if success && @checked_out_release_source
 end
 
 def prepare_deploy_release_resume(step_index)
     return if step_index < 4
 
     checkout_release_source
+    verify_release_tag_matches_release_source if step_index > 4 && !@skip_release_tag
 end
 
 parse_release_options!(flow_name: 'deploy release', version_required: true)
@@ -25,6 +27,7 @@ steps = [
     method(:check_permissions),
     method(:ensure_clean_repo),
     method(:checkout_release_source),
+    method(:create_release_tag),
     method(:publish_to_sonatype),
     method(:create_github_release),
     method(:update_pay_server_docs),

--- a/scripts/deploy/propose_release.rb
+++ b/scripts/deploy/propose_release.rb
@@ -2,7 +2,6 @@
 
 require_relative 'permissions_check'
 require_relative 'release_cli'
-require_relative 'release_tag_steps'
 require_relative 'translations'
 require_relative 'update_version_numbers'
 require_relative 'validate_version_number'
@@ -12,46 +11,11 @@ def print_propose_release_handoff
     rputs "propose release complete"
     puts "Version: #{@version}"
     puts "Branch: #{release_branch}"
-    puts "Tag: #{release_tag_name}"
-
-    if @is_dry_run
-        rputs "Dry run: the signed tag was created locally but not pushed. Use deploy release only after a real propose release has created the final remote tag."
-    else
-        rputs "Hand off #{release_tag_name} to deploy release."
-    end
-end
-
-def pause_for_pr_merge
-    if @is_dry_run
-        rputs "Dry run: skipping PR merge wait. Continuing to create release tag."
-        return
-    end
-
-    resume_command = "./scripts/deploy/propose_release.rb --continue-from 8 --version #{@version}"
-    resume_command += " --branch #{@deploy_branch}" if @deploy_branch != 'master'
     puts ""
-    rputs "Version bump PR has been created. Get it reviewed and merged."
-    puts ""
-    puts "Once the PR is merged, resume the release process by running:"
-    puts ""
-    puts "  #{resume_command}"
-    puts ""
-
-    exit 0
-end
-
-def prepare_propose_release_resume(step_index)
-    # When resuming after the PR merge pause (step 8+), ensure we have a
-    # clean repo and are on the deploy branch with latest changes.
-    return if step_index < 8
-
-    ensure_clean_repo
-    execute_or_fail("git checkout #{@deploy_branch}")
-    execute_or_fail("git pull")
+    rputs "Wait for the version bump PR to merge, then let the deployer know that #{@version} is ready to deploy."
 end
 
 def cleanup_propose_release_dry_run
-    delete_release_tag
     delete_git_branch(release_branch, @deploy_branch)
 end
 
@@ -64,15 +28,13 @@ steps = [
     method(:ensure_clean_repo),
     method(:pull_latest),
     method(:create_version_bump_pr),
-    method(:pause_for_pr_merge),
-    method(:create_release_tag),
     method(:print_propose_release_handoff),
 ]
 
 @propose_release_succeeded = false
 
 begin
-    execute_steps(steps, before_resume: method(:prepare_propose_release_resume))
+    execute_steps(steps)
     @propose_release_succeeded = true
 ensure
     if @is_dry_run && @propose_release_succeeded

--- a/scripts/deploy/release_tag_steps.rb
+++ b/scripts/deploy/release_tag_steps.rb
@@ -39,26 +39,17 @@ end
 
 def verify_release_tag_exists
     unless local_git_tag_exists?(release_tag_name)
-        raise "Release tag #{release_tag_name} does not exist locally. Run `git fetch origin --tags` or confirm `propose release` completed."
+        raise "Release tag #{release_tag_name} does not exist locally. Run `git fetch origin --tags` or restart the deploy release tag step."
     end
 end
 
 def create_release_tag
-    if @is_dry_run
-        pr = fetch_release_pr
-        if pr.nil?
-            raise "Could not find a version bump PR for #{release_branch} targeting #{@deploy_branch}. Run `propose release` first."
-        end
-
-        if pr.head.sha.nil? || pr.head.sha.empty?
-            raise "Could not determine the release branch head for dry-run tag creation."
-        end
-
-        @release_source_sha = pr.head.sha
-        rputs "Dry run: using release branch head #{@release_source_sha} as a stand-in for the merged PR revision."
-    else
-        prepare_release_source_from_merged_pr
+    if @skip_release_tag
+        rputs "Dry run: skipping release tag creation because the release source is unavailable."
+        return
     end
+
+    raise "Release source has not been checked out." if @release_source_sha.nil?
 
     if local_git_tag_exists?(release_tag_name)
         verify_release_tag_matches_release_source
@@ -67,6 +58,7 @@ def create_release_tag
         verify_release_tag_matches_release_source
     else
         create_local_release_tag
+        @created_local_release_tag = true
     end
 
     if @is_dry_run
@@ -81,14 +73,20 @@ end
 
 def checkout_release_source
     begin
-        prepare_release_source_from_merged_pr
-        verify_release_tag_matches_release_source
-        checkout_release_tag
+        if @is_dry_run
+            prepare_dry_run_release_source
+        else
+            prepare_release_source_from_merged_pr
+        end
+
+        execute_or_fail("git checkout --detach #{@release_source_sha}")
+        @checked_out_release_source = true
     rescue StandardError => e
         raise unless @is_dry_run
 
         rputs "Dry run: continuing without checked-out release source: #{e.message}"
-        rputs "Dry run: remaining deploy release steps will run from the current checkout instead of #{release_tag_name}."
+        rputs "Dry run: remaining deploy release steps will run from the current checkout without creating #{release_tag_name}."
+        @skip_release_tag = true
     end
 end
 
@@ -101,12 +99,6 @@ def verify_release_tag_matches_release_source
     end
 
     puts "Verified release tag #{release_tag_name} points to #{@release_source_sha}".green
-end
-
-def checkout_release_tag
-    verify_release_tag_exists
-    execute_or_fail("git checkout --detach refs/tags/#{release_tag_name}")
-    @checked_out_release_tag = true
 end
 
 def delete_release_tag(delete_remote: false, delete_local: true)
@@ -126,6 +118,26 @@ private def create_local_release_tag
             env: env
         )
     end
+end
+
+private def prepare_dry_run_release_source
+    pr = fetch_release_pr
+    if pr.nil?
+        raise "Could not find a version bump PR for #{release_branch} targeting #{@deploy_branch}. Run `propose release` first."
+    end
+
+    if pr.head.sha.nil? || pr.head.sha.empty?
+        raise "Could not determine the release branch head for dry-run tag creation."
+    end
+
+    @release_source_sha = pr.head.sha
+    execute_or_fail("git fetch --tags origin #{@deploy_branch} #{release_branch}")
+
+    unless git_commit_exists?(@release_source_sha)
+        raise "Release branch head #{@release_source_sha} is not available locally after fetching #{release_branch}."
+    end
+
+    rputs "Dry run: using release branch head #{@release_source_sha} as a stand-in for the merged PR revision."
 end
 
 private def fetch_release_pr


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Move release tag creation to deploy flow

Now the deployer creates the release tag based on the commit of the merged version bump PR.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improve experience for proposer while maintaining property that deployer deploys exactly what the proposer proposed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Ran propose and deploy dry runs. This manual testing is kinda mid because we don't merge the version bump PR in a dry run which these changes rely on.