### PR TITLE
Allow overriding merchant display name; fallback to session business name.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.checkout.injection.MerchantDisplayName
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -8,15 +7,13 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
-internal class CheckoutCommonConfigurationFactory @Inject constructor(
-    @MerchantDisplayName private val merchantDisplayName: String,
-) {
+internal class CheckoutCommonConfigurationFactory @Inject constructor() {
     fun create(
         configuration: CheckoutController.Configuration.State,
         checkoutSessionResponse: CheckoutSessionResponse,
         collectedDetails: CheckoutCollectedDetails,
     ): CommonConfiguration = CommonConfiguration(
-        merchantDisplayName = merchantDisplayName,
+        merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse),
         customer = ConfigurationDefaults.customer,
         googlePay = configuration.toGooglePayConfiguration(checkoutSessionResponse),
         link = ConfigurationDefaults.link,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -14,6 +14,11 @@ internal fun CheckoutController.Configuration.State.toBillingDetailsCollectionCo
         .asPaymentSheet()
 
 @OptIn(CheckoutSessionPreview::class)
+internal fun CheckoutController.Configuration.State.resolveMerchantDisplayName(
+    checkoutSessionResponse: CheckoutSessionResponse,
+): String = merchantDisplayName ?: checkoutSessionResponse.businessName.orEmpty()
+
+@OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutController.Configuration.State.toGooglePayConfiguration(
     checkoutSessionResponse: CheckoutSessionResponse,
 ): PaymentSheet.GooglePayConfiguration? =

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -805,6 +805,7 @@ class CheckoutController @Inject internal constructor(
     class Configuration {
         private var adaptivePricingAllowed: Boolean = false
         private var defaultBillingAddress: Address? = null
+        private var merchantDisplayName: String? = null
         private var googlePayConfiguration: GooglePayConfiguration? = null
         private var paymentElementConfiguration: PaymentElement.Configuration = PaymentElement.Configuration()
         private var currencySelectorElementConfiguration: CurrencySelectorElement.Configuration =
@@ -833,6 +834,17 @@ class CheckoutController @Inject internal constructor(
             defaultBillingAddress: Address,
         ): Configuration = apply {
             this.defaultBillingAddress = defaultBillingAddress
+        }
+
+        /**
+         * Sets the merchant display name shown to the customer during checkout.
+         *
+         * If not set, the business name from the checkout session is used.
+         */
+        fun merchantDisplayName(
+            merchantDisplayName: String,
+        ): Configuration = apply {
+            this.merchantDisplayName = merchantDisplayName
         }
 
         /**
@@ -884,6 +896,7 @@ class CheckoutController @Inject internal constructor(
         internal data class State(
             val adaptivePricingAllowed: Boolean,
             val defaultBillingAddress: Address.State?,
+            val merchantDisplayName: String?,
             val googlePayConfiguration: GooglePayConfiguration.State?,
             val paymentElementConfiguration: PaymentElement.Configuration.State,
             val currencySelectorElementConfiguration: CurrencySelectorElement.Configuration.State,
@@ -894,6 +907,7 @@ class CheckoutController @Inject internal constructor(
         internal fun build(): State = State(
             adaptivePricingAllowed = adaptivePricingAllowed,
             defaultBillingAddress = defaultBillingAddress?.build(),
+            merchantDisplayName = merchantDisplayName,
             paymentElementConfiguration = paymentElementConfiguration.build(),
             currencySelectorElementConfiguration = currencySelectorElementConfiguration.build(),
             shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -1,20 +1,18 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.checkout.injection.MerchantDisplayName
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
-internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
-    @MerchantDisplayName private val merchantDisplayName: String,
-) {
+internal class CheckoutEmbeddedConfigurationFactory @Inject constructor() {
     fun create(
         configuration: CheckoutController.Configuration.State,
         checkoutSessionResponse: CheckoutSessionResponse,
         collectedDetails: CheckoutCollectedDetails,
     ): EmbeddedPaymentElement.Configuration {
+        val merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse)
         return EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
             .embeddedViewDisplaysMandateText(
                 configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -232,12 +232,6 @@ internal interface CheckoutControllerModule {
         }
 
         @Provides
-        @MerchantDisplayName
-        fun provideMerchantDisplayName(application: Application): String {
-            return application.applicationInfo.loadLabel(application.packageManager).toString()
-        }
-
-        @Provides
         fun providesInternalRowSelectionCallback(
             @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
         ): InternalRowSelectionCallback? {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/MerchantDisplayName.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/MerchantDisplayName.kt
@@ -1,6 +1,0 @@
-package com.stripe.android.checkout.injection
-
-import javax.inject.Qualifier
-
-@Qualifier
-internal annotation class MerchantDisplayName

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -31,6 +31,7 @@ internal data class CheckoutSessionResponse(
     val allowedShippingCountries: List<String>?,
     val requiresBillingAddress: Boolean,
     val merchantCountry: String?,
+    val businessName: String?,
 ) : StripeModel {
 
     val collectsTaxFromBillingAddress: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -61,9 +61,11 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             SetupIntentJsonParser().parse(it)
         }
 
+        val elementsSessionJson = json.optJSONObject(FIELD_ELEMENTS_SESSION)
+        val businessName = elementsSessionJson?.let { StripeJsonUtils.optString(it, FIELD_BUSINESS_NAME) }
         val parsedElementsSession = parseElementsSession(
             serverBuiltElementsSessionParams = json.optJSONObject(FIELD_SERVER_BUILT_ELEMENTS_SESSION_PARAMS),
-            elementsSessionJson = json.optJSONObject(FIELD_ELEMENTS_SESSION),
+            elementsSessionJson = elementsSessionJson,
             liveMode = liveMode,
         )
         val elementsSession = if (parsedElementsSession != null) {
@@ -112,6 +114,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
             merchantCountry = merchantCountry,
+            businessName = businessName,
         )
     }
 
@@ -545,6 +548,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
     private const val FIELD_CURRENCY = "currency"
     private const val FIELD_CUSTOMER_EMAIL = "customer_email"
     private const val FIELD_ELEMENTS_SESSION = "elements_session"
+    private const val FIELD_BUSINESS_NAME = "business_name"
     private const val FIELD_TOTAL_SUMMARY = "total_summary"
     private const val FIELD_DUE = "due"
     private const val FIELD_PAYMENT_INTENT = "payment_intent"

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -48,10 +48,10 @@ internal class CheckoutCommonConfigurationFactoryTest {
             shippingAddress = address(),
         )
 
-        val expected = CheckoutEmbeddedConfigurationFactory(merchantDisplayName = "Example, Inc.")
+        val expected = CheckoutEmbeddedConfigurationFactory()
             .create(configuration, checkoutSessionResponse, collectedDetails)
             .asCommonConfiguration()
-        val actual = factory(merchantDisplayName = "Example, Inc.")
+        val actual = factory()
             .create(configuration, checkoutSessionResponse, collectedDetails)
 
         assertThat(actual).isEqualTo(expected)
@@ -59,13 +59,28 @@ internal class CheckoutCommonConfigurationFactoryTest {
 
     @Test
     fun `uses the provided merchant display name`() {
-        val result = factory(merchantDisplayName = "Acme Corp").create(
-            configuration = controllerConfiguration(),
+        val configuration = CheckoutController.Configuration()
+            .merchantDisplayName("Acme Corp")
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = collectedDetails(),
         )
 
         assertThat(result.merchantDisplayName).isEqualTo("Acme Corp")
+    }
+
+    @Test
+    fun `falls back to the checkout session business name when merchant display name is unset`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(businessName = "Session Biz"),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("Session Biz")
     }
 
     @Test
@@ -144,9 +159,7 @@ internal class CheckoutCommonConfigurationFactoryTest {
         assertThat(result.googlePlacesApiKey).isNull()
     }
 
-    private fun factory(
-        merchantDisplayName: String = "Example, Inc.",
-    ) = CheckoutCommonConfigurationFactory(merchantDisplayName = merchantDisplayName)
+    private fun factory() = CheckoutCommonConfigurationFactory()
 
     private fun controllerConfiguration(
         billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -26,9 +26,7 @@ internal object CheckoutControllerStateFactory {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration: CommonConfiguration = CheckoutCommonConfigurationFactory(
-            merchantDisplayName = "Example, Inc.",
-        ).create(
+        commonConfiguration: CommonConfiguration = CheckoutCommonConfigurationFactory().create(
             configuration = configuration,
             checkoutSessionResponse = checkoutSessionResponse,
             collectedDetails = collectedDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -201,7 +201,7 @@ internal class CheckoutControllerStateHolderTest {
         collectedDetails = CheckoutCollectedDetails(),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration = CheckoutCommonConfigurationFactory("Example, Inc.").create(
+        commonConfiguration = CheckoutCommonConfigurationFactory().create(
             configuration = CheckoutController.Configuration().build(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = CheckoutCollectedDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -56,13 +56,7 @@ internal class CheckoutControllerTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
     private val networkRule = NetworkRule()
 
-    // The controller defaults the merchant display name to the host app's label, never the checkout
-    // session. Mirroring that resolution here keeps the assertion decoupled from Robolectric's
-    // package naming while still failing if the code regresses to a session-sourced value.
-    private val expectedMerchantDisplayName: String
-        get() = applicationContext.applicationInfo
-            .loadLabel(applicationContext.packageManager)
-            .toString()
+    private val expectedMerchantDisplayName = "Mobile Example Account"
 
     // Destroys built controllers when the test finishes, releasing each one's viewModelScope.
     private val destroyControllerRule = CleanupTestRule(CheckoutController::destroy)
@@ -201,11 +195,21 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `configure uses app name as merchant display name, not checkout session data`() =
+    fun `configure defaults merchant display name to the checkout session business name`() =
         runConfigureScenario {
             result.getOrThrow()
             assertThat(committedState?.embeddedConfiguration?.merchantDisplayName)
                 .isEqualTo(expectedMerchantDisplayName)
+        }
+
+    @Test
+    fun `configure uses the configured merchant display name over the checkout session business name`() =
+        runConfigureScenario(
+            configuration = CheckoutController.Configuration().merchantDisplayName("Acme Corp"),
+        ) {
+            result.getOrThrow()
+            assertThat(committedState?.embeddedConfiguration?.merchantDisplayName)
+                .isEqualTo("Acme Corp")
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -17,13 +17,28 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
 
     @Test
     fun `uses the provided merchant display name`() {
-        val result = factory(merchantDisplayName = "Acme Corp").create(
-            configuration = controllerConfiguration(),
+        val configuration = CheckoutController.Configuration()
+            .merchantDisplayName("Acme Corp")
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = collectedDetails(),
         )
 
         assertThat(result.merchantDisplayName).isEqualTo("Acme Corp")
+    }
+
+    @Test
+    fun `falls back to the checkout session business name when merchant display name is unset`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(businessName = "Session Biz"),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("Session Biz")
     }
 
     @Test
@@ -215,9 +230,7 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         assertThat(result.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod).isTrue()
     }
 
-    private fun factory(
-        merchantDisplayName: String = "Example, Inc.",
-    ) = CheckoutEmbeddedConfigurationFactory(merchantDisplayName = merchantDisplayName)
+    private fun factory() = CheckoutEmbeddedConfigurationFactory()
 
     private fun controllerConfiguration(
         embeddedViewDisplaysMandateText: Boolean = true,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -278,7 +278,7 @@ internal class CheckoutStateLoaderTest {
         collectedDetails = CheckoutCollectedDetails(),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration = CheckoutCommonConfigurationFactory("Example, Inc.").create(
+        commonConfiguration = CheckoutCommonConfigurationFactory().create(
             configuration = CheckoutController.Configuration().build(),
             checkoutSessionResponse = checkoutSessionResponse,
             collectedDetails = CheckoutCollectedDetails(),
@@ -304,7 +304,6 @@ internal class CheckoutStateLoaderTest {
     )
 
     private fun runScenario(
-        merchantDisplayName: String = "Example, Inc.",
         loaderSelection: PaymentSelection? = null,
         chosenSelection: PaymentSelection? = null,
         shouldFail: Boolean = false,
@@ -344,8 +343,8 @@ internal class CheckoutStateLoaderTest {
             customer = customer,
         )
         val loader = CheckoutStateLoader(
-            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(merchantDisplayName),
-            commonConfigurationFactory = CheckoutCommonConfigurationFactory(merchantDisplayName),
+            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(),
+            commonConfigurationFactory = CheckoutCommonConfigurationFactory(),
             flagImageResolver = flagImageResolver,
             paymentElementLoader = paymentElementLoader,
             selectionChooser = chooser,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseFactory.kt
@@ -30,6 +30,7 @@ internal object CheckoutSessionResponseFactory {
         allowedShippingCountries: List<String>? = null,
         requiresBillingAddress: Boolean = false,
         merchantCountry: String? = "US",
+        businessName: String? = "Example, Inc.",
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -54,6 +55,7 @@ internal object CheckoutSessionResponseFactory {
             allowedShippingCountries = allowedShippingCountries,
             requiresBillingAddress = requiresBillingAddress,
             merchantCountry = merchantCountry,
+            businessName = businessName,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -28,6 +28,7 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result?.mode).isEqualTo(CheckoutSessionResponse.Mode.PAYMENT)
         assertThat(result?.status).isEqualTo(CheckoutSessionResponse.Status.OPEN)
         assertThat(result?.liveMode).isFalse()
+        assertThat(result?.businessName).isEqualTo("Mobile Example Account")
 
         // Verify ElementsSession is parsed correctly
         val elementsSession = result?.elementsSession


### PR DESCRIPTION
# Summary
This PR updates the Checkout experience so that the merchant display name can be explicitly set via configuration. If not set, it falls back to the `businessName` provided in the checkout session response. Removes reliance on application label for merchant name.

# Motivation
Getting ready for API review.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
