### PR TITLE
Disable NFC scanning if Stripe Card Scan is enabled

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
@@ -19,7 +19,9 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
     private val mode: EventReporter.Mode,
 ) : IsNfcScanningAvailable {
     override fun get(metadata: PaymentMethodMetadata): Boolean {
-        val hasRequirements = metadata.isNfcScanningEnabled && !metadata.isTapToAddSupported
+        val hasRequirements = metadata.isNfcScanningEnabled &&
+            !metadata.isTapToAddSupported &&
+            !metadata.isStripeCardScanAllowed
 
         if (!hasRequirements) {
             return false

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
@@ -43,6 +43,20 @@ internal class IsNfcScanningAvailableTest {
     }
 
     @Test
+    fun `returns false when stripe card scan is allowed`() {
+        val isNfcScanningAvailable = createIsNfcScanningAvailable()
+
+        assertThat(
+            isNfcScanningAvailable.get(
+                metadata = createMetadata(
+                    isNfcScanningEnabled = true,
+                    isStripeCardScanAllowed = true,
+                ),
+            )
+        ).isFalse()
+    }
+
+    @Test
     fun `returns false when device is not secure`() {
         val isNfcScanningAvailable = createIsNfcScanningAvailable(
             isDeviceSecureForNfc = FakeIsDeviceSecureForNfc(result = false),
@@ -222,10 +236,12 @@ internal class IsNfcScanningAvailableTest {
     private fun createMetadata(
         isNfcScanningEnabled: Boolean,
         isTapToAddSupported: Boolean = false,
+        isStripeCardScanAllowed: Boolean = false,
         experimentVariant: String? = null,
     ) = PaymentMethodMetadataFactory.create(
         isNfcScanningEnabled = isNfcScanningEnabled,
         isTapToAddSupported = isTapToAddSupported,
+        isStripeCardScanAllowed = isStripeCardScanAllowed,
         experimentsData = experimentVariant?.let { variant ->
             ElementsSession.ExperimentsData(
                 arbId = "test_arb_id",


### PR DESCRIPTION
# Summary
Disable NFC scanning if Stripe Card Scan is enabled

# Motivation
Ensure users who imported Stripe Card Scan are not affected by NFC scanning being enabled

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified