### PR TITLE
Update tax region in checkout controller configure when default billi…

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -104,6 +104,16 @@ class CheckoutController @Inject internal constructor(
                 sessionId = sessionId,
                 adaptivePricingAllowed = configurationState.adaptivePricingAllowed,
             ).mapCatching { response ->
+                if (configurationState.defaultBillingAddress != null &&
+                    response.automaticTaxEnabled &&
+                    response.taxAddressSource == CheckoutSessionResponse.TaxAddressSource.BILLING
+                ) {
+                    checkoutSessionRepository.updateTaxRegion(sessionId, configurationState.defaultBillingAddress)
+                        .getOrThrow()
+                } else {
+                    response
+                }
+            }.mapCatching { response ->
                 checkoutStateLoader.loadInitial(
                     configuration = configurationState,
                     checkoutSessionResponse = response,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -171,6 +171,36 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `configure sends default billing address when automatic tax targets billing`() = runConfigureScenario(
+        configuration = CheckoutController.Configuration().defaultBillingAddress(
+            CheckoutController.Address()
+                .city("San Francisco")
+                .country("US")
+                .line1("510 Townsend St")
+                .line2("Suite 100")
+                .postalCode("94103")
+                .state("CA")
+        ),
+        networkSetup = {
+            networkRule.checkoutInit(
+                responseFactory = successResponseFactory(automaticTaxFor("billing")),
+            )
+            networkRule.checkoutUpdate(
+                bodyPart("tax_region[country]", "US"),
+                bodyPart("tax_region[city]", "San Francisco"),
+                bodyPart("tax_region[state]", "CA"),
+                bodyPart("tax_region[postal_code]", "94103"),
+                bodyPart("tax_region[line1]", "510 Townsend St"),
+                bodyPart("tax_region[line2]", "Suite 100"),
+                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+                responseFactory = successResponseFactory(automaticTaxFor("billing")),
+            )
+        },
+    ) {
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
     fun `configure uses app name as merchant display name, not checkout session data`() =
         runConfigureScenario {
             result.getOrThrow()


### PR DESCRIPTION
…ng address is provided

# Summary
<!-- Simple summary of what was changed. -->
Update tax region in checkout controller configure when default billing address is provided

Matches iOS init behavior which:
- [calls init](https://github.com/stripe/stripe-ios/blob/80bdf29e3facd8a979f89b865c581b7f7ba0ce4d/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift#L124-L133)
- then [applyDefaults](https://github.com/stripe/stripe-ios/blob/80bdf29e3facd8a979f89b865c581b7f7ba0ce4d/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift#L355-L369), which updates tax region

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Ensure we have proper tax estimates on initialization when default billing address is provided and auto tax is based on billing address.

Need this for gpay <> auto tax w/ billing address as tax source implementation

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified