### PR TITLE
Rename CheckoutSession.customerEmail to email.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -427,7 +427,7 @@ class CheckoutController @Inject internal constructor(
         /**
          * The customer's email address from the checkout session.
          */
-        val customerEmail: String?,
+        val email: String?,
         /**
          * The tax computation status for this checkout session.
          */

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -19,7 +19,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
         status = status.asStatus(),
         liveMode = liveMode,
         currency = currency,
-        customerEmail = customerEmail,
+        email = customerEmail,
         tax = taxStatus.asTax(),
         totalSummary = totalSummary?.asTotalSummary(),
         lineItems = lineItems.map { it.asLineItem() },

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -584,7 +584,7 @@ internal class CheckoutControllerTest {
         val result = controller.updateEmail("checkout@example.com")
 
         result.getOrThrow()
-        assertThat(controller.session.value?.customerEmail).isEqualTo("checkout@example.com")
+        assertThat(controller.session.value?.email).isEqualTo("checkout@example.com")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -63,13 +63,13 @@ class CheckoutSessionMappersTest {
     @Test
     fun `maps customerEmail`() {
         val session = createSession(customerEmail = "test@example.com")
-        assertThat(session.customerEmail).isEqualTo("test@example.com")
+        assertThat(session.email).isEqualTo("test@example.com")
     }
 
     @Test
     fun `null customerEmail maps to null`() {
         val session = createSession(customerEmail = null)
-        assertThat(session.customerEmail).isNull()
+        assertThat(session.email).isNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Renamed the `customerEmail` property to `email` within the `CheckoutSession` model and updated all related usages and tests.

# Motivation
Preparing for API review.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
