### PR TITLE
Fix standalone AE pass publishable key instead of client secret to AddressLauncher.present()

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.rememberCustomerSheet
@@ -454,7 +455,6 @@ internal class PaymentSheetPlaygroundActivity :
                 if (playgroundState.displaysShippingAddressButton()) {
                     ShippingAddressButton(
                         addressLauncher = addressLauncher,
-                        playgroundState = playgroundState,
                         address = { flowController.shippingDetails },
                     )
                 }
@@ -682,7 +682,6 @@ internal class PaymentSheetPlaygroundActivity :
     @Composable
     private fun ShippingAddressButton(
         addressLauncher: AddressLauncher,
-        playgroundState: PlaygroundState.Payment,
         address: () -> AddressDetails?,
     ) {
         val context = LocalContext.current
@@ -693,7 +692,7 @@ internal class PaymentSheetPlaygroundActivity :
                     .googlePlacesApiKey(Settings(context).googlePlacesApiKey)
                     .appearance(AppearanceStore.state.toPaymentSheetAppearance())
                     .build()
-                addressLauncher.present(playgroundState.clientSecret, configuration)
+                addressLauncher.present(PaymentConfiguration.getInstance(context).publishableKey, configuration)
             },
             modifier = Modifier.fillMaxWidth(),
         ) {


### PR DESCRIPTION

# Summary
<!-- Simple summary of what was changed. -->
 
 Fixes a 401 on POST /v1/elements/address/autocomplete when using the standalone Address Element in the playground. The ShippingAddressButton composable was calling addressLauncher.present(playgroundState.clientSecret, configuration), passing a payment intent client secret where a publishable key is required. This caused the autocomplete endpoint to receive a client secret as the Authorization: Bearer header, resulting in a 401.

MPE was unaffected because it routes autocomplete requests directly through BillingInlineAutocompleteAddressInteractor → DefaultStripeAutocompleteRepository and never calls AddressLauncher.present().

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

POST /v1/elements/address/autocomplete was returning 401 for the standalone Address Element in the playground but not MPE. The endpoint authenticates via publishable key; passing a client secret causes an auth failure.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
Playground app fix