### PR TITLE
Use stable automatic-tax billing source signal (MOBILESDK-4667)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -99,10 +99,12 @@ internal data class PaymentMethodMetadata(
     val disableSsdOcrCardScan: Boolean,
     val cardArts: List<PaymentMethod.Card.CardArt>,
     val shouldUseAutocompleteProxyEndpoints: Boolean,
-    val requiresBillingAddressForAutomaticTax: Boolean,
     val checkoutSessionResponse: CheckoutSessionResponse?,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
 ) : Parcelable {
+
+    val requiresBillingAddressForAutomaticTax: Boolean
+        get() = checkoutSessionResponse?.collectsTaxFromBillingAddress == true
 
     fun paymentMethodOrientation(): PaymentMethodOrientation {
         return when (paymentMethodLayout) {
@@ -441,7 +443,6 @@ internal data class PaymentMethodMetadata(
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = cardArts,
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
-                requiresBillingAddressForAutomaticTax = initializationMode.requiresBillingAddressForAutomaticTax(),
                 checkoutSessionResponse =
                     (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
                         ?.checkoutSessionResponse,
@@ -516,7 +517,6 @@ internal data class PaymentMethodMetadata(
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
-                requiresBillingAddressForAutomaticTax = false,
                 checkoutSessionResponse = null,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -33,7 +33,7 @@ internal data class CheckoutSessionResponse(
     val merchantCountry: String?,
 ) : StripeModel {
 
-    val shouldDisableWalletsForAutomaticTaxBilling: Boolean
+    val collectsTaxFromBillingAddress: Boolean
         get() = automaticTaxEnabled && taxAddressSource == TaxAddressSource.BILLING
 
     enum class TaxAddressSource {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -117,23 +117,13 @@ internal interface PaymentElementLoader {
         fun walletsDisabledReason(): WalletsDisabledReason? {
             val shouldDisable = (this as? CheckoutSession)
                 ?.checkoutSessionResponse
-                ?.shouldDisableWalletsForAutomaticTaxBilling == true
+                ?.collectsTaxFromBillingAddress == true
 
             return if (shouldDisable) {
                 WalletsDisabledReason.AutomaticTaxBillingAddress
             } else {
                 null
             }
-        }
-
-        /**
-         * Deliberately narrower than [walletsDisabledReason]: true only while an address is
-         * still needed, not for the rest of the session once tax is satisfied.
-         */
-        fun requiresBillingAddressForAutomaticTax(): Boolean {
-            val checkoutSession = this as? CheckoutSession ?: return false
-            return checkoutSession.checkoutSessionResponse.taxStatus ==
-                CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS
         }
 
         enum class WalletsDisabledReason {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -82,7 +82,6 @@ internal object PaymentMethodMetadataFactory {
         disableSsdOcrCardScan: Boolean = false,
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
-        requiresBillingAddressForAutomaticTax: Boolean = false,
         checkoutSessionResponse: CheckoutSessionResponse? = null,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
     ): PaymentMethodMetadata {
@@ -157,7 +156,6 @@ internal object PaymentMethodMetadataFactory {
             disableSsdOcrCardScan = disableSsdOcrCardScan,
             cardArts = cardArts,
             shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
-            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
             checkoutSessionResponse = checkoutSessionResponse,
             paymentMethodLayout = paymentMethodLayout,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1221,7 +1221,6 @@ internal class PaymentMethodMetadataTest {
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
-            requiresBillingAddressForAutomaticTax = false,
             checkoutSessionResponse = null,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
@@ -1383,7 +1382,6 @@ internal class PaymentMethodMetadataTest {
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
-            requiresBillingAddressForAutomaticTax = false,
             checkoutSessionResponse = null,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
@@ -2176,12 +2174,14 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `createForPaymentElement sets requiresBillingAddressForAutomaticTax true when checkout session requires it`() {
+    fun `createForPaymentElement requires automatic tax billing address when tax status requires it`() {
         val metadata = createPaymentElementMetadata(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "key",
                 checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                     taxStatus = CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS,
+                    automaticTaxEnabled = true,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
                 ),
             ),
             integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
@@ -2191,12 +2191,46 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `createForPaymentElement sets requiresBillingAddressForAutomaticTax false when tax status is ready`() {
+    fun `createForPaymentElement requires automatic tax billing address when tax status is ready`() {
         val metadata = createPaymentElementMetadata(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "key",
                 checkoutSessionResponse = CheckoutSessionResponseFactory.create(
                     taxStatus = CheckoutSessionResponse.TaxStatus.READY,
+                    automaticTaxEnabled = true,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                ),
+            ),
+            integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
+        )
+
+        assertThat(metadata.requiresBillingAddressForAutomaticTax).isTrue()
+    }
+
+    @Test
+    fun `createForPaymentElement does not require automatic tax billing address when automatic tax is disabled`() {
+        val metadata = createPaymentElementMetadata(
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+                instancesKey = "key",
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    automaticTaxEnabled = false,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                ),
+            ),
+            integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
+        )
+
+        assertThat(metadata.requiresBillingAddressForAutomaticTax).isFalse()
+    }
+
+    @Test
+    fun `createForPaymentElement does not require automatic tax billing address when tax uses shipping`() {
+        val metadata = createPaymentElementMetadata(
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+                instancesKey = "key",
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    automaticTaxEnabled = true,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
                 ),
             ),
             integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -27,6 +27,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
@@ -424,7 +426,9 @@ class CardDefinitionTest {
 
     @Test
     fun `createFormElements shows only postal code for CA when automatic tax billing address is required`() {
-        val cardBillingElement = createAutomaticCardBillingAddressElement(requiresBillingAddressForAutomaticTax = true)
+        val cardBillingElement = createAutomaticCardBillingAddressElement(
+            checkoutSessionResponse = automaticTaxCheckoutSessionResponse(),
+        )
         cardBillingElement.countryElement.controller.onRawValueChange("CA")
 
         assertThat(cardBillingElement.shownIdentifierParamPaths()).containsExactly(
@@ -435,7 +439,9 @@ class CardDefinitionTest {
 
     @Test
     fun `createFormElements shows line1, city, state, and postal code for US when automatic tax billing is required`() {
-        val cardBillingElement = createAutomaticCardBillingAddressElement(requiresBillingAddressForAutomaticTax = true)
+        val cardBillingElement = createAutomaticCardBillingAddressElement(
+            checkoutSessionResponse = automaticTaxCheckoutSessionResponse(),
+        )
         cardBillingElement.countryElement.controller.onRawValueChange("US")
 
         assertThat(cardBillingElement.shownIdentifierParamPaths()).containsExactly(
@@ -449,7 +455,9 @@ class CardDefinitionTest {
 
     @Test
     fun `createFormElements does not show additional fields for a country not requiring them`() {
-        val cardBillingElement = createAutomaticCardBillingAddressElement(requiresBillingAddressForAutomaticTax = true)
+        val cardBillingElement = createAutomaticCardBillingAddressElement(
+            checkoutSessionResponse = automaticTaxCheckoutSessionResponse(),
+        )
         cardBillingElement.countryElement.controller.onRawValueChange("FR")
 
         assertThat(cardBillingElement.shownIdentifierParamPaths()).containsExactly("billing_details[address][country]")
@@ -457,7 +465,12 @@ class CardDefinitionTest {
 
     @Test
     fun `createFormElements does not union tax fields when requiresBillingAddressForAutomaticTax is false`() {
-        val cardBillingElement = createAutomaticCardBillingAddressElement(requiresBillingAddressForAutomaticTax = false)
+        val cardBillingElement = createAutomaticCardBillingAddressElement(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = false,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
         cardBillingElement.countryElement.controller.onRawValueChange("FR")
 
         assertThat(cardBillingElement.shownIdentifierParamPaths()).containsExactly("billing_details[address][country]")
@@ -783,14 +796,14 @@ class CardDefinitionTest {
     }
 
     private fun createAutomaticCardBillingAddressElement(
-        requiresBillingAddressForAutomaticTax: Boolean,
+        checkoutSessionResponse: CheckoutSessionResponse?,
     ): CardBillingAddressElement {
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
                 ),
-                requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
+                checkoutSessionResponse = checkoutSessionResponse,
             )
         )
 
@@ -798,6 +811,13 @@ class CardDefinitionTest {
             .flatMap { it.fields }
             .filterIsInstance<CardBillingAddressElement>()
             .first()
+    }
+
+    private fun automaticTaxCheckoutSessionResponse(): CheckoutSessionResponse {
+        return CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
     }
 
     private fun CardBillingAddressElement.shownIdentifierParamPaths(): List<String> {


### PR DESCRIPTION
# Summary
Use the stable Checkout Session configuration signal `automaticTaxEnabled && taxAddressSource == BILLING` to decide whether PaymentSheet needs billing-address fields for automatic tax.

This is the bottom prerequisite for the MOBILESDK-4667 stack:

- #13717 makes the shared billing-address element explicitly configurable.
- #13723 migrates LPM country collection to that shared element without changing tax-disabled behavior.
- #13713 widens or appends the shared address for normal new-payment-method forms.
- #13718 applies the same behavior to the separately rendered US bank account form.

# Motivation
The previous flag followed the transient `taxStatus == REQUIRES_BILLING_ADDRESS` value. That status can become `READY` after an address is supplied, but new-payment-method forms still need to collect enough billing address data for the selected payment method. iOS uses the stable automatic-tax-enabled plus billing-source configuration for the same decision.

Wallet disabling already used this stable configuration. This PR names that predicate `collectsTaxFromBillingAddress` and reuses it for both behaviors. Non-Checkout, automatic-tax-disabled, and shipping-sourced sessions remain false.

Related card entry support: #13470.

JIRA: [MOBILESDK-4667](https://jira.corp.stripe.com/browse/MOBILESDK-4667)

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`PaymentMethodMetadataTest` covers billing-sourced automatic tax with both `REQUIRES_BILLING_ADDRESS` and `READY` statuses, plus disabled automatic tax and shipping-sourced tax.

# Screenshots
N/A - no direct UI change.

# Changelog
N/A - Checkout Session is behind `@CheckoutSessionPreview`; the implementation is internal.
