### PR TITLE
Improve WebView polling interval and timeout for test element finding.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/WebviewInteraction.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/WebviewInteraction.kt
@@ -9,21 +9,28 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Find a button in a web view using its `data-testid` ID (commonly used in Stripe frontend surfaces)
+ * Find a button in a web view using its `data-testid` ID (commonly used in Stripe frontend surfaces).
+ *
+ * The default [timeout] is generous because the first lookup after a web-based auth activity opens
+ * absorbs the full cost of navigating to, bootstrapping, and rendering a remote single-page app whose
+ * content only appears after an async data fetch. This mirrors the equally generous activity and
+ * idling-resource timeouts elsewhere in the driver and stays well under the 90s per-test timeout.
  */
 internal fun WebInteraction<Void>.withElementByTestId(
     testId: String,
-): WebInteraction<Void> = retryUntil {
+    timeout: Duration = 30.seconds,
+): WebInteraction<Void> = retryUntil(timeout = timeout) {
     runCatching { withElement(findElement(Locator.CSS_SELECTOR, "[data-testid='$testId']")) }
         .getOrNull()
 }
 
 /**
- * Retry until the given block returns a non-null value or the timeout is reached.
+ * Retry until the given block returns a non-null value or the timeout is reached. Polls frequently so
+ * the target is detected promptly once it renders rather than up to a full [pollInterval] later.
  */
 private fun <T> retryUntil(
-    timeout: Duration = 15.seconds,
-    pollInterval: Duration = 3.seconds,
+    timeout: Duration = 30.seconds,
+    pollInterval: Duration = 1.seconds,
     block: () -> T?
 ): T {
     val endTime = elapsedRealtime() + timeout.inWholeMilliseconds


### PR DESCRIPTION
# Summary
Increased the default timeout and decreased the polling interval for locating web elements by test ID in the webview test utility. Also updated documentation to explain the rationale for these values.

# Motivation
The first lookup in a web-based auth activity can be slow due to remote content loading and async data fetches. More frequent polling improves detection responsiveness, and a longer timeout accommodates real-world delays. This helps tests remain robust to variable network and rendering times.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Changed] Updated webview element lookup retry behavior for better reliability in tests.