### PR TITLE
Share automatic-tax billing address primitives (MOBILESDK-4667)

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFields.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFields.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+/**
+ * Billing address fields required in addition to country for automatic tax calculation.
+ * Countries absent from this map require country only.
+ *
+ * Source: https://docs.stripe.com/tax/customer-locations
+ */
+@get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+val additionalAutomaticTaxFieldsByCountry: Map<String, Set<IdentifierSpec>> = mapOf(
+    "CA" to setOf(IdentifierSpec.PostalCode),
+    "GB" to setOf(IdentifierSpec.PostalCode),
+    "IN" to setOf(IdentifierSpec.PostalCode),
+    "PR" to setOf(IdentifierSpec.Line1, IdentifierSpec.City, IdentifierSpec.PostalCode),
+    "US" to setOf(IdentifierSpec.Line1, IdentifierSpec.City, IdentifierSpec.State, IdentifierSpec.PostalCode),
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun automaticTaxRequiredFields(countryCode: String): Set<IdentifierSpec> {
+    return additionalAutomaticTaxFieldsByCountry[countryCode].orEmpty()
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
@@ -58,7 +58,7 @@ fun cardBillingAddressCollectionMode(
                 }
                 if (requiresBillingAddressForAutomaticTax) {
                     additionalAutomaticTaxFieldsByCountry.forEach { (countryCode, fields) ->
-                        merge(countryCode, fields) { existing, additional -> existing + additional }
+                        put(countryCode, get(countryCode).orEmpty() + fields)
                     }
                 }
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
@@ -79,7 +79,6 @@ class BillingAddressElement(
         CountryConfig(countryCodes),
         rawValuesMap[IdentifierSpec.Country]
     ),
-    countryElementIdentifier: IdentifierSpec,
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
@@ -133,7 +132,7 @@ class BillingAddressElement(
                 emailConfig = emailConfig,
             ),
             countryElement = CountryElement(
-                identifier = countryElementIdentifier,
+                identifier = IdentifierSpec.Country,
                 controller = countryDropdownFieldController,
             ),
             shippingValuesMap = shippingValuesMap,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
@@ -29,13 +29,49 @@ import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed interface BillingAddressCollectionMode {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Never : BillingAddressCollectionMode
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Full : BillingAddressCollectionMode
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Country(
+        val additionalFieldsByCountry: Map<String, Set<IdentifierSpec>>,
+    ) : BillingAddressCollectionMode
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun cardBillingAddressCollectionMode(
+    addressCollectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode,
+    requiresBillingAddressForAutomaticTax: Boolean,
+): BillingAddressCollectionMode {
+    return when (addressCollectionMode) {
+        BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> BillingAddressCollectionMode.Never
+        BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> BillingAddressCollectionMode.Full
+        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
+            val additionalFieldsByCountry = buildMap {
+                listOf("US", "GB", "CA").forEach { countryCode ->
+                    put(countryCode, setOf(IdentifierSpec.PostalCode))
+                }
+                if (requiresBillingAddressForAutomaticTax) {
+                    additionalAutomaticTaxFieldsByCountry.forEach { (countryCode, fields) ->
+                        merge(countryCode, fields) { existing, additional -> existing + additional }
+                    }
+                }
+            }
+            BillingAddressCollectionMode.Country(additionalFieldsByCountry)
+        }
+    }
+}
+
 /**
- * This is a special type of AddressElement that
- * removes fields from the address based on the country.  It
- * is only intended to be used with the card payment method.
+ * An address element that dynamically removes fields based on the selected country and collection mode.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class CardBillingAddressElement(
+class BillingAddressElement(
     override val identifier: IdentifierSpec,
     rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
     countryCodes: Set<String> = emptySet(),
@@ -43,13 +79,14 @@ class CardBillingAddressElement(
         CountryConfig(countryCodes),
         rawValuesMap[IdentifierSpec.Country]
     ),
+    countryElementIdentifier: IdentifierSpec,
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
+    private val addressCollectionMode: BillingAddressCollectionMode,
     private val collectionConfiguration: BillingDetailsCollectionConfiguration =
         BillingDetailsCollectionConfiguration(),
     private val shouldHideCountryOnNoAddressCollection: Boolean = true,
-    private val requiresBillingAddressForAutomaticTax: Boolean = false,
 ) : AddressFieldsElement {
     private val nameConfig = if (collectionConfiguration.collectName) {
         AddressFieldConfiguration.REQUIRED
@@ -71,7 +108,7 @@ class CardBillingAddressElement(
 
     @VisibleForTesting
     val addressElement = autocompleteAddressInteractorFactory?.takeIf {
-        collectionConfiguration.address == BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+        addressCollectionMode == BillingAddressCollectionMode.Full
     }?.let { factory ->
         AutocompleteAddressElement(
             identifier = identifier,
@@ -96,13 +133,13 @@ class CardBillingAddressElement(
                 emailConfig = emailConfig,
             ),
             countryElement = CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = countryElementIdentifier,
                 controller = countryDropdownFieldController,
             ),
             shippingValuesMap = shippingValuesMap,
             sameAsShippingElement = sameAsShippingElement,
             hideCountry = shouldHideCountryOnNoAddressCollection &&
-                collectionConfiguration.address == BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                addressCollectionMode == BillingAddressCollectionMode.Never,
         )
     }
 
@@ -164,28 +201,18 @@ class CardBillingAddressElement(
     // card and achv2 uses save for future use
     val hiddenIdentifiers: StateFlow<Set<IdentifierSpec>> =
         countryDropdownFieldController.rawFieldValue.mapAsStateFlow { countryCode ->
-            when (collectionConfiguration.address) {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
+            when (val mode = addressCollectionMode) {
+                BillingAddressCollectionMode.Never -> {
                     FieldType.entries
                         .filterNot { it == FieldType.Name }
                         .map { it.identifierSpec }
                         .toSet()
                 }
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                BillingAddressCollectionMode.Full -> {
                     emptySet()
                 }
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
-                    val avsShownFields = when (countryCode) {
-                        "US", "GB", "CA" -> setOf(FieldType.PostalCode.identifierSpec)
-                        else -> emptySet()
-                    }
-                    val automaticTaxShownFields = if (requiresBillingAddressForAutomaticTax && countryCode != null) {
-                        automaticTaxRequiredFields(countryCode)
-                    } else {
-                        emptySet()
-                    }
-                    val shownFields = avsShownFields + automaticTaxShownFields
-
+                is BillingAddressCollectionMode.Country -> {
+                    val shownFields = mode.additionalFieldsByCountry[countryCode].orEmpty()
                     FieldType.entries
                         // Filtering name causes the field to be hidden even outside
                         // of this form.
@@ -212,26 +239,4 @@ class CardBillingAddressElement(
     override fun onValidationStateChanged(isValidating: Boolean) {
         addressElement.onValidationStateChanged(isValidating)
     }
-}
-
-/**
- * Billing address fields required in addition to the country, for a Checkout Session using
- * automatic tax with the billing address as the tax source. Most countries only need the
- * country. Source: https://docs.stripe.com/tax/customer-locations
- *
- * Billing only - shipping is out of scope, since it's always collected in full for delivery
- * regardless of tax, so there's no omittable mode there for tax to rescue.
- */
-private val additionalAutomaticTaxFieldsByCountry: Map<String, Set<IdentifierSpec>> = mapOf(
-    "CA" to setOf(IdentifierSpec.PostalCode),
-    "GB" to setOf(IdentifierSpec.PostalCode),
-    "IN" to setOf(IdentifierSpec.PostalCode),
-    "PR" to setOf(IdentifierSpec.Line1, IdentifierSpec.City, IdentifierSpec.PostalCode),
-    "US" to setOf(IdentifierSpec.Line1, IdentifierSpec.City, IdentifierSpec.State, IdentifierSpec.PostalCode),
-)
-
-private fun automaticTaxRequiredFields(countryCode: String): Set<IdentifierSpec> {
-    // Matches the raw, non-uppercased comparison the AVS check above uses - countryCode is
-    // already an uppercase ISO code in practice (from CountryConfig).
-    return additionalAutomaticTaxFieldsByCountry[countryCode].orEmpty()
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -312,7 +312,6 @@ internal class CardBillingAddressElementTest {
             rawValuesMap = emptyMap(),
             countryCodes = emptySet(),
             countryDropdownFieldController = dropdownFieldController,
-            countryElementIdentifier = IdentifierSpec.Country,
             autocompleteAddressInteractorFactory = null,
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -383,7 +382,6 @@ internal class CardBillingAddressElementTest {
                 rawValuesMap = emptyMap(),
                 countryCodes = emptySet(),
                 countryDropdownFieldController = dropdownFieldController,
-                countryElementIdentifier = IdentifierSpec.Country,
                 autocompleteAddressInteractorFactory = {
                     object : AutocompleteAddressInteractor {
                         override val autocompleteConfig: AutocompleteAddressInteractor.Config =

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -64,6 +64,18 @@ internal class CardBillingAddressElementTest {
     }
 
     @Test
+    fun `Verify that country-only collection does not apply card AVS fields`() = runTest {
+        val element = createBillingAddressElement(
+            addressCollectionMode = BillingAddressCollectionMode.Country(emptyMap()),
+        )
+
+        element.hiddenIdentifiers.test {
+            dropdownFieldController.onRawValueChange("US")
+            expectMostRecentItem().verifyFieldsShown()
+        }
+    }
+
+    @Test
     fun `Verify that automatic tax fields are unioned with AVS defaults for IN`() = runTest {
         val element = createCardBillingAddressElement(requiresBillingAddressForAutomaticTax = true)
 
@@ -281,17 +293,31 @@ internal class CardBillingAddressElementTest {
     private fun createCardBillingAddressElement(
         requiresBillingAddressForAutomaticTax: Boolean = false,
         collectionConfiguration: BillingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(),
-    ): CardBillingAddressElement {
-        return CardBillingAddressElement(
+    ): BillingAddressElement {
+        return createBillingAddressElement(
+            collectionConfiguration = collectionConfiguration,
+            addressCollectionMode = cardBillingAddressCollectionMode(
+                addressCollectionMode = collectionConfiguration.address,
+                requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
+            ),
+        )
+    }
+
+    private fun createBillingAddressElement(
+        collectionConfiguration: BillingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(),
+        addressCollectionMode: BillingAddressCollectionMode,
+    ): BillingAddressElement {
+        return BillingAddressElement(
             identifier = IdentifierSpec.Generic("billing_element"),
             rawValuesMap = emptyMap(),
             countryCodes = emptySet(),
             countryDropdownFieldController = dropdownFieldController,
+            countryElementIdentifier = IdentifierSpec.Country,
             autocompleteAddressInteractorFactory = null,
             sameAsShippingElement = null,
             shippingValuesMap = null,
+            addressCollectionMode = addressCollectionMode,
             collectionConfiguration = collectionConfiguration,
-            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
         )
     }
 
@@ -349,14 +375,15 @@ internal class CardBillingAddressElementTest {
 
     private fun autocompleteTest(
         configuration: BillingDetailsCollectionConfiguration,
-        block: (CardBillingAddressElement) -> Unit,
+        block: (BillingAddressElement) -> Unit,
     ) = runTest {
         block(
-            CardBillingAddressElement(
+            BillingAddressElement(
                 identifier = IdentifierSpec.Generic("billing_element"),
                 rawValuesMap = emptyMap(),
                 countryCodes = emptySet(),
                 countryDropdownFieldController = dropdownFieldController,
+                countryElementIdentifier = IdentifierSpec.Country,
                 autocompleteAddressInteractorFactory = {
                     object : AutocompleteAddressInteractor {
                         override val autocompleteConfig: AutocompleteAddressInteractor.Config =
@@ -376,6 +403,10 @@ internal class CardBillingAddressElementTest {
                 },
                 sameAsShippingElement = null,
                 shippingValuesMap = null,
+                addressCollectionMode = cardBillingAddressCollectionMode(
+                    addressCollectionMode = configuration.address,
+                    requiresBillingAddressForAutomaticTax = false,
+                ),
                 collectionConfiguration = configuration,
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -290,7 +290,6 @@ private fun cardBillingElements(
         IdentifierSpec.Generic("credit_billing"),
         countryCodes = allowedCountries,
         rawValuesMap = initialValues,
-        countryElementIdentifier = IdentifierSpec.Country,
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = shippingValues,
         addressCollectionMode = cardBillingAddressCollectionMode(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -27,13 +27,14 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsAction
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
 import com.stripe.android.ui.core.elements.CardScanAction
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.RenderableFormElement
+import com.stripe.android.ui.core.elements.cardBillingAddressCollectionMode
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -285,15 +286,19 @@ private fun cardBillingElements(
                     controller = SameAsShippingController(it)
                 )
             }
-    val addressElement = CardBillingAddressElement(
+    val addressElement = BillingAddressElement(
         IdentifierSpec.Generic("credit_billing"),
         countryCodes = allowedCountries,
         rawValuesMap = initialValues,
+        countryElementIdentifier = IdentifierSpec.Country,
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = shippingValues,
+        addressCollectionMode = cardBillingAddressCollectionMode(
+            addressCollectionMode = collectionConfiguration.address,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
+        ),
         collectionConfiguration = collectionConfiguration,
         autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-        requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
     )
 
     val title = when {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.connectBillingDetailsFields
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
@@ -60,7 +60,7 @@ internal class FormViewModel(
 
     private val cardBillingElement = elements.filterIsInstance<SectionElement>()
         .flatMap { it.fields }
-        .filterIsInstance<CardBillingAddressElement>()
+        .filterIsInstance<BillingAddressElement>()
         .firstOrNull()
 
     private var externalHiddenIdentifiers = MutableStateFlow(emptySet<IdentifierSpec>())

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -44,7 +44,6 @@ internal class BillingDetailsForm(
         sameAsShippingElement = null,
         shippingValuesMap = null,
         countryCodes = allowedBillingCountries,
-        countryElementIdentifier = IdentifierSpec.Country,
         collectionConfiguration = BillingDetailsCollectionConfiguration(
             address = when (addressCollectionMode) {
                 AddressCollectionMode.Automatic ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -6,7 +6,8 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
+import com.stripe.android.ui.core.elements.cardBillingAddressCollectionMode
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
@@ -38,11 +39,12 @@ internal class BillingDetailsForm(
         null
     }
 
-    private val cardBillingAddressElement: CardBillingAddressElement = CardBillingAddressElement(
+    private val cardBillingAddressElement: BillingAddressElement = BillingAddressElement(
         identifier = IdentifierSpec.BillingAddress,
         sameAsShippingElement = null,
         shippingValuesMap = null,
         countryCodes = allowedBillingCountries,
+        countryElementIdentifier = IdentifierSpec.Country,
         collectionConfiguration = BillingDetailsCollectionConfiguration(
             address = when (addressCollectionMode) {
                 AddressCollectionMode.Automatic ->
@@ -53,6 +55,15 @@ internal class BillingDetailsForm(
             collectName = nameCollection == NameCollection.InBillingDetailsForm,
             collectEmail = collectEmail,
             collectPhone = collectPhone,
+        ),
+        addressCollectionMode = cardBillingAddressCollectionMode(
+            addressCollectionMode = when (addressCollectionMode) {
+                AddressCollectionMode.Automatic ->
+                    BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+                AddressCollectionMode.Never -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                AddressCollectionMode.Full -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+            },
+            requiresBillingAddressForAutomaticTax = false,
         ),
         rawValuesMap = rawAddressValues(billingDetails),
         autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -51,7 +51,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
 import com.stripe.android.uicore.elements.FormElement
@@ -474,7 +474,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             assertThat(formElements[0]).isInstanceOf<CardDetailsSectionElement>()
             assertThat(formElements[1]).isInstanceOf<SectionElement>()
             assertThat(formElements[1].asSectionElement().fields[0])
-                .isInstanceOf<CardBillingAddressElement>()
+                .isInstanceOf<BillingAddressElement>()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
@@ -21,7 +21,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.navigation.NavigationManager
@@ -170,9 +170,9 @@ class UpdateCardScreenViewModelTest {
                     val nonNullBillingElements = requireNotNull(billingElements)
 
                     assertThat(nonNullBillingElements).hasSize(1)
-                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<BillingAddressElement>()
 
-                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+                    val cardBillingAddressElement = nonNullBillingElements[0] as BillingAddressElement
 
                     val addressFields = cardBillingAddressElement.addressController.value.fieldsFlowable.value
 
@@ -216,9 +216,9 @@ class UpdateCardScreenViewModelTest {
                     val nonNullBillingElements = requireNotNull(billingElements)
 
                     assertThat(nonNullBillingElements).hasSize(1)
-                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<BillingAddressElement>()
 
-                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+                    val cardBillingAddressElement = nonNullBillingElements[0] as BillingAddressElement
 
                     val addressFields = cardBillingAddressElement.addressController.value.fieldsFlowable.value
 
@@ -262,9 +262,9 @@ class UpdateCardScreenViewModelTest {
                     val nonNullBillingElements = requireNotNull(billingElements)
 
                     assertThat(nonNullBillingElements).hasSize(1)
-                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<BillingAddressElement>()
 
-                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+                    val cardBillingAddressElement = nonNullBillingElements[0] as BillingAddressElement
 
                     val addressFields = cardBillingAddressElement.addressController.value.fieldsFlowable.value
 
@@ -315,9 +315,9 @@ class UpdateCardScreenViewModelTest {
                     val nonNullBillingElements = requireNotNull(billingElements)
 
                     assertThat(nonNullBillingElements).hasSize(1)
-                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<BillingAddressElement>()
 
-                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+                    val cardBillingAddressElement = nonNullBillingElements[0] as BillingAddressElement
 
                     assertThat(cardBillingAddressElement.countryElement.controller.displayItems)
                         .hasSize(CountryUtils.supportedBillingCountries.size)
@@ -356,9 +356,9 @@ class UpdateCardScreenViewModelTest {
                     val nonNullBillingElements = requireNotNull(billingElements)
 
                     assertThat(nonNullBillingElements).hasSize(1)
-                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<BillingAddressElement>()
 
-                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+                    val cardBillingAddressElement = nonNullBillingElements[0] as BillingAddressElement
 
                     // Billing details update flow should respect country filtering
                     assertThat(cardBillingAddressElement.countryElement.controller.displayItems).containsExactly(
@@ -400,9 +400,9 @@ class UpdateCardScreenViewModelTest {
                     val nonNullBillingElements = requireNotNull(billingElements)
 
                     assertThat(nonNullBillingElements).hasSize(1)
-                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<BillingAddressElement>()
 
-                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+                    val cardBillingAddressElement = nonNullBillingElements[0] as BillingAddressElement
 
                     // Regular edit flow should show all countries, ignoring filter
                     assertThat(cardBillingAddressElement.countryElement.controller.displayItems)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -31,7 +31,7 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsAction
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
@@ -94,7 +94,7 @@ class CardDefinitionTest {
         val contactElement = formElements[1] as SectionElement
         assertThat(contactElement.fields).hasSize(1)
 
-        val cardBillingElement = contactElement.fields[0] as CardBillingAddressElement
+        val cardBillingElement = contactElement.fields[0] as BillingAddressElement
         val billingElements = cardBillingElement.addressController.value.fieldsFlowable.value
 
         assertThat(billingElements.size).isEqualTo(7)
@@ -133,7 +133,7 @@ class CardDefinitionTest {
         val contactInformationElement = formElements[1] as SectionElement
         val contactInformationFields = contactInformationElement.fields
 
-        val cardBillingElement = contactInformationFields[0] as CardBillingAddressElement
+        val cardBillingElement = contactInformationFields[0] as BillingAddressElement
         val billingElements = cardBillingElement.addressController.value.fieldsFlowable.value
 
         assertThat(billingElements.size).isEqualTo(6)
@@ -416,7 +416,7 @@ class CardDefinitionTest {
         )
 
         val cardBillingAddressElements = formElements.filterIsInstance<SectionElement>().map {
-            it.fields.filterIsInstance<CardBillingAddressElement>().firstOrNull()
+            it.fields.filterIsInstance<BillingAddressElement>().firstOrNull()
         }
 
         assertThat(cardBillingAddressElements).hasSize(1)
@@ -497,9 +497,9 @@ class CardDefinitionTest {
         val sectionFields = sectionElement.fields
 
         assertThat(sectionFields.size).isEqualTo(1)
-        assertThat(sectionFields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+        assertThat(sectionFields.firstOrNull()).isInstanceOf<BillingAddressElement>()
 
-        val addressElement = sectionFields.first() as CardBillingAddressElement
+        val addressElement = sectionFields.first() as BillingAddressElement
 
         assertThat(addressElement.countryElement.controller.displayItems)
             .hasSize(CountryUtils.supportedBillingCountries.size)
@@ -526,9 +526,9 @@ class CardDefinitionTest {
         val sectionFields = sectionElement.fields
 
         assertThat(sectionFields.size).isEqualTo(1)
-        assertThat(sectionFields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+        assertThat(sectionFields.firstOrNull()).isInstanceOf<BillingAddressElement>()
 
-        val addressElement = sectionFields.first() as CardBillingAddressElement
+        val addressElement = sectionFields.first() as BillingAddressElement
 
         assertThat(addressElement.countryElement.controller.displayItems).containsExactly(
             "\uD83C\uDDFA\uD83C\uDDF8 United States",
@@ -797,7 +797,7 @@ class CardDefinitionTest {
 
     private fun createAutomaticCardBillingAddressElement(
         checkoutSessionResponse: CheckoutSessionResponse?,
-    ): CardBillingAddressElement {
+    ): BillingAddressElement {
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -809,7 +809,7 @@ class CardDefinitionTest {
 
         return formElements.filterIsInstance<SectionElement>()
             .flatMap { it.fields }
-            .filterIsInstance<CardBillingAddressElement>()
+            .filterIsInstance<BillingAddressElement>()
             .first()
     }
 
@@ -820,7 +820,7 @@ class CardDefinitionTest {
         )
     }
 
-    private fun CardBillingAddressElement.shownIdentifierParamPaths(): List<String> {
+    private fun BillingAddressElement.shownIdentifierParamPaths(): List<String> {
         return addressController.value.fieldsFlowable.value
             .filterOutHiddenIdentifiers(hiddenIdentifiers.value)
             .flatMap { field ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -72,9 +72,9 @@ internal class BillingDetailsFormTest {
         allowedCountries = emptySet()
     ) {
         assertThat(addressSectionElement.fields.size).isEqualTo(1)
-        assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+        assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<BillingAddressElement>()
 
-        val cardBillingAddressElement = addressSectionElement.fields[0] as CardBillingAddressElement
+        val cardBillingAddressElement = addressSectionElement.fields[0] as BillingAddressElement
 
         assertThat(cardBillingAddressElement.countryElement.controller.displayItems)
             .hasSize(CountryUtils.supportedBillingCountries.size)
@@ -85,9 +85,9 @@ internal class BillingDetailsFormTest {
         allowedCountries = setOf("US", "CA")
     ) {
         assertThat(addressSectionElement.fields.size).isEqualTo(1)
-        assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+        assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<BillingAddressElement>()
 
-        val cardBillingAddressElement = addressSectionElement.fields[0] as CardBillingAddressElement
+        val cardBillingAddressElement = addressSectionElement.fields[0] as BillingAddressElement
 
         assertThat(cardBillingAddressElement.countryElement.controller.displayItems).containsExactly(
             "\uD83C\uDDFA\uD83C\uDDF8 United States",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -15,7 +15,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.ui.core.elements.CardBillingAddressElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -607,9 +607,9 @@ internal class DefaultEditCardDetailsInteractorTest {
             val addressSectionElement = requireNotNull(billingAddressForm).addressSectionElement
 
             assertThat(addressSectionElement.fields.size).isEqualTo(1)
-            assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+            assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<BillingAddressElement>()
 
-            val cardBillingAddressElement = addressSectionElement.fields[0] as CardBillingAddressElement
+            val cardBillingAddressElement = addressSectionElement.fields[0] as BillingAddressElement
 
             assertThat(cardBillingAddressElement.countryElement.controller.displayItems)
                 .hasSize(CountryUtils.supportedBillingCountries.size)
@@ -632,9 +632,9 @@ internal class DefaultEditCardDetailsInteractorTest {
             val addressSectionElement = requireNotNull(billingAddressForm).addressSectionElement
 
             assertThat(addressSectionElement.fields.size).isEqualTo(1)
-            assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+            assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<BillingAddressElement>()
 
-            val cardBillingAddressElement = addressSectionElement.fields[0] as CardBillingAddressElement
+            val cardBillingAddressElement = addressSectionElement.fields[0] as BillingAddressElement
 
             assertThat(cardBillingAddressElement.countryElement.controller.displayItems).containsExactly(
                 "\uD83C\uDDFA\uD83C\uDDF8 United States",


### PR DESCRIPTION
# Summary

Rename and generalize the card billing-address element as `BillingAddressElement`, with explicit collection modes for no address, full address, and country-first collection.

Card behavior is unchanged. `cardBillingAddressCollectionMode` retains Automatic-mode AVS postal-code collection for US, GB, and CA, then additively applies the Checkout Session automatic-tax requirements when applicable. The implementation uses an API-23-compatible map update.

This PR deliberately keeps the nested country element at `IdentifierSpec.Country`. It does not add `countryElementIdentifier` or change card call sites. #13723 adds that required parameter when `CountrySpec` first needs its own API path.

# Motivation

Card Automatic collection is not a safe default for a country-only LPM because it asks for postal code in the US, GB, and CA even when automatic tax is disabled. Separating the card policy from generic country-first collection keeps that LPM work in the following PRs.

No automatic-tax policy, saved-PM behavior, or saved-card-editing behavior changes in this PR.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`CardBillingAddressElementTest` covers retained card AVS behavior, additive automatic-tax fields, country-only collection without AVS defaults, Full collection, and country changes. Focused verification passed:

`./gradlew :payments-ui-core:lintRelease :payments-ui-core:detekt :payments-ui-core:apiCheck :payments-ui-core:testDebugUnitTest :paymentsheet:lintRelease :paymentsheet:detekt :paymentsheet:apiCheck :paymentsheet:testDebugUnitTest`

# Screenshots

N/A: refactor only.

# Changelog

N/A: internal/library-group implementation.
