### PR TITLE
Collect automatic-tax billing address for US bank accounts (MOBILESDK-4667)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -903,6 +903,7 @@ internal class CustomerSheetViewModel(
             sellerBusinessName = null,
             forceSetupFutureUseBehavior = false,
             clientAttributionMetadata = clientAttributionMetadata,
+            requiresBillingAddressForAutomaticTax = false,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection.New
@@ -56,6 +55,7 @@ import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SameAsShippingElementUI
 import com.stripe.android.uicore.elements.Section
 import com.stripe.android.uicore.elements.SectionCard
+import com.stripe.android.uicore.elements.SectionFieldValidationController
 import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldSection
@@ -102,6 +102,7 @@ internal fun USBankAccountForm(
                 sellerBusinessName = usBankAccountFormArgs.sellerBusinessName,
                 forceSetupFutureUseBehavior = usBankAccountFormArgs.forceSetupFutureUseBehavior,
                 clientAttributionMetadata = usBankAccountFormArgs.clientAttributionMetadata,
+                requiresBillingAddressForAutomaticTax = usBankAccountFormArgs.requiresBillingAddressForAutomaticTax,
             )
         },
     )
@@ -109,6 +110,7 @@ internal fun USBankAccountForm(
     val state by viewModel.currentScreenState.collectAsState()
     val lastTextFieldIdentifier by viewModel.lastTextFieldIdentifier.collectAsState()
     val addressController by viewModel.addressElement.addressController.collectAsState()
+    val addressHiddenIdentifiers by viewModel.addressHiddenIdentifiers.collectAsState()
     val isEnabled = !state.isProcessing && enabled
 
     USBankAccountEmitters(
@@ -127,6 +129,9 @@ internal fun USBankAccountForm(
         emailController = viewModel.emailController,
         phoneController = viewModel.phoneController,
         addressController = addressController,
+        addressValidationController = viewModel.addressElement.sectionFieldErrorController(),
+        addressHiddenIdentifiers = addressHiddenIdentifiers,
+        showAddress = viewModel.collectingAddress,
         lastTextFieldIdentifier = lastTextFieldIdentifier,
         sameAsShippingElement = viewModel.sameAsShippingElement,
         saveForFutureUseElement = viewModel.saveForFutureUseElement,
@@ -148,6 +153,9 @@ internal fun BankAccountForm(
     emailController: TextFieldController,
     phoneController: PhoneNumberController,
     addressController: AddressController,
+    addressValidationController: SectionFieldValidationController,
+    addressHiddenIdentifiers: Set<IdentifierSpec>,
+    showAddress: Boolean,
     lastTextFieldIdentifier: IdentifierSpec?,
     sameAsShippingElement: SameAsShippingElement?,
     saveForFutureUseElement: SaveForFutureUseElement,
@@ -165,6 +173,9 @@ internal fun BankAccountForm(
             emailController = emailController,
             phoneController = phoneController,
             addressController = addressController,
+            addressValidationController = addressValidationController,
+            addressHiddenIdentifiers = addressHiddenIdentifiers,
+            showAddress = showAddress,
             lastTextFieldIdentifier = lastTextFieldIdentifier,
             sameAsShippingElement = sameAsShippingElement,
             enabled = enabled
@@ -215,6 +226,9 @@ private fun BillingDetailsForm(
     emailController: TextFieldController,
     phoneController: PhoneNumberController,
     addressController: AddressController,
+    addressValidationController: SectionFieldValidationController,
+    addressHiddenIdentifiers: Set<IdentifierSpec>,
+    showAddress: Boolean,
     lastTextFieldIdentifier: IdentifierSpec?,
     sameAsShippingElement: SameAsShippingElement?,
 ) {
@@ -292,10 +306,12 @@ private fun BillingDetailsForm(
                 modifier = Modifier.padding(top = 16.dp)
             )
         }
-        if (formArgs.billingDetailsCollectionConfiguration.address == AddressCollectionMode.Full) {
+        if (showAddress) {
             AddressSection(
                 enabled = enabled,
                 addressController = addressController,
+                addressValidationController = addressValidationController,
+                hiddenIdentifiers = addressHiddenIdentifiers,
                 lastTextFieldIdentifier = lastTextFieldIdentifier,
                 sameAsShippingElement = sameAsShippingElement,
                 modifier = Modifier.padding(top = 16.dp)
@@ -337,11 +353,13 @@ private fun PhoneSection(
 private fun AddressSection(
     enabled: Boolean,
     addressController: AddressController,
+    addressValidationController: SectionFieldValidationController,
+    hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?,
     sameAsShippingElement: SameAsShippingElement?,
     modifier: Modifier = Modifier,
 ) {
-    val validationMessage by addressController.validationMessage.collectAsState()
+    val validationMessage by addressValidationController.validationMessage.collectAsState()
 
     Box(
         modifier = Modifier
@@ -357,7 +375,7 @@ private fun AddressSection(
                 AddressElementUI(
                     enabled = enabled,
                     controller = addressController,
-                    hiddenIdentifiers = emptySet(),
+                    hiddenIdentifiers = hiddenIdentifiers,
                     lastTextFieldIdentifier = lastTextFieldIdentifier,
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -70,6 +70,7 @@ internal class USBankAccountFormArguments(
     val sellerBusinessName: String?,
     val forceSetupFutureUseBehavior: Boolean,
     val clientAttributionMetadata: ClientAttributionMetadata,
+    val requiresBillingAddressForAutomaticTax: Boolean,
 ) {
     companion object {
         fun create(
@@ -121,6 +122,8 @@ internal class USBankAccountFormArguments(
                 sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
                 forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
                 clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+                requiresBillingAddressForAutomaticTax = paymentMethodMetadata.requiresBillingAddressForAutomaticTax &&
+                    instantDebits.not(),
             )
         }
 
@@ -182,6 +185,8 @@ internal class USBankAccountFormArguments(
                 sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
                 forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
                 clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+                requiresBillingAddressForAutomaticTax = paymentMethodMetadata.requiresBillingAddressForAutomaticTax &&
+                    instantDebits.not(),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -46,11 +46,18 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.BankFormScreenS
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormViewModel.AnalyticsEvent.Finished
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.DaggerUSBankAccountFormComponent
 import com.stripe.android.paymentsheet.utils.getSetAsDefaultPaymentMethodFromPaymentSelection
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.elements.BillingAddressCollectionMode
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
+import com.stripe.android.ui.core.elements.additionalAutomaticTaxFieldsByCountry
 import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
@@ -81,8 +88,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     private val defaultBillingDetails = args.formArgs.billingDetails
     private val collectionConfiguration = args.formArgs.billingDetailsCollectionConfiguration
 
-    private val collectingAddress =
-        args.formArgs.billingDetailsCollectionConfiguration.address == AddressCollectionMode.Full
+    private val collectingTaxAddress = args.requiresBillingAddressForAutomaticTax &&
+        collectionConfiguration.address == AddressCollectionMode.Automatic
+
+    val collectingAddress = collectionConfiguration.address == AddressCollectionMode.Full ||
+        collectingTaxAddress
 
     private val collectingPhone =
         args.formArgs.billingDetailsCollectionConfiguration.phone == CollectionMode.Always
@@ -171,6 +181,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         null
     }
 
+    private val defaultAddressValues = defaultAddress?.asFormFieldValues() ?: emptyMap()
+
     val sameAsShippingElement = args.formArgs.shippingDetails
         ?.toIdentifierMap(defaultBillingDetails)
         ?.get(IdentifierSpec.SameAsShipping)
@@ -185,7 +197,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     private val autocompleteAddressElement = autocompleteAddressInteractorFactory?.let {
         AutocompleteAddressElement(
             identifier = IdentifierSpec.Generic("billing_details[address]"),
-            initialValues = defaultAddress?.asFormFieldValues() ?: emptyMap(),
+            initialValues = defaultAddressValues,
             countryCodes = collectionConfiguration.allowedBillingCountries,
             sameAsShippingElement = sameAsShippingElement,
             interactorFactory = it,
@@ -193,28 +205,63 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         )
     }
 
-    val addressElement = autocompleteAddressElement ?: AddressElement(
-        _identifier = IdentifierSpec.Generic("billing_details[address]"),
-        rawValuesMap = defaultAddress?.asFormFieldValues() ?: emptyMap(),
-        countryCodes = collectionConfiguration.allowedBillingCountries,
-        sameAsShippingElement = sameAsShippingElement,
-        shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
-    )
+    val addressElement: AddressFieldsElement = if (collectingTaxAddress) {
+        BillingAddressElement(
+            configuration = BillingAddressElement.Configuration(
+                identifier = IdentifierSpec.Generic("billing_details[address]"),
+                initialValues = defaultAddressValues,
+                countryCodes = collectionConfiguration.allowedBillingCountries,
+                autocompleteAddressInteractorFactory = null,
+                shippingValues = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
+                addressCollectionMode = BillingAddressCollectionMode.Country(
+                    additionalFieldsByCountry = additionalAutomaticTaxFieldsByCountry,
+                ),
+                collectionConfiguration = BillingDetailsCollectionConfiguration(
+                    collectName = false,
+                    collectEmail = false,
+                    collectPhone = false,
+                    address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                    allowedCountries = collectionConfiguration.allowedBillingCountries,
+                ),
+                shouldHideCountryOnNoAddressCollection = false,
+            ),
+            countryDropdownFieldController = DropdownFieldController(
+                config = CountryConfig(collectionConfiguration.allowedBillingCountries),
+                initialValue = defaultAddressValues[IdentifierSpec.Country],
+            ),
+            sameAsShippingElement = sameAsShippingElement,
+        )
+    } else {
+        autocompleteAddressElement ?: AddressElement(
+            _identifier = IdentifierSpec.Generic("billing_details[address]"),
+            rawValuesMap = defaultAddressValues,
+            countryCodes = collectionConfiguration.allowedBillingCountries,
+            sameAsShippingElement = sameAsShippingElement,
+            shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
+        )
+    }
 
-    val address: StateFlow<Address?> = addressElement.getFormFieldValueFlow().mapAsStateFlow { formFieldValues ->
-        formFieldValues.takeIf {
-            it.all { value ->
-                value.second.isComplete
+    val addressHiddenIdentifiers: StateFlow<Set<IdentifierSpec>> =
+        (addressElement as? BillingAddressElement)?.hiddenIdentifiers ?: stateFlowOf(emptySet())
+
+    val address: StateFlow<Address?> = combineAsStateFlow(
+        addressElement.getFormFieldValueFlow(),
+        addressHiddenIdentifiers,
+    ) { formFieldValues, hiddenIdentifiers ->
+        formFieldValues.filterNot { it.first in hiddenIdentifiers }
+            .takeIf { visibleValues -> visibleValues.all { it.second.isComplete } }
+            ?.let { values ->
+                val rawMap = values.associate { it.first to it.second.value }
+                Address.fromFormFieldValues(rawMap)
             }
-        }?.let { values ->
-            val rawMap = values.associate { it.first to it.second.value }
-            Address.fromFormFieldValues(rawMap)
-        }
     }
 
     val lastTextFieldIdentifier: StateFlow<IdentifierSpec?> = if (collectingAddress) {
-        addressElement.getTextFieldIdentifiers().mapAsStateFlow {
-            it.lastOrNull() ?: lastNonAddressTextFieldIdentifier
+        combineAsStateFlow(
+            addressElement.getTextFieldIdentifiers(),
+            addressHiddenIdentifiers,
+        ) { identifiers, hiddenIdentifiers ->
+            identifiers.lastOrNull { it !in hiddenIdentifiers } ?: lastNonAddressTextFieldIdentifier
         }
     } else {
         stateFlowOf(lastNonAddressTextFieldIdentifier)
@@ -279,9 +326,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         nameController.formFieldValue.mapAsStateFlow { it.isComplete },
         emailController.formFieldValue.mapAsStateFlow { it.isComplete },
         phoneController.formFieldValue.mapAsStateFlow { it.isComplete },
-        addressElement.getFormFieldValueFlow().mapAsStateFlow { formFieldValues ->
-            formFieldValues.all { it.second.isComplete }
-        }
+        address.mapAsStateFlow { it != null },
     ) { validName, validEmail, validPhone, validAddress ->
         val validBaseInfo = if (args.instantDebits) {
             validEmail
@@ -290,7 +335,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         }
 
         val validAddressInfo = (validPhone || collectionConfiguration.phone != CollectionMode.Always) &&
-            (validAddress || collectionConfiguration.address != AddressCollectionMode.Full)
+            (validAddress || collectingAddress.not())
 
         validBaseInfo && validAddressInfo
     }
@@ -873,6 +918,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val sellerBusinessName: String?,
         val forceSetupFutureUseBehavior: Boolean,
         val clientAttributionMetadata: ClientAttributionMetadata,
+        val requiresBillingAddressForAutomaticTax: Boolean,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -99,6 +99,7 @@ internal class CustomerSheetScreenshotTest {
         sellerBusinessName = null,
         forceSetupFutureUseBehavior = false,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+        requiresBillingAddressForAutomaticTax = false,
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
@@ -205,6 +205,7 @@ internal class AccountPreviewScreenshotTest {
         showCheckboxes: Boolean = false,
     ) {
         paparazzi.snapshot {
+            val addressController = createAddressController(fillAddress = fillAddress)
             BankAccountForm(
                 state = state,
                 instantDebits = instantDebits,
@@ -213,7 +214,11 @@ internal class AccountPreviewScreenshotTest {
                 nameController = createNameController(),
                 emailController = createEmailController(),
                 phoneController = createPhoneNumberController(),
-                addressController = createAddressController(fillAddress = fillAddress),
+                addressController = addressController,
+                addressValidationController = addressController,
+                addressHiddenIdentifiers = emptySet(),
+                showAddress = formArguments.billingDetailsCollectionConfiguration.address ==
+                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 sameAsShippingElement = sameAsShippingElement,
                 saveForFutureUseElement = saveForFutureUseElement,
                 setAsDefaultPaymentMethodElement = setAsDefaultPaymentMethodElement,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
@@ -147,6 +147,7 @@ internal class BillingDetailsCollectionScreenshotTest {
         enabled: Boolean = true,
     ) {
         paparazzi.snapshot {
+            val addressController = createAddressController(fillAddress)
             BankAccountForm(
                 state = bankFormScreenState,
                 formArgs = formArgs,
@@ -155,7 +156,11 @@ internal class BillingDetailsCollectionScreenshotTest {
                 nameController = createNameController(nameControllerInitialValue),
                 emailController = createEmailController(emailControllerInitialValue),
                 phoneController = createPhoneNumberController(phoneControllerInitialValue),
-                addressController = createAddressController(fillAddress),
+                addressController = addressController,
+                addressValidationController = addressController,
+                addressHiddenIdentifiers = emptySet(),
+                showAddress = formArgs.billingDetailsCollectionConfiguration.address ==
+                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 sameAsShippingElement = null,
                 saveForFutureUseElement = saveForFutureUseElement,
                 setAsDefaultPaymentMethodElement = setAsDefaultPaymentMethodElement,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -95,6 +95,7 @@ class USBankAccountFormViewModelTest {
         sellerBusinessName = null,
         forceSetupFutureUseBehavior = false,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+        requiresBillingAddressForAutomaticTax = false,
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
@@ -128,6 +129,135 @@ class USBankAccountFormViewModelTest {
                 args = defaultArgs.copy(instantDebits = true),
             )
 
+            assertThat(viewModel.requiredFields.value).isTrue()
+        }
+
+    @Test
+    fun `automatic tax updates US bank account address fields when country changes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(
+                    requiresBillingAddressForAutomaticTax = true,
+                    formArgs = defaultArgs.formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            address = AddressCollectionMode.Automatic,
+                        )
+                    ),
+                )
+            )
+
+            viewModel.addressElement.countryElement.controller.onRawValueChange("US")
+            assertThat(viewModel.addressHiddenIdentifiers.value).doesNotContain(IdentifierSpec.Line1)
+            assertThat(viewModel.addressHiddenIdentifiers.value).doesNotContain(IdentifierSpec.City)
+            assertThat(viewModel.addressHiddenIdentifiers.value).doesNotContain(IdentifierSpec.State)
+            assertThat(viewModel.addressHiddenIdentifiers.value).doesNotContain(IdentifierSpec.PostalCode)
+
+            viewModel.addressElement.countryElement.controller.onRawValueChange("CA")
+            assertThat(viewModel.addressHiddenIdentifiers.value).contains(IdentifierSpec.Line1)
+            assertThat(viewModel.addressHiddenIdentifiers.value).contains(IdentifierSpec.City)
+            assertThat(viewModel.addressHiddenIdentifiers.value).contains(IdentifierSpec.State)
+            assertThat(viewModel.addressHiddenIdentifiers.value).doesNotContain(IdentifierSpec.PostalCode)
+        }
+
+    @Test
+    fun `automatic tax address is required for US bank account`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(
+                    requiresBillingAddressForAutomaticTax = true,
+                    formArgs = defaultArgs.formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            address = AddressCollectionMode.Automatic,
+                        )
+                    ),
+                )
+            )
+            viewModel.addressElement.countryElement.controller.onRawValueChange("US")
+
+            assertThat(viewModel.requiredFields.value).isFalse()
+
+            val addressValues = Address(
+                line1 = "510 Townsend Street",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+                country = "US",
+            ).asFormFieldValues()
+            viewModel.addressElement.addressController.value.fieldsFlowable.value.forEach { field ->
+                field.setRawValue(addressValues)
+            }
+
+            assertThat(viewModel.requiredFields.value).isTrue()
+        }
+
+    @Test
+    fun `automatic tax CA address requires only postal code for US bank account`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(
+                    requiresBillingAddressForAutomaticTax = true,
+                    formArgs = defaultArgs.formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            address = AddressCollectionMode.Automatic,
+                        )
+                    ),
+                )
+            )
+            viewModel.addressElement.countryElement.controller.onRawValueChange("CA")
+
+            assertThat(viewModel.requiredFields.value).isFalse()
+
+            val addressValues = Address(
+                postalCode = "M5V 1E3",
+                country = "CA",
+            ).asFormFieldValues()
+            viewModel.addressElement.addressController.value.fieldsFlowable.value.forEach { field ->
+                field.setRawValue(addressValues)
+            }
+
+            assertThat(viewModel.requiredFields.value).isTrue()
+            assertThat(viewModel.address.value?.country).isEqualTo("CA")
+            assertThat(viewModel.address.value?.postalCode).isEqualTo("M5V1E3")
+            assertThat(viewModel.address.value?.line1).isNull()
+        }
+
+    @Test
+    fun `automatic tax country-only address is complete for US bank account`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(
+                    requiresBillingAddressForAutomaticTax = true,
+                    formArgs = defaultArgs.formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            address = AddressCollectionMode.Automatic,
+                        )
+                    ),
+                )
+            )
+
+            viewModel.addressElement.countryElement.controller.onRawValueChange("FR")
+
+            assertThat(viewModel.requiredFields.value).isTrue()
+            assertThat(viewModel.address.value?.country).isEqualTo("FR")
+            assertThat(viewModel.address.value?.postalCode).isNull()
+            assertThat(viewModel.address.value?.line1).isNull()
+        }
+
+    @Test
+    fun `automatic tax disabled keeps automatic US bank account address hidden`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(
+                    requiresBillingAddressForAutomaticTax = false,
+                    formArgs = defaultArgs.formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            address = AddressCollectionMode.Automatic,
+                        )
+                    ),
+                )
+            )
+
+            assertThat(viewModel.collectingAddress).isFalse()
             assertThat(viewModel.requiredFields.value).isTrue()
         }
 


### PR DESCRIPTION
# Summary
Apply the shared automatic-tax billing-address behavior to the separately rendered US bank account form.

This is the special-form companion to the normal LPM integration in #13713. It uses the explicit shared address configuration from #13717 and preserves the behavior-neutral LPM migration in #13723.

# Motivation
US bank account bypasses the normal `UiDefinitionFactory` pipeline, so #13713 deliberately excludes it. Without explicit wiring here, billing-sourced automatic-tax sessions would still omit required address fields on this path.

This PR:

- threads the stable automatic-tax billing requirement into US bank account form arguments;
- uses country-first `BillingAddressElement` collection with shared per-country tax minimums;
- renders and validates only visible fields as country changes;
- keeps last-text-field and same-as-shipping behavior correct; and
- preserves non-Checkout, disabled-tax, Full-collection, and autocomplete behavior.

JIRA: [MOBILESDK-4667](https://jira.corp.stripe.com/browse/MOBILESDK-4667)

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`USBankAccountFormViewModelTest` covers US, CA, and country-only requirements, dynamic country changes, completion, automatic-tax gating off, and existing Full-address behavior. `:paymentsheet:detekt` and `:paymentsheet:apiCheck` passed.

# Screenshots
N/A.

# Changelog
N/A - Checkout Session is behind `@CheckoutSessionPreview`; the implementation is internal.
