### PR TITLE
Add inline notification banner task support

### DIFF
--- a/connect-example/src/main/AndroidManifest.xml
+++ b/connect-example/src/main/AndroidManifest.xml
@@ -25,5 +25,9 @@
             android:name=".ui.features.payments.PaymentsExampleActivity"
             android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+        <activity
+            android:name=".ui.features.notificationbanner.NotificationBannerExampleActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
 </manifest>

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/Badge.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/Badge.kt
@@ -19,6 +19,16 @@ import com.stripe.android.connect.example.R
 
 @Composable
 fun BetaBadge() {
+    PreviewBadge(label = stringResource(R.string.beta_all_caps))
+}
+
+@Composable
+fun ExperimentalBadge() {
+    PreviewBadge(label = stringResource(R.string.experimental_all_caps))
+}
+
+@Composable
+private fun PreviewBadge(label: String) {
     val shape = RoundedCornerShape(4.dp)
     val labelMediumEmphasized = TextStyle.Default.copy(
         fontSize = 14.sp,
@@ -41,7 +51,7 @@ fun BetaBadge() {
         fontSize = 12.sp,
         lineHeight = 16.sp,
         style = labelMediumEmphasized,
-        text = stringResource(R.string.beta_all_caps)
+        text = label
     )
 }
 

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/componentpicker/ComponentPickerScreen.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/componentpicker/ComponentPickerScreen.kt
@@ -49,8 +49,10 @@ import com.stripe.android.connect.example.ui.appearance.AppearanceViewModel
 import com.stripe.android.connect.example.ui.common.BetaBadge
 import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
 import com.stripe.android.connect.example.ui.common.CustomizeAppearanceIconButton
+import com.stripe.android.connect.example.ui.common.ExperimentalBadge
 import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentLoaderViewModel
 import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentManagerLoader
+import com.stripe.android.connect.example.ui.features.notificationbanner.NotificationBannerExampleActivity
 import com.stripe.android.connect.example.ui.features.payments.PaymentsExampleActivity
 import com.stripe.android.connect.example.ui.features.payouts.PayoutsExampleActivity
 import com.stripe.android.connect.example.ui.settings.SettingsViewModel
@@ -149,6 +151,9 @@ fun ComponentPickerContent(
                             MenuItem.Payments -> {
                                 context.startActivity(Intent(context, PaymentsExampleActivity::class.java))
                             }
+                            MenuItem.NotificationBanner -> {
+                                context.startActivity(Intent(context, NotificationBannerExampleActivity::class.java))
+                            }
                         }
                     },
                 )
