### PR TITLE
[Embedded horizontal 2/5] Add EmbeddedAddPaymentMethodInteractorFactory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
@@ -1,0 +1,118 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.job
+import javax.inject.Inject
+
+internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val embeddedSelectionHolder: EmbeddedSelectionHolder,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+    private val tapToAddHelper: TapToAddHelper,
+    private val eventReporter: EventReporter,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    private val customerStateHolder: CustomerStateHolder,
+) {
+    @Suppress("LongMethod")
+    fun create(): AddPaymentMethodInteractor {
+        val formScope = CoroutineScope(
+            viewModelScope.coroutineContext + SupervisorJob(viewModelScope.coroutineContext.job)
+        )
+        val initialCode = (embeddedSelectionHolder.selection.value as? PaymentSelection.New)?.paymentMethodType
+            ?: paymentMethodMetadata.supportedPaymentMethodTypes().first()
+        val hasSavedPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty()
+
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = formScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            automaticallyLaunchedCardScanFormDataHelper =
+                embeddedFormHelperFactory.createAutomaticallyLaunchedCardScanFormDataHelper(
+                    selectedPaymentMethodCode = initialCode,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                ),
+            selectionUpdater = { embeddedSelectionHolder.setSelection(it) },
+            tapToAddHelper = tapToAddHelper,
+            // If no saved payment methods, then first saved payment method is automatically set as default
+            setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+        )
+
+        return DefaultAddPaymentMethodInteractor(
+            initiallySelectedPaymentMethodType = initialCode,
+            selection = embeddedSelectionHolder.selection,
+            processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
+            validationRequested = MutableSharedFlow(),
+            incentive = PaymentMethodIncentiveInteractor(
+                paymentMethodMetadata.paymentMethodIncentive
+            ).displayedIncentive,
+            supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods(),
+            createFormArguments = formHelper::createFormArguments,
+            formElementsForCode = formHelper::formElementsForCode,
+            clearErrorMessages = { sheetActivityStateHolder.updateError(null) },
+            reportFieldInteraction = eventReporter::onPaymentMethodFormInteraction,
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportPromotionDisplayed = { code ->
+                paymentMethodMessagePromotionsHelper.reportPromotionDisplayed(code, paymentMethodMetadata)
+            },
+            createUSBankAccountFormArguments = { code ->
+                createUsBankAccountFormArguments(code, hasSavedPaymentMethods)
+            },
+            coroutineScope = formScope,
+            uiContext = Dispatchers.Main,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = null,
+                    isVerticalLayout = false,
+                )
+            },
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+        )
+    }
+
+    private fun createUsBankAccountFormArguments(
+        paymentMethodCode: PaymentMethodCode,
+        hasSavedPaymentMethods: Boolean,
+    ): USBankAccountFormArguments {
+        return USBankAccountFormArguments.createForEmbedded(
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectedPaymentMethodCode = paymentMethodCode,
+            hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
+            setSelection = embeddedSelectionHolder::setSelection,
+            hasSavedPaymentMethods = hasSavedPaymentMethods,
+            onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
+            onMandateTextChanged = { mandateText, _ ->
+                sheetActivityStateHolder.updateMandate(mandateText)
+            },
+            onUpdatePrimaryButtonUIState = sheetActivityStateHolder::updatePrimaryButton,
+            onError = sheetActivityStateHolder::updateError,
+            onFormCompleted = { eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code) },
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactoryTest.kt
@@ -1,0 +1,129 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.taptoadd.FakeTapToAddHelper
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.FakeIsNfcScanningAvailable
+import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
+import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.Test
+
+internal class EmbeddedAddPaymentMethodInteractorFactoryTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `exposes the metadata's sorted supported payment methods`() = runScenario {
+        assertThat(interactor.state.value.supportedPaymentMethods)
+            .isEqualTo(paymentMethodMetadata.sortedSupportedPaymentMethods())
+    }
+
+    @Test
+    fun `is not live mode for a test intent`() = runScenario {
+        assertThat(interactor.isLiveMode).isFalse()
+    }
+
+    @Test
+    fun `initial code defaults to the first supported payment method when there is no new selection`() = runScenario {
+        assertThat(interactor.state.value.selectedPaymentMethodCode)
+            .isEqualTo(paymentMethodMetadata.supportedPaymentMethodTypes().first())
+    }
+
+    @Test
+    fun `initial code seeds from the current new selection`() = runScenario(
+        initialSelection = PaymentSelection.New.GenericPaymentMethod(
+            label = "Cash App Pay".resolvableString,
+            iconResource = 0,
+            iconResourceNight = null,
+            lightThemeIconUrl = null,
+            darkThemeIconUrl = null,
+            paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(),
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        ),
+    ) {
+        assertThat(interactor.state.value.selectedPaymentMethodCode).isEqualTo("cashapp")
+    }
+
+    @Test
+    fun `OnPaymentMethodSelected updates the selected code`() = runScenario {
+        interactor.handleViewAction(
+            AddPaymentMethodInteractor.ViewAction.OnPaymentMethodSelected("cashapp")
+        )
+
+        assertThat(interactor.state.value.selectedPaymentMethodCode).isEqualTo("cashapp")
+    }
+
+    private fun runScenario(
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            ),
+        ),
+        initialSelection: PaymentSelection? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        // A separate scope so the interactor's never-completing state collectors don't keep runTest from finishing.
+        val viewModelScope = TestScope(UnconfinedTestDispatcher())
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()).apply {
+            setSelection(initialSelection)
+        }
+        val embeddedFormHelperFactory = EmbeddedFormHelperFactory(
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            embeddedSelectionHolder = selectionHolder,
+            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+            savedStateHandle = SavedStateHandle(),
+            isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
+        )
+        val customerStateHolder = DefaultCustomerStateHolder(
+            customerMetadata = stateFlowOf(null),
+            paymentMethodMetadataFlow = stateFlowOf(paymentMethodMetadata),
+            savedStateHandle = SavedStateHandle(),
+            selection = selectionHolder.selection,
+        )
+        val factory = EmbeddedAddPaymentMethodInteractorFactory(
+            paymentMethodMetadata = paymentMethodMetadata,
+            embeddedSelectionHolder = selectionHolder,
+            embeddedFormHelperFactory = embeddedFormHelperFactory,
+            viewModelScope = viewModelScope,
+            sheetActivityStateHolder = FakeSheetActivityStateHolder(),
+            tapToAddHelper = FakeTapToAddHelper.noOp(),
+            eventReporter = FakeEventReporter(),
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            customerStateHolder = customerStateHolder,
+        )
+        val interactor = factory.create()
+
+        Scenario(
+            interactor = interactor,
+            paymentMethodMetadata = paymentMethodMetadata,
+        ).apply { block() }
+
+        interactor.close()
+        viewModelScope.cancel()
+    }
+
+    private data class Scenario(
+        val interactor: AddPaymentMethodInteractor,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
@@ -28,6 +28,7 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
         )
 
     val resultTurbine = Turbine<EmbeddedActivityResult>()
