### PR TITLE
[Embedded horizontal 3/5] Add Screen.HorizontalPaymentOptions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -9,20 +9,27 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.EmbeddedFormInteractorFactory
+import com.stripe.android.paymentelement.embedded.form.FormActivityError
 import com.stripe.android.paymentelement.embedded.form.FormActivityPrimaryButton
 import com.stripe.android.paymentelement.embedded.form.FormScreenContent
+import com.stripe.android.paymentelement.embedded.form.USBankAccountMandate
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.navigation.NavigationHandler
+import com.stripe.android.paymentsheet.ui.AddPaymentMethod
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
+import com.stripe.android.paymentsheet.utils.isOnlyOneNonCardPaymentMethod
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenUI
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
@@ -41,6 +48,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.Closeable
 import javax.inject.Inject
+import com.stripe.android.R as PaymentsCoreR
 
 internal class EmbeddedNavigator private constructor(
     private val eventReporter: EventReporter,
@@ -109,6 +117,7 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageUpdate -> eventReporter.onShowEditablePaymentOption()
             is Screen.Form -> Unit
             is Screen.VerticalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
+            is Screen.HorizontalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
         }
     }
 
@@ -118,6 +127,7 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageUpdate -> eventReporter.onHideEditablePaymentOption()
             is Screen.Form -> Unit
             is Screen.VerticalPaymentOptions -> Unit
+            is Screen.HorizontalPaymentOptions -> Unit
         }
     }
 
@@ -305,6 +315,53 @@ internal class EmbeddedNavigator private constructor(
                     onClick = onContinueClick,
                 )
                 PaymentSheetContentPadding()
+            }
+
+            override fun close() {
+                interactor.close()
+            }
+        }
+
+        class HorizontalPaymentOptions(
+            private val interactor: AddPaymentMethodInteractor,
+            private val eventReporter: EventReporter,
+            private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
+            private val onContinueClick: () -> Unit,
+        ) : Screen(), Closeable {
+            override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
+                PaymentSheetTopBarState(
+                    showTestModeLabel = !interactor.isLiveMode,
+                    showEditMenu = false,
+                    isEditing = false,
+                    onEditIconPressed = {},
+                )
+            )
+
+            override fun title(): StateFlow<ResolvableString?> = interactor.state.mapAsStateFlow { state ->
+                when {
+                    state.supportedPaymentMethods.isOnlyOneNonCardPaymentMethod() -> null
+                    state.supportedPaymentMethods.singleOrNull()?.code == PaymentMethod.Type.Card.code ->
+                        PaymentsCoreR.string.stripe_title_add_a_card.resolvableString
+                    else -> R.string.stripe_paymentsheet_choose_payment_method.resolvableString
+                }
+            }
+
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> = stateFlowOf(false)
+
+            @Composable
+            override fun Content() {
+                EventReporterProvider(eventReporter) {
+                    AddPaymentMethod(interactor = interactor)
+                    val state by sheetActivityState.collectAsState()
+                    USBankAccountMandate(state)
+                    FormActivityError(state)
+                    Spacer(Modifier.height(40.dp))
+                    FormActivityPrimaryButton(
+                        state = state,
+                        onClick = onContinueClick,
+                    )
+                    PaymentSheetContentPadding()
+                }
             }
 
             override fun close() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.FakeUpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
@@ -340,6 +341,18 @@ internal class EmbeddedNavigatorTest {
     }
 
     @Test
+    fun `initial screen HorizontalPaymentOptions calls onShowNewPaymentOptions`() = runTest {
+        val eventReporter = FakeEventReporter()
+        EmbeddedNavigator(
+            coroutineScope = this,
+            eventReporter = eventReporter,
+            initialScreen = createHorizontalPaymentOptionsScreen(),
+        )
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+        eventReporter.validate()
+    }
+
+    @Test
     fun `initial back stack with a form on top starts on the form and can go back`() = runTest {
         val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
@@ -597,6 +610,24 @@ internal class EmbeddedNavigatorTest {
         return EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = FakePaymentMethodVerticalLayoutInteractor.create(),
             isLiveMode = isLiveMode,
+            sheetActivityState = stateFlowOf(
+                SheetActivityStateHolder.State(
+                    primaryButtonLabel = "".resolvableString,
+                    isEnabled = false,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    isProcessing = false,
+                    shouldDisplayLockIcon = true,
+                    savedPaymentSelectionToConfirm = null,
+                )
+            ),
+            onContinueClick = {},
+        )
+    }
+
+    private fun createHorizontalPaymentOptionsScreen(): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
+        return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
+            interactor = FakeAddPaymentMethodInteractor(FakeAddPaymentMethodInteractor.createState()),
+            eventReporter = FakeEventReporter(),
             sheetActivityState = stateFlowOf(
                 SheetActivityStateHolder.State(
                     primaryButtonLabel = "".resolvableString,


### PR DESCRIPTION
## Summary

PR **3 of 5** re-landing the intent of #13653 (horizontal payment-options layout in embedded PaymentSheet).

Adds `EmbeddedNavigator.Screen.HorizontalPaymentOptions` — the horizontal variant of the payment-options screen: payment-method tabs + the selected method's form inline on one screen, followed by the US-bank mandate, error, and primary **Continue** button (via the shared `FormActivityUI` composables).
- `topBarState()`: test-mode label from `!interactor.isLiveMode`, no edit menu.
- `title()`: mirrors the flow-controller add screen — `null` for a single non-card PM, "Add a card" for a single card, "Choose a payment method" otherwise.
- `Content()`: `AddPaymentMethod(interactor)` inside `EventReporterProvider`, then mandate/error/`Continue`.
- Both navigator `when` blocks handle the new screen (shown → `onShowNewPaymentOptions()`).

Still **constructed nowhere in production** (wired in PR 4). Base: #13762.

## Testing
- `:paymentsheet:testDebugUnitTest` — `EmbeddedNavigatorTest` incl. new "initial screen HorizontalPaymentOptions calls onShowNewPaymentOptions" ✅
- `:paymentsheet:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)