### PR TITLE
[Embedded horizontal 5/5] Loader carries the Checkout layout into metadata (activation)

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -73,6 +73,7 @@ internal class CheckoutStateLoader @Inject constructor(
             integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
                 isRowSelectionImmediateAction = false,
                 configuration = embeddedConfig,
+                paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet(),
             ),
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
@@ -7,6 +7,7 @@ import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -83,6 +84,7 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
                         integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
                             isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
                             configuration = configuration,
+                            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                         ),
                         metadata = PaymentElementLoader.Metadata(
                             isReloadingAfterProcessDeath = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -93,6 +93,7 @@ internal interface PaymentElementLoader {
         data class Embedded(
             val isRowSelectionImmediateAction: Boolean,
             val configuration: EmbeddedPaymentElement.Configuration,
+            val paymentMethodLayout: PaymentMethodLayout,
         ) : Configuration {
             override val commonConfiguration: CommonConfiguration = configuration.asCommonConfiguration()
         }
@@ -621,8 +622,16 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     ): PaymentMethodLayout {
         return when (integrationConfiguration) {
             is PaymentElementLoader.Configuration.CryptoOnramp,
-            is PaymentElementLoader.Configuration.StandaloneLink,
-            is PaymentElementLoader.Configuration.Embedded -> PaymentMethodLayout.Vertical
+            is PaymentElementLoader.Configuration.StandaloneLink -> PaymentMethodLayout.Vertical
+            is PaymentElementLoader.Configuration.Embedded ->
+                if (
+                    elementsSession.forceVerticalPaymentMethodLayout &&
+                    integrationConfiguration.paymentMethodLayout == PaymentMethodLayout.Automatic
+                ) {
+                    PaymentMethodLayout.Vertical
+                } else {
+                    integrationConfiguration.paymentMethodLayout
+                }
             is PaymentElementLoader.Configuration.PaymentSheet ->
                 if (
                     elementsSession.forceVerticalPaymentMethodLayout &&

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -671,6 +671,7 @@ class DefaultAnalyticsMetadataFactoryTest {
             configuration = EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName = "Test Merchant")
                 .build(),
             isRowSelectionImmediateAction = false,
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         )
         val resultMap = createAnalyticsMetadata(
             configuration = configuration
@@ -705,6 +706,7 @@ class DefaultAnalyticsMetadataFactoryTest {
                 )
                 .build(),
             isRowSelectionImmediateAction = false,
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         )
         val resultMap = createAnalyticsMetadata(
             configuration = configuration

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -58,6 +58,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.Status.Canceled
 import com.stripe.android.model.StripeIntent.Status.Succeeded
 import com.stripe.android.model.wallets.Wallet
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
@@ -3890,6 +3891,92 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
+
+    @Test
+    fun `Uses horizontal payment method orientation for embedded when layout is horizontal`() = runScenario {
+        val result = createPaymentElementLoader().loadEmbedded(PaymentSheet.PaymentMethodLayout.Horizontal)
+
+        assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
+            .isEqualTo(PaymentMethodOrientation.Horizontal)
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `Uses horizontal payment method orientation for embedded automatic layout with two payment methods`() =
+        runScenario {
+            val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            )
+
+            val result = createPaymentElementLoader(stripeIntent = stripeIntent)
+                .loadEmbedded(PaymentSheet.PaymentMethodLayout.Automatic)
+
+            assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
+                .isEqualTo(PaymentMethodOrientation.Horizontal)
+            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+        }
+
+    @Test
+    fun `Uses vertical payment method orientation for embedded automatic layout with three payment methods`() =
+        runScenario {
+            val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp", "klarna"),
+            )
+
+            val result = createPaymentElementLoader(stripeIntent = stripeIntent)
+                .loadEmbedded(PaymentSheet.PaymentMethodLayout.Automatic)
+
+            assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
+                .isEqualTo(PaymentMethodOrientation.Vertical)
+            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+        }
+
+    @Test
+    fun `Forces vertical payment method orientation for embedded automatic layout when session flag is set`() =
+        runScenario {
+            val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            )
+            val loader = createPaymentElementLoader(
+                stripeIntent = stripeIntent,
+                elementsSessionRepository = FakeElementsSessionRepository(
+                    stripeIntent = stripeIntent,
+                    error = null,
+                    linkSettings = null,
+                    flags = mapOf(
+                        ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_VERTICAL_PAYMENT_METHOD_LAYOUT to true,
+                    ),
+                ),
+            )
+
+            val result = loader.loadEmbedded(PaymentSheet.PaymentMethodLayout.Automatic)
+
+            assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
+                .isEqualTo(PaymentMethodOrientation.Vertical)
+            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+        }
+
+    private suspend fun PaymentElementLoader.loadEmbedded(
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+    ): PaymentElementLoader.State {
+        return load(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                isRowSelectionImmediateAction = false,
+                configuration = EmbeddedPaymentElement.Configuration.Builder(
+                    merchantDisplayName = "Merchant, Inc.",
+                ).build(),
+                paymentMethodLayout = paymentMethodLayout,
+            ),
+            metadata = PaymentElementLoader.Metadata(initializedViaCompose = false),
+        ).getOrThrow()
+    }
 
     @OptIn(CardFundingFilteringPrivatePreview::class)
     private fun testCardFundingFiltering(


### PR DESCRIPTION
## Summary

PR **5 of 5** re-landing the intent of #13653 (horizontal payment-options layout in embedded PaymentSheet). **This is the activation** — the only behavior-changing PR in the stack, and small/revertable.

`PaymentMethodMetadata.paymentMethodLayout` was previously forced to `Vertical` for every embedded flow at `getPaymentMethodLayout`. Now:
- `PaymentElementLoader.Configuration.Embedded` carries a `paymentMethodLayout`.
- `getPaymentMethodLayout` returns it for `Embedded`, mirroring the PaymentSheet branch's `forceVerticalPaymentMethodLayout` + `Automatic` guard, instead of hardcoding `Vertical`.
- `CheckoutStateLoader` passes the merchant's `PaymentElement` layout (`…paymentMethodLayout.asPaymentSheet()`) — the value that was previously dropped before the loader.
- The plain `EmbeddedPaymentElement` (no layout API) explicitly stays `Vertical`.

Combined with PR 4, Checkout embedded `PaymentOptions` now renders horizontal tabs + inline form when the merchant selects `Horizontal` (or `Automatic` with ≤2 payment methods).

**Deviation from the plan:** `Configuration.Embedded` is `internal`, so per the repo's "no defaults for internal code" convention the new `paymentMethodLayout` field has **no default** — every call site decides explicitly (Checkout → merchant layout, plain embedded → `Vertical`, tests → `Vertical`) rather than relying on a default.

Other `paymentMethodOrientation()` consumers were audited: the remaining ones are PaymentSheet-flow (unaffected by embedded metadata) or analytics/experiment signals (`DefaultEventReporter`, `PaymentMethodMessagePromotionsExperimentHandler`) that now *correctly* reflect the real layout for checkout-embedded — the intended activation effect, not a regression.

Base: #13764.

## Testing
- `:paymentsheet:testDebugUnitTest` — `DefaultPaymentElementLoaderTest` (new embedded cases: Horizontal→Horizontal; Automatic→Horizontal at 2 PMs / Vertical at 3 PMs; force-vertical flag forces Vertical), plus full suite + `DefaultAnalyticsMetadataFactoryTest`, `CheckoutStateLoaderTest`, `DefaultEmbeddedConfigurationHandlerTest` ✅
- `:paymentsheet:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)