+    val updateErrorTurbine = Turbine<ResolvableString?>()
 
     override val result: SharedFlow<EmbeddedActivityResult> = MutableSharedFlow<EmbeddedActivityResult>()
 
@@ -40,7 +41,7 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
     }
 
     override fun updateError(error: ResolvableString?) {
-        error("This should never be called!")
+        updateErrorTurbine.add(error)
     }
 
     override fun setResult(result: EmbeddedActivityResult) {
@@ -53,5 +54,6 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
 
     fun validate() {
         resultTurbine.ensureAllEventsConsumed()
+        updateErrorTurbine.ensureAllEventsConsumed()
     }
 }


### PR DESCRIPTION
## Summary

PR **2 of 5** re-landing the intent of #13653 (horizontal payment-options layout in embedded PaymentSheet).

Adds `EmbeddedAddPaymentMethodInteractorFactory` — an `@Inject` factory that builds a `DefaultAddPaymentMethodInteractor` for the embedded sheet, mirroring `EmbeddedFormInteractorFactory`:
- form-scope = `viewModelScope + SupervisorJob(viewModelScope.job)`
- full-variant `EmbeddedFormHelperFactory.create(...)` (card-scan helper for the initial code + tap-to-add, `setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods`)
- US-bank args via `USBankAccountFormArguments.createForEmbedded(...)` wired to `sheetActivityStateHolder` + `embeddedSelectionHolder::setSelection`
- `initialCode` = current `PaymentSelection.New` code, else first supported PM
- visibility snapshot reported with `isVerticalLayout = false`

**Not yet wired into any screen** — used only by its unit test, so this is a no-op in production. Also relaxes `FakeSheetActivityStateHolder.updateError` to record to a turbine instead of throwing (the interactor clears error messages on init).

Base: #13761.

## Testing
- `:paymentsheet:testDebugUnitTest` — new `EmbeddedAddPaymentMethodInteractorFactoryTest` (sorted PMs exposed, not-live, initial code default/seed-from-New, `OnPaymentMethodSelected`) ✅
- embedded `sheet.*` + `form.*` suites ✅
- `:paymentsheet:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)