### PR TITLE
Close embedded content interactors when replaced

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContent.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodEmbeddedLayoutUI
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.uicore.StripeTheme
+import java.io.Closeable
 
 @Immutable
 internal data class EmbeddedContent(
@@ -17,7 +18,11 @@ internal data class EmbeddedContent(
     private val embeddedViewDisplaysMandateText: Boolean,
     private val appearance: Embedded,
     private val isImmediateAction: Boolean,
-) {
+) : Closeable {
+    override fun close() {
+        interactor.close()
+    }
+
     @Composable
     fun Content() {
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -37,23 +37,23 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     init {
         coroutineScope.launch {
             state.collect { state ->
-                _embeddedContent.value = if (state == null) {
-                    null
-                } else {
+                val replacement = state?.let { currentState ->
                     val isImmediateAction = internalRowSelectionCallback.get() != null
                     EmbeddedContent(
                         interactor = verticalLayoutInteractorFactory.create(
-                            paymentMethodMetadata = state.paymentMethodMetadata,
-                            configuration = state.configuration,
-                            walletsState = embeddedWalletsHelper.walletsState(state.paymentMethodMetadata),
+                            paymentMethodMetadata = currentState.paymentMethodMetadata,
+                            configuration = currentState.configuration,
+                            walletsState = embeddedWalletsHelper.walletsState(currentState.paymentMethodMetadata),
                             isImmediateAction = isImmediateAction,
-                            embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
+                            embeddedViewDisplaysMandateText = currentState.embeddedViewDisplaysMandateText,
                         ),
-                        embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
-                        appearance = state.appearance,
+                        embeddedViewDisplaysMandateText = currentState.embeddedViewDisplaysMandateText,
+                        appearance = currentState.appearance,
                         isImmediateAction = isImmediateAction,
                     )
                 }
+                _embeddedContent.value?.close()
+                _embeddedContent.value = replacement
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
@@ -7,13 +7,10 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Tracks stability of payment method positioning and dispatches analytics when stable
@@ -28,7 +25,7 @@ import kotlin.coroutines.CoroutineContext
 internal class PaymentMethodInitialVisibilityTracker(
     private var expectedItems: List<String> = emptyList(),
     private val renderedLpmCallback: (List<String>, List<String>) -> Unit,
-    dispatcher: CoroutineContext = Dispatchers.Default,
+    private val coroutineScope: CoroutineScope,
 ) {
     private data class CoordinateSnapshot(
         val positionInWindow: Offset,
@@ -41,7 +38,6 @@ internal class PaymentMethodInitialVisibilityTracker(
     private val coordinateStabilityMap = mutableMapOf<String, Boolean>()
     private var hasDispatched = false
 
-    private val coroutineScope = CoroutineScope(dispatcher)
     private var dispatchEventJob: Job? = null
 
     fun updateExpectedItems(items: List<String>) {
@@ -182,7 +178,7 @@ internal class PaymentMethodInitialVisibilityTracker(
         visibilityMap.clear()
         hasDispatched = false
         dispatchEventJob?.cancel()
-        coroutineScope.cancel() // Cancel the entire scope
+        dispatchEventJob = null
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -604,7 +604,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         renderedLpmCallback = { visiblePaymentMethods, hiddenPaymentMethods ->
             onInitiallyDisplayedPaymentMethodVisibilitySnapshot(visiblePaymentMethods, hiddenPaymentMethods)
         },
-        dispatcher = dispatcher
+        coroutineScope = coroutineScope,
     )
 
     private fun updatePaymentMethodVisibility(itemCode: String, layoutCoordinates: LayoutCoordinates) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.embedded.content
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
@@ -11,26 +10,17 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
-import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.utils.stateFlowOf
-import com.stripe.android.utils.FakeIsNfcScanningAvailable
-import com.stripe.android.utils.FakeLinkConfigurationCoordinator
-import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
-import com.stripe.android.utils.FakeSavedPaymentMethodRepository
-import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -56,7 +46,7 @@ internal class DefaultEmbeddedContentHelperTest {
     }
 
     @Test
-    fun `embeddedContent emits null when state is set to null`() = testScenario {
+    fun `clearing content closes the current interactor and emits null`() = testScenario {
         embeddedContentHelper.embeddedContent.test {
             assertThat(awaitItem()).isNull()
             state.value = EmbeddedContentHelperStateHolder.State(
@@ -66,8 +56,33 @@ internal class DefaultEmbeddedContentHelperTest {
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
             )
             assertThat(awaitItem()).isNotNull()
+            val interactor = verticalLayoutInteractors.single()
+
             state.value = null
+
             assertThat(awaitItem()).isNull()
+            interactor.closeCalls.awaitItem()
+        }
+    }
+
+    @Test
+    fun `replacing content closes only the previous interactor`() = testScenario {
+        embeddedContentHelper.embeddedContent.test {
+            assertThat(awaitItem()).isNull()
+            state.value = EmbeddedContentHelperStateFactory.create(
+                appearance = Embedded(Embedded.RowStyle.FlatWithRadio.default),
+            )
+            assertThat(awaitItem()).isNotNull()
+            val previousInteractor = verticalLayoutInteractors.single()
+
+            state.value = EmbeddedContentHelperStateFactory.create(
+                appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
+            )
+
+            assertThat(awaitItem()).isNotNull()
+            val replacementInteractor = verticalLayoutInteractors.last()
+            previousInteractor.closeCalls.awaitItem()
+            replacementInteractor.closeCalls.expectNoEvents()
         }
     }
 
@@ -137,6 +152,7 @@ internal class DefaultEmbeddedContentHelperTest {
         val state: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
         val sheetStateHolder: SheetStateHolder,
         val errorReporter: FakeErrorReporter,
+        val verticalLayoutInteractors: List<FakePaymentMethodVerticalLayoutInteractor>,
     )
 
     @OptIn(ExperimentalAnalyticEventCallbackApi::class)
@@ -148,20 +164,7 @@ internal class DefaultEmbeddedContentHelperTest {
     ) = runTest(UnconfinedTestDispatcher()) {
         val savedStateHandle = SavedStateHandle().apply { setup() }
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
-        val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
-            embeddedSelectionHolder = selectionHolder,
-            savedStateHandle = savedStateHandle,
-            isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
-        )
-        val confirmationHandler = FakeConfirmationHandler()
-        val eventReporter = FakeEventReporter()
         val errorReporter = FakeErrorReporter()
-        val immediateActionHandler = DefaultEmbeddedRowSelectionImmediateActionHandler(
-            coroutineScope = backgroundScope,
-            internalRowSelectionCallback = { null }
-        )
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,
@@ -170,34 +173,15 @@ internal class DefaultEmbeddedContentHelperTest {
             ),
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
-        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
 
         val state = MutableStateFlow(initialState)
-        val savedPaymentMethodMutatorFactory = EmbeddedContentSavedPaymentMethodMutatorFactory(
-            eventReporter = eventReporter,
-            workContext = Dispatchers.Unconfined,
-            uiContext = Dispatchers.Unconfined,
-            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
-            selectionHolder = selectionHolder,
-            customerStateHolder = customerStateHolder,
-            linkAccountHolder = linkAccountHolder,
-            coroutineScope = backgroundScope,
-            sheetStateHolder = sheetStateHolder,
-        )
-        val verticalLayoutInteractorFactory = DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory(
-            eventReporter = eventReporter,
-            embeddedFormHelperFactory = embeddedFormHelperFactory,
-            confirmationHandler = confirmationHandler,
-            selectionHolder = selectionHolder,
-            customerStateHolder = customerStateHolder,
-            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
-            rowSelectionImmediateActionHandler = immediateActionHandler,
-            coroutineScope = backgroundScope,
-            sheetStateHolder = sheetStateHolder,
-            savedPaymentMethodMutatorFactory = savedPaymentMethodMutatorFactory,
-            linkAccountHolder = linkAccountHolder,
-        )
+        val verticalLayoutInteractors = mutableListOf<FakePaymentMethodVerticalLayoutInteractor>()
+        val verticalLayoutInteractorFactory = EmbeddedPaymentMethodVerticalLayoutInteractorFactory {
+            paymentMethodMetadata, _, _, _, _ ->
+            FakePaymentMethodVerticalLayoutInteractor.create(paymentMethodMetadata)
+                .also(verticalLayoutInteractors::add)
+        }
 
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
             coroutineScope = backgroundScope,
@@ -215,9 +199,9 @@ internal class DefaultEmbeddedContentHelperTest {
             state = state,
             sheetStateHolder = sheetStateHolder,
             errorReporter = errorReporter,
+            verticalLayoutInteractors = verticalLayoutInteractors,
         ).block()
-        confirmationHandler.validate()
-        eventReporter.validate()
+        verticalLayoutInteractors.forEach(FakePaymentMethodVerticalLayoutInteractor::validate)
     }
 
     private class RecordingEmbeddedSheetLauncher : EmbeddedSheetLauncher {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1762,24 +1762,83 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun visibilityTracker_doesNotEmitWhenCancellingTracking() = runScenario(
-        initialPaymentMethods = PaymentMethodFixtures.createCards(1)
+    fun visibilityTracker_doesNotEmitWhenCancellingPendingTracking() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card")
+            )
+        ),
     ) {
-        val fakeLayoutCoordinates = FakeLayoutCoordinatesFixtures.FULLY_HIDDEN_COORDINATES
+        val fakeLayoutCoordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
 
         interactor.handleViewAction(
-            ViewAction.UpdatePaymentMethodVisibility("saved", fakeLayoutCoordinates)
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
+        )
+        interactor.handleViewAction(
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
         )
 
-        // Resets tracking so the second action should not emit an event
+        interactor.handleViewAction(
+            ViewAction.CancelPaymentMethodVisibilityTracking
+        )
+
+        testScope.testScheduler.advanceUntilIdle()
+
+        visibilitySnapshotTurbine.expectNoEvents()
+    }
+
+    @Test
+    fun visibilityTracker_emitsAfterCancellingAndRestartingTracking() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card")
+            )
+        ),
+    ) {
+        val fakeLayoutCoordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
+
+        interactor.handleViewAction(
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
+        )
+        interactor.handleViewAction(
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
+        )
         interactor.handleViewAction(
             ViewAction.CancelPaymentMethodVisibilityTracking
         )
 
         interactor.handleViewAction(
-            ViewAction.UpdatePaymentMethodVisibility("saved", fakeLayoutCoordinates)
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
+        )
+        interactor.handleViewAction(
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
         )
 
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertThat(visibilitySnapshotTurbine.awaitItem()).isEqualTo(
+            Pair(listOf("card"), emptyList<String>())
+        )
+    }
+
+    @Test
+    fun visibilityTracker_doesNotEmitPendingEventAfterClose() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card")
+            )
+        ),
+    ) {
+        val fakeLayoutCoordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
+
+        interactor.handleViewAction(
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
+        )
+        interactor.handleViewAction(
+            ViewAction.UpdatePaymentMethodVisibility("card", fakeLayoutCoordinates)
+        )
+
+        interactor.close()
         testScope.testScheduler.advanceUntilIdle()
 
         visibilitySnapshotTurbine.expectNoEvents()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTrackerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTrackerTest.kt
@@ -3,8 +3,8 @@ package com.stripe.android.paymentsheet.verticalmode
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.IntSize
 import com.stripe.android.testing.CoroutineTestRule
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -267,7 +267,7 @@ class PaymentMethodInitialVisibilityTrackerTest {
     }
 
     @Test
-    fun `dispose - cancels pending jobs and cleans up resources`() = runTest {
+    fun `reset - cancels pending jobs and clears tracking state`() = runTest {
         val tracker = getTracker(
             expectedItems = listOf("card"),
         )
@@ -278,11 +278,30 @@ class PaymentMethodInitialVisibilityTrackerTest {
         tracker.updateVisibility("card", coordinates)
         tracker.updateVisibility("card", coordinates)
 
+        advanceTimeBy(TIME_ADVANCE_LESSER_THAN_DEBOUNCE_DELAY)
         tracker.reset()
 
         // Should not dispatch even after delay
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
         verifyNoCallback(callback)
+    }
+
+    @Test
+    fun `reset - tracker can dispatch a new event after reset`() = runTest {
+        val tracker = getTracker(
+            expectedItems = listOf("card"),
+        )
+        val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
+
+        tracker.updateVisibility("card", coordinates)
+        tracker.updateVisibility("card", coordinates)
+        tracker.reset()
+
+        tracker.updateVisibility("card", coordinates)
+        tracker.updateVisibility("card", coordinates)
+        advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
+
+        verify(callback).invoke(listOf("card"), emptyList())
     }
 
     @Test
@@ -369,11 +388,11 @@ class PaymentMethodInitialVisibilityTrackerTest {
     private val defaultCoordinateSize = IntSize(100, 50)
     private val defaultBounds = Rect(0f, 0f, 100f, 50f)
 
-    private fun getTracker(expectedItems: List<String>): PaymentMethodInitialVisibilityTracker {
+    private fun TestScope.getTracker(expectedItems: List<String>): PaymentMethodInitialVisibilityTracker {
         return PaymentMethodInitialVisibilityTracker(
             expectedItems = expectedItems,
             renderedLpmCallback = callback,
-            dispatcher = Dispatchers.Main,
+            coroutineScope = this,
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We were not cancelling the interactor used prior to the data causing it to be replaced.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Ensure we don't have lingering listeners that cause leaks or confusing debugging flows.