### PR TITLE
Don't expand form on fetchPlace failure in inline autocomplete

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -78,7 +78,6 @@ internal class InlineAutocompleteController(
     fun onPredictionSelected(predictionId: String) {
         selectionJob?.cancel()
         val queryAtSelection = queryFlow?.value
-        val countryAtSelection = countryFlow?.value
         selectionJob = coroutineScope.launch {
             val locale = AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault()
             try {
@@ -86,7 +85,7 @@ internal class InlineAutocompleteController(
                 ensureActive()
                 result.fold(
                     onSuccess = { handleFetchPlaceSuccess(it) },
-                    onFailure = { handleFailure(queryAtSelection, countryAtSelection) }
+                    onFailure = { handleFailure(queryAtSelection) }
                 )
             } finally {
                 placesClient.resetSession()
@@ -185,12 +184,12 @@ internal class InlineAutocompleteController(
         )
     }
 
-    private fun handleFailure(query: String?, country: String?) {
+    private fun handleFailure(query: String?) {
         lastPredictionLine1 = null
-        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
-        if (config.shouldUseStripeHostedAutocomplete) {
-            emitExpandForm(query = query, country = country)
-        }
+        _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Results(
+            query = query ?: "",
+            predictions = emptyList(),
+        )
     }
 
     private fun emitExpandForm(query: String?, country: String?) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -281,7 +281,7 @@ class InlineAutocompleteControllerTest {
             fakePlacesClient.fetchPlaceCalls.awaitItem()
             fakePlacesClient.resetSessionCalls.awaitItem()
             assertThat(delegate.inlinePredictionsState.value)
-                .isEqualTo(InlinePredictionsState.Idle)
+                .isEqualTo(InlinePredictionsState.Results(query = "", predictions = emptyList()))
         }
 
     @Test
@@ -728,9 +728,8 @@ class InlineAutocompleteControllerTest {
         val call = fakePlacesClient.fetchPlaceCalls.awaitItem()
         assertThat(call.placeId).isEqualTo("place-id-123")
         fakePlacesClient.resetSessionCalls.awaitItem()
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
-        assertThat(eventCalls.awaitItem())
-            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+        assertThat(delegate.inlinePredictionsState.value)
+            .isEqualTo(InlinePredictionsState.Results(query = "", predictions = emptyList()))
     }
 
     @Test
@@ -761,14 +760,8 @@ class InlineAutocompleteControllerTest {
 
         fakePlacesClient.fetchPlaceCalls.awaitItem()
         fakePlacesClient.resetSessionCalls.awaitItem()
-        assertThat(delegate.inlinePredictionsState.value).isEqualTo(InlinePredictionsState.Idle)
-        assertThat(eventCalls.awaitItem()).isEqualTo(
-            AutocompleteAddressInteractor.Event.OnExpandForm(
-                values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main",
-                    IdentifierSpec.Country to "US",
-                )
-            )
+        assertThat(delegate.inlinePredictionsState.value).isEqualTo(
+            InlinePredictionsState.Results(query = "123 Main", predictions = emptyList())
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
On fetchPlace failure in inline autocomplete, keep the dropdown open with empty results instead of expanding to the full address form.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When the Stripe-hosted autocomplete proxy failed to resolve a place, the controller emitted OnExpandForm, which rebuilt the entire address form (inline → full). This caused a jarring UI jump, focus loss, and keyboard dismissal, a poor UX with no easy recovery path. Now on failure, the state transitions to Results(empty) which keeps the dropdown visible with the "Enter manually" button accessible, letting the user choose how to proceed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

Updated 3 existing tests in InlineAutocompleteControllerTest to assert the new behavior.
<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->