### PR TITLE
Add analytics to billing address fields

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivityResult.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.bundleOf
 import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
@@ -27,7 +28,8 @@ internal sealed class PaymentOptionsActivityResult(
     data class Succeeded(
         val paymentSelection: PaymentSelection,
         override val linkAccountInfo: LinkAccountUpdate.Value,
-        override val paymentMethods: List<PaymentMethod>? = null
+        override val paymentMethods: List<PaymentMethod>? = null,
+        val autocompleteFilledAddress: Address? = null,
     ) : PaymentOptionsActivityResult(Activity.RESULT_OK)
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -402,7 +402,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     PaymentOptionsActivityResult.Succeeded(
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         paymentSelection = paymentSelection.withLinkDetails(),
-                        paymentMethods = customerStateHolder.paymentMethods.value
+                        paymentMethods = customerStateHolder.paymentMethods.value,
+                        autocompleteFilledAddress = autocompleteFilledAddress,
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -695,14 +695,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
         if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
-        val billingAddress = paymentSelection.billingDetails?.address ?: return
-        val countryCode = billingAddress.country ?: return
-        val filledAddress = autocompleteFilledAddress
-        val autocompleteUsed =
-            filledAddress != null || savedStateHandle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
-        val editDistance = filledAddress?.let {
-            computeBillingEditDistance(it, billingAddress)
-        } ?: savedStateHandle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
+        val countryCode = paymentSelection.billingDetails?.address?.country ?: return
+        val autocompleteUsed = savedStateHandle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
+        val editDistance = savedStateHandle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
         savedStateHandle.remove<Boolean>(AUTOCOMPLETE_USED_KEY)
         savedStateHandle.remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
         eventReporter.onBillingAddressCompleted(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -682,6 +682,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
         if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
+        if (paymentSelection !is PaymentSelection.New) return
         val billingAddress = paymentSelection.billingDetails?.address ?: return
         val countryCode = billingAddress.country ?: return
         val filledAddress = autocompleteFilledAddress

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -583,6 +583,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
             val confirmationOption = withContext(viewModelScope.coroutineContext) {
                 inProgressSelection = paymentSelection
+                persistBillingAnalytics(paymentSelection)
 
                 paymentSelectionWithCvcIfEnabled(paymentSelection)
                     ?.toConfirmationOption(
@@ -680,18 +681,33 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
+    private fun persistBillingAnalytics(paymentSelection: PaymentSelection?) {
+        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
+        if (paymentSelection !is PaymentSelection.New) return
+        val billingAddress = paymentSelection.billingDetails?.address ?: return
+        val filledAddress = autocompleteFilledAddress
+        savedStateHandle[AUTOCOMPLETE_USED_KEY] = filledAddress != null
+        savedStateHandle[AUTOCOMPLETE_EDIT_DISTANCE_KEY] = filledAddress?.let {
+            computeBillingEditDistance(it, billingAddress)
+        }
+    }
+
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
         if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
         val billingAddress = paymentSelection.billingDetails?.address ?: return
         val countryCode = billingAddress.country ?: return
         val filledAddress = autocompleteFilledAddress
+        val autocompleteUsed =
+            filledAddress != null || savedStateHandle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
         val editDistance = filledAddress?.let {
             computeBillingEditDistance(it, billingAddress)
-        }
+        } ?: savedStateHandle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
+        savedStateHandle.remove<Boolean>(AUTOCOMPLETE_USED_KEY)
+        savedStateHandle.remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
         eventReporter.onBillingAddressCompleted(
             addressCountryCode = countryCode,
-            autocompleteResultSelected = filledAddress != null,
+            autocompleteResultSelected = autocompleteUsed,
             editDistance = editDistance,
         )
     }
@@ -833,6 +849,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private companion object {
         const val IN_PROGRESS_SELECTION = "IN_PROGRESS_PAYMENT_SELECTION"
+        const val AUTOCOMPLETE_USED_KEY = "BILLING_AUTOCOMPLETE_USED"
+        const val AUTOCOMPLETE_EDIT_DISTANCE_KEY = "BILLING_AUTOCOMPLETE_EDIT_DISTANCE"
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -24,6 +24,7 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
@@ -46,12 +47,14 @@ import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.computeBillingEditDistance
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
+import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.isLink
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
@@ -658,6 +661,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
                 intentId = intentId,
             )
+            reportBillingAddressCompleted(paymentSelection)
         }
 
         // Log out of Link to invalidate the token
@@ -674,6 +678,21 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 _paymentSheetResult.tryEmit(PaymentSheetResult.Completed())
             }
         }
