### PR TITLE
Respect Link consumer supported funding sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 NEXT_VERSION_BUMP: PATCH
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
+
 ## 23.14.0 - 2026-08-03
 
 ### CryptoOnramp

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -33,6 +33,8 @@ data class ConsumerSession(
     val minimumAuthenticationLevel: AuthenticationLevel? = null,
     @SerialName("link_brand")
     val linkBrand: LinkBrand? = null,
+    @SerialName("support_payment_details_types")
+    val supportedPaymentDetailsTypes: List<String> = emptyList(),
 ) : StripeModel {
 
     val meetsMinimumAuthenticationLevel: Boolean

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -37,6 +37,11 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             LinkBrand.entries.firstOrNull { it.value == value }
         }
 
+        val supportedPaymentDetailsTypes =
+            consumerSessionJson.optJSONArray(FIELD_SUPPORT_PAYMENT_DETAILS_TYPES)
+                ?.let { array -> (0 until array.length()).map { array.getString(it) } }
+                ?: emptyList()
+
         return ConsumerSession(
             clientSecret = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_SECRET),
             emailAddress = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_EMAIL),
@@ -49,6 +54,7 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             currentAuthenticationLevel = currentAuthenticationLevel,
             minimumAuthenticationLevel = minimumAuthenticationLevel,
             linkBrand = linkBrand,
+            supportedPaymentDetailsTypes = supportedPaymentDetailsTypes,
         )
     }
 
@@ -88,6 +94,7 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
         private const val FIELD_VERIFICATION_SESSION_STATE = "state"
 
         private const val FIELD_LINK_BRAND = "link_brand"
+        private const val FIELD_SUPPORT_PAYMENT_DETAILS_TYPES = "support_payment_details_types"
         private const val FIELD_WEBVIEW_REQUIREMENT_TYPE = "webview_requirement_type"
         private const val FIELD_WEBVIEW_OPEN_URL = "webview_open_url"
     }

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -27,6 +27,7 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
+                supportedPaymentDetailsTypes = listOf("CARD"),
             )
         )
     }
@@ -49,6 +50,7 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Verified
                     )
                 ),
+                supportedPaymentDetailsTypes = listOf("CARD"),
             )
         )
     }
@@ -90,6 +92,7 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
+                supportedPaymentDetailsTypes = listOf("CARD"),
             )
         )
     }
@@ -161,5 +164,44 @@ class ConsumerSessionJsonParserTest {
         )
         val result = ConsumerSessionJsonParser().parse(json)
         assertThat(result?.linkBrand).isNull()
