### PR TITLE
Add support for updating customer email in checkout session.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -181,6 +181,18 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
+     * Updates the customer's email address.
+     *
+     * @param email The email address to set. Pass `null` to clear the customer's email.
+     * Leading/trailing whitespace is trimmed.
+     */
+    suspend fun updateEmail(
+        email: String?,
+    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
+        checkoutSessionRepository.updateEmail(sessionId, email?.trim().orEmpty())
+    }
+
+    /**
      * Sets the billing address for this checkout.
      *
      * The address is stored locally and used when presenting payment UI. If automatic tax is

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -181,6 +181,17 @@ internal class CheckoutSessionRepository @Inject constructor(
         ),
     )
 
+    suspend fun updateEmail(
+        sessionId: String,
+        email: String,
+    ): Result<CheckoutSessionResponse> = executePost(
+        url = updateUrl(sessionId),
+        params = mapOf(
+            "customer_email" to email,
+            "elements_session_client[is_aggregation_expected]" to "true",
+        ),
+    )
+
     suspend fun updateCurrency(
         sessionId: String,
         currencyCode: String,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -553,6 +553,58 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `updateEmail sends customer_email and updates session on success`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("customer_email", "checkout@example.com"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.updateEmail("checkout@example.com")
+
+        result.getOrThrow()
+        assertThat(controller.checkoutSession.value?.customerEmail).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `updateEmail trims whitespace`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("customer_email", "checkout@example.com"),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.updateEmail("  checkout@example.com  ")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateEmail sends empty customer_email when cleared with null`() = runMutationScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("customer_email", ""),
+            responseFactory = successResponseFactory(),
+        )
+
+        val result = controller.updateEmail(null)
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateEmail returns failure and preserves session on error`() = runMutationScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid email"}}""")
+        }
+        val before = controller.checkoutSession.value
+
+        val result = controller.updateEmail("invalid")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(controller.checkoutSession.value).isEqualTo(before)
+    }
+
+    @Test
     fun `updateShippingAddress sends tax_region and stores address when automatic tax targets shipping`() =
         runMutationScenario(initModifier = automaticTaxFor("shipping")) {
             networkRule.checkoutUpdate(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -63,6 +63,38 @@ class CheckoutSessionRepositoryTest {
     }
 
     @Test
+    fun `updateEmail sends customer_email and returns response on success`() = runTest {
+        networkRule.checkoutUpdate(
+            bodyPart("customer_email", "checkout@example.com"),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-init.json")
+        }
+
+        val result = repository.updateEmail(
+            sessionId = DEFAULT_CHECKOUT_SESSION_ID,
+            email = "checkout@example.com",
+        )
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `updateEmail returns failure on error response`() = runTest {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error": {"message": "Invalid email"}}""")
+        }
+
+        val result = repository.updateEmail(
+            sessionId = DEFAULT_CHECKOUT_SESSION_ID,
+            email = "invalid",
+        )
+
+        assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
     fun `updateCurrency sends currency code and returns response on success`() = runTest {
         networkRule.checkoutUpdate(
             bodyPart("updated_currency", "eur"),


### PR DESCRIPTION
# Summary
Added support for updating the customer's email address via CheckoutController and CheckoutSessionRepository. Included tests to verify success, trimming, clearing, and error scenarios.

# Motivation
Preparing for API review.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
