### PR TITLE
Include the executed APDU commands in reported NFC attempt error

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporter.kt
@@ -113,7 +113,7 @@ internal class DefaultNfcScanningEventReporter @Inject constructor(
 
     private fun fireEvent(
         eventName: String,
-        additionalParams: Map<String, Any> = emptyMap()
+        additionalParams: Map<String, Any?> = emptyMap()
     ) {
         analyticsRequestExecutor.executeAsync(
             analyticsRequestFactory.createRequest(

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcCardReader.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.nfcscan.scanner
 
+import com.stripe.android.common.nfcscan.scanner.apdu.ApduCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.GetProcessingOptionsCommand
 import com.stripe.android.common.nfcscan.scanner.apdu.PdolTemplate
 import com.stripe.android.common.nfcscan.scanner.apdu.ReadRecordCommand
@@ -30,27 +31,34 @@ internal class ApduCardReader @Inject constructor(
     private val cardDataParser: NfcCardDataParser,
 ) : NfcCardReader {
     override suspend fun readCard(transceiver: NfcTagTransceiver): NfcCardReader.Result {
-        return runCatching {
-            readFromTransceiver(transceiver)
-        }.fold(
-            onSuccess = { it },
-            onFailure = {
-                NfcCardReader.Result.Error(mapError(it))
-            },
-        )
+        return withEnvironment(transceiver) {
+            runCatching {
+                readFromTransceiver(transceiver)
+            }.fold(
+                onSuccess = { it },
+                onFailure = {
+                    val cause = mapError(it)
+
+                    NfcCardReader.Result.Error(
+                        NfcReadingSequenceError(
+                            cause = cause,
+                            executedCommands = executedCommands(),
+                        )
+                    )
+                },
+            )
+        }
     }
 
-    private suspend fun readFromTransceiver(
+    private fun ApduEnvironment.readFromTransceiver(
         transceiver: NfcTagTransceiver
-    ): NfcCardReader.Result = withContext(workContext) {
+    ): NfcCardReader.Result {
         try {
             transceiver.open()
 
-            val applicationIdentifier = SelectPpseCommand.transceiveWith(transceiver).getOrThrow()
+            val applicationIdentifier = SelectPpseCommand.execute().getOrThrow()
 
-            val pdolTemplate = SelectApplicationCommand(applicationIdentifier)
-                .transceiveWith(transceiver)
-                .getOrThrow()
+            val pdolTemplate = SelectApplicationCommand(applicationIdentifier).execute().getOrThrow()
 
             val pdolData = when (pdolTemplate) {
                 is PdolTemplate.Available -> pdolBuilder.fromTemplate(
@@ -61,7 +69,7 @@ internal class ApduCardReader @Inject constructor(
             }
 
             val processingOptionsInfo = GetProcessingOptionsCommand(pdolData)
-                .transceiveWith(transceiver)
+                .execute()
                 .getOrThrow()
 
             val records = processingOptionsInfo.records.toMutableMap()
@@ -69,14 +77,14 @@ internal class ApduCardReader @Inject constructor(
             processingOptionsInfo.aflEntries.forEach { entry ->
                 for (record in entry.firstRecord..entry.lastRecord) {
                     ReadRecordCommand(record, entry.shortFileIdentifier)
-                        .transceiveWith(transceiver)
+                        .execute()
                         .onSuccess { readRecords ->
                             records += readRecords
                         }
                 }
             }
 
-            when (val parseResult = cardDataParser.parse(records)) {
+            return when (val parseResult = cardDataParser.parse(records)) {
                 is NfcCardDataParser.Result.Success -> NfcCardReader.Result.Found(
                     scannedCardData = parseResult.cardData
                 )
@@ -98,9 +106,43 @@ internal class ApduCardReader @Inject constructor(
         }
     }
 
+    private suspend fun <T> withEnvironment(
+        transceiver: NfcTagTransceiver,
+        block: suspend ApduEnvironment.() -> T
+    ) = withContext(workContext) {
+        block(ApduEnvironment(transceiver))
+    }
+
     private companion object {
         const val UNKNOWN_NFC_ERROR = "unknownNfcError"
         const val TRANSCEIVER_SECURITY_ERROR_CODE = "nfcTransceiverSecurityError"
         const val TRANSCEIVER_IO_ERROR_CODE = "nfcTransceiverIoError"
+    }
+
+    private class ApduEnvironment(
+        private val transceiver: NfcTagTransceiver,
+    ) {
+        private val executedCommands = mutableListOf<String>()
+
+        fun executedCommands(): List<String> = executedCommands
+
+        fun <TResponse> ApduCommand<TResponse>.execute(): Result<TResponse> {
+            executedCommands.add(name)
+
+            return transceiveWith(transceiver)
+        }
+    }
+}
+
+internal class NfcReadingSequenceError(
+    override val cause: NfcScanningError,
+    executedCommands: List<String>,
+) : NfcScanningError() {
+    override val errorCode = cause.errorCode
+    override val userMessage = cause.userMessage
+    override val parameters = cause.parameters + mapOf(FIELD_EXECUTED_COMMANDS to executedCommands)
+
+    private companion object {
+        const val FIELD_EXECUTED_COMMANDS = "executed_commands"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcScanningError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/NfcScanningError.kt
@@ -9,12 +9,12 @@ internal abstract class NfcScanningError : Throwable() {
 
     abstract val userMessage: ResolvableString
 
-    open val parameters: Map<String, String> = emptyMap()
+    open val parameters: Map<String, Any?> = emptyMap()
 }
 
 internal data class GenericNfcScanningError(
     override val errorCode: String,
     override val userMessage: ResolvableString =
         R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-    override val parameters: Map<String, String> = emptyMap(),
+    override val parameters: Map<String, Any?> = emptyMap(),
 ) : NfcScanningError()

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
@@ -8,6 +8,11 @@ import com.stripe.android.common.nfcscan.scanner.NfcTagTransceiver
  */
 internal abstract class ApduCommand<TResponseData> {
     /**
+     * Human-readable name for debugging and analytics.
+     */
+    abstract val name: String
+
+    /**
      * Instruction class - indicates the type of command
      */
     protected abstract val classByte: Byte

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/GetProcessingOptionsCommand.kt
@@ -6,6 +6,7 @@ package com.stripe.android.common.nfcscan.scanner.apdu
 internal class GetProcessingOptionsCommand(
     val pdolData: ByteArray,
 ) : ApduCommand<ProcessingOptionsInfo>() {
+    override val name = "getProcessingOptions"
     override val classByte = 0x80.toByte()
     override val instructionByte = 0xA8.toByte()
     override val firstParameterByte = 0x00.toByte()

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ReadRecordCommand.kt
@@ -7,6 +7,8 @@ internal data class ReadRecordCommand(
     val recordNumber: Int,
     val shortFileIdentifier: Int,
 ) : ApduCommand<Map<String, ByteArray>>() {
+    override val name = "readRecord(sfi=$shortFileIdentifier, number=$recordNumber)"
+
     /*
      * Interindustry standardized command for ISO 7816-4
      */

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectApplicationCommand.kt
@@ -6,6 +6,8 @@ package com.stripe.android.common.nfcscan.scanner.apdu
 internal data class SelectApplicationCommand(
     val aid: ApplicationIdentifier,
 ) : ApduCommand<PdolTemplate>() {
+    override val name = "selectApplication(aid=${aid.value.uppercase()})"
+
     /*
      * Interindustry standardized command for ISO 7816-4
      */

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/SelectPpseCommand.kt
@@ -6,6 +6,8 @@ import com.stripe.android.model.CardBrand
  * An APDU command for retrieving the payment application on the credit card chip
  */
 internal data object SelectPpseCommand : ApduCommand<ApplicationIdentifier>() {
+    override val name = "selectPpse"
+
     /*
      * Interindustry standardized command for ISO 7816-4
      */

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTest.kt
@@ -80,7 +80,14 @@ internal class NfcScanningActivityAnalyticsTest {
     fun `declined card fires attempt failed with error code`() {
         networkRule.expectNfcScanStarted()
         networkRule.expectNfcScanAttemptStarted()
-        networkRule.expectNfcScanAttemptFailed(errorCode = "cardDeclinedByNfc")
+        networkRule.expectNfcScanAttemptFailed(
+            errorCode = "cardDeclinedByNfc",
+            errorMatchers = createApduErrorMatchers(
+                executedCommands = listOf("selectPpse"),
+                sw1 = "69",
+                sw2 = "85",
+            ),
+        )
 
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.declinedCardResponses())
@@ -93,7 +100,14 @@ internal class NfcScanningActivityAnalyticsTest {
     fun `unsupported card fires attempt failed with error code`() {
         networkRule.expectNfcScanStarted()
         networkRule.expectNfcScanAttemptStarted()
-        networkRule.expectNfcScanAttemptFailed(errorCode = "cardUnsupportedByNfc")
+        networkRule.expectNfcScanAttemptFailed(
+            errorCode = "cardUnsupportedByNfc",
+            errorMatchers = createApduErrorMatchers(
+                executedCommands = listOf("selectPpse"),
+                sw1 = "6A",
+                sw2 = "82",
+            ),
+        )
 
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.unsupportedCardResponses())
@@ -103,10 +117,38 @@ internal class NfcScanningActivityAnalyticsTest {
     }
 
     @Test
+    fun `select application failure includes executed commands in analytics`() {
+        networkRule.expectNfcScanStarted()
+        networkRule.expectNfcScanAttemptStarted()
+        networkRule.expectNfcScanAttemptFailed(
+            errorCode = "cardUnsupportedByNfc",
+            errorMatchers = createApduErrorMatchers(
+                executedCommands = listOf(
+                    "selectPpse",
+                    "selectApplication(aid=A0000000031010)",
+                ),
+                sw1 = "6A",
+                sw2 = "82",
+            ),
+        )
+
+        launchScenario {
+            dispatchCardRead(NfcScanningActivityTestFixtures.selectApplicationFailureResponses())
+            assertErrorIsDisplayed(errorText = "Card not supported. Try another card.")
+            isoDep.assertConnect()
+            isoDep.assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_PPSE)
+            isoDep.assertCommand(NfcScanningActivityTestFixtures.ApduCommands.SELECT_VISA_APPLICATION)
+            isoDep.assertClose()
+        }
+    }
+
+    @Test
     fun `expired card fires attempt failed with error code`() {
         networkRule.expectNfcScanStarted()
         networkRule.expectNfcScanAttemptStarted()
-        networkRule.expectNfcScanAttemptFailed(errorCode = "expiredCard")
+        networkRule.expectNfcScanAttemptFailed(
+            errorCode = "expiredCard",
+        )
 
         launchScenario {
             dispatchCardRead(NfcScanningActivityTestFixtures.expiredCardResponses())

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTestHelpers.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.nfcscan
 
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.query
@@ -30,24 +31,39 @@ internal fun NetworkRule.expectNfcScanSuccess() {
 
 internal fun NetworkRule.expectNfcScanAttemptFailed(
     errorCode: String,
+    errorMatchers: List<RequestMatcher> = emptyList(),
 ) {
     expectAnalyticsEvent(
         eventName = "${EVENT_PREFIX}nfc_scan_attempt_failed",
-        errorCode = errorCode,
+        matchers = listOf(
+            query("error_code", errorCode),
+        ) + errorMatchers,
+    )
+}
+
+internal fun createApduErrorMatchers(
+    executedCommands: List<String>,
+    sw1: String,
+    sw2: String
+): List<RequestMatcher> {
+    return listOf(
+        query("sw1", sw1),
+        query("sw2", sw2),
+        RequestMatcher { request ->
+            request.queryParameterValues("executed_commands[]") == executedCommands
+        },
     )
 }
 
 private fun NetworkRule.expectAnalyticsEvent(
     eventName: String,
-    errorCode: String? = null,
+    matchers: List<RequestMatcher> = emptyList(),
 ) {
     val matchers = buildList {
         add(host(ANALYTICS_HOST))
         add(method("GET"))
         add(query("event", eventName))
-        if (errorCode != null) {
-            add(query("error_code", errorCode))
-        }
+        addAll(matchers)
     }
 
     enqueue(*matchers.toTypedArray()) { response ->

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTestFixtures.kt
@@ -126,6 +126,11 @@ internal object NfcScanningActivityTestFixtures {
         FILE_NOT_FOUND_RESPONSE,
     )
 
+    fun selectApplicationFailureResponses(): List<ByteArray> = listOf(
+        apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
+        FILE_NOT_FOUND_RESPONSE,
+    )
+
     fun expiredCardResponses(): List<ByteArray> = listOf(
         apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
         apduSuccessResponse(EMPTY_PDOL_TEMPLATE),

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/ApduCardReaderTest.kt
@@ -155,9 +155,7 @@ internal class ApduCardReaderTest {
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
-        assertThat(readerError.error).isSameInstanceAs(UNSUPPORTED_CARD_ERROR)
+        assertThat(result).isEqualTo(NfcCardReader.Result.Error(UNSUPPORTED_CARD_ERROR))
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -173,15 +171,19 @@ internal class ApduCardReaderTest {
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
-        assertThat(readerError.error).isEqualTo(
-            ApduResponseError.Command(
-                apduCommand = SelectPpseCommand,
-                sw1 = 0x6A.toByte(),
-                sw2 = 0x82.toByte(),
-            ),
-        )
+        assertSequenceError(
+            result = result,
+            executedCommands = listOf("selectPpse"),
+        ) {
+            assertThat(cause).isEqualTo(
+                ApduResponseError.Command(
+                    apduCommand = SelectPpseCommand,
+                    sw1 = 0x6A.toByte(),
+                    sw2 = 0x82.toByte(),
+                )
+            )
+        }
+
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
     }
 
@@ -194,22 +196,31 @@ internal class ApduCardReaderTest {
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
+        assertSequenceError(
+            result = result,
+            executedCommands = listOf(
+                "selectPpse",
+                "selectApplication(aid=A0000000031010)",
+            ),
+        ) {
+            assertThat(cause).isInstanceOf<ApduResponseError.Command>()
+            val commandError = cause as ApduResponseError.Command
 
-        assertThat(readerError.error).isInstanceOf<ApduResponseError.Command>()
-        val commandError = readerError.error as ApduResponseError.Command
+            assertThat(commandError.apduCommand).isInstanceOf<SelectApplicationCommand>()
 
-        assertThat(commandError.apduCommand).isInstanceOf<SelectApplicationCommand>()
-        assertThat(commandError.sw1).isEqualTo(0x6A.toByte())
-        assertThat(commandError.sw2).isEqualTo(0x82.toByte())
+            assertThat(commandError.sw1).isEqualTo(0x6A.toByte())
+            assertThat(commandError.sw2).isEqualTo(0x82.toByte())
+
+            assertThat(commandError.parameters[SW1_PARAMETER]).isEqualTo("6A")
+            assertThat(commandError.parameters[SW2_PARAMETER]).isEqualTo("82")
+        }
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
     }
 
     @Test
-    fun `readCard propagates GetProcessingOptions failure`() = runScenario(
+    fun `readCard wraps GetProcessingOptions failure with executed commands`() = runScenario(
         transceiveResults = listOf(
             apduSuccessResponse(tlv(tag = 0x4F, value = VISA_AID)),
             apduSuccessResponse(
@@ -220,13 +231,21 @@ internal class ApduCardReaderTest {
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
-        val commandError = readerError.error as ApduResponseError.Command
-        assertThat(commandError.errorCode).isEqualTo("nfcCardReadFailed")
-        assertThat(commandError.apduCommand).isInstanceOf<GetProcessingOptionsCommand>()
-        assertThat(commandError.sw1).isEqualTo(0x6A.toByte())
-        assertThat(commandError.sw2).isEqualTo(0x82.toByte())
+        assertSequenceError(
+            result = result,
+            executedCommands = listOf(
+                "selectPpse",
+                "selectApplication(aid=A0000000031010)",
+                "getProcessingOptions",
+            ),
+        ) {
+            assertThat(cause).isInstanceOf<ApduResponseError.Command>()
+            val commandError = cause as ApduResponseError.Command
+
+            assertThat(commandError.apduCommand).isInstanceOf<GetProcessingOptionsCommand>()
+            assertThat(commandError.sw1).isEqualTo(0x6A.toByte())
+            assertThat(commandError.sw2).isEqualTo(0x82.toByte())
+        }
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_VISA_APPLICATION_REQUEST)
@@ -239,65 +258,81 @@ internal class ApduCardReaderTest {
     }
 
     @Test
-    fun `readCard returns transceiver io error when open fails`() = runScenario(
+    fun `readCard wraps transceiver io error when open fails`() = runScenario(
         openException = IOException("open failed"),
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
-        val scanningError = readerError.error as GenericNfcScanningError
-        assertThat(scanningError.errorCode).isEqualTo("nfcTransceiverIoError")
-        assertThat(scanningError.userMessage).isEqualTo(
-            R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-        )
+        assertSequenceError(
+            result = result,
+            executedCommands = emptyList(),
+        ) {
+            assertThat(cause)
+                .isEqualTo(GenericNfcScanningError(TRANSCEIVER_IO_ERROR_CODE))
+        }
     }
 
     @Test
-    fun `readCard returns transceiver io error when transceive fails`() = runScenario(
+    fun `readCard wraps transceiver io error when transceive fails`() = runScenario(
         transceiveException = IOException("transceive failed"),
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
-        val scanningError = readerError.error as GenericNfcScanningError
-        assertThat(scanningError.errorCode).isEqualTo("nfcTransceiverIoError")
-        assertThat(scanningError.userMessage).isEqualTo(
-            R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-        )
+        assertSequenceError(
+            result = result,
+            executedCommands = listOf("selectPpse"),
+        ) {
+            assertThat(cause)
+                .isEqualTo(GenericNfcScanningError(TRANSCEIVER_IO_ERROR_CODE))
+        }
 
         assertThat(transceiver.transceiveCalls.awaitItem()).isEqualTo(SELECT_PPSE_REQUEST)
     }
 
     @Test
-    fun `readCard returns transceiver security error when open fails with SecurityException`() = runScenario(
+    fun `readCard wraps transceiver security error when open fails with SecurityException`() = runScenario(
         openException = SecurityException("NFC access denied"),
     ) {
         val result = cardReader.readCard(transceiver)
 
-        assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
-        val readerError = result as NfcCardReader.Result.Error
-        val scanningError = readerError.error as GenericNfcScanningError
-        assertThat(scanningError.errorCode).isEqualTo("nfcTransceiverSecurityError")
-        assertThat(scanningError.userMessage).isEqualTo(
-            R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-        )
+        assertSequenceError(
+            result = result,
+            executedCommands = emptyList(),
+        ) {
+            assertThat(cause)
+                .isEqualTo(GenericNfcScanningError(TRANSCEIVER_SECURITY_ERROR_CODE))
+        }
     }
 
     @Test
-    fun `readCard returns unknown error for unrecognized throwable`() = runScenario(
+    fun `readCard wraps unknown error for unrecognized throwable`() = runScenario(
         openException = RuntimeException("unexpected"),
     ) {
         val result = cardReader.readCard(transceiver)
 
+        assertSequenceError(
+            result = result,
+            executedCommands = emptyList(),
+        ) {
+            assertThat(cause)
+                .isEqualTo(GenericNfcScanningError(UNKNOWN_NFC_ERROR_CODE))
+        }
+    }
+
+    private fun assertSequenceError(
+        result: NfcCardReader.Result,
+        executedCommands: List<String>,
+        block: NfcReadingSequenceError.() -> Unit = {},
+    ) {
         assertThat(result).isInstanceOf<NfcCardReader.Result.Error>()
         val readerError = result as NfcCardReader.Result.Error
-        val scanningError = readerError.error as GenericNfcScanningError
-        assertThat(scanningError.errorCode).isEqualTo("unknownNfcError")
-        assertThat(scanningError.userMessage).isEqualTo(
-            R.string.stripe_tap_to_add_card_default_error_action.resolvableString,
-        )
+
+        assertThat(readerError.error).isInstanceOf<NfcReadingSequenceError>()
+        val sequenceError = readerError.error as NfcReadingSequenceError
+
+        block(sequenceError)
+
+        assertThat(sequenceError.parameters[EXECUTED_COMMANDS_PARAMETER]).isEqualTo(executedCommands)
     }
 
     private fun runScenario(
@@ -357,6 +392,14 @@ internal class ApduCardReaderTest {
     )
 
     private companion object {
+        const val EXECUTED_COMMANDS_PARAMETER = "executed_commands"
+        const val SW1_PARAMETER = "sw1"
+        const val SW2_PARAMETER = "sw2"
+
+        const val TRANSCEIVER_IO_ERROR_CODE = "nfcTransceiverIoError"
+        const val TRANSCEIVER_SECURITY_ERROR_CODE = "nfcTransceiverSecurityError"
+        const val UNKNOWN_NFC_ERROR_CODE = "unknownNfcError"
+
         val UNSUPPORTED_CARD_ERROR = GenericNfcScanningError(
             errorCode = "cardUnsupportedByNfc",
             userMessage = R.string.stripe_nfc_scan_unsupported_card.resolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
@@ -151,6 +151,7 @@ internal class ApduCommandTest {
         override val dataArray: ByteArray? = null,
         private val response: String?,
     ) : ApduCommand<String>() {
+        override val name: String = "test"
         override fun responseData(tlv: Map<String, ByteArray>): String? = response
     }
 }


### PR DESCRIPTION
# Summary
Include the executed APDU commands in reported NFC attempt error by wrapping NFC errors that occur during the reader flow into another `NFCScanningError` type which includes a list of executed commands. `ApduCardReader` tracks every command executes via an `Environment` private class which can then be used to fetched the executed commands.

Updated unit tests and various analytic activity tests. 

# Motivation
Better visibility into what commands were executed before an error occurred. Will allow for better tracking down unsupported cards or other issues that we may have failed to account for.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified