### PR TITLE
Pass CommonConfiguration directly to checkout state and confirmation logic.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/AddressMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/AddressMapper.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun Address.State.asPaymentSheet(): PaymentSheet.Address = PaymentSheet.Address(
+    city = city,
+    country = country,
+    line1 = line1,
+    line2 = line2,
+    postalCode = postalCode,
+    state = state,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.checkout.injection.MerchantDisplayName
+import com.stripe.android.common.configuration.ConfigurationDefaults
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutCommonConfigurationFactory @Inject constructor(
+    @MerchantDisplayName private val merchantDisplayName: String,
+) {
+    fun create(
+        configuration: CheckoutController.Configuration.State,
+        checkoutSessionResponse: CheckoutSessionResponse,
+        collectedDetails: CheckoutCollectedDetails,
+    ): CommonConfiguration = CommonConfiguration(
+        merchantDisplayName = merchantDisplayName,
+        customer = ConfigurationDefaults.customer,
+        googlePay = configuration.toGooglePayConfiguration(checkoutSessionResponse),
+        link = ConfigurationDefaults.link,
+        defaultBillingDetails = collectedDetails.toBillingDetails(checkoutSessionResponse),
+        shippingDetails = collectedDetails.toShippingDetails(),
+        allowsDelayedPaymentMethods = ConfigurationDefaults.allowsDelayedPaymentMethods,
+        allowsPaymentMethodsRequiringShippingAddress =
+            ConfigurationDefaults.allowsPaymentMethodsRequiringShippingAddress,
+        billingDetailsCollectionConfiguration =
+            configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse),
+        preferredNetworks = ConfigurationDefaults.preferredNetworks,
+        allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
+        paymentMethodOrder = ConfigurationDefaults.paymentMethodOrder,
+        externalPaymentMethods = ConfigurationDefaults.externalPaymentMethods,
+        cardBrandAcceptance = ConfigurationDefaults.cardBrandAcceptance,
+        allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,
+        customPaymentMethods = ConfigurationDefaults.customPaymentMethods,
+        googlePlacesApiKey = null,
+        termsDisplay = emptyMap(),
+        walletButtons = null,
+        opensCardScannerAutomatically = ConfigurationDefaults.opensCardScannerAutomatically,
+        userOverrideCountry = ConfigurationDefaults.userOverrideCountry,
+        appearance = ConfigurationDefaults.appearance,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun CheckoutController.Configuration.State.toBillingDetailsCollectionConfiguration(
+    checkoutSessionResponse: CheckoutSessionResponse,
+): PaymentSheet.BillingDetailsCollectionConfiguration =
+    paymentElementConfiguration.billingDetailsCollectionConfiguration
+        .reconcile(checkoutSessionResponse.requiresBillingAddress)
+        .asPaymentSheet()
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun CheckoutController.Configuration.State.toGooglePayConfiguration(
+    checkoutSessionResponse: CheckoutSessionResponse,
+): PaymentSheet.GooglePayConfiguration? =
+    checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
+        googlePayConfiguration?.asPaymentSheet(merchantCountry)
+    }
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun CheckoutCollectedDetails.toBillingDetails(
+    checkoutSessionResponse: CheckoutSessionResponse,
+): PaymentSheet.BillingDetails = PaymentSheet.BillingDetails(
+    address = billingAddress?.asPaymentSheet(),
+    email = checkoutSessionResponse.customerEmail,
+    name = billingName,
+    phone = billingPhoneNumber,
+)
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun CheckoutCollectedDetails.toShippingDetails(): AddressDetails = AddressDetails(
+    name = shippingName,
+    address = shippingAddress?.asPaymentSheet(),
+    phoneNumber = shippingPhoneNumber,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
@@ -27,7 +26,7 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
 
     private fun confirmationArgs(): ConfirmationHandler.Args? {
         val state = stateHolder.state ?: return null
-        val configuration = state.embeddedConfiguration.asCommonConfiguration()
+        val configuration = state.commonConfiguration
         val confirmationOption = state.paymentSelection?.toConfirmationOption(
             configuration = configuration,
             linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
+import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -12,18 +13,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import kotlinx.parcelize.Parcelize
 
-/**
- * Internal state for [CheckoutController] and its single source of truth. It holds the controller's
- * own [CheckoutController.Configuration.State] directly, so the configuration doesn't have to be
- * reconstructed and can be read back via [configuration]. It is only ever built by
- * [CheckoutStateLoader] after a payment element load, so
- * the resolved [paymentMethodMetadata] and [embeddedConfiguration] are always present; everything
- * the controller and its collaborators observe is derived from this one value.
- *
- * [CheckoutStateLoader] builds every committed state after a load, but the selection setters on
- * [CheckoutControllerStateHolder] (which implements [EmbeddedSelectionHolder]) also [copy] it to
- * update [paymentSelection]/[temporarySelection]/[previousNewSelections] without a reload.
- */
 @OptIn(CheckoutSessionPreview::class)
 @Parcelize
 internal data class CheckoutControllerState(
@@ -33,6 +22,7 @@ internal data class CheckoutControllerState(
     val collectedDetails: CheckoutCollectedDetails,
     val paymentMethodMetadata: PaymentMethodMetadata,
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
+    val commonConfiguration: CommonConfiguration,
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,
     val previousNewSelections: Bundle,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -1,11 +1,8 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.checkout.CheckoutController.Address
 import com.stripe.android.checkout.injection.MerchantDisplayName
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
@@ -18,49 +15,16 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
         checkoutSessionResponse: CheckoutSessionResponse,
         collectedDetails: CheckoutCollectedDetails,
     ): EmbeddedPaymentElement.Configuration {
-        val billingDetailsCollectionConfiguration = configuration.paymentElementConfiguration
-            .billingDetailsCollectionConfiguration
-            .reconcile(checkoutSessionResponse.requiresBillingAddress)
-            .asPaymentSheet()
-            .copy(attachDefaultsToPaymentMethod = true)
-
         return EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
             .embeddedViewDisplaysMandateText(
                 configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText
             )
-            .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
-            .googlePay(
-                googlePay = checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
-                    configuration.googlePayConfiguration?.asPaymentSheet(merchantCountry)
-                }
+            .billingDetailsCollectionConfiguration(
+                configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse)
             )
-            .defaultBillingDetails(
-                PaymentSheet.BillingDetails(
-                    address = collectedDetails.billingAddress?.asPaymentSheetAddress(),
-                    email = checkoutSessionResponse.customerEmail,
-                    name = collectedDetails.billingName,
-                    phone = collectedDetails.billingPhoneNumber,
-                )
-            )
-            .shippingDetails(
-                AddressDetails(
-                    name = collectedDetails.shippingName,
-                    address = collectedDetails.shippingAddress?.asPaymentSheetAddress(),
-                    phoneNumber = collectedDetails.shippingPhoneNumber,
-                )
-            )
+            .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))
+            .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
+            .shippingDetails(collectedDetails.toShippingDetails())
             .build()
     }
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun Address.State.asPaymentSheetAddress(): PaymentSheet.Address {
-    return PaymentSheet.Address(
-        city = city,
-        country = country,
-        line1 = line1,
-        line2 = line2,
-        postalCode = postalCode,
-        state = state,
-    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -2,7 +2,6 @@ package com.stripe.android.checkout
 
 import android.graphics.Bitmap
 import android.os.Bundle
-import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -14,6 +13,7 @@ import javax.inject.Inject
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
     private val embeddedConfigurationFactory: CheckoutEmbeddedConfigurationFactory,
+    private val commonConfigurationFactory: CheckoutCommonConfigurationFactory,
     private val flagImageResolver: FlagImageResolver,
     private val paymentElementLoader: PaymentElementLoader,
     private val selectionChooser: EmbeddedSelectionChooser,
@@ -59,6 +59,12 @@ internal class CheckoutStateLoader @Inject constructor(
             collectedDetails = collectedDetails,
         )
 
+        val commonConfiguration = commonConfigurationFactory.create(
+            configuration = configuration,
+            checkoutSessionResponse = response,
+            collectedDetails = collectedDetails,
+        )
+
         val loaderState = paymentElementLoader.load(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = response.id,
@@ -82,7 +88,7 @@ internal class CheckoutStateLoader @Inject constructor(
             paymentMethods = loaderState.customer?.paymentMethods,
             previousSelection = carryForward.previousSelection,
             newSelection = loaderState.paymentSelection,
-            newConfiguration = embeddedConfig.asCommonConfiguration(),
+            newConfiguration = commonConfiguration,
             formSheetAction = embeddedConfig.formSheetAction,
         )
 
@@ -93,6 +99,7 @@ internal class CheckoutStateLoader @Inject constructor(
             collectedDetails = collectedDetails,
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
+            commonConfiguration = commonConfiguration,
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,
             previousNewSelections = carryForward.previousNewSelections,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -2,7 +2,6 @@ package com.stripe.android.checkout.ece
 
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
-import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
@@ -63,7 +62,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         state: CheckoutControllerState,
         paymentSelection: PaymentSelection,
     ): ConfirmationHandler.Args? {
-        val configuration = state.embeddedConfiguration.asCommonConfiguration()
+        val configuration = state.commonConfiguration
         val confirmationOption = paymentSelection.toConfirmationOption(
             configuration = configuration,
             linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -1,0 +1,194 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.checkout.PaymentElement.Configuration.BillingDetailsCollectionConfiguration
+import com.stripe.android.checkout.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+import com.stripe.android.checkout.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+import com.stripe.android.common.configuration.ConfigurationDefaults
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import org.junit.Test
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutCommonConfigurationFactoryTest {
+
+    @Test
+    fun `matches the common configuration derived from the embedded configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration()
+                    .embeddedViewDisplaysMandateText(false)
+                    .billingDetailsCollectionConfiguration(
+                        BillingDetailsCollectionConfiguration().address(Full)
+                    )
+            )
+            .googlePayConfiguration(
+                GooglePayConfiguration(GooglePayConfiguration.Environment.Production)
+                    .label("Total")
+                    .buttonType(GooglePayConfiguration.ButtonType.Checkout)
+                    .additionalEnabledNetworks(listOf("INTERAC"))
+            )
+            .build()
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            merchantCountry = "GB",
+            customerEmail = "checkout@example.com",
+            requiresBillingAddress = true,
+        )
+        val collectedDetails = collectedDetails(
+            billingName = "Jane Billing",
+            billingPhoneNumber = "5559876543",
+            billingAddress = address(),
+            shippingName = "John Shipping",
+            shippingPhoneNumber = "5551234567",
+            shippingAddress = address(),
+        )
+
+        val expected = CheckoutEmbeddedConfigurationFactory(merchantDisplayName = "Example, Inc.")
+            .create(configuration, checkoutSessionResponse, collectedDetails)
+            .asCommonConfiguration()
+        val actual = factory(merchantDisplayName = "Example, Inc.")
+            .create(configuration, checkoutSessionResponse, collectedDetails)
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `uses the provided merchant display name`() {
+        val result = factory(merchantDisplayName = "Acme Corp").create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("Acme Corp")
+    }
+
+    @Test
+    fun `maps googlePay using the checkout session country`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(
+                googlePayConfiguration = GooglePayConfiguration(GooglePayConfiguration.Environment.Production),
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = "GB"),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.googlePay?.countryCode).isEqualTo("GB")
+        assertThat(result.googlePay?.environment)
+            .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Production)
+    }
+
+    @Test
+    fun `leaves googlePay null when the checkout session country is missing`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(
+                googlePayConfiguration = GooglePayConfiguration(GooglePayConfiguration.Environment.Production),
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = null),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.googlePay).isNull()
+    }
+
+    @Test
+    fun `sources the billing email from the checkout session customer email`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(customerEmail = "checkout@example.com"),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.defaultBillingDetails?.email).isEqualTo("checkout@example.com")
+    }
+
+    @Test
+    fun `upgrades billing address collection to Full when the session requires a billing address`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(billingDetailsAddress = Automatic),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(requiresBillingAddress = true),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(PSFull)
+    }
+
+    @Test
+    fun `leaves billing address collection Automatic when the session does not require a billing address`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(billingDetailsAddress = Automatic),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(requiresBillingAddress = false),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.billingDetailsCollectionConfiguration.address).isEqualTo(PSAutomatic)
+    }
+
+    @Test
+    fun `applies configuration defaults for fields checkout does not configure`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.customer).isEqualTo(ConfigurationDefaults.customer)
+        assertThat(result.cardBrandAcceptance).isEqualTo(ConfigurationDefaults.cardBrandAcceptance)
+        assertThat(result.customPaymentMethods).isEqualTo(ConfigurationDefaults.customPaymentMethods)
+        assertThat(result.walletButtons).isNull()
+        assertThat(result.googlePlacesApiKey).isNull()
+    }
+
+    private fun factory(
+        merchantDisplayName: String = "Example, Inc.",
+    ) = CheckoutCommonConfigurationFactory(merchantDisplayName = merchantDisplayName)
+
+    private fun controllerConfiguration(
+        billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
+        googlePayConfiguration: GooglePayConfiguration? = null,
+    ): CheckoutController.Configuration.State {
+        val builder = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration()
+                    .billingDetailsCollectionConfiguration(
+                        BillingDetailsCollectionConfiguration().address(billingDetailsAddress)
+                    )
+            )
+        if (googlePayConfiguration != null) {
+            builder.googlePayConfiguration(googlePayConfiguration)
+        }
+        return builder.build()
+    }
+
+    private fun address() = Address.State(
+        city = "Denver",
+        country = "US",
+        line1 = "123 Main St",
+        line2 = "Apt 4",
+        postalCode = "80202",
+        state = "CO",
+    )
+
+    private fun collectedDetails(
+        shippingName: String? = null,
+        billingName: String? = null,
+        shippingPhoneNumber: String? = null,
+        billingPhoneNumber: String? = null,
+        shippingAddress: Address.State? = null,
+        billingAddress: Address.State? = null,
+    ): CheckoutCollectedDetails {
+        return CheckoutCollectedDetails(
+            shippingName = shippingName,
+            billingName = billingName,
+            shippingPhoneNumber = shippingPhoneNumber,
+            billingPhoneNumber = billingPhoneNumber,
+            shippingAddress = shippingAddress,
+            billingAddress = billingAddress,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -6,12 +6,11 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import kotlinx.coroutines.test.runTest
@@ -83,14 +82,10 @@ internal class CheckoutConfirmationPerformerTest {
     ): CheckoutControllerState {
         return CheckoutControllerStateFactory.create(
             paymentSelection = paymentSelection,
-            embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                        countryCode = "US",
-                    )
-                )
+            configuration = CheckoutController.Configuration()
+                .googlePayConfiguration(GooglePayConfiguration(GooglePayConfiguration.Environment.Test))
                 .build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = "US"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.checkout.ece.FakeAvailableExpressButtonTypesFactory
+import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -25,6 +26,13 @@ internal object CheckoutControllerStateFactory {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        commonConfiguration: CommonConfiguration = CheckoutCommonConfigurationFactory(
+            merchantDisplayName = "Example, Inc.",
+        ).create(
+            configuration = configuration,
+            checkoutSessionResponse = checkoutSessionResponse,
+            collectedDetails = collectedDetails,
+        ),
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
@@ -36,6 +44,7 @@ internal object CheckoutControllerStateFactory {
             collectedDetails = collectedDetails,
             paymentMethodMetadata = paymentMethodMetadata,
             embeddedConfiguration = embeddedConfiguration,
+            commonConfiguration = commonConfiguration,
             paymentSelection = paymentSelection,
             temporarySelection = temporarySelection,
             previousNewSelections = previousNewSelections,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -201,6 +201,11 @@ internal class CheckoutControllerStateHolderTest {
         collectedDetails = CheckoutCollectedDetails(),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        commonConfiguration = CheckoutCommonConfigurationFactory("Example, Inc.").create(
+            configuration = CheckoutController.Configuration().build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = CheckoutCollectedDetails(),
+        ),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -58,6 +58,18 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `loadInitial commits common configuration derived from the controller configuration`() = runScenario {
+        loader.loadInitial(
+            configuration = CheckoutController.Configuration()
+                .googlePayConfiguration(GooglePayConfiguration(GooglePayConfiguration.Environment.Test))
+                .build(),
+            checkoutSessionResponse = response(merchantCountry = "US"),
+        )
+
+        assertThat(stateHolder.state?.commonConfiguration?.googlePay?.countryCode).isEqualTo("US")
+    }
+
+    @Test
     fun `loadInitial seeds collected details with default billing address`() = runScenario {
         val address = CheckoutController.Address()
             .city(" San Francisco ")
@@ -266,6 +278,11 @@ internal class CheckoutStateLoaderTest {
         collectedDetails = CheckoutCollectedDetails(),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        commonConfiguration = CheckoutCommonConfigurationFactory("Example, Inc.").create(
+            configuration = CheckoutController.Configuration().build(),
+            checkoutSessionResponse = checkoutSessionResponse,
+            collectedDetails = CheckoutCollectedDetails(),
+        ),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,
@@ -328,6 +345,7 @@ internal class CheckoutStateLoaderTest {
         )
         val loader = CheckoutStateLoader(
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(merchantDisplayName),
+            commonConfigurationFactory = CheckoutCommonConfigurationFactory(merchantDisplayName),
             flagImageResolver = flagImageResolver,
             paymentElementLoader = paymentElementLoader,
             selectionChooser = chooser,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout.ece
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
@@ -13,13 +14,12 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.FakeErrorReporter
@@ -149,14 +149,10 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
 
     private fun googlePayState(): CheckoutControllerState {
         return CheckoutControllerStateFactory.create(
-            embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                        countryCode = "US",
-                    )
-                )
+            configuration = CheckoutController.Configuration()
+                .googlePayConfiguration(GooglePayConfiguration(GooglePayConfiguration.Environment.Test))
                 .build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = "US"),
         )
     }
 


### PR DESCRIPTION
# Summary
Checkout flow now directly uses CommonConfiguration instead of extracting it from EmbeddedPaymentElement.Configuration. CheckoutControllerState and confirmation performer classes have been updated, and tests adapted to support this change.

# Motivation
This refactoring clarifies the separation of common vs embedded configuration and avoids unnecessary conversion, making the codebase cleaner and easier to maintain.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog