### PR TITLE
Annotate LinkVisibility and GooglePayVisibility with CheckoutSessionPreview.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ExpressCheckoutElement.kt
@@ -25,12 +25,14 @@ class ExpressCheckoutElement @Inject internal constructor(
     class Configuration {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @CheckoutSessionPreview
         enum class LinkVisibility {
             Auto,
             Never,
         }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @CheckoutSessionPreview
         enum class GooglePayVisibility {
             Auto,
             Never,


### PR DESCRIPTION
# Summary
Added the @CheckoutSessionPreview annotation to the LinkVisibility and GooglePayVisibility enums in ExpressCheckoutElement.Configuration.

# Motivation
To clearly indicate that these enums are related to checkout session preview functionality, improving code clarity and maintainability.
