### PR TITLE
Remove unused Intents.release() from BasePlaygroundTest

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/BasePlaygroundTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android
 
-import androidx.test.espresso.intent.Intents
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.stripe.android.test.core.PlaygroundTestDriver
@@ -34,6 +33,5 @@ internal open class BasePlaygroundTest(
         // Runs even if the test body threw before its own teardown() call, so a destroyed
         // activity is never left referenced by the driver.
         testDriver.teardown()
-        Intents.release()
     }
 }


### PR DESCRIPTION
## Summary

`BasePlaygroundTest.after()` called `Intents.release()`, but no test in `paymentsheet-example` ever calls `Intents.init()`, `intending()`, or `intended()` — so this line was dead/defensive code.

In espresso-intents 3.7.0, `release()` is null-guarded (it no-ops when `init()` was never called), so it never did anything here and never threw. Removing it (and the now-unused `Intents` import) has no behavioral effect.

Git history confirms `Intents.init()`/`intending` have never existed anywhere in `paymentsheet-example`; the call was carried over when the file was created in #7380.

Tests that actually use the Espresso-Intents mechanism live in other modules (e.g. `paymentsheet` androidTest `GooglePayTest`, `connect`, `financial-connections`) and are unaffected — they run in separate instrumentation processes and manage init/release themselves (inline or via `IntentsRule`).

## Testing

No behavior change; the removed call was a no-op in this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)