@@ -159,7 +164,14 @@ fun ComponentPickerContent(
 
 @Composable
 private fun ComponentPickerList(onMenuItemClick: (MenuItem) -> Unit) {
-    val items = remember { listOf(MenuItem.AccountOnboarding, MenuItem.Payouts, MenuItem.Payments) }
+    val items = remember {
+        listOf(
+            MenuItem.AccountOnboarding,
+            MenuItem.NotificationBanner,
+            MenuItem.Payouts,
+            MenuItem.Payments,
+        )
+    }
     LazyColumn {
         items(items) { menuItem ->
             MenuRowItem(menuItem, onMenuItemClick)
@@ -195,6 +207,9 @@ private fun LazyItemScope.MenuRowItem(
                     if (menuItem.isBeta) {
                         BetaBadge()
                     }
+                    if (menuItem.isExperimental) {
+                        ExperimentalBadge()
+                    }
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
@@ -220,6 +235,7 @@ private enum class MenuItem(
     @StringRes val title: Int,
     @StringRes val subtitle: Int,
     val isBeta: Boolean = false,
+    val isExperimental: Boolean = false,
 ) {
     AccountOnboarding(
         title = R.string.account_onboarding,
@@ -235,6 +251,11 @@ private enum class MenuItem(
         title = R.string.payments,
         subtitle = R.string.payments_menu_subtitle,
         isBeta = false,
+    ),
+    NotificationBanner(
+        title = R.string.notification_banner,
+        subtitle = R.string.notification_banner_menu_subtitle,
+        isExperimental = true,
     ),
 }
 

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/notificationbanner/NotificationBannerExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/notificationbanner/NotificationBannerExampleActivity.kt
@@ -7,8 +7,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -146,7 +146,7 @@ class NotificationBannerExampleActivity : BaseActivity() {
         var contentHeight by remember(manager) { mutableIntStateOf(0) }
         val bannerAlpha by animateFloatAsState(
             targetValue = if (initialLoadState == NotificationBannerView.InitialLoadState.LOADED) 1f else 0f,
-            animationSpec = tween(200),
+            animationSpec = tween(BANNER_TRANSITION_DURATION_MILLIS),
             label = "notification banner alpha",
         )
         val listener = remember(manager) {
@@ -248,8 +248,8 @@ class NotificationBannerExampleActivity : BaseActivity() {
     private fun LoadingSkeleton(visible: Boolean, appearance: HostAppearance) {
         AnimatedVisibility(
             visible = visible,
-            enter = fadeIn(tween(200)),
-            exit = fadeOut(tween(200)),
+            enter = fadeIn(tween(BANNER_TRANSITION_DURATION_MILLIS)),
+            exit = fadeOut(tween(BANNER_TRANSITION_DURATION_MILLIS)),
         ) {
             NotificationBannerSkeleton(appearance)
         }
@@ -409,6 +409,7 @@ class NotificationBannerExampleActivity : BaseActivity() {
     )
 
     private companion object {
+        private const val BANNER_TRANSITION_DURATION_MILLIS = 200
         private const val LOG_TAG = "NotificationBanner"
         private val SAMPLE_PAYMENTS = listOf(
             Triple("Acme Coffee Co.", "Today, 9:41 AM", "\$4.50"),

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/notificationbanner/NotificationBannerExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/notificationbanner/NotificationBannerExampleActivity.kt
@@ -1,0 +1,421 @@
+package com.stripe.android.connect.example.ui.features.notificationbanner
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.stripe.android.connect.EmbeddedComponentManager
+import com.stripe.android.connect.NotificationBannerListener
+import com.stripe.android.connect.NotificationBannerView
+import com.stripe.android.connect.example.BaseActivity
+import com.stripe.android.connect.example.R
+import com.stripe.android.connect.example.ui.appearance.AppearanceInfo
+import com.stripe.android.connect.example.ui.appearance.AppearanceView
+import com.stripe.android.connect.example.ui.appearance.AppearanceViewModel
+import com.stripe.android.connect.example.ui.common.BackIconButton
+import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
+import com.stripe.android.connect.example.ui.common.ConnectSdkExampleTheme
+import com.stripe.android.connect.example.ui.common.CustomizeAppearanceIconButton
+import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentManagerLoader
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@SuppressLint("RestrictedApi")
+@AndroidEntryPoint
+class NotificationBannerExampleActivity : BaseActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ConnectSdkExampleTheme {
+                NotificationBannerExample()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    @Composable
+    private fun NotificationBannerExample() {
+        val managerState by loaderViewModel.state.collectAsState()
+        val appearanceViewModel = hiltViewModel<AppearanceViewModel>()
+        val appearanceState by appearanceViewModel.state.collectAsState()
+        val sheetState = rememberModalBottomSheetState(
+            initialValue = ModalBottomSheetValue.Hidden,
+            skipHalfExpanded = true,
+        )
+        val coroutineScope = rememberCoroutineScope()
+
+        ModalBottomSheetLayout(
+            modifier = Modifier.fillMaxSize(),
+            sheetState = sheetState,
+            sheetContent = {
+                AppearanceView(
+                    viewModel = appearanceViewModel,
+                    onDismiss = { coroutineScope.launch { sheetState.hide() } },
+                )
+            },
+        ) {
+            ConnectExampleScaffold(
+                title = getString(R.string.notification_banner),
+                navigationIcon = { BackIconButton(onClick = ::finish) },
+                actions = {
+                    CustomizeAppearanceIconButton(
+                        onClick = { coroutineScope.launch { sheetState.show() } }
+                    )
+                },
+            ) {
+                EmbeddedComponentManagerLoader(
+                    embeddedComponentAsync = managerState.embeddedComponentManagerAsync,
+                    reload = loaderViewModel::reload,
+                    openSettings = {},
+                ) { manager ->
+                    NotificationBannerContent(
+                        manager = manager,
+                        appearanceId = appearanceState.selectedAppearance,
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    @Suppress("LongMethod")
+    private fun NotificationBannerContent(
+        manager: EmbeddedComponentManager,
+        appearanceId: AppearanceInfo.AppearanceId,
+    ) {
+        val hostAppearance = hostAppearance(appearanceId)
+        var initialLoadState by remember(manager) {
+            mutableStateOf(NotificationBannerView.InitialLoadState.LOADING)
+        }
+        var notificationTotal by remember(manager) { mutableIntStateOf(0) }
+        var actionRequiredCount by remember(manager) { mutableIntStateOf(0) }
+        var contentHeight by remember(manager) { mutableIntStateOf(0) }
+        val bannerAlpha by animateFloatAsState(
+            targetValue = if (initialLoadState == NotificationBannerView.InitialLoadState.LOADED) 1f else 0f,
+            animationSpec = tween(200),
+            label = "notification banner alpha",
+        )
+        val listener = remember(manager) {
+            object : NotificationBannerListener {
+                override fun onNotificationsChanged(total: Int, actionRequired: Int) {
+                    notificationTotal = total
+                    this@NotificationBannerExampleActivity.logNotificationCount(total, actionRequired)
+                    actionRequiredCount = actionRequired
+                }
+
+                override fun onContentHeightChanged(height: Int) {
+                    contentHeight = height
+                }
+
+                override fun onInitialLoadStateChanged(state: NotificationBannerView.InitialLoadState) {
+                    initialLoadState = state
+                }
+
+                override fun onLoadError(error: Throwable) {
+                    Log.e(LOG_TAG, "Notification banner failed to load", error)
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(hostAppearance.background)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateContentSize(),
+            ) {
+                AndroidView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .alpha(bannerAlpha),
+                    factory = { context ->
+                        val bannerView = manager.createNotificationBannerView(
+                            context = context,
+                            listener = listener,
+                            cacheKey = "NotificationBannerExampleActivity",
+                        )
+                        bannerView.taskTitle = "Update information"
+                        initialLoadState = bannerView.initialLoadState
+                        bannerView
+                    },
+                )
+                LoadingSkeleton(
+                    visible = initialLoadState == NotificationBannerView.InitialLoadState.LOADING,
+                    appearance = hostAppearance,
+                )
+            }
+
+            Text(
+                text = "loadState → $initialLoadState\n" +
+                    "notifications → total: $notificationTotal, actionRequired: $actionRequiredCount\n" +
+                    "height → ${contentHeight}px",
+                color = hostAppearance.secondaryText,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+            )
+            Text(
+                text = "YOUR APP CONTENT",
+                color = hostAppearance.secondaryText,
+                fontFamily = hostAppearance.fontFamily,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            HostCard(hostAppearance) {
+                Text("Available balance", color = hostAppearance.secondaryText)
+                Text(
+                    text = "\$2,438.19",
+                    color = hostAppearance.text,
+                    fontFamily = hostAppearance.fontFamily,
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            SAMPLE_PAYMENTS.forEach { payment ->
+                HostCard(hostAppearance) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(payment.first, color = hostAppearance.text)
+                            Text(payment.second, color = hostAppearance.secondaryText, fontSize = 12.sp)
+                        }
+                        Text(payment.third, color = hostAppearance.text)
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun LoadingSkeleton(visible: Boolean, appearance: HostAppearance) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(tween(200)),
+            exit = fadeOut(tween(200)),
+        ) {
+            NotificationBannerSkeleton(appearance)
+        }
+    }
+
+    @Composable
+    @Suppress("MagicNumber")
+    private fun NotificationBannerSkeleton(appearance: HostAppearance) {
+        val transition = rememberInfiniteTransition(label = "notification banner skeleton")
+        val alpha by transition.animateFloat(
+            initialValue = 1f,
+            targetValue = 0.45f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(800),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "skeleton alpha",
+        )
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(104.dp),
+            color = appearance.surface,
+            shape = RoundedCornerShape(appearance.cornerRadius.dp),
+            border = BorderStroke(1.dp, appearance.border),
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    SkeletonBar(156, 16, appearance.secondaryText.copy(alpha = 0.18f * alpha))
+                    SkeletonBar(220, 12, appearance.secondaryText.copy(alpha = 0.18f * alpha))
+                }
+                Spacer(Modifier.width(16.dp))
+                SkeletonBar(72, 36, appearance.secondaryText.copy(alpha = 0.18f * alpha))
+            }
+        }
+    }
+
+    @Composable
+    private fun SkeletonBar(width: Int, height: Int, color: Color) {
+        Spacer(
+            Modifier
+                .width(width.dp)
+                .height(height.dp)
+                .background(color, RoundedCornerShape((height / 2).dp))
+        )
+    }
+
+    @Composable
+    private fun HostCard(appearance: HostAppearance, content: @Composable ColumnScope.() -> Unit) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = appearance.surface,
+            shape = RoundedCornerShape(appearance.cornerRadius.dp),
+            border = BorderStroke(1.dp, appearance.border),
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                content = content,
+            )
+        }
+    }
+
+    @Composable
+    @Suppress("LongMethod", "MagicNumber")
+    private fun hostAppearance(id: AppearanceInfo.AppearanceId): HostAppearance {
+        val context = LocalContext.current
+        val defaults = HostAppearance(
+            background = MaterialTheme.colors.background,
+            surface = MaterialTheme.colors.surface,
+            text = MaterialTheme.colors.onSurface,
+            secondaryText = MaterialTheme.colors.onSurface.copy(alpha = 0.65f),
+            border = MaterialTheme.colors.onSurface.copy(alpha = 0.18f),
+            cornerRadius = 8f,
+            fontFamily = FontFamily.Default,
+        )
+        fun color(resource: Int) = Color(ContextCompat.getColor(context, resource))
+
+        return when (id) {
+            AppearanceInfo.AppearanceId.Default,
+            AppearanceInfo.AppearanceId.CustomFont -> defaults
+            AppearanceInfo.AppearanceId.Ogre -> defaults.copy(
+                background = color(R.color.ogre_background),
+                surface = color(R.color.ogre_background),
+                text = color(R.color.ogre_text),
+            )
+            AppearanceInfo.AppearanceId.HotDog -> defaults.copy(
+                background = color(R.color.hot_dog_background),
+                surface = color(R.color.hot_dog_offset_background),
+                text = color(R.color.hot_dog_text),
+                secondaryText = color(R.color.hot_dog_secondary_text),
+                cornerRadius = 0f,
+            )
+            AppearanceInfo.AppearanceId.OceanBreeze -> defaults.copy(
+                background = color(R.color.ocean_breeze_background),
+                surface = color(R.color.ocean_breeze_background),
+                cornerRadius = 23f,
+            )
+            AppearanceInfo.AppearanceId.Link -> defaults.copy(
+                background = color(R.color.link_background),
+                surface = color(R.color.link_background),
+                text = color(R.color.link_text),
+                secondaryText = color(R.color.link_secondary_text),
+                cornerRadius = 5f,
+            )
+            AppearanceInfo.AppearanceId.Dynamic -> defaults.copy(
+                background = color(R.color.dynamic_colors_background),
+                surface = color(R.color.dynamic_colors_offset_background),
+                text = color(R.color.dynamic_colors_text),
+                secondaryText = color(R.color.dynamic_colors_secondary_text),
+                border = color(R.color.dynamic_colors_border),
+            )
+            AppearanceInfo.AppearanceId.Retro -> defaults.copy(
+                background = color(R.color.retro_background),
+                surface = color(R.color.retro_offset_background),
+                text = color(R.color.retro_text),
+                secondaryText = color(R.color.retro_secondary_text),
+                border = color(R.color.retro_border),
+                cornerRadius = 0f,
+                fontFamily = FontFamily.Monospace,
+            )
+            AppearanceInfo.AppearanceId.Forest -> defaults.copy(
+                background = color(R.color.forest_background),
+                surface = color(R.color.forest_offset_background),
+                secondaryText = color(R.color.forest_secondary_text),
+                border = color(R.color.forest_border),
+                cornerRadius = 24f,
+            )
+            AppearanceInfo.AppearanceId.DarkMode -> defaults.copy(
+                background = color(R.color.dark_mode_background),
+                surface = color(R.color.dark_mode_offset_background),
+                text = color(R.color.dark_mode_text),
+                secondaryText = color(R.color.dark_mode_secondary_text),
+                border = color(R.color.dark_mode_border),
+            )
+        }
+    }
+
+    private fun logNotificationCount(total: Int, actionRequired: Int) {
+        Log.d(LOG_TAG, "Notifications changed: total=$total, actionRequired=$actionRequired")
+    }
+
+    private data class HostAppearance(
+        val background: Color,
+        val surface: Color,
+        val text: Color,
+        val secondaryText: Color,
+        val border: Color,
+        val cornerRadius: Float,
+        val fontFamily: FontFamily,
+    )
+
+    private companion object {
+        private const val LOG_TAG = "NotificationBanner"
+        private val SAMPLE_PAYMENTS = listOf(
+            Triple("Acme Coffee Co.", "Today, 9:41 AM", "\$4.50"),
+            Triple("Blue Bottle", "Today, 8:12 AM", "\$6.25"),
+            Triple("Corner Bakery", "Yesterday", "\$12.80"),
+            Triple("Downtown Deli", "Yesterday", "\$18.40"),
+            Triple("Elm St. Grocers", "Mar 12", "\$54.10"),
+        )
+    }
+}

--- a/connect-example/src/main/res/values/strings.xml
+++ b/connect-example/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_name">Connect Example</string>
 
     <string name="beta_all_caps">BETA</string>
+    <string name="experimental_all_caps">EXPERIMENTAL</string>
     <string name="account_onboarding">Account Onboarding</string>
     <string name="onboarding_settings">Onboarding Settings</string>
     <string name="presentation_settings">Presentation Settings</string>
@@ -11,6 +12,8 @@
     <string name="payouts_menu_subtitle">Show payout information and allow your users to perform payouts</string>
     <string name="payments">Payments</string>
     <string name="payments_menu_subtitle">Show payments and allow your users to view payment details and manage disputes</string>
+    <string name="notification_banner">Notification banner</string>
+    <string name="notification_banner_menu_subtitle">Show account notifications inline with your app content</string>
     <string name="connect_sdk_example">Connect SDK Example</string>
     <string name="customize_appearance">Customize Appearance</string>
     <string name="settings">Settings</string>

--- a/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import androidx.core.content.withStyledAttributes
 import com.stripe.android.connect.webview.StripeConnectWebViewContainer
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
 import com.stripe.android.connect.webview.serialization.SetOnExit
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import dev.drewhamilton.poko.Poko
@@ -24,6 +25,7 @@ internal class AccountOnboardingView internal constructor(
         attrs = attrs,
         defStyleAttr = defStyleAttr,
         embeddedComponent = StripeEmbeddedComponent.ACCOUNT_ONBOARDING,
+        webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
         embeddedComponentManager = embeddedComponentManager,
         listener = listener,
         listenerDelegate = AccountOnboardingListenerDelegate,

--- a/connect/src/main/java/com/stripe/android/connect/ComponentProps.kt
+++ b/connect/src/main/java/com/stripe/android/connect/ComponentProps.kt
@@ -13,6 +13,8 @@ internal fun Any.toComponentPropsJsonObject(): JsonObject {
         EmptyProps -> JsonObject(emptyMap())
         is AccountOnboardingProps -> ConnectJson.encodeToJsonElement(toJs()).jsonObject
         is PaymentsProps.State -> ConnectJson.encodeToJsonElement(toJs()).jsonObject
+        is NotificationBannerProps -> ConnectJson.encodeToJsonElement(toJs()).jsonObject
+        is NotificationBannerTaskProps -> ConnectJson.encodeToJsonElement(toJs()).jsonObject
         else -> throw IllegalArgumentException("Unsupported props type: $this")
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
+++ b/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
@@ -3,6 +3,7 @@ package com.stripe.android.connect
 import android.content.Context
 import android.view.View
 import androidx.activity.ComponentActivity
+import androidx.annotation.RestrictTo
 import androidx.fragment.app.FragmentActivity
 import com.stripe.android.connect.appearance.Appearance
 import com.stripe.android.connect.appearance.fonts.CustomFontSource
@@ -110,6 +111,31 @@ class EmbeddedComponentManager @JvmOverloads constructor(
             embeddedComponentManager = this,
             listener = listener,
             props = props,
+            cacheKey = cacheKey,
+        )
+    }
+
+    /**
+     * Creates an inline notification banner that sizes itself to its rendered content.
+     *
+     * @param context The [Context] used to create the view.
+     * @param listener Optional listener for banner events.
+     * @param collectionOptions Specifies which account requirements Stripe collects.
+     * @param cacheKey Key used to retain the internal WebView across configuration changes.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @JvmOverloads
+    fun createNotificationBannerView(
+        context: Context,
+        listener: NotificationBannerListener? = null,
+        collectionOptions: AccountOnboardingProps.CollectionOptions? = null,
+        cacheKey: String? = null,
+    ): NotificationBannerView {
+        return NotificationBannerView(
+            context = context,
+            notificationBannerManager = this,
+            listener = listener,
+            collectionOptions = collectionOptions,
             cacheKey = cacheKey,
         )
     }

--- a/connect/src/main/java/com/stripe/android/connect/NotificationBannerTaskController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/NotificationBannerTaskController.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.connect
+
+import android.content.Context
+import android.os.Parcelable
+import androidx.fragment.app.FragmentActivity
+import com.stripe.android.connect.webview.StripeConnectWebViewContainer
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
+import kotlinx.parcelize.Parcelize
+
+internal class NotificationBannerTaskController(
+    activity: FragmentActivity,
+    embeddedComponentManager: EmbeddedComponentManager,
+    title: String?,
+    props: NotificationBannerTaskProps,
+) : StripeComponentController<StripeEmbeddedComponentListener, NotificationBannerTaskProps>(
+    dfClass = NotificationBannerTaskDialogFragment::class.java,
+    activity = activity,
+    embeddedComponentManager = embeddedComponentManager,
+    title = title,
+    props = props,
+)
+
+internal class NotificationBannerTaskDialogFragment :
+    StripeComponentDialogFragment<
+        NotificationBannerTaskView,
+        StripeEmbeddedComponentListener,
+        NotificationBannerTaskProps,
+        >() {
+
+    override fun createComponentView(
+        embeddedComponentManager: EmbeddedComponentManager
+    ): NotificationBannerTaskView {
+        return NotificationBannerTaskView(
+            context = requireContext(),
+            embeddedComponentManager = embeddedComponentManager,
+            listener = listener,
+            props = checkNotNull(props),
+            cacheKey = javaClass.simpleName,
+        )
+    }
+}
+
+internal class NotificationBannerTaskView(
+    context: Context,
+    embeddedComponentManager: EmbeddedComponentManager,
+    listener: StripeEmbeddedComponentListener?,
+    props: NotificationBannerTaskProps,
+    cacheKey: String,
+) : StripeComponentView<StripeEmbeddedComponentListener, NotificationBannerTaskProps>(
+    context = context,
+    attrs = null,
+    defStyleAttr = 0,
+    embeddedComponent = StripeEmbeddedComponent.NOTIFICATION_BANNER,
+    webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
+    embeddedComponentManager = embeddedComponentManager,
+    listener = listener,
+    props = props,
+),
+    StripeConnectWebViewContainer<StripeEmbeddedComponentListener, NotificationBannerTaskProps> {
+    init {
+        initializeView(cacheKey)
+    }
+}
+
+@Parcelize
+internal data class NotificationBannerTaskProps(
+    val collectionOptions: AccountOnboardingProps.CollectionOptions?,
+    val task: String,
+) : Parcelable

--- a/connect/src/main/java/com/stripe/android/connect/NotificationBannerView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/NotificationBannerView.kt
@@ -10,8 +10,6 @@ import com.stripe.android.connect.webview.serialization.SetOnLoadError
 import com.stripe.android.connect.webview.serialization.SetOnNotificationsChange
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import java.util.UUID
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class NotificationBannerView internal constructor(
@@ -48,7 +46,7 @@ class NotificationBannerView internal constructor(
     /** The title shown by full-screen tasks opened from this banner. */
     var taskTitle: String? = null
 
-    /** The banner's current initial-load state. */
+    /** The banner's current load state. */
     var initialLoadState: InitialLoadState = InitialLoadState.LOADING
         private set
 
@@ -128,6 +126,20 @@ class NotificationBannerView internal constructor(
         listener?.onInitialLoadStateChanged(state)
     }
 
+    private fun reloadBanner() {
+        removeCallbacks(finishLoading)
+        didReceiveInitialNotifications = false
+        pendingContentHeight = 0
+
+        if (initialLoadState != InitialLoadState.LOADING) {
+            initialLoadState = InitialLoadState.LOADING
+            listener?.onInitialLoadStateChanged(InitialLoadState.LOADING)
+        }
+
+        publishSettledContentHeight()
+        reloadConcealedWebContent()
+    }
+
     private fun presentTask(task: JsonObject) {
         if (notificationBannerTaskController != null) {
             return
@@ -149,10 +161,7 @@ class NotificationBannerView internal constructor(
         }
         controller.onDismissListener = StripeComponentController.OnDismissListener {
             notificationBannerTaskController = null
-            callSetterWithSerializableValue(
-                setter = "setMobileNotificationRefreshToken",
-                value = JsonPrimitive(UUID.randomUUID().toString()),
-            )
+            reloadBanner()
         }
         notificationBannerTaskController = controller
         controller.show()
@@ -171,7 +180,7 @@ interface NotificationBannerListener : StripeEmbeddedComponentListener {
     /** Called after the banner publishes a new content height, in pixels. */
     fun onContentHeightChanged(height: Int) {}
 
-    /** Called when the banner finishes its one-time initial-load lifecycle. */
+    /** Called when the banner's load state changes. */
     fun onInitialLoadStateChanged(state: NotificationBannerView.InitialLoadState) {}
 }
 

--- a/connect/src/main/java/com/stripe/android/connect/NotificationBannerView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/NotificationBannerView.kt
@@ -1,0 +1,193 @@
+package com.stripe.android.connect
+
+import android.content.Context
+import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
+import com.stripe.android.connect.util.findActivity
+import com.stripe.android.connect.webview.StripeConnectWebViewContainer
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
+import com.stripe.android.connect.webview.serialization.SetOnLoadError
+import com.stripe.android.connect.webview.serialization.SetOnNotificationsChange
+import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.util.UUID
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class NotificationBannerView internal constructor(
+    context: Context,
+    private val notificationBannerManager: EmbeddedComponentManager,
+    listener: NotificationBannerListener?,
+    private val collectionOptions: AccountOnboardingProps.CollectionOptions?,
+    cacheKey: String?,
+) : StripeComponentView<NotificationBannerListener, NotificationBannerProps>(
+    context = context,
+    attrs = null,
+    defStyleAttr = 0,
+    embeddedComponent = StripeEmbeddedComponent.NOTIFICATION_BANNER,
+    webViewLayout = StripeConnectWebViewLayout.SIZES_TO_CONTENT,
+    embeddedComponentManager = notificationBannerManager,
+    listener = listener,
+    listenerDelegate = NotificationBannerListenerDelegate,
+    props = NotificationBannerProps(collectionOptions),
+),
+    StripeConnectWebViewContainer<NotificationBannerListener, NotificationBannerProps> {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class InitialLoadState {
+        /** The banner is fetching and rendering its initial content. */
+        LOADING,
+
+        /** Initial rendering finished, including when there is nothing to display. */
+        LOADED,
+
+        /** Initial loading failed. */
+        FAILED,
+    }
+
+    /** The title shown by full-screen tasks opened from this banner. */
+    var taskTitle: String? = null
+
+    /** The banner's current initial-load state. */
+    var initialLoadState: InitialLoadState = InitialLoadState.LOADING
+        private set
+
+    private var didReceiveInitialNotifications = false
+    private var pendingContentHeight = 0
+    private var lastPublishedContentHeight: Int? = null
+    private var notificationBannerTaskController: NotificationBannerTaskController? = null
+
+    private val finishLoading = Runnable {
+        if (initialLoadState == InitialLoadState.LOADING && didReceiveInitialNotifications) {
+            publishSettledContentHeight()
+            revealWebContent()
+            transitionInitialLoadState(InitialLoadState.LOADED)
+        }
+    }
+
+    init {
+        initializeView(cacheKey)
+    }
+
+    override fun onComponentEvent(event: ComponentEvent) {
+        when (event) {
+            is ComponentEvent.ContentHeightChanged -> contentHeightDidChange(event.height)
+            is ComponentEvent.LoadError -> transitionInitialLoadState(InitialLoadState.FAILED)
+            is ComponentEvent.Message -> handleMessage(event.message)
+            is ComponentEvent.OpenNotificationBannerTask -> presentTask(event.task)
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        removeCallbacks(finishLoading)
+        super.onDetachedFromWindow()
+    }
+
+    private fun handleMessage(message: SetterFunctionCalledMessage) {
+        when (message.value) {
+            is SetOnLoadError -> transitionInitialLoadState(InitialLoadState.FAILED)
+            is SetOnNotificationsChange -> {
+                if (initialLoadState == InitialLoadState.LOADING) {
+                    didReceiveInitialNotifications = true
+                    removeCallbacks(finishLoading)
+                    requestContentHeightUpdate()
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    private fun contentHeightDidChange(height: Int) {
+        pendingContentHeight = height
+        when (initialLoadState) {
+            InitialLoadState.LOADING -> {
+                if (didReceiveInitialNotifications) {
+                    removeCallbacks(finishLoading)
+                    postDelayed(finishLoading, SETTLE_DELAY_MILLIS)
+                }
+            }
+            InitialLoadState.LOADED -> publishSettledContentHeight()
+            InitialLoadState.FAILED -> Unit
+        }
+    }
+
+    private fun publishSettledContentHeight() {
+        publishContentHeight(pendingContentHeight)
+        if (lastPublishedContentHeight != pendingContentHeight) {
+            lastPublishedContentHeight = pendingContentHeight
+            listener?.onContentHeightChanged(pendingContentHeight)
+        }
+    }
+
+    private fun transitionInitialLoadState(state: InitialLoadState) {
+        if (initialLoadState != InitialLoadState.LOADING || state == InitialLoadState.LOADING) {
+            return
+        }
+        removeCallbacks(finishLoading)
+        initialLoadState = state
+        listener?.onInitialLoadStateChanged(state)
+    }
+
+    private fun presentTask(task: JsonObject) {
+        if (notificationBannerTaskController != null) {
+            return
+        }
+        val activity = context.findActivity() as? FragmentActivity ?: return
+        val controller = NotificationBannerTaskController(
+            activity = activity,
+            embeddedComponentManager = notificationBannerManager,
+            title = taskTitle,
+            props = NotificationBannerTaskProps(
+                collectionOptions = collectionOptions,
+                task = task.toString(),
+            ),
+        )
+        controller.listener = object : StripeEmbeddedComponentListener {
+            override fun onLoadError(error: Throwable) {
+                listener?.onLoadError(error)
+            }
+        }
+        controller.onDismissListener = StripeComponentController.OnDismissListener {
+            notificationBannerTaskController = null
+            callSetterWithSerializableValue(
+                setter = "setMobileNotificationRefreshToken",
+                value = JsonPrimitive(UUID.randomUUID().toString()),
+            )
+        }
+        notificationBannerTaskController = controller
+        controller.show()
+    }
+
+    private companion object {
+        private const val SETTLE_DELAY_MILLIS = 200L
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface NotificationBannerListener : StripeEmbeddedComponentListener {
+    /** Called when the total and action-required notification counts change. */
+    fun onNotificationsChanged(total: Int, actionRequired: Int) {}
+
+    /** Called after the banner publishes a new content height, in pixels. */
+    fun onContentHeightChanged(height: Int) {}
+
+    /** Called when the banner finishes its one-time initial-load lifecycle. */
+    fun onInitialLoadStateChanged(state: NotificationBannerView.InitialLoadState) {}
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class NotificationBannerProps internal constructor(
+    internal val collectionOptions: AccountOnboardingProps.CollectionOptions?,
+)
+
+internal object NotificationBannerListenerDelegate : ComponentListenerDelegate<NotificationBannerListener>() {
+    override fun delegate(listener: NotificationBannerListener, message: SetterFunctionCalledMessage) {
+        val value = message.value
+        if (value is SetOnNotificationsChange) {
+            listener.onNotificationsChanged(
+                total = value.total,
+                actionRequired = value.actionRequired,
+            )
+        }
+    }
+}

--- a/connect/src/main/java/com/stripe/android/connect/PaymentsView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/PaymentsView.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import androidx.core.content.withStyledAttributes
 import com.stripe.android.connect.webview.StripeConnectWebViewContainer
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 
@@ -22,6 +23,7 @@ internal class PaymentsView internal constructor(
         attrs = attrs,
         defStyleAttr = defStyleAttr,
         embeddedComponent = StripeEmbeddedComponent.PAYMENTS,
+        webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
         embeddedComponentManager = embeddedComponentManager,
         listener = listener,
         props = props?.build(),

--- a/connect/src/main/java/com/stripe/android/connect/PayoutsView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/PayoutsView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.withStyledAttributes
 import com.stripe.android.connect.webview.StripeConnectWebViewContainer
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
 
 internal class PayoutsView internal constructor(
     context: Context,
@@ -18,6 +19,7 @@ internal class PayoutsView internal constructor(
         attrs = attrs,
         defStyleAttr = defStyleAttr,
         embeddedComponent = StripeEmbeddedComponent.PAYOUTS,
+        webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
         embeddedComponentManager = embeddedComponentManager,
         listener = listener,
         props = EmptyProps,

--- a/connect/src/main/java/com/stripe/android/connect/StripeComponentView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeComponentView.kt
@@ -341,6 +341,12 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
         webView?.isVisible = viewModel?.stateFlow?.value?.isNativeLoadingIndicatorVisible == false
     }
 
+    internal fun reloadConcealedWebContent() {
+        isWebContentVisible = false
+        webView?.isVisible = false
+        webView?.reload()
+    }
+
     internal open fun onComponentEvent(event: ComponentEvent) {}
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/connect/src/main/java/com/stripe/android/connect/StripeComponentView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeComponentView.kt
@@ -2,10 +2,12 @@ package com.stripe.android.connect
 
 import android.app.Application
 import android.content.Context
+import android.graphics.Outline
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewOutlineProvider
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
 import androidx.annotation.RestrictTo
@@ -26,6 +28,7 @@ import com.stripe.android.connect.webview.StripeConnectWebView
 import com.stripe.android.connect.webview.StripeConnectWebViewContainer
 import com.stripe.android.connect.webview.StripeConnectWebViewContainerState
 import com.stripe.android.connect.webview.StripeConnectWebViewContainerViewModel
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
 import com.stripe.android.connect.webview.StripeWebViewSpinner
 import com.stripe.android.core.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,15 +36,18 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Suppress("TooManyFunctions")
 abstract class StripeComponentView<Listener, Props> internal constructor(
     context: Context,
     attrs: AttributeSet?,
     defStyleAttr: Int,
     private val embeddedComponent: StripeEmbeddedComponent,
+    private val webViewLayout: StripeConnectWebViewLayout,
     private var embeddedComponentManager: EmbeddedComponentManager?,
     listener: Listener?,
     props: Props?,
@@ -57,6 +63,16 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
     private var viewModel: StripeConnectWebViewContainerViewModel? = null
 
     private var progressBar: StripeWebViewSpinner? = null
+    private var contentHeight = 0
+    private var isWebContentVisible = webViewLayout == StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE
+
+    private val roundedOutlineProvider = object : ViewOutlineProvider() {
+        var radius = 0f
+
+        override fun getOutline(view: View, outline: Outline) {
+            outline.setRoundRect(0, 0, view.width, view.height, radius)
+        }
+    }
 
     // See StripeConnectWebViewContainerViewModel for why we're getting a WebView from a ViewModel.
     private val webView: StripeConnectWebView? get() = viewModel?.webView
@@ -202,6 +218,7 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
                         clock = AndroidClock(),
                         embeddedComponentManager = embeddedComponentManager,
                         embeddedComponent = embeddedComponent,
+                        webViewLayout = webViewLayout,
                     )
                 )
             }
@@ -226,8 +243,9 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
             }
         addView(webView)
 
-        // Add progress bar on top of WebView.
-        addProgressBar()
+        if (webViewLayout == StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE) {
+            addProgressBar()
+        }
     }
 
     internal fun setPropsFromXml(props: Props) {
@@ -261,6 +279,14 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
         _receivedCloseWebView.value = state.receivedCloseWebView
         setBackgroundColor(state.backgroundColor)
 
+        if (webViewLayout == StripeConnectWebViewLayout.SIZES_TO_CONTENT) {
+            roundedOutlineProvider.radius = resources.displayMetrics.density *
+                (state.appearance?.cornerRadius?.base ?: DEFAULT_CORNER_RADIUS_DP)
+            outlineProvider = roundedOutlineProvider
+            clipToOutline = true
+            invalidateOutline()
+        }
+
         webView?.let { bindWebView(it, state) }
         progressBar?.let { bindProgressBar(it, state) }
     }
@@ -270,7 +296,7 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
         state: StripeConnectWebViewContainerState
     ) {
         webView.setBackgroundColor(state.backgroundColor)
-        webView.isVisible = !state.isNativeLoadingIndicatorVisible
+        webView.isVisible = isWebContentVisible && !state.isNativeLoadingIndicatorVisible
     }
 
     private fun bindProgressBar(progressBar: StripeWebViewSpinner, state: StripeConnectWebViewContainerState) {
@@ -295,7 +321,47 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
         webView?.mobileInputReceived(input, resultCallback)
     }
 
+    internal fun requestContentHeightUpdate() {
+        viewModel?.requestContentHeightUpdate()
+    }
+
+    internal fun callSetterWithSerializableValue(setter: String, value: JsonElement) {
+        viewModel?.callSetterWithSerializableValue(setter, value)
+    }
+
+    internal fun publishContentHeight(height: Int) {
+        if (contentHeight != height) {
+            contentHeight = height
+            requestLayout()
+        }
+    }
+
+    internal fun revealWebContent() {
+        isWebContentVisible = true
+        webView?.isVisible = viewModel?.stateFlow?.value?.isNativeLoadingIndicatorVisible == false
+    }
+
+    internal open fun onComponentEvent(event: ComponentEvent) {}
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        if (webViewLayout == StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+            return
+        }
+
+        val resolvedHeight = resolveSize(contentHeight, heightMeasureSpec)
+        super.onMeasure(
+            widthMeasureSpec,
+            MeasureSpec.makeMeasureSpec(resolvedHeight, MeasureSpec.EXACTLY)
+        )
+    }
+
     private fun handleEvent(event: ComponentEvent) {
+        onComponentEvent(event)
         listener?.let { listenerDelegate.delegate(it, event) }
+    }
+
+    private companion object {
+        private const val DEFAULT_CORNER_RADIUS_DP = 8f
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponent.kt
@@ -20,4 +20,9 @@ internal enum class StripeEmbeddedComponent(val componentName: String) {
      * Represents the Payments component: [https://docs.stripe.com/connect/supported-embedded-components/payments](https://docs.stripe.com/connect/supported-embedded-components/payments)
      */
     PAYMENTS("payments"),
+
+    /**
+     * Represents the Notification Banner component.
+     */
+    NOTIFICATION_BANNER("notification-banner"),
 }

--- a/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponentListener.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeEmbeddedComponentListener.kt
@@ -3,6 +3,7 @@ package com.stripe.android.connect
 import com.stripe.android.connect.webview.serialization.SetOnLoadError
 import com.stripe.android.connect.webview.serialization.SetOnLoaderStart
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
+import kotlinx.serialization.json.JsonObject
 
 interface StripeEmbeddedComponentListener {
     /**
@@ -29,6 +30,10 @@ internal open class ComponentListenerDelegate<Listener : StripeEmbeddedComponent
 
     fun delegate(listener: Listener, event: ComponentEvent) {
         when (event) {
+            is ComponentEvent.ContentHeightChanged,
+            is ComponentEvent.OpenNotificationBannerTask -> {
+                // Handled by components that support these events.
+            }
             is ComponentEvent.LoadError -> {
                 listener.onLoadError(event.error)
             }
@@ -53,6 +58,8 @@ internal open class ComponentListenerDelegate<Listener : StripeEmbeddedComponent
 }
 
 internal sealed interface ComponentEvent {
+    data class ContentHeightChanged(val height: Int) : ComponentEvent
     data class LoadError(val error: Throwable) : ComponentEvent
     data class Message(val message: SetterFunctionCalledMessage) : ComponentEvent
+    data class OpenNotificationBannerTask(val task: JsonObject) : ComponentEvent
 }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -56,6 +56,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
+import kotlin.math.roundToInt
 
 /**
  * WebView to display an embedded Stripe.js component.
@@ -130,7 +131,7 @@ internal class StripeConnectWebView private constructor(
         result: FinancialConnectionsSheetResult
     ) {
         val payload = SetCollectMobileFinancialConnectionsResultPayloadJs.from(id, result)
-        callSetterWithSerializableValue(
+        evaluateSetterWithSerializableValue(
             setter = "setCollectMobileFinancialConnectionsResult",
             value = ConnectJson.encodeToJsonElement(payload).jsonObject
         )
@@ -153,6 +154,22 @@ internal class StripeConnectWebView private constructor(
                 put("url", url)
             },
         )
+    }
+
+    fun callSetterWithSerializableValue(setter: String, value: JsonElement) {
+        evaluateSetterWithSerializableValue(setter, value)
+    }
+
+    fun startObservingContentHeight() {
+        post {
+            evaluateJavascript(CONTENT_HEIGHT_OBSERVER_SCRIPT, null)
+        }
+    }
+
+    fun requestContentHeightUpdate() {
+        post {
+            evaluateJavascript("window.__stripeConnectReportContentHeight?.()", null)
+        }
     }
 
     override fun onAttachedToWindow() {
@@ -319,6 +336,16 @@ internal class StripeConnectWebView private constructor(
          * Callback to invoke upon receiving 'openAuthenticatedWebView' message.
          */
         fun onReceivedOpenAuthenticatedWebView(activity: Activity, message: OpenAuthenticatedWebViewMessage)
+
+        /**
+         * Callback to invoke upon receiving 'openNotificationBannerForm' message.
+         */
+        fun onReceivedOpenNotificationBannerForm(task: JsonObject)
+
+        /**
+         * Callback to invoke when content-driven WebView height changes.
+         */
+        fun onContentHeightChanged(height: Int)
 
         /**
          * Callback to invoke upon receiving 'openFinancialConnections' message.
@@ -578,6 +605,26 @@ internal class StripeConnectWebView private constructor(
         }
 
         @JavascriptInterface
+        fun openNotificationBannerForm(message: String) {
+            val task = tryDeserializeWebMessage<JsonObject>(
+                webFunctionName = "openNotificationBannerForm",
+                message = message,
+            ) ?: return
+
+            logger.debug("($loggerTag) Open notification banner form")
+            delegate.onReceivedOpenNotificationBannerForm(task)
+        }
+
+        @JavascriptInterface
+        fun contentHeightChanged(height: Double) {
+            if (!height.isFinite() || height < 0) {
+                return
+            }
+            val heightPx = (height * resources.displayMetrics.density).roundToInt()
+            delegate.onContentHeightChanged(heightPx)
+        }
+
+        @JavascriptInterface
         fun pageDidLoad(message: String) {
             val pageLoadMessage = tryDeserializeWebMessage<PageLoadMessage>(
                 webFunctionName = "pageDidLoad",
@@ -647,7 +694,7 @@ internal class StripeConnectWebView private constructor(
         }
     }
 
-    private fun WebView.callSetterWithSerializableValue(setter: String, value: JsonElement) {
+    private fun WebView.evaluateSetterWithSerializableValue(setter: String, value: JsonElement) {
         evaluateSdkJs(
             "callSetterWithSerializableValue",
             buildJsonObject {
@@ -693,5 +740,23 @@ internal class StripeConnectWebView private constructor(
     internal companion object {
         private const val ANDROID_JS_INTERFACE = "Android"
         private const val EVALUATE_SDK_JS_ERROR_PREFIX = "__STRIPE_EVALUATE_SDK_JS_ERROR__:"
+        private val CONTENT_HEIGHT_OBSERVER_SCRIPT = """
+            (function() {
+              if (window.__stripeConnectHeightObserver) return;
+              window.__stripeConnectHeightObserver = true;
+              var last = -1;
+              function report(force) {
+                var body = document.body;
+                if (!body) return;
+                var height = body.getBoundingClientRect().height;
+                if (!force && last >= 0 && Math.abs(height - last) < 0.5) return;
+                last = height;
+                Android.contentHeightChanged(height);
+              }
+              window.__stripeConnectReportContentHeight = function() { report(true); };
+              new ResizeObserver(function() { report(false); }).observe(document.body);
+              report(false);
+            })();
+        """.trimIndent()
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -77,6 +78,7 @@ internal class StripeConnectWebViewContainerViewModel(
     private val clock: Clock,
     private val embeddedComponentManager: EmbeddedComponentManager,
     private val embeddedComponent: StripeEmbeddedComponent,
+    private val webViewLayout: StripeConnectWebViewLayout,
     private val analyticsService: ComponentAnalyticsService,
     private val logger: Logger,
     private val stripeIntentLauncher: StripeIntentLauncher = StripeIntentLauncherImpl(),
@@ -180,6 +182,9 @@ internal class StripeConnectWebViewContainerViewModel(
         }
 
         override fun onPageFinished(url: String) {
+            if (webViewLayout == StripeConnectWebViewLayout.SIZES_TO_CONTENT) {
+                webView.startObservingContentHeight()
+            }
             val timeToLoad = clock.millis() - (stateFlow.value.didBeginLoadingMillis ?: 0)
             analyticsService.track(ConnectAnalyticsEvent.WebPageLoaded(timeToLoad))
         }
@@ -339,6 +344,14 @@ internal class StripeConnectWebViewContainerViewModel(
             )
         }
 
+        override fun onReceivedOpenNotificationBannerForm(task: JsonObject) {
+            _eventFlow.tryEmit(ComponentEvent.OpenNotificationBannerTask(task))
+        }
+
+        override fun onContentHeightChanged(height: Int) {
+            _eventFlow.tryEmit(ComponentEvent.ContentHeightChanged(height))
+        }
+
         override suspend fun onOpenFinancialConnections(
             activity: Activity,
             message: OpenFinancialConnectionsMessage,
@@ -414,6 +427,16 @@ internal class StripeConnectWebViewContainerViewModel(
         webView.returnedFromAuthenticatedWebView(message.url)
     }
 
+    fun requestContentHeightUpdate() {
+        if (webViewLayout == StripeConnectWebViewLayout.SIZES_TO_CONTENT) {
+            webView.requestContentHeightUpdate()
+        }
+    }
+
+    fun callSetterWithSerializableValue(setter: String, value: JsonElement) {
+        webView.callSetterWithSerializableValue(setter, value)
+    }
+
     private inline fun updateState(
         update: StripeConnectWebViewContainerState.() -> StripeConnectWebViewContainerState
     ) {
@@ -438,6 +461,7 @@ internal class StripeConnectWebViewContainerViewModel(
                     clock = baseDependencies.clock,
                     embeddedComponentManager = baseDependencies.embeddedComponentManager,
                     embeddedComponent = baseDependencies.embeddedComponent,
+                    webViewLayout = baseDependencies.webViewLayout,
                     stripeIntentLauncher = baseDependencies.stripeIntentLauncher,
                     logger = baseDependencies.logger,
                 )
@@ -449,6 +473,7 @@ internal class StripeConnectWebViewContainerViewModel(
         val clock: Clock,
         val embeddedComponentManager: EmbeddedComponentManager,
         val embeddedComponent: StripeEmbeddedComponent,
+        val webViewLayout: StripeConnectWebViewLayout,
         val stripeIntentLauncher: StripeIntentLauncher = StripeIntentLauncherImpl(),
         val logger: Logger = StripeConnectComponent.instance.logger,
     ) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewLayout.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewLayout.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.connect.webview
+
+internal enum class StripeConnectWebViewLayout {
+    FILLS_AVAILABLE_SPACE,
+    SIZES_TO_CONTENT,
+}

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AccountOnboardingPropsJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AccountOnboardingPropsJs.kt
@@ -31,19 +31,21 @@ internal fun AccountOnboardingProps.toJs(): AccountOnboardingPropsJs {
         setPrivacyPolicyUrl = privacyPolicyUrl,
         setRecipientTermsOfServiceUrl = recipientTermsOfServiceUrl,
         setSkipTermsOfServiceCollection = skipTermsOfServiceCollection,
-        setCollectionOptions = collectionOptions?.let {
-            AccountOnboardingPropsJs.CollectionOptionsJs(
-                fields = it.fields?.value,
-                futureRequirements = it.futureRequirements?.value,
-                requirements = it.requirements?.let { req ->
-                    when (req) {
-                        is AccountOnboardingProps.RequirementsOption.Only ->
-                            AccountOnboardingPropsJs.RequirementsJs(only = req.only, exclude = null)
-                        is AccountOnboardingProps.RequirementsOption.Exclude ->
-                            AccountOnboardingPropsJs.RequirementsJs(only = null, exclude = req.exclude)
-                    }
-                }
-            )
+        setCollectionOptions = collectionOptions?.toJs()
+    )
+}
+
+internal fun AccountOnboardingProps.CollectionOptions.toJs(): AccountOnboardingPropsJs.CollectionOptionsJs {
+    return AccountOnboardingPropsJs.CollectionOptionsJs(
+        fields = fields?.value,
+        futureRequirements = futureRequirements?.value,
+        requirements = requirements?.let { requirements ->
+            when (requirements) {
+                is AccountOnboardingProps.RequirementsOption.Only ->
+                    AccountOnboardingPropsJs.RequirementsJs(only = requirements.only, exclude = null)
+                is AccountOnboardingProps.RequirementsOption.Exclude ->
+                    AccountOnboardingPropsJs.RequirementsJs(only = null, exclude = requirements.exclude)
+            }
         }
     )
 }

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/NotificationBannerPropsJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/NotificationBannerPropsJs.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.connect.webview.serialization
+
+import com.stripe.android.connect.NotificationBannerProps
+import com.stripe.android.connect.NotificationBannerTaskProps
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+@Serializable
+internal data class NotificationBannerPropsJs(
+    val setCollectionOptions: AccountOnboardingPropsJs.CollectionOptionsJs?,
+    val setMobileNotificationBannerForm: JsonObject?,
+)
+
+internal fun NotificationBannerProps.toJs(): NotificationBannerPropsJs {
+    return NotificationBannerPropsJs(
+        setCollectionOptions = collectionOptions?.toJs(),
+        setMobileNotificationBannerForm = null,
+    )
+}
+
+internal fun NotificationBannerTaskProps.toJs(): NotificationBannerPropsJs {
+    return NotificationBannerPropsJs(
+        setCollectionOptions = collectionOptions?.toJs(),
+        setMobileNotificationBannerForm = ConnectJson.parseToJsonElement(task).jsonObject,
+    )
+}

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/SetterFunctionCalledMessage.kt
@@ -76,6 +76,15 @@ internal data class SetOnLoadError(
 }
 
 /**
+ * The notification banner's notification counts changed.
+ */
+@Serializable
+internal data class SetOnNotificationsChange(
+    val total: Int,
+    val actionRequired: Int,
+) : SetterFunctionCalledMessage.Value
+
+/**
  * The connected account has exited the onboarding process.
  */
 @Serializable

--- a/connect/src/test/java/com/stripe/android/connect/test/TestComponentUi.kt
+++ b/connect/src/test/java/com/stripe/android/connect/test/TestComponentUi.kt
@@ -11,6 +11,7 @@ import com.stripe.android.connect.StripeComponentView
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.StripeEmbeddedComponentListener
 import com.stripe.android.connect.manager.EmbeddedComponentCoordinator
+import com.stripe.android.connect.webview.StripeConnectWebViewLayout
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
@@ -58,6 +59,7 @@ internal class TestComponentView(
     attrs = null,
     defStyleAttr = 0,
     embeddedComponent = StripeEmbeddedComponent.ACCOUNT_ONBOARDING,
+    webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
     embeddedComponentManager = null,
     listener = null,
     props = null,

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -104,6 +104,7 @@ class StripeConnectWebViewContainerViewModelTest {
             clock = androidClock,
             embeddedComponentManager = embeddedComponentManager,
             embeddedComponent = embeddedComponent,
+            webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
             stripeIntentLauncher = mockStripeIntentLauncher,
             logger = mockLogger,
             createWebView = { _, _, _ -> webView }
@@ -122,6 +123,7 @@ class StripeConnectWebViewContainerViewModelTest {
             clock = androidClock,
             embeddedComponentManager = embeddedComponentManager,
             embeddedComponent = embeddedComponent,
+            webViewLayout = StripeConnectWebViewLayout.FILLS_AVAILABLE_SPACE,
             analyticsService = analyticsService,
             logger = Logger.noop(),
             // Default `createWebView` value


### PR DESCRIPTION
## Summary

- Add an experimental, Dashboard-only notification banner that renders inline and sizes itself to settled web content.
- Expose optional initial-load and content-height observation so hosts can provide their own loading skeleton and layout animation.
- Present notification tasks in a separate full-screen webview with host-configurable navigation title, secure-flow dismissal, and banner refresh on return.
- Keep task payloads opaque to the native SDK so future notification interventions remain web-owned.
- Add an example screen showing appearance-aware host content, a native skeleton, inline resizing, and task presentation.

https://github.com/user-attachments/assets/02b85ba0-f8ad-4e03-8e60-4d3b7771df0f



## Testing

- `./gradlew :connect:detekt :connect:apiCheck :connect:lintDebug :connect:testDebugUnitTest :connect-example:assembleDebug`
- Manually rebuilt and exercised the Connect Example on Android to verify inline loading, resizing, full-screen task presentation, dismissal, refresh, links, and appearance changes.
- No tests were newly ignored.

## Changelog

No changelog entry. The notification banner API is experimental and restricted to the SDK library group.
