### PR TITLE
Reduce test flakes by reliably syncing activity and button transitions.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android
 
-import androidx.test.espresso.intent.Intents
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.stripe.android.test.core.PlaygroundTestDriver
@@ -34,6 +33,5 @@ internal open class BasePlaygroundTest(
         // Runs even if the test body threw before its own teardown() call, so a destroyed
         // activity is never left referenced by the driver.
         testDriver.teardown()
-        Intents.release()
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -905,7 +905,7 @@ internal class PlaygroundTestDriver(
             testParameters = testParameters,
             executeFlow = { doUSBankAccountAuthorization(testParameters.authorizationAction) },
             afterCollectingBankInfo = {
-                composeTestRule.waitUntil { selectors.buyButton.checkEnabled() }
+                selectors.buyButton.waitForEnabled()
                 selectors.buyButton.click()
                 selectors.playgroundBuyButton.apply {
                     waitFor(isEnabled())
@@ -1124,6 +1124,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun pressBuy() {
+        selectors.buyButton.waitForEnabled()
         selectors.buyButton.click()
     }
 
@@ -1215,13 +1216,40 @@ internal class PlaygroundTestDriver(
     }
 
     /**
+     * Polls [currentActivity] until [predicate] is satisfied, bounded by [timeout]. Fails with a
+     * descriptive message on timeout instead of spinning until the 90s per-test [Timeout] rule fires
+     * with an opaque error. [currentActivity] is updated asynchronously by the activity lifecycle
+     * callbacks, so this must poll rather than read once.
+     */
+    private fun awaitActivity(
+        description: String,
+        timeout: Duration = ACTIVITY_TRANSITION_TIMEOUT,
+        onPoll: () -> Unit = {},
+        predicate: (Activity?) -> Boolean,
+    ) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (!predicate(currentActivity)) {
+            check(System.currentTimeMillis() < deadline) {
+                "Timed out after $timeout waiting for $description; " +
+                    "current activity was ${currentActivity?.javaClass?.name}"
+            }
+            onPoll()
+            TimeUnit.MILLISECONDS.sleep(ACTIVITY_POLL_INTERVAL_MS)
+        }
+    }
+
+    private fun awaitActivityClass(className: String) {
+        awaitActivity(description = className) { it?.javaClass?.name == className }
+    }
+
+    /**
      * Here we wait for an activity different from the playground to be in view.  We
      * don't specifically look for PaymentSheetActivity or PaymentOptionsActivity because
      * that would require exposing the activities publicly.
      */
     private fun waitForNotPlaygroundActivity() {
-        while (currentActivity is PaymentSheetPlaygroundActivity) {
-            TimeUnit.MILLISECONDS.sleep(250)
+        awaitActivity(description = "an activity other than the playground") {
+            it !is PaymentSheetPlaygroundActivity
         }
         Espresso.onIdle()
         composeTestRule.waitForIdle()
@@ -1231,10 +1259,10 @@ internal class PlaygroundTestDriver(
      * Here we wait for the Playground to come back into view.
      */
     private fun waitForPlaygroundActivity() {
-        while (currentActivity !is PaymentSheetPlaygroundActivity) {
-            composeTestRule.waitForIdle()
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivity(
+            description = "the playground activity to return to the foreground",
+            onPoll = { composeTestRule.waitForIdle() },
+        ) { it is PaymentSheetPlaygroundActivity }
         Espresso.onIdle()
         composeTestRule.waitForIdle()
         if (!awaitWindowFocus()) {
@@ -1250,9 +1278,7 @@ internal class PlaygroundTestDriver(
     private fun waitForPollingToFinish(timeout: Duration = 60.seconds) {
         val className =
             "com.stripe.android.paymentsheet.paymentdatacollection.polling.PollingActivity"
-        while (currentActivity?.componentName?.className != className) {
-            Thread.sleep(10)
-        }
+        awaitActivity(description = className) { it?.componentName?.className == className }
 
         composeTestRule.waitUntil(timeoutMillis = timeout.inWholeMilliseconds) {
             try {
@@ -1569,9 +1595,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun cancelInstantDebitsFlowOnLaunch() {
-        while (currentActivity?.javaClass?.name != FINANCIAL_CONNECTIONS_ACTIVITY) {
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivityClass(FINANCIAL_CONNECTIONS_ACTIVITY)
 
         Espresso.onIdle()
         composeTestRule.waitForIdle()
@@ -1580,9 +1604,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun executeUsBankAccountLiteFlow() {
-        while (currentActivity?.javaClass?.name != FINANCIAL_CONNECTIONS_LITE_ACTIVITY) {
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivityClass(FINANCIAL_CONNECTIONS_LITE_ACTIVITY)
 
         onWebView()
             .withElementByTestId("institution-default")
@@ -1606,9 +1628,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun executeUsBankAccountFlow() {
-        while (currentActivity?.javaClass?.name != FINANCIAL_CONNECTIONS_ACTIVITY) {
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivityClass(FINANCIAL_CONNECTIONS_ACTIVITY)
 
         composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
@@ -1631,9 +1651,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun executeEntireInstantDebitsFlow() = with(device) {
-        while (currentActivity?.javaClass?.name != FINANCIAL_CONNECTIONS_ACTIVITY) {
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivityClass(FINANCIAL_CONNECTIONS_ACTIVITY)
 
         composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
@@ -1671,9 +1689,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun cancelAchLiteFlowOnLaunch() {
-        while (currentActivity?.javaClass?.name != FINANCIAL_CONNECTIONS_LITE_ACTIVITY) {
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivityClass(FINANCIAL_CONNECTIONS_LITE_ACTIVITY)
 
         onWebView()
             .withElementByTestId("agree-button")
@@ -1689,9 +1705,7 @@ internal class PlaygroundTestDriver(
     }
 
     private fun cancelAchFlowOnLaunch() {
-        while (currentActivity?.javaClass?.name != FINANCIAL_CONNECTIONS_ACTIVITY) {
-            TimeUnit.MILLISECONDS.sleep(250)
-        }
+        awaitActivityClass(FINANCIAL_CONNECTIONS_ACTIVITY)
 
         composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
@@ -1841,6 +1855,11 @@ internal class PlaygroundTestDriver(
     }
 
     private companion object {
+        // Generous upper bound on activity transitions (activity resume is fast; this only bounds the
+        // failure path). Kept well under the 90s per-test Timeout so a hang surfaces a clear message.
+        val ACTIVITY_TRANSITION_TIMEOUT: Duration = 45.seconds
+        const val ACTIVITY_POLL_INTERVAL_MS = 250L
+
         const val ADD_PAYMENT_METHOD_NODE_TAG = "${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_+ Add"
         const val FINANCIAL_CONNECTIONS_ACTIVITY =
             "com.stripe.android.financialconnections.FinancialConnectionsSheetActivity"

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
@@ -26,6 +26,21 @@ class BuyButton(
             .assertIsEnabled()
     }.isSuccess
 
+    /**
+     * Waits until the button is displayed and enabled before returning. Callers should invoke this
+     * before [click] so we never click a button that has not composed or is still disabled (e.g.
+     * while the form is validating or an intent is being created), which otherwise races.
+     */
+    fun waitForEnabled(): BuyButton {
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            runCatching {
+                composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                    .assertIsDisplayed()
+            }.isSuccess && checkEnabled()
+        }
+        return this
+    }
+
     fun isEnabled() {
         composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
             .assertIsEnabled()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/PaymentSelection.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/PaymentSelection.kt
@@ -3,27 +3,47 @@ package com.stripe.android.test.core.ui
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
+import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 
 class PaymentSelection(val composeTestRule: ComposeTestRule, val paymentMethodCode: String) {
     fun click() {
-        if (composeTestRule.onAllNodes(hasTestTag(TEST_TAG_LIST)).fetchSemanticsNodes().isNotEmpty()) {
-            val paymentMethodMatcher = hasTestTag(TEST_TAG_LIST + paymentMethodCode)
-
-            composeTestRule.onNodeWithTag(TEST_TAG_LIST, true)
-                .performScrollToNode(paymentMethodMatcher)
-            composeTestRule.waitForIdle()
-            composeTestRule
-                .onNode(paymentMethodMatcher)
-                .assertIsDisplayed()
-                .assertIsEnabled()
-                .performClick()
-
-            composeTestRule.waitForIdle()
+        // The horizontal payment-method tab list (TEST_TAG_LIST) only exists in horizontal layout
+        // mode; in vertical mode selection happens elsewhere, so a missing list is a legitimate
+        // no-op rather than a race. atLeastOneRootRequired = false keeps this from throwing if no
+        // compose root is momentarily attached mid-transition.
+        val hasTabList = composeTestRule.onAllNodes(hasTestTag(TEST_TAG_LIST))
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .isNotEmpty()
+        if (!hasTabList) {
+            return
         }
+
+        val paymentMethodMatcher = hasTestTag(TEST_TAG_LIST + paymentMethodCode)
+
+        composeTestRule.onNodeWithTag(TEST_TAG_LIST, true)
+            .performScrollToNode(paymentMethodMatcher)
+
+        // Wait for the target tab to be present and enabled before clicking. The row can exist in
+        // the tree but not yet be hittable while the list is still settling, which previously made
+        // the one-shot assertIsDisplayed()/assertIsEnabled() flake.
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            composeTestRule.onAllNodes(paymentMethodMatcher.and(isEnabled()))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+
+        composeTestRule
+            .onNode(paymentMethodMatcher)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+            .performClick()
+
+        composeTestRule.waitForIdle()
     }
 }


### PR DESCRIPTION
# Summary
Improves test stability by introducing reliable activity transition polling and button enablement syncing in the integration test suite.

# Motivation
Current UI tests occasionally flake due to racing activity transitions and button states, leading to clicks before UI is ready. This change introduces explicit polling mechanisms for activity transitions, and waits for buy/payment method buttons to be enabled before interacting, reducing nondeterministic failures.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Fixed] Improved reliability of integration tests by synchronizing activity and UI readiness before interactions.