### PR TITLE
Trigger autocomplete after 3 characters are typed instead of 2

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -266,6 +266,6 @@ internal class AutocompleteViewModel @Inject constructor(
     companion object {
         const val SEARCH_DEBOUNCE_MS = 400L
         const val MAX_DISPLAYED_RESULTS = 4
-        const val MIN_CHARS_AUTOCOMPLETE = 2
+        const val MIN_CHARS_AUTOCOMPLETE = 3
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -175,10 +175,10 @@ class AutocompleteViewModelTest {
     }
 
     @Test
-    fun `query is valid when 2 characters are entered`() = runTest(UnconfinedTestDispatcher()) {
+    fun `query is valid when 3 characters are entered`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel()
 
-        viewModel.textFieldController.onRawValueChange("12")
+        viewModel.textFieldController.onRawValueChange("123")
 
         whenever(mockClient.findAutocompletePredictions(any(), any(), any())).thenReturn(
             Result.success(
@@ -201,10 +201,10 @@ class AutocompleteViewModelTest {
     }
 
     @Test
-    fun `query is invalid when less than 2 characters are entered`() = runTest(UnconfinedTestDispatcher()) {
+    fun `query is invalid when less than 3 characters are entered`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel()
 
-        viewModel.textFieldController.onRawValueChange("1")
+        viewModel.textFieldController.onRawValueChange("12")
 
         verify(mockClient, never()).findAutocompletePredictions(any(), any(), any())
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -34,7 +34,7 @@ class InlineAutocompleteControllerTest {
     fun `query shorter than minimum chars stays Idle`() = runScenario {
         delegate.observeQueryChanges(queryFlow, countryFlow)
 
-        queryFlow.value = "a"
+        queryFlow.value = "ab"
         advanceTimeBy(500)
 
         assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
@@ -47,11 +47,11 @@ class InlineAutocompleteControllerTest {
         )
         delegate.observeQueryChanges(queryFlow, countryFlow)
 
-        queryFlow.value = "ab"
+        queryFlow.value = "abc"
         advanceTimeBy(500)
 
         val call = fakePlacesClient.findPredictionsCalls.awaitItem()
-        assertThat(call.query).isEqualTo("ab")
+        assertThat(call.query).isEqualTo("abc")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Raise the inline autocomplete trigger threshold from 2 characters to 3. MIN_CHARS_AUTOCOMPLETE is updated from 2 to 3 inAutocompleteViewModel.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Autocomplete was triggering on very short inputs (2 chars), which produces low-quality predictions and unnecessary API calls. Waiting for 3 characters yields more meaningful results.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

 Updated AutocompleteViewModelTest and InlineAutocompleteControllerTest to reflect the new minimum
<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
