### PR TITLE
Rename CheckoutController.checkoutSession to session and update docs.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -69,7 +69,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                             ErrorContent(currentStatus.message)
                         }
                         is CheckoutControllerExampleViewModel.Status.Configured -> {
-                            val session = currentStatus.checkoutSession
+                            val session = currentStatus.session
                             if (session != null) {
                                 LineItemsSection(session)
                                 TotalSummarySection(session)
@@ -83,7 +83,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                 },
                 bottomBarContent = {
                     val configured = status as? CheckoutControllerExampleViewModel.Status.Configured
-                    PaymentOptionRow(configured?.checkoutSession?.paymentOptionDisplayData)
+                    PaymentOptionRow(configured?.session?.paymentOptionDisplayData)
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(
                         onClick = { paymentElement.presentPaymentOptions() },

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -48,8 +48,8 @@ internal class CheckoutControllerExampleViewModel(
             fetchAndConfigure()
         }
         viewModelScope.launch {
-            controller.checkoutSession.collect { session ->
-                updateConfiguredState { it.copy(checkoutSession = session) }
+            controller.session.collect { session ->
+                updateConfiguredState { it.copy(session = session) }
                 if (session?.status == Session.Status.Complete) {
                     _sessionComplete.tryEmit(Unit)
                 }
@@ -78,7 +78,7 @@ internal class CheckoutControllerExampleViewModel(
                 ).fold(
                     onSuccess = {
                         _status.value = Status.Configured(
-                            checkoutSession = controller.checkoutSession.value,
+                            session = controller.session.value,
                         )
                     },
                     onFailure = { error ->
@@ -102,7 +102,7 @@ internal class CheckoutControllerExampleViewModel(
     sealed interface Status {
         data object Loading : Status
         data class Configured(
-            val checkoutSession: Session?,
+            val session: Session?,
         ) : Status
         data class Error(val message: String) : Status
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -43,6 +43,13 @@ import kotlin.time.Duration.Companion.seconds
 
 private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 
+/**
+ * Controls a Stripe Checkout Session: load it with [configure], observe it through
+ * [session], mutate it with the various `update`/`apply`/`select` methods, and present
+ * payment UI with a [CheckoutPresenter] created via [createPresenter].
+ *
+ * Create instances with [Builder].
+ */
 @Singleton
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -57,8 +64,11 @@ class CheckoutController @Inject internal constructor(
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
 ) {
-    val checkoutSession: StateFlow<Session?>
-        get() = stateHolder.checkoutSession
+    /**
+     * The latest [Session] data, or `null` until [configure] has completed successfully.
+     */
+    val session: StateFlow<Session?>
+        get() = stateHolder.session
 
     private val mutex = Mutex()
     private val pendingMutations = AtomicInteger(0)
@@ -70,6 +80,13 @@ class CheckoutController @Inject internal constructor(
      */
     val isUpdating: StateFlow<Boolean> = _isUpdating.asStateFlow()
 
+    /**
+     * Loads the Checkout Session identified by [checkoutSessionClientSecret] and prepares the
+     * payment UI, populating [session] on success.
+     *
+     * @param checkoutSessionClientSecret The client secret of the Checkout Session to load.
+     * @param configuration Options controlling how the checkout is configured and displayed.
+     */
     suspend fun configure(
         checkoutSessionClientSecret: String,
         configuration: Configuration = Configuration(),
@@ -219,7 +236,7 @@ class CheckoutController @Inject internal constructor(
 
     /**
      * Runs an async function that calls your server to update the Checkout Session,
-     * then automatically refreshes [checkoutSession] with the latest session data.
+     * then automatically refreshes [session] with the latest session data.
      *
      * A 20-second timeout is enforced. If [serverUpdate] doesn't complete within 20 seconds,
      * this method returns a [kotlin.Result.failure] with a timeout exception.
@@ -343,6 +360,12 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
+    /**
+     * Creates a [CheckoutPresenter] bound to [activity], used to present the payment UI for this
+     * checkout session.
+     *
+     * @param activity The activity the payment UI will be presented from.
+     */
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {
         val subcomponent = checkoutPresenterSubcomponentFactory.create(
             activityResultCaller = PaymentElementActivityResultCaller(
@@ -356,6 +379,10 @@ class CheckoutController @Inject internal constructor(
         return subcomponent.presenter
     }
 
+    /**
+     * Releases resources held by this controller and clears its loaded state. Call this when the
+     * controller is no longer needed.
+     */
     fun destroy() {
         viewModelScope.cancel()
         stateHolder.state = null
@@ -641,6 +668,9 @@ class CheckoutController @Inject internal constructor(
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class PaymentOptionDisplayData internal constructor(
+            /**
+             * Loads the payment method image. Prefer [iconPainter] to render it in Compose.
+             */
             @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             val imageLoader: suspend () -> Drawable,
             /**
@@ -662,7 +692,7 @@ class CheckoutController @Inject internal constructor(
              */
             val paymentMethodType: String,
             /**
-             * If you set [CheckoutController.Configuration.embeddedViewDisplaysMandateText] to `false`, this text
+             * If you set [PaymentElement.Configuration.embeddedViewDisplaysMandateText] to `false`, this text
              * must be displayed to the customer near your "Buy" button to comply with regulations.
              */
             val mandateText: AnnotatedString?,
@@ -738,6 +768,13 @@ class CheckoutController @Inject internal constructor(
         )
     }
 
+    /**
+     * Builds [CheckoutController] instances.
+     *
+     * @param application The application context.
+     * @param savedStateHandle The [SavedStateHandle] used to persist and restore controller state
+     * across process death.
+     */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Builder(
@@ -747,6 +784,9 @@ class CheckoutController @Inject internal constructor(
         private var resultCallback: ResultCallback = ResultCallback {}
         private var integrationName: String = "stripe_checkout"
 
+        /**
+         * Sets the [ResultCallback] invoked when a payment flow finishes.
+         */
         fun resultCallback(
             resultCallback: ResultCallback
         ): Builder = apply {
@@ -768,6 +808,9 @@ class CheckoutController @Inject internal constructor(
             this.integrationName = integrationName
         }
 
+        /**
+         * Builds a [CheckoutController] from the current configuration.
+         */
         fun build(): CheckoutController {
             val component = DaggerCheckoutControllerComponent.factory().create(
                 application = application,
@@ -780,6 +823,10 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
+    /**
+     * Configuration options for a [CheckoutController], including per-element configuration and
+     * feature toggles. Build with the fluent setters and pass to [CheckoutController.configure].
+     */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
@@ -794,6 +841,9 @@ class CheckoutController @Inject internal constructor(
         private var expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration =
             ExpressCheckoutElement.Configuration()
 
+        /**
+         * Sets whether adaptive pricing is allowed for this checkout session.
+         */
         fun adaptivePricingAllowed(
             adaptivePricingAllowed: Boolean
         ): Configuration = apply {
@@ -812,30 +862,45 @@ class CheckoutController @Inject internal constructor(
             this.defaultBillingAddress = defaultBillingAddress
         }
 
+        /**
+         * Sets the configuration for the payment element.
+         */
         fun paymentElement(
             configuration: PaymentElement.Configuration
         ): Configuration = apply {
             this.paymentElementConfiguration = configuration
         }
 
+        /**
+         * Sets the configuration for the currency selector element.
+         */
         fun currencySelectorElement(
             configuration: CurrencySelectorElement.Configuration
         ): Configuration = apply {
             this.currencySelectorElementConfiguration = configuration
         }
 
+        /**
+         * Sets the configuration for the shipping address element.
+         */
         fun shippingAddressElement(
             configuration: ShippingAddressElement.Configuration
         ): Configuration = apply {
             this.shippingAddressElementConfiguration = configuration
         }
 
+        /**
+         * Sets the configuration for the express checkout element.
+         */
         fun expressCheckoutElement(
             configuration: ExpressCheckoutElement.Configuration
         ): Configuration = apply {
             this.expressCheckoutElementConfiguration = configuration
         }
 
+        /**
+         * Sets the Google Pay configuration for this checkout session.
+         */
         fun googlePayConfiguration(
             configuration: GooglePayConfiguration,
         ): Configuration = apply {
@@ -864,6 +929,9 @@ class CheckoutController @Inject internal constructor(
         )
     }
 
+    /**
+     * Builder for an address passed to [updateShippingAddress] and [updateBillingAddress].
+     */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Address {
@@ -874,26 +942,44 @@ class CheckoutController @Inject internal constructor(
         private var postalCode: String? = null
         private var state: String? = null
 
+        /**
+         * Sets the city, district, suburb, town, or village.
+         */
         fun city(city: String?) = apply {
             this.city = city
         }
 
+        /**
+         * Sets the two-letter country code (ISO 3166-1 alpha-2). Required.
+         */
         fun country(country: String) = apply {
             this.country = country
         }
 
+        /**
+         * Sets address line 1 (e.g., street, PO Box, or company name).
+         */
         fun line1(line1: String?) = apply {
             this.line1 = line1
         }
 
+        /**
+         * Sets address line 2 (e.g., apartment, suite, unit, or building).
+         */
         fun line2(line2: String?) = apply {
             this.line2 = line2
         }
 
+        /**
+         * Sets the ZIP or postal code.
+         */
         fun postalCode(postalCode: String?) = apply {
             this.postalCode = postalCode
         }
 
+        /**
+         * Sets the state, county, province, or region.
+         */
         fun state(state: String?) = apply {
             this.state = state
         }
@@ -922,26 +1008,46 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
+    /**
+     * The result of a checkout payment flow, delivered to [ResultCallback].
+     */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Result {
+        /**
+         * The customer completed the payment flow.
+         */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class Completed internal constructor() : Result
 
+        /**
+         * The customer canceled the payment flow.
+         */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class Canceled internal constructor() : Result
 
+        /**
+         * The payment flow failed with [error].
+         *
+         * @property error The error that caused the payment flow to fail.
+         */
         @Poko
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class Failed internal constructor(val error: Throwable) : Result
     }
 
+    /**
+     * Callback invoked with the [Result] of a checkout payment flow.
+     */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun interface ResultCallback {
+        /**
+         * Called when the payment flow finishes with [result].
+         */
         fun onResult(result: Result)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 /**
  * Owns [CheckoutController]'s [CheckoutControllerState] — the single source of truth for the
  * controller — persisting it in [SavedStateHandle] so it survives process death. All observable
- * projections (e.g. [checkoutSession]) are derived from the one [stateFlow]. Kept separate from the
+ * projections (e.g. [session]) are derived from the one [stateFlow]. Kept separate from the
  * controller so [CheckoutStateLoader] can commit loaded state directly rather than reaching back
  * into the controller.
  */
@@ -40,7 +40,7 @@ internal class CheckoutControllerStateHolder @Inject constructor(
     val stateFlow: StateFlow<CheckoutControllerState?> =
         savedStateHandle.getStateFlow(STATE_KEY, null)
 
-    val checkoutSession: StateFlow<Session?> =
+    val session: StateFlow<Session?> =
         stateFlow.mapAsStateFlow {
             it?.asCheckoutSession(
                 paymentOptionFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorElement.kt
@@ -34,8 +34,8 @@ class CurrencySelectorElement @Inject internal constructor(
         val state by stateHolder.stateFlow.collectAsState()
         val appearanceState = state?.configuration?.currencySelectorElementConfiguration?.appearance ?: return
         val isUpdating by checkoutController.isUpdating.collectAsState()
-        val checkoutSession by checkoutController.checkoutSession.collectAsState()
-        val currencySelectorOptions = checkoutSession?.currencySelectorOptions ?: return
+        val session by checkoutController.session.collectAsState()
+        val currencySelectorOptions = session?.currencySelectorOptions ?: return
         val showCurrencyCode = appearanceState.labelContent == Appearance.LabelContent.CURRENCY_CODE
         val errorMessage by viewModel.errorMessage.collectAsState()
         CurrencySelectorToggle(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CurrencySelectorViewModel.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 
 @CheckoutSessionPreview
 internal class CurrencySelectorViewModel(
-    private val checkoutSession: StateFlow<Session?>,
+    private val session: StateFlow<Session?>,
     private val updateCurrency: suspend (String) -> Result<Unit>,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
@@ -38,7 +38,7 @@ internal class CurrencySelectorViewModel(
         }
 
         viewModelScope.launch {
-            checkoutSession.collect {
+            session.collect {
                 _errorMessage.value = null
             }
         }
@@ -84,7 +84,7 @@ internal class CurrencySelectorViewModel(
             extras: androidx.lifecycle.viewmodel.CreationExtras
         ): T {
             return CurrencySelectorViewModel(
-                checkoutSession = checkoutController.checkoutSession,
+                session = checkoutController.session,
                 updateCurrency = checkoutController::updateCurrency,
                 analyticsRequestExecutor = analyticsRequestExecutor,
                 paymentAnalyticsRequestFactory = paymentAnalyticsRequestFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementEventReporter.kt
@@ -94,7 +94,7 @@ internal class DefaultExpressCheckoutElementEventReporter @Inject constructor(
     private fun defaultParams(): Map<String, Any> {
         val state = stateHolder.state ?: return emptyMap()
         val expressCheckoutElementConfiguration = state.configuration.expressCheckoutElementConfiguration
-        val orderedLpms = stateHolder.checkoutSession.value?.availableExpressButtonTypes.orEmpty().map {
+        val orderedLpms = stateHolder.session.value?.availableExpressButtonTypes.orEmpty().map {
             when (it) {
                 is ExpressButtonType.GooglePay -> "google_pay"
                 ExpressButtonType.Link -> "link"

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
@@ -46,14 +46,14 @@ internal class DefaultExpressCheckoutElementInteractor @Inject constructor(
     override val state: StateFlow<ExpressCheckoutElementInteractor.State> = combineAsStateFlow(
         linkAccountHolder.linkAccountInfo,
         stateHolder.stateFlow,
-        stateHolder.checkoutSession,
-    ) { linkAccountInfo, state, checkoutSession, ->
-        if (state == null || checkoutSession == null) {
+        stateHolder.session,
+    ) { linkAccountInfo, state, session, ->
+        if (state == null || session == null) {
             return@combineAsStateFlow ExpressCheckoutElementInteractor.State(expressButtons = emptyList())
         }
 
         ExpressCheckoutElementInteractor.State(
-            expressButtons = checkoutSession.availableExpressButtonTypes.map { expressButtonType ->
+            expressButtons = session.availableExpressButtonTypes.map { expressButtonType ->
                 when (expressButtonType) {
                     ExpressButtonType.Link -> ExpressButton.Link.create(
                         paymentMethodMetadata = state.paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -31,7 +31,7 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
-    fun `checkoutSession projects the paymentOption the factory builds from the committed state`() {
+    fun `session projects the paymentOption the factory builds from the committed state`() {
         val expectedOption = PaymentOptionDisplayData(
             imageLoader = { error("not needed for this test") },
             label = "Google Pay",
@@ -48,7 +48,7 @@ internal class CheckoutControllerStateHolderTest {
         testScenario(paymentOptionFactory = factory) {
             stateHolder.state = committedState(paymentSelection = PaymentSelection.GooglePay)
 
-            assertThat(stateHolder.checkoutSession.value?.paymentOptionDisplayData).isSameInstanceAs(expectedOption)
+            assertThat(stateHolder.session.value?.paymentOptionDisplayData).isSameInstanceAs(expectedOption)
             assertThat(capturedSelection).isEqualTo(PaymentSelection.GooglePay)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -86,17 +86,17 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `configure emits checkoutSession with id from response`() = runConfigureScenario {
+    fun `configure emits session with id from response`() = runConfigureScenario {
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        assertThat(controller.session.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
     }
 
     @Test
-    fun `checkoutSession flow transitions from null to loaded session`() = runTest {
+    fun `session flow transitions from null to loaded session`() = runTest {
         networkRule.defaultInit()
         val controller = createController()
 
-        controller.checkoutSession.test {
+        controller.session.test {
             assertThat(awaitItem()).isNull()
 
             controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
@@ -225,7 +225,7 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `configure does not emit checkoutSession when network request fails`() = runConfigureScenario(
+    fun `configure does not emit session when network request fails`() = runConfigureScenario(
         networkSetup = {
             networkRule.checkoutInit { response ->
                 response.setResponseCode(500)
@@ -234,7 +234,7 @@ internal class CheckoutControllerTest {
         },
     ) {
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isNull()
+        assertThat(controller.session.value).isNull()
         assertThat(committedState).isNull()
     }
 
@@ -256,15 +256,15 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `checkoutSession is null before configure`() = runTest {
+    fun `session is null before configure`() = runTest {
         val savedStateHandle = SavedStateHandle()
         val controller = createController(savedStateHandle)
-        assertThat(controller.checkoutSession.value).isNull()
+        assertThat(controller.session.value).isNull()
         assertThat(committedStateFor(savedStateHandle)).isNull()
     }
 
     @Test
-    fun `checkoutSession is restored from savedStateHandle after recreation`() = runTest {
+    fun `session is restored from savedStateHandle after recreation`() = runTest {
         networkRule.defaultInit()
         val savedStateHandle = SavedStateHandle()
         val controller = createController(savedStateHandle)
@@ -273,7 +273,7 @@ internal class CheckoutControllerTest {
         // Simulate process death: persist the handle and build a new controller from the restored copy.
         val recreated = createController(savedStateHandle.simulateProcessDeath())
 
-        assertThat(recreated.checkoutSession.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        assertThat(recreated.session.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
     }
 
     @Test
@@ -300,7 +300,7 @@ internal class CheckoutControllerTest {
         controller.destroy()
 
         assertThat(committedState).isNull()
-        assertThat(controller.checkoutSession.value).isNull()
+        assertThat(controller.session.value).isNull()
     }
 
     @Test
@@ -317,7 +317,7 @@ internal class CheckoutControllerTest {
             )
 
         val controller = createController(savedStateHandle)
-        controller.checkoutSession.test {
+        controller.session.test {
             assertThat(awaitItem()?.paymentOptionDisplayData).isNotNull()
 
             assertThat(controller.clearPaymentOption().isSuccess).isTrue()
@@ -351,7 +351,7 @@ internal class CheckoutControllerTest {
             assertThat(result.exceptionOrNull()).hasMessageThat()
                 .isEqualTo("Cannot mutate checkout session while a payment flow is presented.")
             // The rejected clear leaves the selection intact.
-            assertThat(controller.checkoutSession.value?.paymentOptionDisplayData).isNotNull()
+            assertThat(controller.session.value?.paymentOptionDisplayData).isNotNull()
         }
 
     @Test
@@ -391,8 +391,8 @@ internal class CheckoutControllerTest {
 
             // Both controllers share the parent handle, but each persists under its own namespace, so
             // configuring the first leaves the second's state untouched.
-            assertThat(first.checkoutSession.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-            assertThat(second.checkoutSession.value).isNull()
+            assertThat(first.session.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+            assertThat(second.session.value).isNull()
         }
 
     @Test
@@ -405,7 +405,7 @@ internal class CheckoutControllerTest {
         // After process death, a controller under a different name starts from empty state.
         val recreated = createController(savedStateHandle.simulateProcessDeath(), integrationName = "second")
 
-        assertThat(recreated.checkoutSession.value).isNull()
+        assertThat(recreated.session.value).isNull()
     }
 
     @Test
@@ -439,12 +439,12 @@ internal class CheckoutControllerTest {
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid promotion code"}}""")
         }
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.applyPromotionCode("INVALID")
 
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -473,7 +473,7 @@ internal class CheckoutControllerTest {
         val result = controller.updateLineItemQuantity("li_1", 3)
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(7000)
+        assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(7000)
     }
 
     @Test
@@ -482,12 +482,12 @@ internal class CheckoutControllerTest {
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid quantity"}}""")
         }
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.updateLineItemQuantity("li_1", -1)
 
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -502,7 +502,7 @@ internal class CheckoutControllerTest {
         val result = controller.updateCurrency("usd")
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(5099)
+        assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(5099)
     }
 
     @Test
@@ -511,12 +511,12 @@ internal class CheckoutControllerTest {
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid currency"}}""")
         }
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.updateCurrency("invalid")
 
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -538,12 +538,12 @@ internal class CheckoutControllerTest {
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid shipping rate"}}""")
         }
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.selectShippingOption("shr_invalid")
 
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -584,7 +584,7 @@ internal class CheckoutControllerTest {
         val result = controller.updateEmail("checkout@example.com")
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.customerEmail).isEqualTo("checkout@example.com")
+        assertThat(controller.session.value?.customerEmail).isEqualTo("checkout@example.com")
     }
 
     @Test
@@ -617,12 +617,12 @@ internal class CheckoutControllerTest {
             response.setResponseCode(400)
             response.setBody("""{"error": {"message": "Invalid email"}}""")
         }
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.updateEmail("invalid")
 
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -788,18 +788,18 @@ internal class CheckoutControllerTest {
         val result = controller.runServerUpdate { Result.success(Unit) }
 
         result.getOrThrow()
-        assertThat(controller.checkoutSession.value?.totalSummary?.totalDueToday).isEqualTo(8000)
+        assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(8000)
     }
 
     @Test
     fun `runServerUpdate returns failure when serverUpdate throws`() = runMutationScenario {
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.runServerUpdate { throw IllegalStateException("Server error") }
 
         assertThat(result.isFailure).isTrue()
         assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo("Server error")
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -818,12 +818,12 @@ internal class CheckoutControllerTest {
             response.setResponseCode(500)
             response.setBody("""{"error": {"message": "Internal server error"}}""")
         }
-        val before = controller.checkoutSession.value
+        val before = controller.session.value
 
         val result = controller.runServerUpdate { Result.success(Unit) }
 
         assertThat(result.isFailure).isTrue()
-        assertThat(controller.checkoutSession.value).isEqualTo(before)
+        assertThat(controller.session.value).isEqualTo(before)
     }
 
     @Test
@@ -1026,7 +1026,7 @@ internal class CheckoutControllerTest {
 
             assertThat(results[0].isSuccess).isTrue()
             assertThat(results[1].isSuccess).isTrue()
-            assertThat(controller.checkoutSession.value?.id).isEqualTo("cs_test_after_promo")
+            assertThat(controller.session.value?.id).isEqualTo("cs_test_after_promo")
         }
 
     @Test
@@ -1126,7 +1126,7 @@ internal class CheckoutControllerTest {
             initModifier = allowedShippingCountries(listOf("US", "CA")),
             assertLoadingConsumed = true,
         ) {
-            val before = controller.checkoutSession.value
+            val before = controller.session.value
 
             // Fast-fail returns before runSerialized, so isUpdating must never flip to true.
             assertThat(isUpdatingTurbine.awaitItem()).isFalse()
@@ -1143,7 +1143,7 @@ internal class CheckoutControllerTest {
             assertThat(exception).hasMessageThat().isEqualTo(
                 "Country code 'DE' is not in allowedShippingCountries"
             )
-            assertThat(controller.checkoutSession.value).isEqualTo(before)
+            assertThat(controller.session.value).isEqualTo(before)
         }
 
     @Test
@@ -1162,7 +1162,7 @@ internal class CheckoutControllerTest {
     @Test
     fun `updateShippingAddress fails for all countries when allowedShippingCountries is empty`() =
         runMutationScenario(initModifier = allowedShippingCountries(emptyList())) {
-            val before = controller.checkoutSession.value
+            val before = controller.session.value
 
             val result = controller.updateShippingAddress(
                 name = null,
@@ -1176,7 +1176,7 @@ internal class CheckoutControllerTest {
             assertThat(exception).hasMessageThat().isEqualTo(
                 "Country code 'US' is not in allowedShippingCountries"
             )
-            assertThat(controller.checkoutSession.value).isEqualTo(before)
+            assertThat(controller.session.value).isEqualTo(before)
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -175,7 +175,7 @@ internal class CheckoutStateLoaderTest {
     fun `loadInitial commits state that exposes the checkout session`() = runScenario {
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
 
-        assertThat(stateHolder.checkoutSession.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        assertThat(stateHolder.session.value?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
         // No adaptive pricing in the response, so no flag images are resolved.
         assertThat(stateHolder.state?.flagImages).isNull()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorElementContentUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorElementContentUITest.kt
@@ -129,7 +129,7 @@ internal class CurrencySelectorElementContentUITest {
 
     @Test
     fun clickingUnselectedOption_sendsUpdateCurrencyRequest() = runScenario {
-        assertThat(controller.checkoutSession.value?.currencySelectorOptions?.selectedCode)
+        assertThat(controller.session.value?.currencySelectorOptions?.selectedCode)
             .isEqualTo("EUR")
 
         // The bodyPart matcher asserts the request carried updated_currency=USD; a request that

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
@@ -83,7 +83,7 @@ internal class CurrencySelectorViewModelTest {
         viewModel.errorMessage.test {
             assertThat(awaitItem()).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
 
-            checkoutSessionFlow.value = CheckoutSessionResponseFactory.create(currency = "eur")
+            sessionFlow.value = CheckoutSessionResponseFactory.create(currency = "eur")
                 .asCheckoutSession(
                     flagImages = null,
                     paymentOptionDisplayData = null,
@@ -125,7 +125,7 @@ internal class CurrencySelectorViewModelTest {
     ) = runTest(dispatcher) {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val fakeAnalyticsRequestExecutor = FakeAnalyticsRequestExecutor()
-        val checkoutSessionFlow = MutableStateFlow(
+        val sessionFlow = MutableStateFlow(
             CheckoutSessionResponseFactory.create().asCheckoutSession(
                 flagImages = null,
                 paymentOptionDisplayData = null,
@@ -136,7 +136,7 @@ internal class CurrencySelectorViewModelTest {
         val updateCurrencyResult = Turbine<Result<Unit>>()
 
         val viewModel = CurrencySelectorViewModel(
-            checkoutSession = checkoutSessionFlow,
+            session = sessionFlow,
             updateCurrency = { code ->
                 updateCurrencyCalls.add(code)
                 updateCurrencyResult.awaitItem()
@@ -151,7 +151,7 @@ internal class CurrencySelectorViewModelTest {
 
         Scenario(
             fakeAnalyticsRequestExecutor = fakeAnalyticsRequestExecutor,
-            checkoutSessionFlow = checkoutSessionFlow,
+            sessionFlow = sessionFlow,
             updateCurrencyCalls = updateCurrencyCalls,
             updateCurrencyResult = updateCurrencyResult,
             viewModel = viewModel,
@@ -163,7 +163,7 @@ internal class CurrencySelectorViewModelTest {
 
     private class Scenario(
         val fakeAnalyticsRequestExecutor: FakeAnalyticsRequestExecutor,
-        val checkoutSessionFlow: MutableStateFlow<Session>,
+        val sessionFlow: MutableStateFlow<Session>,
         val updateCurrencyCalls: Turbine<String>,
         val updateCurrencyResult: Turbine<Result<Unit>>,
         val viewModel: CurrencySelectorViewModel,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -108,7 +108,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
     }
 
     @Test
-    fun `state reflects available express button types from checkoutSession`() {
+    fun `state reflects available express button types from session`() {
         val googlePayConfiguration = createGooglePayConfiguration(
             buttonType = GooglePayConfiguration.ButtonType.Checkout,
             additionalEnabledNetworks = listOf("INTERAC"),


### PR DESCRIPTION
# Summary
Renamed CheckoutController.checkoutSession to session throughout the SDK, updated related docs and references, and updated usages in sample and test code.

# Motivation
Preparing for API review.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
