### PR TITLE
Remove updateLineItemQuantity, selectShippingOption, and updateTaxId.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -131,30 +131,6 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
-     * Updates the quantity of a line item.
-     *
-     * @param lineItemId The ID of the line item to update.
-     * @param quantity The new quantity.
-     */
-    suspend fun updateLineItemQuantity(
-        lineItemId: String,
-        quantity: Int,
-    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
-        checkoutSessionRepository.updateLineItemQuantity(sessionId, lineItemId, quantity)
-    }
-
-    /**
-     * Selects a shipping option.
-     *
-     * @param id The ID of the shipping option to select.
-     */
-    suspend fun selectShippingOption(
-        id: String,
-    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
-        checkoutSessionRepository.selectShippingRate(sessionId, id)
-    }
-
-    /**
      * Sets the shipping address for this checkout.
      *
      * The address is stored locally and used when presenting payment UI. If automatic tax is
@@ -182,19 +158,6 @@ class CheckoutController @Inject internal constructor(
                 ),
             )
         }
-    }
-
-    /**
-     * Updates the customer's tax ID.
-     *
-     * @param type The type of tax ID (e.g. "eu_vat"). Leading/trailing whitespace is trimmed.
-     * @param value The tax ID value. Leading/trailing whitespace is trimmed.
-     */
-    suspend fun updateTaxId(
-        type: String,
-        value: String,
-    ): kotlin.Result<Unit> = withCheckoutState { sessionId ->
-        checkoutSessionRepository.updateTaxId(sessionId, type.trim(), value.trim())
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -128,30 +128,6 @@ internal class CheckoutSessionRepository @Inject constructor(
         ),
     )
 
