### PR TITLE
[Embedded horizontal 1/5] Rename Screen.PaymentOptions to VerticalPaymentOptions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -108,7 +108,7 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageAll -> eventReporter.onShowManageSavedPaymentMethods()
             is Screen.ManageUpdate -> eventReporter.onShowEditablePaymentOption()
             is Screen.Form -> Unit
-            is Screen.PaymentOptions -> eventReporter.onShowNewPaymentOptions()
+            is Screen.VerticalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
         }
     }
 
@@ -117,7 +117,7 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageAll -> Unit
             is Screen.ManageUpdate -> eventReporter.onHideEditablePaymentOption()
             is Screen.Form -> Unit
-            is Screen.PaymentOptions -> Unit
+            is Screen.VerticalPaymentOptions -> Unit
         }
     }
 
@@ -271,7 +271,7 @@ internal class EmbeddedNavigator private constructor(
             }
         }
 
-        class PaymentOptions(
+        class VerticalPaymentOptions(
             private val interactor: PaymentMethodVerticalLayoutInteractor,
             private val isLiveMode: Boolean,
             private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -53,7 +53,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
 ) {
     fun createInitialScreen(): List<EmbeddedNavigator.Screen> {
         val formHelper = createFormHelper()
-        val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
+        val paymentOptionsScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = createInteractor(formHelper),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             sheetActivityState = sheetActivityStateHolder.state,
@@ -158,7 +158,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private fun isCurrentScreen(): StateFlow<Boolean> = flow {
         emitAll(embeddedNavigatorProvider.get().screen)
     }.map { screen ->
-        screen is EmbeddedNavigator.Screen.PaymentOptions
+        screen is EmbeddedNavigator.Screen.VerticalPaymentOptions
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -344,7 +344,7 @@ internal class EmbeddedNavigatorTest {
         val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
         val paymentOptionsInteractor = FakePaymentMethodVerticalLayoutInteractor.create()
-        val paymentOptionsScreen = EmbeddedNavigator.Screen.PaymentOptions(
+        val paymentOptionsScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = paymentOptionsInteractor,
             isLiveMode = true,
             sheetActivityState = stateFlowOf(
@@ -593,8 +593,8 @@ internal class EmbeddedNavigatorTest {
 
     private fun createPaymentOptionsScreen(
         isLiveMode: Boolean = true,
-    ): EmbeddedNavigator.Screen.PaymentOptions {
-        return EmbeddedNavigator.Screen.PaymentOptions(
+    ): EmbeddedNavigator.Screen.VerticalPaymentOptions {
+        return EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = FakePaymentMethodVerticalLayoutInteractor.create(),
             isLiveMode = isLiveMode,
             sheetActivityState = stateFlowOf(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -43,7 +43,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
     ) {
         val screens = factory.createInitialScreen()
         assertThat(screens).hasSize(1)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
     @Test
@@ -72,7 +72,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         val screens = factory.createInitialScreen()
 
         assertThat(screens).hasSize(1)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
     @Test
@@ -82,7 +82,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         val screens = factory.createInitialScreen()
 
         assertThat(screens).hasSize(2)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
         assertThat(screens[1]).isInstanceOf<EmbeddedNavigator.Screen.Form>()
     }
 
@@ -99,7 +99,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         val screens = factory.createInitialScreen()
 
         assertThat(screens).hasSize(1)
-        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
     @Suppress("LongMethod")
@@ -155,7 +155,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
 
         val fakeInteractor =
             com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor.create()
-        val initialScreen = EmbeddedNavigator.Screen.PaymentOptions(
+        val initialScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = fakeInteractor,
             isLiveMode = true,
             sheetActivityState = sheetActivityStateHolder.state,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -126,7 +126,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         scenario.onActivity { activity ->
             assertThat(activity.embeddedNavigator.canGoBack).isFalse()
             assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.PaymentOptions>()
+                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
         }
     }
 


### PR DESCRIPTION
## Summary

PR **1 of 5** in a stack re-landing the intent of #13653 (horizontal payment-options layout in embedded PaymentSheet), split into independent, mostly behavior-preserving layers.

This layer is a **pure mechanical rename**: `EmbeddedNavigator.Screen.PaymentOptions` → `EmbeddedNavigator.Screen.VerticalPaymentOptions`, to make room for an upcoming `HorizontalPaymentOptions` screen. **No behavior change.**

## The stack
1. **(this) Rename `Screen.PaymentOptions` → `VerticalPaymentOptions`** — no-op
2. Add `EmbeddedAddPaymentMethodInteractorFactory` — new, unwired
3. Add `Screen.HorizontalPaymentOptions` — new, unconstructed
4. Branch `InitialPaymentOptionsScreenFactory` on orientation — no-op (metadata still Vertical)
5. Loader carries Checkout layout into metadata — **activation**

## Testing
- `:paymentsheet:testDebugUnitTest` — `EmbeddedNavigatorTest`, `InitialPaymentOptionsScreenFactoryTest`, `PaymentOptionsEmbeddedSheetActivityTest` ✅
- `:paymentsheet:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)