+    }
+
+    private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
+        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
+        val billingAddress = paymentSelection.billingDetails?.address ?: return
+        val countryCode = billingAddress.country ?: return
+        val filledAddress = autocompleteFilledAddress
+        val editDistance = filledAddress?.let {
+            computeBillingEditDistance(it, billingAddress)
+        }
+        eventReporter.onBillingAddressCompleted(
+            addressCountryCode = countryCode,
+            autocompleteResultSelected = filledAddress != null,
+            editDistance = editDistance,
+        )
     }
 
     private fun processConfirmationResult(result: ConfirmationHandler.Result?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressUtils.kt
@@ -56,6 +56,20 @@ internal fun AddressDetails.editDistance(otherAddress: AddressDetails?): Int {
     return editDistance
 }
 
+internal fun computeBillingEditDistance(
+    autocompleteAddress: com.stripe.android.model.Address,
+    billingAddress: com.stripe.android.model.Address,
+): Int {
+    var editDistance = 0
+    editDistance += (autocompleteAddress.city ?: "").levenshtein(billingAddress.city ?: "")
+    editDistance += (autocompleteAddress.country ?: "").levenshtein(billingAddress.country ?: "")
+    editDistance += (autocompleteAddress.line1 ?: "").levenshtein(billingAddress.line1 ?: "")
+    editDistance += (autocompleteAddress.line2 ?: "").levenshtein(billingAddress.line2 ?: "")
+    editDistance += (autocompleteAddress.postalCode ?: "").levenshtein(billingAddress.postalCode ?: "")
+    editDistance += (autocompleteAddress.state ?: "").levenshtein(billingAddress.state ?: "")
+    return editDistance
+}
+
 @Composable
 internal fun ScrollableColumn(
     modifier: Modifier = Modifier,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressUtils.kt
@@ -61,12 +61,11 @@ internal fun computeBillingEditDistance(
     billingAddress: com.stripe.android.model.Address,
 ): Int {
     var editDistance = 0
-    editDistance += (autocompleteAddress.city ?: "").levenshtein(billingAddress.city ?: "")
-    editDistance += (autocompleteAddress.country ?: "").levenshtein(billingAddress.country ?: "")
     editDistance += (autocompleteAddress.line1 ?: "").levenshtein(billingAddress.line1 ?: "")
     editDistance += (autocompleteAddress.line2 ?: "").levenshtein(billingAddress.line2 ?: "")
-    editDistance += (autocompleteAddress.postalCode ?: "").levenshtein(billingAddress.postalCode ?: "")
+    editDistance += (autocompleteAddress.city ?: "").levenshtein(billingAddress.city ?: "")
     editDistance += (autocompleteAddress.state ?: "").levenshtein(billingAddress.state ?: "")
+    editDistance += (autocompleteAddress.postalCode ?: "").levenshtein(billingAddress.postalCode ?: "")
     return editDistance
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/BillingInlineAutocompleteAddressInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +52,9 @@ internal class BillingInlineAutocompleteAddressInteractor(
     override fun onEnterManuallyFromInline() {
         inlineController.expandFormFromInline()
     }
+
+    val autocompleteFilledAddress: Address?
+        get() = inlineController.autocompleteFilledAddress
 
     fun dispose() {
         inlineController.dispose()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -32,6 +32,8 @@ internal class InlineAutocompleteController(
     private var countryFlow: StateFlow<String?>? = null
     private var observeJob: Job? = null
     private var selectionJob: Job? = null
+    var autocompleteFilledAddress: Address? = null
+        private set
 
     private val _inlinePredictionsState = MutableStateFlow<AutocompleteAddressInteractor.InlinePredictionsState>(
         AutocompleteAddressInteractor.InlinePredictionsState.Idle
@@ -95,6 +97,7 @@ internal class InlineAutocompleteController(
 
     private fun handleFetchPlaceSuccess(address: Address) {
         lastPredictionLine1 = address.line1
+        autocompleteFilledAddress = address
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
         eventListenerProvider()?.invoke(
             AutocompleteAddressInteractor.Event.OnExpandForm(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -53,6 +53,9 @@ internal class PaymentElementAutocompleteAddressInteractor(
     ) : AutocompleteAddressInteractor.Factory {
         private var activeInlineInteractor: BillingInlineAutocompleteAddressInteractor? = null
 
+        val autocompleteFilledAddress: com.stripe.android.model.Address?
+            get() = activeInlineInteractor?.autocompleteFilledAddress
+
         override fun create(): AutocompleteAddressInteractor {
             if (coroutineScope != null && autocompleteConfig.isInlineAutocompleteEnabled) {
                 val useStripeHosted = shouldUseAutocompleteProxyEndpointsProvider()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -591,6 +591,20 @@ internal class DefaultEventReporter @Inject internal constructor(
         }
     }
 
+    override fun onBillingAddressCompleted(
+        addressCountryCode: String,
+        autocompleteResultSelected: Boolean,
+        editDistance: Int?,
+    ) {
+        fireEvent(
+            PaymentSheetEvent.BillingAddressCompleted(
+                addressCountryCode = addressCountryCode,
+                autocompleteResultSelected = autocompleteResultSelected,
+                editDistance = editDistance,
+            )
+        )
+    }
+
     override fun onPaymentMethodMessagePromotionsFetchBegin() {
         durationProvider.start(DurationProvider.Key.PaymentMethodMessaging)
         fireEvent(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -261,6 +261,15 @@ internal interface EventReporter : CardScanEventsReporter {
     fun onTapToAddAttemptWithUnsupportedDevice()
 
     /**
+     * The user confirms payment with a billing address filled.
+     */
+    fun onBillingAddressCompleted(
+        addressCountryCode: String,
+        autocompleteResultSelected: Boolean,
+        editDistance: Int?,
+    )
+
+    /**
      * Promotions fetched from PMM API.
      */
     fun onPaymentMethodMessagePromotionsFetchBegin()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -603,6 +603,21 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         }
     }
 
+    class BillingAddressCompleted(
+        private val addressCountryCode: String,
+        private val autocompleteResultSelected: Boolean,
+        private val editDistance: Int?,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_billing_address_completed"
+        override val params: Map<String, Any?> = mapOf(
+            FIELD_ADDRESS_DATA_BLOB to buildMap<String, Any> {
+                put(FIELD_ADDRESS_COUNTRY_CODE, addressCountryCode)
+                put(FIELD_AUTO_COMPLETE_RESULT_SELECTED, autocompleteResultSelected)
+                editDistance?.let { put(FIELD_EDIT_DISTANCE, it) }
+            }
+        )
+    }
+
     internal companion object {
         private fun analyticsValue(
             paymentSelection: PaymentSelection?
@@ -656,6 +671,10 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_VISIBLE_PAYMENT_METHODS = "visible_payment_methods"
         const val FIELD_HIDDEN_PAYMENT_METHODS = "hidden_payment_methods"
         const val FIELD_LOAD_TIMINGS = "load_timings"
+        const val FIELD_ADDRESS_DATA_BLOB = "address_data_blob"
+        const val FIELD_ADDRESS_COUNTRY_CODE = "address_country_code"
+        const val FIELD_AUTO_COMPLETE_RESULT_SELECTED = "auto_complete_result_selected"
+        const val FIELD_EDIT_DISTANCE = "edit_distance"
 
         const val VALUE_EDIT_CBC_EVENT_SOURCE = "edit"
         const val VALUE_ADD_CBC_EVENT_SOURCE = "add"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
@@ -58,12 +59,14 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.computeBillingEditDistance
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
+import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.isLink
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.CustomerState
@@ -608,6 +611,7 @@ internal class DefaultFlowController @Inject internal constructor(
         when (result) {
             is PaymentOptionsActivityResult.Succeeded -> {
                 viewModel.paymentSelection = result.paymentSelection.also { it.hasAcknowledgedSepaMandate = true }
+                viewModel.autocompleteFilledAddress = result.autocompleteFilledAddress
                 onPaymentSelection(canceled = false)
             }
             null,
@@ -643,6 +647,7 @@ internal class DefaultFlowController @Inject internal constructor(
                         deferredIntentConfirmationType = result.metadata[DeferredIntentConfirmationTypeKey],
                         intentId = result.intent.id,
                     )
+                    reportBillingAddressCompleted(paymentSelection)
                 }
 
                 onPaymentResult(
@@ -710,6 +715,7 @@ internal class DefaultFlowController @Inject internal constructor(
 
         if (paymentResult is PaymentResult.Completed && shouldResetOnCompleted) {
             viewModel.paymentSelection = null
+            viewModel.autocompleteFilledAddress = null
             viewModel.state = null
             viewModel.previousConfigureRequest = null
             paymentOptionResultCallback.onPaymentOptionResult(PaymentOptionResult(null, false))
@@ -758,6 +764,7 @@ internal class DefaultFlowController @Inject internal constructor(
                         deferredIntentConfirmationType = deferredIntentConfirmationType,
                         intentId = intentId,
                     )
+                    reportBillingAddressCompleted(paymentSelection)
                 }
             }
             is PaymentResult.Failed -> {
@@ -772,6 +779,21 @@ internal class DefaultFlowController @Inject internal constructor(
                 // Nothing to do here
             }
         }
+    }
+
+    private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
+        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
+        val billingAddress = paymentSelection.billingDetails?.address ?: return
+        val countryCode = billingAddress.country ?: return
+        val filledAddress = viewModel.autocompleteFilledAddress
+        val editDistance = filledAddress?.let {
+            computeBillingEditDistance(it, billingAddress)
+        }
+        eventReporter.onBillingAddressCompleted(
+            addressCountryCode = countryCode,
+            autocompleteResultSelected = filledAddress != null,
+            editDistance = editDistance,
+        )
     }
 
     private fun PaymentResult.convertToPaymentSheetResult() = when (this) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -84,6 +84,9 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
 
+private const val AUTOCOMPLETE_USED_KEY = "BILLING_AUTOCOMPLETE_USED"
+private const val AUTOCOMPLETE_EDIT_DISTANCE_KEY = "BILLING_AUTOCOMPLETE_EDIT_DISTANCE"
+
 @Suppress("LargeClass")
 @OptIn(WalletButtonsPreview::class)
 @FlowControllerScope
@@ -553,6 +556,7 @@ internal class DefaultFlowController @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         state: PaymentSheetState.Full,
     ) {
+        persistBillingAnalytics(paymentSelection)
         viewModelScope.launch {
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,
@@ -781,18 +785,33 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
+    private fun persistBillingAnalytics(paymentSelection: PaymentSelection?) {
+        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
+        if (paymentSelection !is PaymentSelection.New) return
+        val billingAddress = paymentSelection.billingDetails?.address ?: return
+        val filledAddress = viewModel.autocompleteFilledAddress
+        viewModel.handle[AUTOCOMPLETE_USED_KEY] = filledAddress != null
+        viewModel.handle[AUTOCOMPLETE_EDIT_DISTANCE_KEY] = filledAddress?.let {
+            computeBillingEditDistance(it, billingAddress)
+        }
+    }
+
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
         if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
         val billingAddress = paymentSelection.billingDetails?.address ?: return
         val countryCode = billingAddress.country ?: return
         val filledAddress = viewModel.autocompleteFilledAddress
+        val autocompleteUsed =
+            filledAddress != null || viewModel.handle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
         val editDistance = filledAddress?.let {
             computeBillingEditDistance(it, billingAddress)
-        }
+        } ?: viewModel.handle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
+        viewModel.handle.remove<Boolean>(AUTOCOMPLETE_USED_KEY)
+        viewModel.handle.remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
         eventReporter.onBillingAddressCompleted(
             addressCountryCode = countryCode,
-            autocompleteResultSelected = filledAddress != null,
+            autocompleteResultSelected = autocompleteUsed,
             editDistance = editDistance,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -799,14 +799,9 @@ internal class DefaultFlowController @Inject internal constructor(
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
         if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
-        val billingAddress = paymentSelection.billingDetails?.address ?: return
-        val countryCode = billingAddress.country ?: return
-        val filledAddress = viewModel.autocompleteFilledAddress
-        val autocompleteUsed =
-            filledAddress != null || viewModel.handle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
-        val editDistance = filledAddress?.let {
-            computeBillingEditDistance(it, billingAddress)
-        } ?: viewModel.handle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
+        val countryCode = paymentSelection.billingDetails?.address?.country ?: return
+        val autocompleteUsed = viewModel.handle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
+        val editDistance = viewModel.handle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
         viewModel.handle.remove<Boolean>(AUTOCOMPLETE_USED_KEY)
         viewModel.handle.remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
         eventReporter.onBillingAddressCompleted(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -783,6 +783,7 @@ internal class DefaultFlowController @Inject internal constructor(
 
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
         if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
+        if (paymentSelection !is PaymentSelection.New) return
         val billingAddress = paymentSelection.billingDetails?.address ?: return
         val countryCode = billingAddress.country ?: return
         val filledAddress = viewModel.autocompleteFilledAddress

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.analytics.SessionSavedStateHandler
 import com.stripe.android.core.utils.requireApplication
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,6 +40,9 @@ internal class FlowControllerViewModel(
 
     @Volatile
     var paymentSelection: PaymentSelection? = null
+
+    @Volatile
+    var autocompleteFilledAddress: Address? = null
 
     // Used to determine if we need to reload the flow controller configuration.
     var previousConfigureRequest: FlowControllerConfigurationHandler.ConfigureRequest?
@@ -77,6 +81,7 @@ internal class FlowControllerViewModel(
     }
 
     fun resetSession() {
+        autocompleteFilledAddress = null
         restartSession()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -89,22 +89,27 @@ internal abstract class BaseSheetViewModel(
         analyticsListener.reportPaymentSheetHidden(poppedScreen)
     }
 
+    private val paymentElementAutocompleteFactory = PaymentElementAutocompleteAddressInteractor.Factory(
+        launcher = autocompleteLauncher,
+        autocompleteConfig = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = config.googlePlacesApiKey,
+            autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+            isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
+        ),
+        placesClient = placesClient,
+        stripeAutocompleteRepository = stripeAutocompleteRepository,
+        coroutineScope = viewModelScope,
+        shouldUseAutocompleteProxyEndpointsProvider = {
+            _paymentMethodMetadata.value?.shouldUseAutocompleteProxyEndpoints ?: false
+        },
+        eventReporter = addressLauncherEventReporter,
+    )
+
     val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory =
-        PaymentElementAutocompleteAddressInteractor.Factory(
-            launcher = autocompleteLauncher,
-            autocompleteConfig = AutocompleteAddressInteractor.Config(
-                googlePlacesApiKey = config.googlePlacesApiKey,
-                autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-                isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
-            ),
-            placesClient = placesClient,
-            stripeAutocompleteRepository = stripeAutocompleteRepository,
-            coroutineScope = viewModelScope,
-            shouldUseAutocompleteProxyEndpointsProvider = {
-                _paymentMethodMetadata.value?.shouldUseAutocompleteProxyEndpoints ?: false
-            },
-            eventReporter = addressLauncherEventReporter,
-        )
+        paymentElementAutocompleteFactory
+
+    val autocompleteFilledAddress: com.stripe.android.model.Address?
+        get() = paymentElementAutocompleteFactory.autocompleteFilledAddress
 
     internal val validationRequested = MutableSharedFlow<Unit>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -3314,6 +3315,100 @@ internal class PaymentSheetViewModelTest {
             }
         }
     }
+
+    @Test
+    fun `reportBillingAddressCompleted fires on successful payment with new card`() = confirmationTest {
+        FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
+        try {
+            val eventReporter = FakeEventReporter()
+            val viewModel = createViewModel(eventReporter = eventReporter)
+
+            viewModel.updateSelection(CARD_PAYMENT_SELECTION)
+            viewModel.checkout()
+
+            assertThat(startTurbine.awaitItem()).isNotNull()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+            )
+
+            val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+            assertThat(call.addressCountryCode).isEqualTo("US")
+            assertThat(call.autocompleteResultSelected).isFalse()
+            assertThat(call.editDistance).isNull()
+        } finally {
+            FeatureFlags.inlineAddressAutocompleteEnabled.reset()
+        }
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted does not fire for saved payment methods`() = confirmationTest {
+        FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
+        try {
+            val eventReporter = FakeEventReporter()
+            val viewModel = createViewModel(eventReporter = eventReporter)
+
+            viewModel.updateSelection(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
+            viewModel.checkout()
+
+            assertThat(startTurbine.awaitItem()).isNotNull()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+            )
+
+            eventReporter.billingAddressCompletedCalls.ensureAllEventsConsumed()
+        } finally {
+            FeatureFlags.inlineAddressAutocompleteEnabled.reset()
+        }
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted uses SavedStateHandle fallback after process death`() =
+        confirmationTest(
+            hasReloadedFromProcessDeath = true,
+            emitNullResults = false,
+            consumeBootstrap = false,
+        ) {
+            FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
+            try {
+                val eventReporter = FakeEventReporter()
+                val savedStateHandle = SavedStateHandle(
+                    mapOf(
+                        "IN_PROGRESS_PAYMENT_SELECTION" to CARD_PAYMENT_SELECTION,
+                        "BILLING_AUTOCOMPLETE_USED" to true,
+                        "BILLING_AUTOCOMPLETE_EDIT_DISTANCE" to 3,
+                    )
+                )
+                val stripeIntent = PaymentIntentFactory.create(
+                    status = StripeIntent.Status.Succeeded
+                )
+                val paymentSheetLoader = RelayingPaymentElementLoader()
+                val viewModel = createViewModel(
+                    eventReporter = eventReporter,
+                    savedStateHandle = savedStateHandle,
+                    stripeIntent = stripeIntent,
+                    paymentElementLoader = paymentSheetLoader,
+                )
+
+                viewModel.paymentSheetResult.test {
+                    paymentSheetLoader.enqueueSuccess(stripeIntent = stripeIntent)
+
+                    awaitResultTurbine.add(
+                        ConfirmationHandler.Result.Succeeded(intent = stripeIntent)
+                    )
+
+                    assertThat(awaitItem()).isEqualTo(PaymentSheetResult.Completed())
+                }
+
+                val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+                assertThat(call.addressCountryCode).isEqualTo("US")
+                assertThat(call.autocompleteResultSelected).isTrue()
+                assertThat(call.editDistance).isEqualTo(3)
+            } finally {
+                FeatureFlags.inlineAddressAutocompleteEnabled.reset()
+            }
+        }
 
     private fun testConfirmationStateRestorationAfterPaymentSuccess(
         loadStateBeforePaymentResult: Boolean

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressUtilsTest.kt
@@ -126,19 +126,6 @@ class AddressUtilsTest {
     }
 
     @Test
-    fun `computeBillingEditDistance returns zero for identical addresses`() {
-        val address = Address(
-            line1 = "510 Townsend St",
-            line2 = "Suite 200",
-            city = "San Francisco",
-            state = "CA",
-            postalCode = "94102",
-            country = "US",
-        )
-        assertThat(computeBillingEditDistance(address, address)).isEqualTo(0)
-    }
-
-    @Test
     fun `computeBillingEditDistance sums edits across fields`() {
         val autocomplete = Address(
             line1 = "510 Townsend St",
@@ -160,21 +147,15 @@ class AddressUtilsTest {
 
     @Test
     fun `computeBillingEditDistance excludes country from calculation`() {
-        val autocomplete = Address(
+        val address = Address(
             line1 = "123 Main St",
             city = "Toronto",
             state = "ON",
             postalCode = "M5V",
             country = "CA",
         )
-        val billing = Address(
-            line1 = "123 Main St",
-            city = "Toronto",
-            state = "ON",
-            postalCode = "M5V",
-            country = "US",
-        )
-        assertThat(computeBillingEditDistance(autocomplete, billing)).isEqualTo(0)
+        val sameWithDifferentCountry = address.copy(country = "US")
+        assertThat(computeBillingEditDistance(address, sameWithDifferentCountry)).isEqualTo(0)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressUtilsTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -121,5 +123,79 @@ class AddressUtilsTest {
         )
 
         Truth.assertThat(address.editDistance(otherAddress)).isEqualTo(13)
+    }
+
+    @Test
+    fun `computeBillingEditDistance returns zero for identical addresses`() {
+        val address = Address(
+            line1 = "510 Townsend St",
+            line2 = "Suite 200",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94102",
+            country = "US",
+        )
+        assertThat(computeBillingEditDistance(address, address)).isEqualTo(0)
+    }
+
+    @Test
+    fun `computeBillingEditDistance sums edits across fields`() {
+        val autocomplete = Address(
+            line1 = "510 Townsend St",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94102",
+            country = "US",
+        )
+        val billing = Address(
+            line1 = "510 Townsend Street",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94103",
+            country = "US",
+        )
+        // "St" -> "Street" = 4, "94102" -> "94103" = 1
+        assertThat(computeBillingEditDistance(autocomplete, billing)).isEqualTo(5)
+    }
+
+    @Test
+    fun `computeBillingEditDistance excludes country from calculation`() {
+        val autocomplete = Address(
+            line1 = "123 Main St",
+            city = "Toronto",
+            state = "ON",
+            postalCode = "M5V",
+            country = "CA",
+        )
+        val billing = Address(
+            line1 = "123 Main St",
+            city = "Toronto",
+            state = "ON",
+            postalCode = "M5V",
+            country = "US",
+        )
+        assertThat(computeBillingEditDistance(autocomplete, billing)).isEqualTo(0)
+    }
+
+    @Test
+    fun `computeBillingEditDistance treats null fields as empty strings`() {
+        val autocomplete = Address(
+            line1 = "123 Main St",
+            line2 = null,
+            city = "SF",
+            state = null,
+            postalCode = null,
+            country = "US",
+        )
+        val billing = Address(
+            line1 = "123 Main St",
+            line2 = "Apt 4",
+            city = "SF",
+            state = "CA",
+            postalCode = "94102",
+            country = "US",
+        )
+        // line2: "" -> "Apt 4" = 5, state: "" -> "CA" = 2, postalCode: "" -> "94102" = 5
+        assertThat(computeBillingEditDistance(autocomplete, billing)).isEqualTo(12)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -871,11 +871,6 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
-    fun `autocompleteFilledAddress is null initially`() = runScenario {
-        assertThat(delegate.autocompleteFilledAddress).isNull()
-    }
-
-    @Test
     fun `autocompleteFilledAddress tracks selected prediction address`() = runScenario {
         val fetchedAddress = Address(
             line1 = "123 Main Street",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -871,6 +871,53 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
+    fun `autocompleteFilledAddress is null initially`() = runScenario {
+        assertThat(delegate.autocompleteFilledAddress).isNull()
+    }
+
+    @Test
+    fun `autocompleteFilledAddress tracks selected prediction address`() = runScenario {
+        val fetchedAddress = Address(
+            line1 = "123 Main Street",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94105",
+            country = "US",
+        )
+        fakePlacesClient.fetchPlaceResult = Result.success(fetchedAddress)
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(emptyList())
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        delegate.onPredictionSelected("place_1")
+        advanceTimeBy(100)
+
+        fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
+        eventCalls.awaitItem()
+
+        assertThat(delegate.autocompleteFilledAddress).isEqualTo(fetchedAddress)
+    }
+
+    @Test
+    fun `autocompleteFilledAddress remains null after failed fetch`() = runScenario {
+        fakePlacesClient.fetchPlaceResult = Result.failure(RuntimeException("network error"))
+        fakePlacesClient.findPredictionsResult = Result.success(
+            FindAutocompletePredictionsResponse(emptyList())
+        )
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        delegate.onPredictionSelected("place_1")
+        advanceTimeBy(100)
+
+        fakePlacesClient.fetchPlaceCalls.awaitItem()
+        fakePlacesClient.resetSessionCalls.awaitItem()
+
+        assertThat(delegate.autocompleteFilledAddress).isNull()
+    }
+
+    @Test
     fun `onDismissed while find-predictions fetch is in-flight prevents stale results`() = runScenario {
         val fetchGate = CompletableDeferred<Unit>()
         fakePlacesClient.onBeforeFindPredictions = { fetchGate.await() }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1395,6 +1395,44 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onBillingAddressCompleted fires event with address data blob`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        eventReporter.onBillingAddressCompleted(
+            addressCountryCode = "US",
+            autocompleteResultSelected = true,
+            editDistance = 5,
+        )
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_billing_address_completed")
+        @Suppress("UNCHECKED_CAST")
+        val blob = request.params["address_data_blob"] as Map<String, Any>
+        assertThat(blob).containsEntry("address_country_code", "US")
+        assertThat(blob).containsEntry("auto_complete_result_selected", true)
+        assertThat(blob).containsEntry("edit_distance", 5)
+    }
+
+    @Test
+    fun `onBillingAddressCompleted omits edit distance when null`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        eventReporter.onBillingAddressCompleted(
+            addressCountryCode = "CA",
+            autocompleteResultSelected = false,
+            editDistance = null,
+        )
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_billing_address_completed")
+        @Suppress("UNCHECKED_CAST")
+        val blob = request.params["address_data_blob"] as Map<String, Any>
+        assertThat(blob).containsEntry("address_country_code", "CA")
+        assertThat(blob).containsEntry("auto_complete_result_selected", false)
+        assertThat(blob).doesNotContainKey("edit_distance")
+    }
+
+    @Test
     fun `onPaymentMethodMessagePromotionDisplayed fires event with duration`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
         durationProvider.elapsedCalls.push(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -97,6 +97,10 @@ internal class FakeEventReporter : EventReporter {
     val tapToAddAttemptWithUnsupportedDeviceCalls: ReceiveTurbine<Unit> =
         _tapToAddAttemptWithUnsupportedDeviceCalls
 
+    private val _billingAddressCompletedCalls = Turbine<BillingAddressCompletedCall>()
+    val billingAddressCompletedCalls: ReceiveTurbine<BillingAddressCompletedCall> =
+        _billingAddressCompletedCalls
+
     private val _pmmPromotionsFetched = Turbine<Unit>()
     val pmmPromotionsFetched: ReceiveTurbine<Unit> =
         _pmmPromotionsFetched
@@ -131,6 +135,7 @@ internal class FakeEventReporter : EventReporter {
         _tapToAddConfirmCalls.ensureAllEventsConsumed()
         _failedToAddCardWithTapToAddCalls.ensureAllEventsConsumed()
         _tapToAddAttemptWithUnsupportedDeviceCalls.ensureAllEventsConsumed()
+        _billingAddressCompletedCalls.ensureAllEventsConsumed()
         _pmmPromotionsFetched.ensureAllEventsConsumed()
         _pmmPromotionsDisplayed.ensureAllEventsConsumed()
     }
@@ -280,6 +285,20 @@ internal class FakeEventReporter : EventReporter {
     override fun onAnalyticsEvent(event: AnalyticsEvent) {
     }
 
+    override fun onBillingAddressCompleted(
+        addressCountryCode: String,
+        autocompleteResultSelected: Boolean,
+        editDistance: Int?,
+    ) {
+        _billingAddressCompletedCalls.add(
+            BillingAddressCompletedCall(
+                addressCountryCode = addressCountryCode,
+                autocompleteResultSelected = autocompleteResultSelected,
+                editDistance = editDistance,
+            )
+        )
+    }
+
     override fun onPaymentMethodMessagePromotionsFetchBegin() {
         _pmmPromotionsFetched.add(Unit)
     }
@@ -391,5 +410,11 @@ internal class FakeEventReporter : EventReporter {
 
     data class FormCompletedCall(
         val code: PaymentMethodCode
+    )
+
+    data class BillingAddressCompletedCall(
+        val addressCountryCode: String,
+        val autocompleteResultSelected: Boolean,
+        val editDistance: Int?,
     )
 }


### PR DESCRIPTION


# Summary
<!-- Simple summary of what was changed. -->
Add mc_billing_address_completed analytics event that fires when the user confirms payment in PaymentSheet or FlowController with billing address filled.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
 We need to track billing address completion analytics to understand autocomplete usage in the billing address flow. This event reports address_country_code, auto_complete_result_selected, and edit_distance (Levenshtein distance between autocomplete-filled  address and final submitted address) within an address_data_blob. All code is gated behind FeatureFlags.inlineAddressAutocompleteEnabled.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