-    suspend fun updateLineItemQuantity(
-        sessionId: String,
-        lineItemId: String,
-        quantity: Int,
-    ): Result<CheckoutSessionResponse> = executePost(
-        url = updateUrl(sessionId),
-        params = mapOf(
-            "updated_line_item_quantity[line_item_id]" to lineItemId,
-            "updated_line_item_quantity[quantity]" to quantity.toString(),
-            "updated_line_item_quantity[fail_update_on_discount_error]" to "true",
-        ),
-    )
-
-    suspend fun selectShippingRate(
-        sessionId: String,
-        shippingRateId: String,
-    ): Result<CheckoutSessionResponse> = executePost(
-        url = updateUrl(sessionId),
-        params = mapOf(
-            "shipping_rate" to shippingRateId,
-            "elements_session_client[is_aggregation_expected]" to "true",
-        ),
-    )
-
     suspend fun updateTaxRegion(
         sessionId: String,
         address: Address.State,
@@ -166,19 +142,6 @@ internal class CheckoutSessionRepository @Inject constructor(
             putIfNotEmpty("tax_region[postal_code]", address.postalCode)
             put("elements_session_client[is_aggregation_expected]", "true")
         },
-    )
-
-    suspend fun updateTaxId(
-        sessionId: String,
-        type: String,
-        value: String,
-    ): Result<CheckoutSessionResponse> = executePost(
-        url = updateUrl(sessionId),
-        params = mapOf(
-            "tax_id_collection[tax_id][type]" to type,
-            "tax_id_collection[tax_id][value]" to value,
-            "elements_session_client[is_aggregation_expected]" to "true",
-        ),
     )
 
     suspend fun updateEmail(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -460,37 +460,6 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `updateLineItemQuantity sends line item params and updates session on success`() = runMutationScenario {
-        networkRule.checkoutUpdate(
-            bodyPart("updated_line_item_quantity[line_item_id]", "li_1"),
-            bodyPart("updated_line_item_quantity[quantity]", "3"),
-            bodyPart("updated_line_item_quantity[fail_update_on_discount_error]", "true"),
-            responseFactory = successResponseFactory { json ->
-                json.put("total_summary", totalSummaryJson(due = 7000))
-            },
-        )
-
-        val result = controller.updateLineItemQuantity("li_1", 3)
-
-        result.getOrThrow()
-        assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(7000)
-    }
-
-    @Test
-    fun `updateLineItemQuantity returns failure and preserves session on error`() = runMutationScenario {
-        networkRule.checkoutUpdate { response ->
-            response.setResponseCode(400)
-            response.setBody("""{"error": {"message": "Invalid quantity"}}""")
-        }
-        val before = controller.session.value
-
-        val result = controller.updateLineItemQuantity("li_1", -1)
-
-        assertThat(result.isFailure).isTrue()
-        assertThat(controller.session.value).isEqualTo(before)
-    }
-
-    @Test
     fun `updateCurrency sends updated_currency and updates session on success`() = runMutationScenario {
         networkRule.checkoutUpdate(
             bodyPart("updated_currency", "usd"),
@@ -517,60 +486,6 @@ internal class CheckoutControllerTest {
 
         assertThat(result.isFailure).isTrue()
         assertThat(controller.session.value).isEqualTo(before)
-    }
-
-    @Test
-    fun `selectShippingOption sends shipping rate on success`() = runMutationScenario {
-        networkRule.checkoutUpdate(
-            bodyPart("shipping_rate", "shr_express"),
-            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
-            responseFactory = successResponseFactory(),
-        )
-
-        val result = controller.selectShippingOption("shr_express")
-
-        assertThat(result.isSuccess).isTrue()
-    }
-
-    @Test
-    fun `selectShippingOption returns failure on error`() = runMutationScenario {
-        networkRule.checkoutUpdate { response ->
-            response.setResponseCode(400)
-            response.setBody("""{"error": {"message": "Invalid shipping rate"}}""")
-        }
-        val before = controller.session.value
-
-        val result = controller.selectShippingOption("shr_invalid")
-
-        assertThat(result.isFailure).isTrue()
-        assertThat(controller.session.value).isEqualTo(before)
-    }
-
-    @Test
-    fun `updateTaxId sends type and value on success`() = runMutationScenario {
-        networkRule.checkoutUpdate(
-            bodyPart("tax_id_collection[tax_id][type]", "us_ein"),
-            bodyPart("tax_id_collection[tax_id][value]", "123456789"),
-            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
-            responseFactory = successResponseFactory(),
-        )
-
-        val result = controller.updateTaxId("us_ein", "123456789")
-
-        assertThat(result.isSuccess).isTrue()
-    }
-
-    @Test
-    fun `updateTaxId trims whitespace from type and value`() = runMutationScenario {
-        networkRule.checkoutUpdate(
-            bodyPart("tax_id_collection[tax_id][type]", "us_ein"),
-            bodyPart("tax_id_collection[tax_id][value]", "123456789"),
-            responseFactory = successResponseFactory(),
-        )
-
-        val result = controller.updateTaxId("  us_ein  ", "  123456789  ")
-
-        assertThat(result.isSuccess).isTrue()
     }
 
     @Test
@@ -1014,14 +929,14 @@ internal class CheckoutControllerTest {
             // The second mutation must target the session id produced by the first, proving the
             // mutex serialized them (an unserialized call would hit the original id and fail).
             networkRule.checkoutUpdate(
-                bodyPart("updated_line_item_quantity[line_item_id]", "li_1"),
+                bodyPart("customer_email", "example3@example.com"),
                 sessionId = "cs_test_after_promo",
                 responseFactory = successResponseFactory { json -> json.put("session_id", "cs_test_after_promo") },
             )
 
             val results = listOf(
                 async { controller.applyPromotionCode("10OFF") },
-                async { controller.updateLineItemQuantity("li_1", 2) },
+                async { controller.updateEmail("example3@example.com") },
             ).awaitAll()
 
             assertThat(results[0].isSuccess).isTrue()


### PR DESCRIPTION
# Summary
Removed support for updateLineItemQuantity, selectShippingOption, and updateTaxId from CheckoutController and related repositories. Corresponding tests have also been deleted.

# Motivation
These APIs will not be part of private preview.
