### PR TITLE
Deliver CheckoutController confirmation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED] `CheckoutController` now delivers results for manual and express checkout confirmation.
+
 ## 23.14.0 - 2026-08-03
 
 ### CryptoOnramp

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -66,6 +66,10 @@ sentry {
 }
 
 android {
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
+
     defaultConfig {
         applicationId "com.stripe.android.paymentsheet.example"
         versionCode 11
@@ -155,6 +159,13 @@ dependencies {
     // Needed for createComposeRule, but not createAndroidComposeRule:
     debugImplementation libs.compose.uiTestManifest
     debugImplementation libs.leakCanary
+
+    testImplementation project(':payments-core-testing')
+    testImplementation testLibs.androidx.composeUi
+    testImplementation testLibs.junit
+    testImplementation testLibs.robolectric
+    testImplementation testLibs.truth
+    testImplementation testLibs.espresso.core
 
     androidTestImplementation project(':payments-ui-core')
     androidTestImplementation project(':payments-core-testing')

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -3,7 +3,6 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -30,13 +29,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.lifecycleScope
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.checkout.CheckoutController.Session.PaymentOptionDisplayData
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
 import com.stripe.android.uicore.format.CurrencyFormatter
-import kotlinx.coroutines.launch
 
 internal class CheckoutControllerExampleActivity : AppCompatActivity() {
 
@@ -49,15 +46,9 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
         val presenter = viewModel.controller.createPresenter(this)
         val paymentElement = presenter.paymentElement()
 
-        lifecycleScope.launch {
-            viewModel.sessionComplete.collect {
-                Toast.makeText(this@CheckoutControllerExampleActivity, "Payment complete!", Toast.LENGTH_LONG).show()
-                finish()
-            }
-        }
-
         setContent {
             val status by viewModel.status.collectAsState()
+            val confirmationResult by viewModel.confirmationResult.collectAsState()
 
             PlaygroundTheme(
                 content = {
@@ -83,25 +74,65 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                 },
                 bottomBarContent = {
                     val configured = status as? CheckoutControllerExampleViewModel.Status.Configured
-                    PaymentOptionRow(configured?.session?.paymentOptionDisplayData)
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = { paymentElement.presentPaymentOptions() },
-                        enabled = configured != null,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("Select Payment Method")
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = { presenter.confirm() },
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("Confirm")
+                    when (val result = confirmationResult) {
+                        null -> {
+                            PaymentOptionRow(configured?.session?.paymentOptionDisplayData)
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Button(
+                                onClick = { paymentElement.presentPaymentOptions() },
+                                enabled = configured != null,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text("Select Payment Method")
+                            }
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Button(
+                                onClick = { presenter.confirm() },
+                                enabled = configured != null,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text("Confirm")
+                            }
+                        }
+                        else -> CheckoutResultSection(
+                            result = result,
+                            onNewPayment = viewModel::startNewPayment,
+                        )
                     }
                 },
             )
         }
+    }
+}
+
+@Composable
+internal fun CheckoutResultSection(
+    result: CheckoutControllerExampleViewModel.ConfirmationResult,
+    onNewPayment: () -> Unit,
+) {
+    when (result) {
+        is CheckoutControllerExampleViewModel.ConfirmationResult.Completed -> {
+            Text(
+                text = "Payment completed",
+                style = MaterialTheme.typography.h6,
+            )
+        }
+        is CheckoutControllerExampleViewModel.ConfirmationResult.Failed -> {
+            Text(
+                text = "Payment failed",
+                style = MaterialTheme.typography.h6,
+                color = Color.Red,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = result.message)
+        }
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+    Button(
+        onClick = onNewPayment,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text("New payment")
     }
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -16,11 +16,8 @@ import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.checkout.GooglePayConfiguration.Environment
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
@@ -33,14 +30,24 @@ internal class CheckoutControllerExampleViewModel(
     private val _status = MutableStateFlow<Status>(Status.Loading)
     val status: StateFlow<Status> = _status.asStateFlow()
 
-    private val _sessionComplete = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val sessionComplete: SharedFlow<Unit> = _sessionComplete.asSharedFlow()
+    private val _confirmationResult = MutableStateFlow<ConfirmationResult?>(null)
+    val confirmationResult: StateFlow<ConfirmationResult?> = _confirmationResult.asStateFlow()
 
     val controller = CheckoutController.Builder(
         application = application,
         savedStateHandle = savedStateHandle,
     ).resultCallback { result ->
-        Log.d(TAG, "Result: $result")
+        when (result) {
+            is CheckoutController.Result.Completed -> {
+                _confirmationResult.value = ConfirmationResult.Completed
+            }
+            is CheckoutController.Result.Failed -> {
+                _confirmationResult.value = ConfirmationResult.Failed(
+                    result.error.message ?: "An unknown error occurred."
+                )
+            }
+            is CheckoutController.Result.Canceled -> Unit
+        }
     }.build()
 
     init {
@@ -50,10 +57,15 @@ internal class CheckoutControllerExampleViewModel(
         viewModelScope.launch {
             controller.session.collect { session ->
                 updateConfiguredState { it.copy(session = session) }
-                if (session?.status == Session.Status.Complete) {
-                    _sessionComplete.tryEmit(Unit)
-                }
             }
+        }
+    }
+
+    fun startNewPayment() {
+        _confirmationResult.value = null
+        _status.value = Status.Loading
+        viewModelScope.launch {
+            fetchAndConfigure()
         }
     }
 
@@ -105,6 +117,11 @@ internal class CheckoutControllerExampleViewModel(
             val session: Session?,
         ) : Status
         data class Error(val message: String) : Status
+    }
+
+    sealed interface ConfirmationResult {
+        data object Completed : ConfirmationResult
+        data class Failed(val message: String) : ConfirmationResult
     }
 
     companion object {

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutResultSectionTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutResultSectionTest.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CheckoutResultSectionTest {
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(createComposeCleanupRule())
+        .around(composeRule)
+        .around(CoroutineTestRule())
+
+    @Test
+    fun `completed result is displayed`() = runScenario(
+        result = CheckoutControllerExampleViewModel.ConfirmationResult.Completed,
+    ) {
+        composeRule.onNodeWithText("Payment completed").assertExists()
+        composeRule.onNodeWithText("New payment").assertExists()
+    }
+
+    @Test
+    fun `failed result and message are displayed`() = runScenario(
+        result = CheckoutControllerExampleViewModel.ConfirmationResult.Failed("Payment was declined"),
+    ) {
+        composeRule.onNodeWithText("Payment failed").assertExists()
+        composeRule.onNodeWithText("Payment was declined").assertExists()
+        composeRule.onNodeWithText("New payment").assertExists()
+    }
+
+    @Test
+    fun `new payment invokes callback`() {
+        var newPaymentRequested = false
+
+        runScenario(
+            result = CheckoutControllerExampleViewModel.ConfirmationResult.Completed,
+            onNewPayment = { newPaymentRequested = true },
+        ) {
+            composeRule.onNodeWithText("New payment").performClick()
+
+            composeRule.runOnIdle {
+                assertThat(newPaymentRequested).isTrue()
+            }
+        }
+    }
+
+    private fun runScenario(
+        result: CheckoutControllerExampleViewModel.ConfirmationResult,
+        onNewPayment: () -> Unit = {},
+        block: () -> Unit,
+    ) {
+        composeRule.setContent {
+            PlaygroundTheme(
+                content = {},
+                bottomBarContent = {
+                    CheckoutResultSection(
+                        result = result,
+                        onNewPayment = onNewPayment,
+                    )
+                },
+            )
+        }
+        composeRule.waitForIdle()
+        block()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -1,7 +1,10 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
 package com.stripe.android.checkout
 
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
@@ -15,6 +18,7 @@ import javax.inject.Named
 internal class CheckoutConfirmationPerformer @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val stateHolder: CheckoutControllerStateHolder,
+    private val resultCallback: CheckoutController.ResultCallback,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
@@ -22,6 +26,9 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
         val arguments = confirmationArgs() ?: return
         viewModelScope.launch {
             confirmationHandler.start(arguments)
+            confirmationHandler.awaitResult()?.let { result ->
+                resultCallback.onResult(result.toCheckoutControllerResult())
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultMapper.kt
@@ -1,0 +1,14 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+
+internal fun ConfirmationHandler.Result.toCheckoutControllerResult(): CheckoutController.Result {
+    return when (this) {
+        is ConfirmationHandler.Result.Succeeded -> CheckoutController.Result.Completed()
+        is ConfirmationHandler.Result.Failed -> CheckoutController.Result.Failed(cause)
+        is ConfirmationHandler.Result.Canceled -> CheckoutController.Result.Canceled()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -1,9 +1,14 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
 package com.stripe.android.checkout.ece
 
+import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.toCheckoutControllerResult
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
@@ -25,6 +30,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     private val confirmationHandler: ConfirmationHandler,
     private val eventReporter: ExpressCheckoutElementEventReporter,
     private val errorReporter: ErrorReporter,
+    private val resultCallback: CheckoutController.ResultCallback,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
@@ -50,11 +56,15 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         viewModelScope.launch {
             confirmationHandler.start(confirmationArgs)
 
-            when (val result = confirmationHandler.awaitResult()) {
+            val result = confirmationHandler.awaitResult()
+            when (result) {
                 is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
                 is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
                 is ConfirmationHandler.Result.Canceled,
                 null -> Unit
+            }
+            result?.let {
+                resultCallback.onResult(it.toCheckoutControllerResult())
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -1,12 +1,16 @@
 package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
@@ -78,6 +82,55 @@ internal class CheckoutConfirmationPerformerTest {
         assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
     }
 
+    @Test
+    fun `confirm reports completed when confirmation succeeds`() = runScenario(
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+    ) {
+        confirmationHandler.awaitResultTurbine.add(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+
+        performer.confirm()
+
+        confirmationHandler.startTurbine.awaitItem()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `confirm reports failed when confirmation fails`() = runScenario(
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+    ) {
+        val error = IllegalStateException("Payment failed")
+        confirmationHandler.awaitResultTurbine.add(
+            ConfirmationHandler.Result.Failed(
+                cause = error,
+                message = "Payment failed".resolvableString,
+                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            )
+        )
+
+        performer.confirm()
+
+        confirmationHandler.startTurbine.awaitItem()
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(error)
+    }
+
+    @Test
+    fun `confirm reports canceled when confirmation is canceled`() = runScenario(
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+    ) {
+        confirmationHandler.awaitResultTurbine.add(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+        )
+
+        performer.confirm()
+
+        confirmationHandler.startTurbine.awaitItem()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+    }
+
     private fun googlePayState(
         paymentSelection: PaymentSelection?,
     ): CheckoutControllerState {
@@ -100,11 +153,13 @@ internal class CheckoutConfirmationPerformerTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         stateHolder.state = state
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,
             stateHolder = stateHolder,
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
             statusBarColor = statusBarColor,
             viewModelScope = backgroundScope,
         )
@@ -113,15 +168,18 @@ internal class CheckoutConfirmationPerformerTest {
             performer = performer,
             confirmationHandler = confirmationHandler,
             stateHolder = stateHolder,
+            resultTurbine = resultTurbine,
         ).block()
 
         confirmationHandler.validate()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val performer: CheckoutConfirmationPerformer,
         val confirmationHandler: FakeConfirmationHandler,
         val stateHolder: CheckoutControllerStateHolder,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.checkout.ece
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
@@ -122,6 +124,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         confirmationHandler.startTurbine.awaitItem()
         assertThat(eventReporter.calls.awaitItem())
             .isEqualTo(FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentSuccess(expressButton))
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test
@@ -145,6 +148,24 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val failureCall = call as FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentFailure
         assertThat(failureCall.expressButton).isEqualTo(expressButton)
         assertThat(failureCall.error.cause.message).isEqualTo("Payment failed")
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        assertThat((result as CheckoutController.Result.Failed).error.message).isEqualTo("Payment failed")
+    }
+
+    @Test
+    fun `confirm reports canceled when confirmation is canceled`() = runScenario(
+        state = googlePayState(),
+        expressButton = createGooglePayExpressButton(),
+    ) {
+        confirmationHandler.awaitResultTurbine.add(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+        )
+
+        performer.confirm(expressButton)
+
+        confirmationHandler.startTurbine.awaitItem()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
     }
 
     private fun googlePayState(): CheckoutControllerState {
@@ -179,6 +200,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val confirmationHandler = FakeConfirmationHandler()
         val eventReporter = FakeExpressCheckoutElementEventReporter()
         val errorReporter = FakeErrorReporter()
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         stateHolder.state = state
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
@@ -186,6 +208,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             confirmationHandler = confirmationHandler,
             eventReporter = eventReporter,
             errorReporter = errorReporter,
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
             statusBarColor = null,
             viewModelScope = backgroundScope,
         )
@@ -197,11 +220,13 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             errorReporter = errorReporter,
             stateHolder = stateHolder,
             expressButton = expressButton,
+            resultTurbine = resultTurbine,
         ).block()
 
         confirmationHandler.validate()
         eventReporter.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -211,5 +236,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val errorReporter: FakeErrorReporter,
         val stateHolder: CheckoutControllerStateHolder,
         val expressButton: ExpressButton,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     )
 }


### PR DESCRIPTION
# Summary
`CheckoutController` now delivers completed, failed, and canceled confirmation results for both manual and express checkout. The example keeps completed and failed results visible in its bottom section, while cancellation leaves the current payment ready to retry. Tapping `New payment` fetches and configures a fresh Checkout Session.

## Flow

```mermaid
stateDiagram-v2
    Ready --> Completed: confirmation succeeds
    Ready --> Failed: confirmation fails
    Ready --> Ready: confirmation canceled
    Completed --> Loading: New payment
    Failed --> Loading: New payment
    Loading --> Ready: fresh session configured
```

# Motivation
The example previously inferred success from Checkout Session status, but confirmation did not refresh that status. The configured result callback was also not invoked by the manual or express confirmation performers, so the example could remain unchanged after success and had no persistent failure state.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutConfirmationPerformerTest --tests com.stripe.android.checkout.ece.DefaultExpressCheckoutElementConfirmationPerformerTest`
- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --tests com.stripe.android.paymentsheet.example.playground.checkout.CheckoutResultSectionTest`
- `./gradlew :paymentsheet:detekt :paymentsheet-example:detekt :paymentsheet:apiCheck`
- Pre-push hook: `./gradlew detekt apiCheck`

# Screenshots
<img width="240" alt="untitled" src="https://github.com/user-attachments/assets/2fbee695-88fd-4b8b-99cf-3203a12a9656" />


# Changelog
* [FIXED] `CheckoutController` now delivers results for manual and express checkout confirmation.
