### PR TITLE
[Embedded horizontal 4/5] Branch InitialPaymentOptionsScreenFactory on orientation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
@@ -50,27 +51,22 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private val sheetActivityStateHolder: SheetActivityStateHolder,
     private val formScreenFactory: EmbeddedFormScreenFactory,
     private val linkAccountHolder: LinkAccountHolder,
+    private val addPaymentMethodInteractorFactory: EmbeddedAddPaymentMethodInteractorFactory,
 ) {
     fun createInitialScreen(): List<EmbeddedNavigator.Screen> {
+        return when (paymentMethodMetadata.paymentMethodOrientation()) {
+            PaymentMethodOrientation.Vertical -> createVerticalInitialScreens()
+            PaymentMethodOrientation.Horizontal -> listOf(createHorizontalScreen())
+        }
+    }
+
+    private fun createVerticalInitialScreens(): List<EmbeddedNavigator.Screen> {
         val formHelper = createFormHelper()
         val paymentOptionsScreen = EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = createInteractor(formHelper),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             sheetActivityState = sheetActivityStateHolder.state,
-            onContinueClick = {
-                sheetActivityStateHolder.setResult(
-                    EmbeddedActivityResult.Complete(
-                        selection = selectionHolder.selection.value,
-                        previousNewSelections = selectionHolder.previousNewSelections,
-                        hasBeenConfirmed = false,
-                        customerState = customerStateHolder.customer.value,
-                        shouldInvokeSelectionCallback = false,
-                        launchMode = EmbeddedLaunchMode.PaymentOptions(
-                            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                        ),
-                    )
-                )
-            },
+            onContinueClick = ::onContinueClick,
         )
         return buildList {
             add(paymentOptionsScreen)
@@ -83,6 +79,30 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                 add(formScreenFactory.createFormScreen(selection.paymentMethodType))
             }
         }
+    }
+
+    private fun createHorizontalScreen(): EmbeddedNavigator.Screen {
+        return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
+            interactor = addPaymentMethodInteractorFactory.create(),
+            eventReporter = eventReporter,
+            sheetActivityState = sheetActivityStateHolder.state,
+            onContinueClick = ::onContinueClick,
+        )
+    }
+
+    private fun onContinueClick() {
+        sheetActivityStateHolder.setResult(
+            EmbeddedActivityResult.Complete(
+                selection = selectionHolder.selection.value,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = false,
+                customerState = customerStateHolder.customer.value,
+                shouldInvokeSelectionCallback = false,
+                launchMode = EmbeddedLaunchMode.PaymentOptions(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                ),
+            )
+        )
     }
 
     private fun createFormHelper(): FormHelper {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInt
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
@@ -92,10 +93,67 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("card", "cashapp"),
             ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
     ) {
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
+    }
+
+    @Test
+    fun `horizontal layout creates a single horizontal payment options screen`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        ),
+    ) {
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.HorizontalPaymentOptions>()
+    }
+
+    @Test
+    fun `horizontal layout stays a single screen even when a new selection would need a form`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        ),
+    ) {
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.HorizontalPaymentOptions>()
+    }
+
+    @Test
+    fun `automatic layout with two payment methods resolves to horizontal`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+        ),
+    ) {
+        val screens = factory.createInitialScreen()
+
+        assertThat(screens).hasSize(1)
+        assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.HorizontalPaymentOptions>()
+    }
+
+    @Test
+    fun `automatic layout with three payment methods resolves to vertical`() = testScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp", "klarna"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
+        ),
+    ) {
         val screens = factory.createInitialScreen()
 
         assertThat(screens).hasSize(1)
@@ -107,6 +165,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         isGooglePayReady: Boolean = true,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             isGooglePayReady = isGooglePayReady,
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
@@ -168,6 +227,18 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         )
         assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
 
+        val addPaymentMethodInteractorFactory = EmbeddedAddPaymentMethodInteractorFactory(
+            paymentMethodMetadata = paymentMethodMetadata,
+            embeddedSelectionHolder = selectionHolder,
+            embeddedFormHelperFactory = formHelperFactory,
+            viewModelScope = testScope,
+            sheetActivityStateHolder = sheetActivityStateHolder,
+            tapToAddHelper = FakeTapToAddHelper.noOp(),
+            eventReporter = FakeEventReporter(),
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+            customerStateHolder = customerStateHolder,
+        )
+
         val factory = InitialPaymentOptionsScreenFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             customerStateHolder = customerStateHolder,
@@ -182,6 +253,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             sheetActivityStateHolder = sheetActivityStateHolder,
             formScreenFactory = formScreenFactory,
             linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+            addPaymentMethodInteractorFactory = addPaymentMethodInteractorFactory,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -150,7 +150,9 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
                 input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+                    ),
                     configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",


### PR DESCRIPTION
## Summary

PR **4 of 5** re-landing the intent of #13653 (horizontal payment-options layout in embedded PaymentSheet).

Wires the horizontal path into the initial-screen factory. `createInitialScreen()` (still parameterless) now dispatches on `paymentMethodMetadata.paymentMethodOrientation()`:
- **Vertical** → today's vertical list, plus the pre-pushed form when a `New` selection needs one (unchanged behavior).
- **Horizontal** → a single `HorizontalPaymentOptions` screen built from the injected `EmbeddedAddPaymentMethodInteractorFactory`, sharing the same result-setting `onContinueClick`. No pre-pushed form screen.

Production `PaymentMethodMetadata.paymentMethodLayout` is still forced to `Vertical` by the loader (changed in PR 5), so the branch always chooses vertical → **no production behavior change**. Base: #13763.

## Testing
- `:paymentsheet:testDebugUnitTest` — `InitialPaymentOptionsScreenFactoryTest`: existing vertical cases pinned to `Vertical`; new cases for `Horizontal`, `Automatic` (2 PMs → horizontal, 3 PMs → vertical), and horizontal staying a single screen even when a `New` selection would need a form ✅
- `:paymentsheet:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)