### PR TITLE
Address inline autocomplete analytics fixes

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -103,9 +103,6 @@ internal class AutocompleteViewModel @Inject constructor(
                 }
             }
         }
-        autocompleteArgs.country?.let { country ->
-            eventReporter.onShow(country)
-        }
     }
 
     fun selectPrediction(prediction: AutocompletePrediction) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -100,6 +101,10 @@ internal fun InputAddressScreen(
             inputAddressViewModelSubcomponentFactoryProvider
         )
     )
+    LaunchedEffect(Unit) {
+        viewModel.onScreenShown()
+    }
+
     val formController = viewModel.addressFormController
 
     val completeValues by formController.completeFormValues.collectAsState()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -121,6 +121,8 @@ internal class InputAddressViewModel @Inject constructor(
     val checkboxChecked: StateFlow<Boolean> = _checkboxChecked
 
     init {
+        eventReporter.onShow(_collectedAddress.value?.address?.country ?: "")
+
         viewModelScope.launch {
             navigator.getResultFlow<AddressElementNavigator.AutocompleteEvent?>(
                 AddressElementNavigator.AutocompleteEvent.KEY

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -120,8 +120,11 @@ internal class InputAddressViewModel @Inject constructor(
     private val _checkboxChecked = MutableStateFlow(false)
     val checkboxChecked: StateFlow<Boolean> = _checkboxChecked
 
+    fun onScreenShown() {
+        eventReporter.onShow(_collectedAddress.value?.address?.country.orEmpty())
+    }
+
     init {
-        eventReporter.onShow(_collectedAddress.value?.address?.country ?: "")
 
         viewModelScope.launch {
             navigator.getResultFlow<AddressElementNavigator.AutocompleteEvent?>(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -17,19 +17,16 @@ internal class StripeHostedPlacesClientProxy(
     private val lock = Any()
     private var sessionToken: String = newSessionToken()
     private var lastQueryLength: Int = 0
+    private var sessionStartReported: Boolean = false
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
-
-    init {
-        eventReporter.onAutocompleteSessionStarted(sessionToken)
-    }
 
     override fun resetSession() {
         synchronized(lock) {
             sessionToken = newSessionToken()
             lastQueryLength = 0
+            sessionStartReported = false
             predictionCache.clear()
         }
-        eventReporter.onAutocompleteSessionStarted(sessionToken)
     }
 
     override suspend fun findAutocompletePredictions(
@@ -39,9 +36,15 @@ internal class StripeHostedPlacesClientProxy(
     ): Result<FindAutocompletePredictionsResponse> {
         val q = query ?: return Result.success(FindAutocompletePredictionsResponse(emptyList()))
         val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
+        var isFirstQuery = false
         val token = synchronized(lock) {
+            isFirstQuery = !sessionStartReported
+            sessionStartReported = true
             lastQueryLength = q.length
             sessionToken
+        }
+        if (isFirstQuery) {
+            eventReporter.onAutocompleteSessionStarted(token)
         }
         eventReporter.onAutocompleteFetchStarted(token)
         return repository.findAutocompletePredictions(
@@ -66,6 +69,7 @@ internal class StripeHostedPlacesClientProxy(
         }.onSuccess { response ->
             eventReporter.onAutocompleteSuggestionsReturned(
                 sessionToken = token,
+                queryLength = q.length,
                 resultCount = response.autocompletePredictions.size,
             )
         }.onFailure { error ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -86,8 +86,8 @@ internal class StripeHostedPlacesClientProxy(
             token = sessionToken
             queryLength = lastQueryLength
         }
-        eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
         if (cached?.address != null) {
+            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
             return Result.success(
                 Address(
                     line1 = cached.address.line1,
@@ -99,6 +99,7 @@ internal class StripeHostedPlacesClientProxy(
                 )
             )
         }
+        eventReporter.onAutocompleteDetailsFetchStarted(sessionToken = token)
         return repository.fetchPlaceDetails(
             placeId = placeId,
             sessionToken = token,
@@ -120,6 +121,8 @@ internal class StripeHostedPlacesClientProxy(
                 postalCode = result.address?.postalCode,
                 country = result.address?.country,
             )
+        }.onSuccess {
+            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -46,7 +46,7 @@ internal class StripeHostedPlacesClientProxy(
         if (isFirstQuery) {
             eventReporter.onAutocompleteSessionStarted(token)
         }
-        eventReporter.onAutocompleteFetchStarted(token)
+        eventReporter.onAutocompleteFetchStarted()
         return repository.findAutocompletePredictions(
             query = q,
             country = country,
@@ -99,7 +99,7 @@ internal class StripeHostedPlacesClientProxy(
                 )
             )
         }
-        eventReporter.onAutocompleteDetailsFetchStarted(sessionToken = token)
+        eventReporter.onAutocompleteDetailsFetchStarted()
         return repository.fetchPlaceDetails(
             placeId = placeId,
             sessionToken = token,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -14,11 +14,10 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         override val eventName: String = "mc_address_show"
         override val additionalParams: Map<String, Any>
             get() {
-                return mapOf(
-                    FIELD_ADDRESS_DATA_BLOB to mapOf(
-                        FIELD_ADDRESS_COUNTRY_CODE to country
-                    )
-                )
+                val data = buildMap<String, Any> {
+                    if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
+                }
+                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
             }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -55,13 +55,13 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             get() = mapOf(
                 FIELD_ADDRESS_DATA_BLOB to mapOf(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
-                    FIELD_ADDRESS_INPUT_MODE to ADDRESS_INPUT_MODE_AUTOCOMPLETE,
                 )
             )
     }
 
     class AutocompleteSuggestions(
         private val autocompleteSessionToken: String,
+        private val queryLength: Int,
         private val timeToFetch: Duration?,
         private val resultCount: Int,
         private val sessionElapsed: Duration?,
@@ -71,6 +71,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
             get() {
                 val data = mutableMapOf<String, Any>(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
+                    FIELD_QUERY_LENGTH to queryLength,
                     FIELD_RESULT_COUNT to resultCount,
                 )
                 timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
@@ -83,16 +84,19 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         private val autocompleteSessionToken: String,
         private val queryLength: Int,
         private val placeId: String,
+        private val sessionElapsed: Duration?,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_selected"
         override val additionalParams: Map<String, Any>
-            get() = mapOf(
-                FIELD_ADDRESS_DATA_BLOB to mapOf(
+            get() {
+                val data = mutableMapOf<String, Any>(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
                     FIELD_QUERY_LENGTH to queryLength,
                     FIELD_PLACE_ID to placeId,
                 )
-            )
+                sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
+                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
+            }
     }
 
     class AutocompleteError(
@@ -117,13 +121,10 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         const val FIELD_EDIT_DISTANCE = "edit_distance"
         const val FIELD_TIME_TO_COMPLETE = "time_to_complete"
         const val FIELD_AUTOCOMPLETE_SESSION_TOKEN = "autocomplete_session_token"
-        const val FIELD_ADDRESS_INPUT_MODE = "address_input_mode"
         const val FIELD_TIME_TO_FETCH = "time_to_fetch"
         const val FIELD_RESULT_COUNT = "result_count"
         const val FIELD_SESSION_ELAPSED = "session_elapsed"
         const val FIELD_QUERY_LENGTH = "query_length"
         const val FIELD_PLACE_ID = "place_id"
-
-        private const val ADDRESS_INPUT_MODE_AUTOCOMPLETE = "autocomplete"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -85,6 +85,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         private val queryLength: Int,
         private val placeId: String,
         private val sessionElapsed: Duration?,
+        private val timeToFetch: Duration?,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_selected"
         override val additionalParams: Map<String, Any>
@@ -95,6 +96,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                     FIELD_PLACE_ID to placeId,
                 )
                 sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
+                timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
                 return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
             }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -11,7 +11,7 @@ internal interface AddressLauncherEventReporter {
 
     fun onAutocompleteSessionStarted(sessionToken: String)
 
-    fun onAutocompleteFetchStarted(sessionToken: String)
+    fun onAutocompleteFetchStarted()
 
     fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
@@ -19,7 +19,7 @@ internal interface AddressLauncherEventReporter {
         resultCount: Int,
     )
 
-    fun onAutocompleteDetailsFetchStarted(sessionToken: String)
+    fun onAutocompleteDetailsFetchStarted()
 
     fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -19,6 +19,8 @@ internal interface AddressLauncherEventReporter {
         resultCount: Int,
     )
 
+    fun onAutocompleteDetailsFetchStarted(sessionToken: String)
+
     fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String)
 
     fun onAutocompleteError(sessionToken: String, error: Throwable)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -15,6 +15,7 @@ internal interface AddressLauncherEventReporter {
 
     fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
+        queryLength: Int,
         resultCount: Int,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -58,6 +58,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
 
     override fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
+        queryLength: Int,
         resultCount: Int,
     ) {
         val fetchDuration = durationProvider.end(DurationProvider.Key.AddressAutocompleteFetch)
@@ -65,6 +66,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         fireEvent(
             AddressLauncherEvent.AutocompleteSuggestions(
                 autocompleteSessionToken = sessionToken,
+                queryLength = queryLength,
                 timeToFetch = fetchDuration,
                 resultCount = resultCount,
                 sessionElapsed = sessionElapsed,
@@ -73,11 +75,13 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
     }
 
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
+        val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteSelected(
                 autocompleteSessionToken = sessionToken,
                 queryLength = queryLength,
                 placeId = placeId,
+                sessionElapsed = sessionElapsed,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -52,11 +52,11 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteFetchStarted(sessionToken: String) {
+    override fun onAutocompleteFetchStarted() {
         durationProvider.start(DurationProvider.Key.AddressAutocompleteFetch, reset = true)
     }
 
-    override fun onAutocompleteDetailsFetchStarted(sessionToken: String) {
+    override fun onAutocompleteDetailsFetchStarted() {
         durationProvider.start(DurationProvider.Key.AddressAutocompleteDetailsFetch, reset = true)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -56,6 +56,10 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         durationProvider.start(DurationProvider.Key.AddressAutocompleteFetch, reset = true)
     }
 
+    override fun onAutocompleteDetailsFetchStarted(sessionToken: String) {
+        durationProvider.start(DurationProvider.Key.AddressAutocompleteDetailsFetch, reset = true)
+    }
+
     override fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
         queryLength: Int,
@@ -76,12 +80,14 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
 
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
+        val timeToFetch = durationProvider.end(DurationProvider.Key.AddressAutocompleteDetailsFetch)
         fireEvent(
             AddressLauncherEvent.AutocompleteSelected(
                 autocompleteSessionToken = sessionToken,
                 queryLength = queryLength,
                 placeId = placeId,
                 sessionElapsed = sessionElapsed,
+                timeToFetch = timeToFetch,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -10,6 +10,7 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
     override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
     override fun onAutocompleteFetchStarted(sessionToken: String) = Unit
     override fun onAutocompleteSuggestionsReturned(sessionToken: String, queryLength: Int, resultCount: Int) = Unit
+    override fun onAutocompleteDetailsFetchStarted(sessionToken: String) = Unit
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
     override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -9,7 +9,7 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
     ) = Unit
     override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
     override fun onAutocompleteFetchStarted(sessionToken: String) = Unit
-    override fun onAutocompleteSuggestionsReturned(sessionToken: String, resultCount: Int) = Unit
+    override fun onAutocompleteSuggestionsReturned(sessionToken: String, queryLength: Int, resultCount: Int) = Unit
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
     override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -8,9 +8,9 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
         editDistance: Int?,
     ) = Unit
     override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
-    override fun onAutocompleteFetchStarted(sessionToken: String) = Unit
+    override fun onAutocompleteFetchStarted() = Unit
     override fun onAutocompleteSuggestionsReturned(sessionToken: String, queryLength: Int, resultCount: Int) = Unit
-    override fun onAutocompleteDetailsFetchStarted(sessionToken: String) = Unit
+    override fun onAutocompleteDetailsFetchStarted() = Unit
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
     override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -143,6 +143,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                     DurationProvider.Key.PaymentMethodMessaging,
                     DurationProvider.Key.AddressAutocompleteSession,
                     DurationProvider.Key.AddressAutocompleteFetch,
+                    DurationProvider.Key.AddressAutocompleteDetailsFetch,
                     DurationProvider.Key.AddressElementCompletion -> null
                 }
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -21,7 +21,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -289,12 +289,6 @@ class AutocompleteViewModelTest {
     }
 
     @Test
-    fun `initializing ViewModel emits onShow event`() {
-        createViewModel()
-        verify(mockEventReporter).onShow(eq("US"))
-    }
-
-    @Test
     fun `clearQuery clears textfield and predictions`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -67,16 +67,18 @@ class InputAddressViewModelTest {
     )
 
     @Test
-    fun `initializing ViewModel fires onShow with initial country`() {
-        createViewModel(
+    fun `onScreenShown fires onShow with initial country`() {
+        val viewModel = createViewModel(
             address = AddressDetails(address = PaymentSheet.Address(country = "US"))
         )
+        viewModel.onScreenShown()
         verify(eventReporter).onShow(eq("US"))
     }
 
     @Test
-    fun `initializing ViewModel fires onShow with empty string when no initial country`() {
-        createViewModel()
+    fun `onScreenShown fires onShow with empty string when no initial country`() {
+        val viewModel = createViewModel()
+        viewModel.onScreenShown()
         verify(eventReporter).onShow(eq(""))
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -67,6 +67,20 @@ class InputAddressViewModelTest {
     )
 
     @Test
+    fun `initializing ViewModel fires onShow with initial country`() {
+        createViewModel(
+            address = AddressDetails(address = PaymentSheet.Address(country = "US"))
+        )
+        verify(eventReporter).onShow(eq("US"))
+    }
+
+    @Test
+    fun `initializing ViewModel fires onShow with empty string when no initial country`() {
+        createViewModel()
+        verify(eventReporter).onShow(eq(""))
+    }
+
+    @Test
     fun `no autocomplete address passed has an empty address to start`() = runTest(UnconfinedTestDispatcher()) {
         val flow = MutableStateFlow<AddressDetails?>(null)
         whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -285,40 +285,87 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `constructing the proxy fires onAutocompleteSessionStarted with the initial token`() = runTest {
+    fun `onAutocompleteSessionStarted is not fired on proxy construction`() = runTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         createProxy(eventReporter = eventReporter)
-
-        val token = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-        assertThat(token).isNotEmpty()
         eventReporter.validate()
     }
 
     @Test
-    fun `resetSession fires onAutocompleteSessionStarted with a new token`() = runTest {
-        val eventReporter = FakeAddressLauncherEventReporter()
-        val proxy = createProxy(eventReporter = eventReporter)
-        val initialToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-
-        proxy.resetSession()
-
-        val newToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-        assertThat(newToken).isNotEqualTo(initialToken)
-        eventReporter.validate()
-    }
-
-    @Test
-    fun `findAutocompletePredictions success fires suggestions returned`() = runTest {
+    fun `first findAutocompletePredictions fires onAutocompleteSessionStarted`() = runTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+
+        val token = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(token).isNotEmpty()
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
+        eventReporter.validate()
+    }
+
+    @Test
+    fun `onAutocompleteSessionStarted only fires once per session across multiple queries`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+
+        proxy.findAutocompletePredictions(query = "123", country = "US", limit = 4)
         eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+
+        repository.ensureAllEventsConsumed()
+        eventReporter.validate()
+    }
+
+    @Test
+    fun `resetSession causes next query to fire onAutocompleteSessionStarted with new token`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        val initialToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+
+        proxy.resetSession()
+
+        proxy.findAutocompletePredictions(query = "456 Oak", country = "US", limit = 4)
+        val newToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(newToken).isNotEqualTo(initialToken)
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+        repository.ensureAllEventsConsumed()
+        eventReporter.validate()
+    }
+
+    @Test
+    fun `findAutocompletePredictions success fires suggestions returned with query length`() = runTest {
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val repository = defaultRepository()
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
 
         val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+        assertThat(suggestionsCall.queryLength).isEqualTo("123 Main".length)
         assertThat(suggestionsCall.resultCount).isEqualTo(1)
         repository.ensureAllEventsConsumed()
         eventReporter.validate()
@@ -331,10 +378,10 @@ class StripeHostedPlacesClientProxyTest {
             predictionsResult = Result.failure(RuntimeException("Network error"))
         }
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
-        eventReporter.autocompleteSessionStartedCalls.awaitItem()
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
 
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
@@ -348,10 +395,10 @@ class StripeHostedPlacesClientProxyTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
-        eventReporter.autocompleteSessionStartedCalls.awaitItem()
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
@@ -372,10 +419,10 @@ class StripeHostedPlacesClientProxyTest {
             detailsResult = Result.failure(RuntimeException("Details error"))
         }
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
-        eventReporter.autocompleteSessionStartedCalls.awaitItem()
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
         repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -391,7 +391,7 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `fetchPlace success fires onAutocompleteSelected with query length and place id`() = runTest {
+    fun `fetchPlace success fires onAutocompleteDetailsFetchStarted then onAutocompleteSelected`() = runTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
@@ -403,6 +403,7 @@ class StripeHostedPlacesClientProxyTest {
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.fetchPlace("place_123", Locale.US)
+        eventReporter.autocompleteDetailsFetchStartedCalls.awaitItem()
         repository.fetchPlaceDetailsCalls.awaitItem()
 
         val selectedCall = eventReporter.autocompleteSelectedCalls.awaitItem()
@@ -413,7 +414,36 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `fetchPlace failure fires onAutocompleteError`() = runTest {
+    fun `fetchPlace with cached inline address fires onAutocompleteSelected without detail fetch`() = runTest {
+        val inlineAddress = StripeProxyAddress(
+            line1 = "123 Main St", line2 = null, city = "SF", state = "CA", postalCode = "94105", country = "US"
+        )
+        val repository = FakeStripeAutocompleteRepository().apply {
+            predictionsResult = Result.success(
+                AutocompletePredictionsResult(
+                    predictions = listOf(AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress))
+                )
+            )
+        }
+        val eventReporter = FakeAddressLauncherEventReporter()
+        val proxy = createProxy(repository = repository, eventReporter = eventReporter)
+
+        proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
+        repository.findPredictionsCalls.awaitItem()
+        eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        eventReporter.autocompleteFetchStartedCalls.awaitItem()
+        eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
+
+        proxy.fetchPlace("place_123", Locale.US)
+
+        val selectedCall = eventReporter.autocompleteSelectedCalls.awaitItem()
+        assertThat(selectedCall.placeId).isEqualTo("place_123")
+        repository.ensureAllEventsConsumed()
+        eventReporter.validate()
+    }
+
+    @Test
+    fun `fetchPlace failure fires onAutocompleteError without onAutocompleteSelected`() = runTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         val repository = defaultRepository().apply {
             detailsResult = Result.failure(RuntimeException("Details error"))
@@ -427,9 +457,9 @@ class StripeHostedPlacesClientProxyTest {
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
 
         proxy.fetchPlace("place_123", Locale.US)
+        eventReporter.autocompleteDetailsFetchStartedCalls.awaitItem()
         repository.fetchPlaceDetailsCalls.awaitItem()
 
-        eventReporter.autocompleteSelectedCalls.awaitItem()
         val errorCall = eventReporter.autocompleteErrorCalls.awaitItem()
         assertThat(errorCall.error).hasMessageThat().isEqualTo("Details error")
         repository.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -13,15 +13,15 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     private val _autocompleteSessionStartedCalls = Turbine<String>()
     val autocompleteSessionStartedCalls: ReceiveTurbine<String> = _autocompleteSessionStartedCalls
 
-    private val _autocompleteFetchStartedCalls = Turbine<String>()
-    val autocompleteFetchStartedCalls: ReceiveTurbine<String> = _autocompleteFetchStartedCalls
+    private val _autocompleteFetchStartedCalls = Turbine<Unit>()
+    val autocompleteFetchStartedCalls: ReceiveTurbine<Unit> = _autocompleteFetchStartedCalls
 
     private val _autocompleteSuggestionsReturnedCalls = Turbine<SuggestionsReturnedCall>()
     val autocompleteSuggestionsReturnedCalls: ReceiveTurbine<SuggestionsReturnedCall> =
         _autocompleteSuggestionsReturnedCalls
 
-    private val _autocompleteDetailsFetchStartedCalls = Turbine<String>()
-    val autocompleteDetailsFetchStartedCalls: ReceiveTurbine<String> = _autocompleteDetailsFetchStartedCalls
+    private val _autocompleteDetailsFetchStartedCalls = Turbine<Unit>()
+    val autocompleteDetailsFetchStartedCalls: ReceiveTurbine<Unit> = _autocompleteDetailsFetchStartedCalls
 
     private val _autocompleteSelectedCalls = Turbine<SelectedCall>()
     val autocompleteSelectedCalls: ReceiveTurbine<SelectedCall> = _autocompleteSelectedCalls
@@ -45,8 +45,8 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteSessionStartedCalls.add(sessionToken)
     }
 
-    override fun onAutocompleteFetchStarted(sessionToken: String) {
-        _autocompleteFetchStartedCalls.add(sessionToken)
+    override fun onAutocompleteFetchStarted() {
+        _autocompleteFetchStartedCalls.add(Unit)
     }
 
     override fun onAutocompleteSuggestionsReturned(
@@ -57,8 +57,8 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, queryLength, resultCount))
     }
 
-    override fun onAutocompleteDetailsFetchStarted(sessionToken: String) {
-        _autocompleteDetailsFetchStartedCalls.add(sessionToken)
+    override fun onAutocompleteDetailsFetchStarted() {
+        _autocompleteDetailsFetchStartedCalls.add(Unit)
     }
 
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -48,9 +48,10 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
 
     override fun onAutocompleteSuggestionsReturned(
         sessionToken: String,
+        queryLength: Int,
         resultCount: Int,
     ) {
-        _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, resultCount))
+        _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, queryLength, resultCount))
     }
 
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
@@ -77,7 +78,7 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         val editDistance: Int?,
     )
 
-    data class SuggestionsReturnedCall(val sessionToken: String, val resultCount: Int)
+    data class SuggestionsReturnedCall(val sessionToken: String, val queryLength: Int, val resultCount: Int)
 
     data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -20,6 +20,9 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     val autocompleteSuggestionsReturnedCalls: ReceiveTurbine<SuggestionsReturnedCall> =
         _autocompleteSuggestionsReturnedCalls
 
+    private val _autocompleteDetailsFetchStartedCalls = Turbine<String>()
+    val autocompleteDetailsFetchStartedCalls: ReceiveTurbine<String> = _autocompleteDetailsFetchStartedCalls
+
     private val _autocompleteSelectedCalls = Turbine<SelectedCall>()
     val autocompleteSelectedCalls: ReceiveTurbine<SelectedCall> = _autocompleteSelectedCalls
 
@@ -54,6 +57,10 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, queryLength, resultCount))
     }
 
+    override fun onAutocompleteDetailsFetchStarted(sessionToken: String) {
+        _autocompleteDetailsFetchStartedCalls.add(sessionToken)
+    }
+
     override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
         _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId))
     }
@@ -68,6 +75,7 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteSessionStartedCalls.ensureAllEventsConsumed()
         _autocompleteFetchStartedCalls.ensureAllEventsConsumed()
         _autocompleteSuggestionsReturnedCalls.ensureAllEventsConsumed()
+        _autocompleteDetailsFetchStartedCalls.ensureAllEventsConsumed()
         _autocompleteSelectedCalls.ensureAllEventsConsumed()
         _autocompleteErrorCalls.ensureAllEventsConsumed()
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -52,6 +52,7 @@ interface DurationProvider {
         ExpressCheckoutElement,
         AddressAutocompleteSession,
         AddressAutocompleteFetch,
+        AddressAutocompleteDetailsFetch,
         AddressElementCompletion
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix three bugs in the inline address autocomplete analytics implementation:
1. mc_address_show was never firing for the inline autocomplete path, it was only called from AutocompleteViewModel.init (the old full-screen autocomplete sub-screen), not when the standalone Address Element first appears. Moved it to InputAddressViewModel.init.
2. mc_address_autocomplete_selected was missing time_to_fetch (the duration of the place details network request). Added a new onAutocompleteDetailsFetchStarted reporter method and AddressAutocompleteDetailsFetch duration key to measure it.
3. On a details fetch failure, both mc_address_autocomplete_selected AND mc_address_autocomplete_error were firing because onAutocompleteSelected was called before the fetch. Restructured fetchPlace so selected only fires on success and error only fires on failure.



# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fixing analytics bugs from bug bash

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

Updated StripeHostedPlacesClientProxyTest

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