+    }
+
+    @Test
+    fun `Parse consumer with support_payment_details_types`() {
+        val json = JSONObject(
+            """
+                {
+                  "consumer_session": {
+                    "client_secret": "secret_123",
+                    "email_address": "test@stripe.com",
+                    "redacted_phone_number": "+1********56",
+                    "redacted_formatted_phone_number": "(***) *** **56",
+                    "verification_sessions": [],
+                    "support_payment_details_types": ["CARD", "BANK_ACCOUNT"]
+                  }
+                }
+            """.trimIndent()
+        )
+        val result = ConsumerSessionJsonParser().parse(json)
+        assertThat(result?.supportedPaymentDetailsTypes).containsExactly("CARD", "BANK_ACCOUNT")
+    }
+
+    @Test
+    fun `Parse consumer without support_payment_details_types returns empty list`() {
+        val json = JSONObject(
+            """
+                {
+                  "consumer_session": {
+                    "client_secret": "secret_123",
+                    "email_address": "test@stripe.com",
+                    "redacted_phone_number": "+1********56",
+                    "redacted_formatted_phone_number": "(***) *** **56",
+                    "verification_sessions": []
+                  }
+                }
+            """.trimIndent()
+        )
+        val result = ConsumerSessionJsonParser().parse(json)
+        assertThat(result?.supportedPaymentDetailsTypes).isEmpty()
     }
 }

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
@@ -37,6 +37,7 @@ class ConsumerSessionLookupJsonParserTest {
                     unredactedPhoneNumber = null,
                     phoneNumberCountry = null,
                     verificationSessions = emptyList(),
+                    supportedPaymentDetailsTypes = listOf("CARD"),
                 ),
                 errorMessage = null,
                 publishableKey = "asdfg123",

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -22,6 +22,9 @@ internal data class LinkAccount(
     val viewedWebviewOpenUrl: Boolean = false,
 ) : Parcelable {
 
+    val supportedPaymentDetailsTypes: List<String>
+        get() = consumerSession.supportedPaymentDetailsTypes
+
     val linkBrand: LinkBrand?
         get() = consumerSession.linkBrand?.let { consumerLinkBrand ->
             if (FeatureFlags.forceOnelinkConsumer.isEnabled) LinkBrand.Onelink else consumerLinkBrand

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/SupportedPaymentMethodTypes.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/SupportedPaymentMethodTypes.kt
@@ -5,10 +5,20 @@ import com.stripe.android.model.StripeIntent
 /**
  * Provides the supported payment method types for the given Link account.
  *
- * The supported payment methods are read from [StripeIntent.linkFundingSources]. Returns an empty
- * set when no funding sources are available; callers should treat this as an error condition
- * rather than falling back to card.
+ * Computes the intersection of [StripeIntent.linkFundingSources] (merchant-configured) and
+ * [consumerSupportedPaymentDetailsTypes] (consumer-level, from the /confirm_verification response).
+ * Comparison is case-insensitive since the two sources use different casing conventions.
+ *
+ * When [consumerSupportedPaymentDetailsTypes] is empty (not yet available), returns all
+ * [StripeIntent.linkFundingSources] to avoid restricting before the consumer session is known.
+ * Returns an empty set when no funding sources are available; callers should treat this as an error
+ * condition rather than falling back to card.
  */
-internal fun StripeIntent.supportedPaymentMethodTypes(): Set<String> {
-    return linkFundingSources.toSet()
+internal fun StripeIntent.supportedPaymentMethodTypes(
+    consumerSupportedPaymentDetailsTypes: List<String>,
+): Set<String> {
+    val fundingSources = linkFundingSources.toSet()
+    if (consumerSupportedPaymentDetailsTypes.isEmpty()) return fundingSources
+    val consumerTypesLower = consumerSupportedPaymentDetailsTypes.map { it.lowercase() }.toSet()
+    return fundingSources.filter { it.lowercase() in consumerTypesLower }.toSet()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/SupportedPaymentMethodTypes.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/SupportedPaymentMethodTypes.kt
@@ -1,14 +1,14 @@
 package com.stripe.android.link.model
 
-import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.StripeIntent
 
 /**
  * Provides the supported payment method types for the given Link account.
  *
- * The supported payment methods are read from [StripeIntent.linkFundingSources], and fallback to
- * card only if the list is empty or none of them is valid.
+ * The supported payment methods are read from [StripeIntent.linkFundingSources]. Returns an empty
+ * set when no funding sources are available; callers should treat this as an error condition
+ * rather than falling back to card.
  */
 internal fun StripeIntent.supportedPaymentMethodTypes(): Set<String> {
-    return linkFundingSources.toSet().takeIf { it.isNotEmpty() } ?: setOf(ConsumerPaymentDetails.Card.TYPE)
+    return linkFundingSources.toSet()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/AddPaymentMethodOptions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/AddPaymentMethodOptions.kt
@@ -17,7 +17,9 @@ internal class AddPaymentMethodOptions @AssistedInject constructor(
 ) {
     val values: List<AddPaymentMethodOption> = run {
         val stripeIntent = configuration.stripeIntent
-        val supportedPaymentMethodTypes = stripeIntent.supportedPaymentMethodTypes()
+        val supportedPaymentMethodTypes = stripeIntent.supportedPaymentMethodTypes(
+            linkAccount.supportedPaymentDetailsTypes
+        )
         val paymentMethodFilters = (linkLaunchMode as? LinkLaunchMode.PaymentMethodSelection)?.paymentMethodFilters
 
         buildList {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -203,7 +203,7 @@ internal class WalletViewModel(
         isAfterAdding: Boolean = false
     ) {
         linkAccountManager.listPaymentDetails(
-            paymentMethodTypes = stripeIntent.supportedPaymentMethodTypes()
+            paymentMethodTypes = stripeIntent.supportedPaymentMethodTypes(linkAccount.supportedPaymentDetailsTypes)
         ).fold(
             onSuccess = { response ->
                 _uiState.update {

--- a/paymentsheet/src/test/java/com/stripe/android/link/model/StripeIntentKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/model/StripeIntentKtxTest.kt
@@ -38,10 +38,10 @@ class StripeIntentKtxTest {
     }
 
     @Test
-    fun `When funding sources is empty then defaults to card`() {
+    fun `When funding sources is empty then returns empty set`() {
         val supportedTypes = stripeIntent(fundingSources = emptyList())
             .supportedPaymentMethodTypes()
-        assertThat(supportedTypes).containsExactly("card")
+        assertThat(supportedTypes).isEmpty()
     }
 
     private fun stripeIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/link/model/StripeIntentKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/model/StripeIntentKtxTest.kt
@@ -10,38 +10,68 @@ import org.robolectric.RobolectricTestRunner
 class StripeIntentKtxTest {
 
     @Test
+    fun `When consumer types is empty then returns all funding sources`() {
+        val supportedTypes = stripeIntent(fundingSources = listOf("card", "bank_account"))
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = emptyList())
+        assertThat(supportedTypes).containsExactly("card", "bank_account")
+    }
+
+    @Test
     fun `When funding sources contains card then returns card`() {
         val supportedTypes = stripeIntent(fundingSources = listOf("card"))
-            .supportedPaymentMethodTypes()
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CARD"))
         assertThat(supportedTypes).containsExactly("card")
     }
 
     @Test
     fun `When funding sources contains card and bank_account then returns both`() {
         val supportedTypes = stripeIntent(fundingSources = listOf("card", "bank_account"))
-            .supportedPaymentMethodTypes()
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CARD", "BANK_ACCOUNT"))
         assertThat(supportedTypes).containsExactly("card", "bank_account")
     }
 
     @Test
     fun `When funding sources contains generic types then returns them`() {
         val supportedTypes = stripeIntent(fundingSources = listOf("card", "crypto", "pix"))
-            .supportedPaymentMethodTypes()
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CARD", "CRYPTO", "PIX"))
         assertThat(supportedTypes).containsExactly("card", "crypto", "pix")
     }
 
     @Test
     fun `When funding sources contains only generic types then returns them`() {
         val supportedTypes = stripeIntent(fundingSources = listOf("crypto", "pix"))
-            .supportedPaymentMethodTypes()
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CRYPTO", "PIX"))
         assertThat(supportedTypes).containsExactly("crypto", "pix")
     }
 
     @Test
     fun `When funding sources is empty then returns empty set`() {
         val supportedTypes = stripeIntent(fundingSources = emptyList())
-            .supportedPaymentMethodTypes()
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CARD"))
         assertThat(supportedTypes).isEmpty()
+    }
+
+    @Test
+    fun `Intersection is case-insensitive`() {
+        val supportedTypes = stripeIntent(fundingSources = listOf("card", "bank_account"))
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CARD"))
+        assertThat(supportedTypes).containsExactly("card")
+    }
+
+    @Test
+    fun `Returns empty when intersection is empty`() {
+        val supportedTypes = stripeIntent(fundingSources = listOf("bank_account"))
+            .supportedPaymentMethodTypes(consumerSupportedPaymentDetailsTypes = listOf("CARD"))
+        assertThat(supportedTypes).isEmpty()
+    }
+
+    @Test
+    fun `Intersection excludes consumer types not in funding sources`() {
+        val supportedTypes = stripeIntent(fundingSources = listOf("card"))
+            .supportedPaymentMethodTypes(
+                consumerSupportedPaymentDetailsTypes = listOf("CARD", "BANK_ACCOUNT", "KLARNA")
+            )
+        assertThat(supportedTypes).containsExactly("card")
     }
 
     private fun stripeIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/AddPaymentMethodOptionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/AddPaymentMethodOptionsTest.kt
@@ -99,11 +99,10 @@ class AddPaymentMethodOptionsTest {
     }
 
     @Test
-    fun `values handles empty funding sources with card fallback`() {
+    fun `values handles empty funding sources with no options`() {
         val options = createOptions(fundingSources = emptyList())
 
-        assertThat(options.values).hasSize(1)
-        assertThat(options.values).containsExactly(AddPaymentMethodOption.Card)
+        assertThat(options.values).isEmpty()
     }
 
     @Test
@@ -150,10 +149,10 @@ class AddPaymentMethodOptionsTest {
     }
 
     @Test
-    fun `default returns card when no funding sources supported`() {
+    fun `default returns null when no funding sources supported`() {
         val options = createOptions(fundingSources = emptyList())
 
-        assertThat(options.default).isEqualTo(AddPaymentMethodOption.Card)
+        assertThat(options.default).isNull()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -44,6 +44,7 @@ import com.stripe.android.link.utils.TestNavigationManager
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkBrand
@@ -802,10 +803,15 @@ internal class WalletScreenTest {
         linkConfirmationHandler: LinkConfirmationHandler = FakeLinkConfirmationHandler(),
         navigationManager: TestNavigationManager = TestNavigationManager(),
         dismissalCoordinator: LinkDismissalCoordinator = RealLinkDismissalCoordinator(),
-        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full
+        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
+        configuration: com.stripe.android.link.LinkConfiguration = TestFactory.LINK_CONFIGURATION.copy(
+            stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                linkFundingSources = listOf(ConsumerPaymentDetails.Card.TYPE)
+            )
+        ),
     ): WalletViewModel {
         return WalletViewModel(
-            configuration = TestFactory.LINK_CONFIGURATION,
+            configuration = configuration,
             linkAccount = TestFactory.LINK_ACCOUNT,
             linkAccountManager = linkAccountManager,
             logger = FakeLogger(),
@@ -822,7 +828,7 @@ internal class WalletScreenTest {
             ),
             addPaymentMethodOptions = AddPaymentMethodOptions(
                 linkAccount = TestFactory.LINK_ACCOUNT,
-                configuration = TestFactory.LINK_CONFIGURATION,
+                configuration = configuration,
                 linkLaunchMode = linkLaunchMode
             )
         ).also { viewModelStoreRule.track(it) }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -44,10 +44,10 @@ import com.stripe.android.link.utils.TestNavigationManager
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -73,13 +73,19 @@ class WalletViewModelTest {
     @Test
     fun `viewmodel should load payment methods on init`() = runTest(dispatcher) {
         val linkAccountManager = WalletLinkAccountManager()
+        val configuration = TestFactory.LINK_CONFIGURATION.copy(
+            stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                linkFundingSources = listOf(ConsumerPaymentDetails.Card.TYPE)
+            )
+        )
 
         val viewModel = createViewModel(
-            linkAccountManager = linkAccountManager
+            linkAccountManager = linkAccountManager,
+            configuration = configuration,
         )
 
         assertThat(linkAccountManager.listPaymentDetailsCalls)
-            .containsExactly(TestFactory.LINK_CONFIGURATION.stripeIntent.paymentMethodTypes.toSet())
+            .containsExactly(setOf(ConsumerPaymentDetails.Card.TYPE))
 
         val state = viewModel.uiState.value
 
@@ -89,7 +95,7 @@ class WalletViewModelTest {
                 email = "email@stripe.com",
                 allowLogOut = true,
                 selectedItemId = null,
-                cardBrandFilter = TestFactory.LINK_CONFIGURATION.cardBrandFilter,
+                cardBrandFilter = configuration.cardBrandFilter,
                 isProcessing = false,
                 hasCompleted = false,
                 userSetIsExpanded = false,
@@ -151,9 +157,16 @@ class WalletViewModelTest {
             navScreen = screen
         }
 
+        val configuration = TestFactory.LINK_CONFIGURATION.copy(
+            stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                linkFundingSources = listOf(ConsumerPaymentDetails.Card.TYPE)
+            )
+        )
+
         createViewModel(
             linkAccountManager = linkAccountManager,
-            navigateAndClearStack = ::navigateAndClearStack
+            navigateAndClearStack = ::navigateAndClearStack,
+            configuration = configuration,
         )
 
         assertThat(navScreen).isEqualTo(LinkScreen.PaymentMethod)
@@ -310,9 +323,7 @@ class WalletViewModelTest {
                 linkAccount = account,
                 configuration = configuration.copy(stripeIntent = stripeIntent.copy(linkFundingSources = emptyList()))
             ).uiState.value.addPaymentMethodOptions
-        ).containsExactly(
-            AddPaymentMethodOption.Card, // Card is available by default.
-        )
+        ).isEmpty()
     }
 
     @Test
@@ -964,6 +975,9 @@ class WalletViewModelTest {
             true to resolvableString(R.string.stripe_wallet_prefer_debit_card_hint),
         ).forEach { (enableHint, expectedHint) ->
             val configuration = TestFactory.LINK_CONFIGURATION.copy(
+                stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                    linkFundingSources = listOf(ConsumerPaymentDetails.Card.TYPE)
+                ),
                 flags = mapOf("link_show_prefer_debit_card_hint" to enableHint)
             )
 
@@ -1029,10 +1043,17 @@ class WalletViewModelTest {
             ConsumerPaymentDetails(paymentDetails = listOf(CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT))
         )
 
+        val configuration = TestFactory.LINK_CONFIGURATION.copy(
+            stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                linkFundingSources = listOf(ConsumerPaymentDetails.Card.TYPE)
+            )
+        )
+
         var navigatedScreen: LinkScreen? = null
 
         createViewModel(
             linkAccountManager = linkAccountManager,
+            configuration = configuration,
             linkLaunchMode = createPaymentMethodSelectionMode(
                 paymentMethodFilters = listOf(LinkPaymentMethodFilter.Card)
             ),


### PR DESCRIPTION
# Summary

The Android SDK wasn't respecting the `support_payment_details_types` field on the Consumer Session object, which dictates which payment method types are available for the given Link consumer. We now compute the available funding sources by taking an intersection between:

1. `elementsSession.linkFundingSources` what the merchant has configured as allowed on their Stripe account
2. `consumerSession.supportedPaymentDetailsTypes` what the server says this consumer can use
3. `linkConfiguration.supportedPaymentMethodTypes` what the merchant has configured as allowed on the Link mobile SDK 

We also now return early if the user has no available funding sources instead of falling back to card.

# Motivation

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-231

# Testing

Before:

https://github.com/user-attachments/assets/739957a7-7bc9-44ba-bc20-a10723fded21

After:

https://github.com/user-attachments/assets/5d8ddfe0-b6c7-4dc5-93c1-7d5df6f33f85


# Changelog

```
### PaymentSheet
* [FIXED] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
```