### PR TITLE
Add KDoc to payment sheet elements and configuration options.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
@@ -15,22 +15,42 @@ class CheckoutPresenter @Inject internal constructor(
     private val checkoutConfirmationPerformerProvider: Provider<CheckoutConfirmationPerformer>,
 ) {
 
+    /**
+     * Returns the [PaymentElement], which displays and collects the customer's payment method.
+     */
     fun paymentElement(): PaymentElement {
         return paymentElementProvider.get()
     }
 
+    /**
+     * Returns the [CurrencySelectorElement], which lets the customer choose the checkout currency
+     * when multiple currencies are available.
+     */
     fun currencySelectorElement(): CurrencySelectorElement {
         return currencySelectorElementProvider.get()
     }
 
+    /**
+     * Returns the [ShippingAddressElement], which collects the customer's shipping address.
+     */
     fun shippingAddressElement(): ShippingAddressElement {
         return shippingAddressElementProvider.get()
     }
 
+    /**
+     * Returns the [ExpressCheckoutElement], which displays express payment buttons such as Google
+     * Pay and Link.
+     */
     fun expressCheckoutElement(): ExpressCheckoutElement {
         return expressCheckoutElementProvider.get()
     }
 
+    /**
+     * Confirms the payment for the customer's currently selected payment option.
+     *
+     * The result is delivered to the [CheckoutController.ResultCallback] supplied when building the
+     * [CheckoutController].
+     */
     fun confirm() {
         checkoutConfirmationPerformerProvider.get().confirm()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/PaymentElement.kt
@@ -16,12 +16,20 @@ class PaymentElement @Inject internal constructor(
     private val contentHelper: EmbeddedContentHelper,
 ) {
 
+    /**
+     * A composable function that displays payment methods inline.
+     *
+     * It can present a sheet to collect more details or display saved payment methods.
+     */
     @Composable
     fun PaymentOptionsContent() {
         val embeddedContent by contentHelper.embeddedContent.collectAsState()
         embeddedContent?.Content()
     }
 
+    /**
+     * Presents a sheet for the customer to select or manage their payment method.
+     */
     fun presentPaymentOptions() {
         contentHelper.presentPaymentOptions()
     }
@@ -34,12 +42,23 @@ class PaymentElement @Inject internal constructor(
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
 
+        /**
+         * Controls whether [PaymentOptionsContent] displays mandate text below the payment methods.
+         * Defaults to `true`.
+         *
+         * When set to `false`, you must display
+         * [CheckoutController.Session.PaymentOptionDisplayData.mandateText] to the customer yourself,
+         * near your "Buy" button, to comply with regulations.
+         */
         fun embeddedViewDisplaysMandateText(
             embeddedViewDisplaysMandateText: Boolean
         ): Configuration = apply {
             this.embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText
         }
 
+        /**
+         * Sets how billing details are collected when displaying payment methods.
+         */
         fun billingDetailsCollectionConfiguration(
             billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration
         ): Configuration = apply {


### PR DESCRIPTION
# Summary
Added comprehensive KDoc comments to the public API for `CheckoutPresenter`, `PaymentElement`, and related configuration options for better developer guidance and documentation.

# Motivation
Improve code readability and provide clear guidance on the usage, purpose, and limitations of public APIs in the checkout flow.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

