### PR TITLE
Disable NFC Scanning if the merchant imported the `cardscan` library

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/IsStripeCardScanAvailable.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/IsStripeCardScanAvailable.kt
@@ -1,10 +1,15 @@
 package com.stripe.android.ui.core.cardscan
 
-internal fun interface IsStripeCardScanAvailable {
+import androidx.annotation.RestrictTo
+import javax.inject.Inject
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface IsStripeCardScanAvailable {
     operator fun invoke(): Boolean
 }
 
-internal class DefaultIsStripeCardScanAvailable : IsStripeCardScanAvailable {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DefaultIsStripeCardScanAvailable @Inject constructor() : IsStripeCardScanAvailable {
     override fun invoke(): Boolean {
         return try {
             Class.forName("com.stripe.android.stripecardscan.cardscan.CardScanSheet")

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailable.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.nfcscan.security.IsDeviceSecureForNfc
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ElementsSession.ExperimentAssignment
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.ui.core.cardscan.IsStripeCardScanAvailable
 import javax.inject.Inject
 
 internal interface IsNfcScanningAvailable {
@@ -17,11 +18,12 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
     private val nfcHardwareDelegate: NfcHardwareDelegate,
     private val eventReporter: EventReporter,
     private val mode: EventReporter.Mode,
+    private val isStripeCardScanAvailable: IsStripeCardScanAvailable,
 ) : IsNfcScanningAvailable {
     override fun get(metadata: PaymentMethodMetadata): Boolean {
         val hasRequirements = metadata.isNfcScanningEnabled &&
             !metadata.isTapToAddSupported &&
-            !metadata.isStripeCardScanAllowed
+            !canUseStripeCardScan(metadata)
 
         if (!hasRequirements) {
             return false
@@ -60,6 +62,12 @@ internal class DefaultIsNfcScanningAvailable @Inject constructor(
         )
 
         eventReporter.onExperimentExposure(exposure)
+    }
+
+    private fun canUseStripeCardScan(
+        metadata: PaymentMethodMetadata,
+    ): Boolean {
+        return metadata.isStripeCardScanAllowed && isStripeCardScanAvailable()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAvailabilityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningAvailabilityModule.kt
@@ -2,6 +2,8 @@ package com.stripe.android.common.nfcscan
 
 import com.stripe.android.common.nfcscan.hardware.NfcHardwareDelegateModule
 import com.stripe.android.common.nfcscan.security.NfcSecurityModule
+import com.stripe.android.ui.core.cardscan.DefaultIsStripeCardScanAvailable
+import com.stripe.android.ui.core.cardscan.IsStripeCardScanAvailable
 import dagger.Binds
 import dagger.Module
 
@@ -14,4 +16,9 @@ import dagger.Module
 internal interface NfcScanningAvailabilityModule {
     @Binds
     fun bindsIsNfcScanningAvailable(isNfcScanningAvailable: DefaultIsNfcScanningAvailable): IsNfcScanningAvailable
+
+    @Binds
+    fun bindsIsStripeCardScanAvailable(
+        isStripeCardScanAvailable: DefaultIsStripeCardScanAvailable
+    ): IsStripeCardScanAvailable
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/IsNfcScanningAvailableTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.ExperimentAssignment
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.ui.core.cardscan.IsStripeCardScanAvailable
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,8 +44,10 @@ internal class IsNfcScanningAvailableTest {
     }
 
     @Test
-    fun `returns false when stripe card scan is allowed`() {
-        val isNfcScanningAvailable = createIsNfcScanningAvailable()
+    fun `returns false when stripe card scan is allowed and SDK is imported`() {
+        val isNfcScanningAvailable = createIsNfcScanningAvailable(
+            isStripeCardScanAvailable = FakeIsStripeCardScanAvailable(result = true),
+        )
 
         assertThat(
             isNfcScanningAvailable.get(
@@ -54,6 +57,22 @@ internal class IsNfcScanningAvailableTest {
                 ),
             )
         ).isFalse()
+    }
+
+    @Test
+    fun `returns true when stripe card scan is allowed but SDK is not imported`() {
+        val isNfcScanningAvailable = createIsNfcScanningAvailable(
+            isStripeCardScanAvailable = FakeIsStripeCardScanAvailable(result = false),
+        )
+
+        assertThat(
+            isNfcScanningAvailable.get(
+                metadata = createMetadata(
+                    isNfcScanningEnabled = true,
+                    isStripeCardScanAllowed = true,
+                ),
+            )
+        ).isTrue()
     }
 
     @Test
@@ -224,13 +243,21 @@ internal class IsNfcScanningAvailableTest {
         nfcHardwareDelegate: FakeNfcHardwareDelegate = FakeNfcHardwareDelegate(result = true),
         eventReporter: FakeEventReporter = FakeEventReporter(),
         mode: EventReporter.Mode = EventReporter.Mode.Complete,
+        isStripeCardScanAvailable: FakeIsStripeCardScanAvailable = FakeIsStripeCardScanAvailable(result = false),
     ): DefaultIsNfcScanningAvailable {
         return DefaultIsNfcScanningAvailable(
             isDeviceSecureForNfc = isDeviceSecureForNfc,
             nfcHardwareDelegate = nfcHardwareDelegate,
             eventReporter = eventReporter,
             mode = mode,
+            isStripeCardScanAvailable = isStripeCardScanAvailable,
         )
+    }
+
+    private class FakeIsStripeCardScanAvailable(
+        private val result: Boolean,
+    ) : IsStripeCardScanAvailable {
+        override fun invoke(): Boolean = result
     }
 
     private fun createMetadata(


### PR DESCRIPTION
# Summary
Disable NFC Scanning if the merchant imported the `cardscan` library.

# Motivation
Fix issue where NFC scanning is unavailable if the only flag is turned on.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified