### PR TITLE
Use scoped appearance values in PaymentSheet

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeTypography
 import com.stripe.android.uicore.text.EmbeddableImage
 import com.stripe.android.uicore.text.Html
 
@@ -49,7 +49,7 @@ fun Mandate(
             style = caption.copy(
                 textAlign = textAlign,
                 lineHeight = lineHeight,
-                fontSize = 11.sp * StripeTheme.typographyMutable.fontSizeMultiplier,
+                fontSize = 11.sp * MaterialTheme.stripeTypography.fontSizeMultiplier,
                 fontWeight = FontWeight.Normal
             ),
             modifier = modifier

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetScaffold.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetScaffold.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -20,7 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.stripe.android.uicore.FormScrollProvider
-import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.stripeFormInsets
 
 @Composable
 internal fun BottomSheetScaffold(
@@ -60,7 +61,7 @@ internal fun BottomSheetScaffold(
                     .then(viewportModifier)
                     .verticalScroll(scrollState)
             ) {
-                Spacer(Modifier.height(StripeTheme.formInsets.top.dp))
+                Spacer(Modifier.height(MaterialTheme.stripeFormInsets.top.dp))
                 content()
                 Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
             }

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetScaffold.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetScaffold.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -19,7 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.stripeFormInsets
 
 @Composable
 internal fun BottomSheetScaffold(
@@ -57,7 +58,7 @@ internal fun BottomSheetScaffold(
                 .imePadding()
                 .verticalScroll(scrollState)
         ) {
-            Spacer(Modifier.height(StripeTheme.formInsets.top.dp))
+            Spacer(Modifier.height(MaterialTheme.stripeFormInsets.top.dp))
             content()
             Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
         }

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/PrimaryButton.kt
@@ -27,11 +27,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBackgroundColor
 import com.stripe.android.uicore.getBorderStrokeColor
 import com.stripe.android.uicore.getComposeTextStyle
 import com.stripe.android.uicore.getOnBackgroundColor
+import com.stripe.android.uicore.stripePrimaryButtonStyle
 import com.stripe.android.ui.core.R as UiCoreR
 
 @Composable
@@ -48,16 +48,17 @@ internal fun PrimaryButton(
     // We need to use PaymentsTheme.primaryButtonStyle instead of MaterialTheme
     // because of the rules API for primary button.
     val context = LocalContext.current
-    val background = Color(StripeTheme.primaryButtonStyle.getBackgroundColor(context))
-    val onBackground = Color(StripeTheme.primaryButtonStyle.getOnBackgroundColor(context))
+    val style = MaterialTheme.stripePrimaryButtonStyle
+    val background = Color(style.getBackgroundColor(context))
+    val onBackground = Color(style.getOnBackgroundColor(context))
     val borderStroke = BorderStroke(
-        StripeTheme.primaryButtonStyle.shape.borderStrokeWidth.dp,
-        Color(StripeTheme.primaryButtonStyle.getBorderStrokeColor(context))
+        style.shape.borderStrokeWidth.dp,
+        Color(style.getBorderStrokeColor(context))
     )
     val shape = RoundedCornerShape(
-        StripeTheme.primaryButtonStyle.shape.cornerRadius.dp
+        style.shape.cornerRadius.dp
     )
-    val textStyle = StripeTheme.primaryButtonStyle.getComposeTextStyle()
+    val textStyle = style.getComposeTextStyle()
 
     CompositionLocalProvider(
         LocalContentAlpha provides if (isEnabled) ContentAlpha.high else ContentAlpha.disabled
@@ -71,7 +72,7 @@ internal fun PrimaryButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .defaultMinSize(
-                        minHeight = StripeTheme.primaryButtonStyle.shape.height.dp
+                        minHeight = style.shape.height.dp
                     ),
                 enabled = isEnabled,
                 shape = shape,
@@ -110,7 +111,7 @@ private fun PrimaryButtonContent(
     displayLockIcon: Boolean,
 ) {
     val context = LocalContext.current
-    val onBackground = Color(StripeTheme.primaryButtonStyle.getOnBackgroundColor(context))
+    val onBackground = Color(MaterialTheme.stripePrimaryButtonStyle.getOnBackgroundColor(context))
 
     BoxWithConstraints(contentAlignment = Alignment.CenterStart) {
         Text(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentElementThemeValues.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentElementThemeValues.kt
@@ -1,0 +1,148 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
+import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
+import com.stripe.android.uicore.FormInsets
+import com.stripe.android.uicore.PrimaryButtonColors
+import com.stripe.android.uicore.PrimaryButtonShape
+import com.stripe.android.uicore.PrimaryButtonStyle
+import com.stripe.android.uicore.PrimaryButtonTypography
+import com.stripe.android.uicore.StripeColors
+import com.stripe.android.uicore.StripeShapes
+import com.stripe.android.uicore.StripeThemeDefaults
+import com.stripe.android.uicore.StripeTypography
+import com.stripe.android.uicore.IconStyle as StripeIconStyle
+
+internal data class PaymentElementThemeValues(
+    val colorsLight: StripeColors,
+    val colorsDark: StripeColors,
+    val shapes: StripeShapes,
+    val typography: StripeTypography,
+    val primaryButtonStyle: PrimaryButtonStyle,
+    val formInsets: FormInsets,
+    val sectionSpacing: Float?,
+    val textFieldInsets: FormInsets,
+    val iconStyle: StripeIconStyle,
+    val verticalModeRowPadding: Float,
+)
+
+@OptIn(AppearanceAPIAdditionsPreview::class)
+internal fun PaymentSheet.Appearance.toPaymentElementThemeValues(): PaymentElementThemeValues {
+    return PaymentElementThemeValues(
+        colorsLight = colorsLight.toStripeColors(isDark = false),
+        colorsDark = colorsDark.toStripeColors(isDark = true),
+        shapes = shapes.toStripeShapes(),
+        typography = typography.toStripeTypography(),
+        primaryButtonStyle = primaryButton.toStripePrimaryButtonStyle(
+            colorsLight = colorsLight,
+            colorsDark = colorsDark,
+            shapes = shapes,
+            typography = typography,
+        ),
+        formInsets = formInsetValues.toStripeFormInsets(),
+        sectionSpacing = sectionSpacing.spacingDp.takeIf { it >= 0f },
+        textFieldInsets = textFieldInsets.toStripeFormInsets(),
+        iconStyle = iconStyle.toStripeIconStyle(),
+        verticalModeRowPadding = verticalModeRowPadding,
+    )
+}
+
+private fun PaymentSheet.Colors.toStripeColors(isDark: Boolean): StripeColors {
+    val materialColors = if (isDark) {
+        darkColors(
+            primary = Color(primary),
+            surface = Color(surface),
+            onSurface = Color(onSurface),
+            error = Color(error),
+        )
+    } else {
+        lightColors(
+            primary = Color(primary),
+            surface = Color(surface),
+            onSurface = Color(onSurface),
+            error = Color(error),
+        )
+    }
+
+    return StripeThemeDefaults.colors(isDark).copy(
+        component = Color(component),
+        componentBorder = Color(componentBorder),
+        componentDivider = Color(componentDivider),
+        onComponent = Color(onComponent),
+        subtitle = Color(subtitle),
+        placeholderText = Color(placeholderText),
+        appBarIcon = Color(appBarIcon),
+        materialColors = materialColors,
+    )
+}
+
+private fun PaymentSheet.Shapes.toStripeShapes(): StripeShapes {
+    return StripeThemeDefaults.shapes.copy(
+        cornerRadius = cornerRadiusDp,
+        bottomSheetCornerRadius = bottomSheetCornerRadiusDp,
+        borderStrokeWidth = borderStrokeWidthDp,
+    )
+}
+
+@OptIn(AppearanceAPIAdditionsPreview::class)
+private fun PaymentSheet.Typography.toStripeTypography(): StripeTypography {
+    return StripeThemeDefaults.typography.copy(
+        fontFamily = fontResId,
+        fontSizeMultiplier = sizeScaleFactor,
+        h4 = custom.h1?.toTextStyle(),
+    )
+}
+
+private fun PaymentSheet.PrimaryButton.toStripePrimaryButtonStyle(
+    colorsLight: PaymentSheet.Colors,
+    colorsDark: PaymentSheet.Colors,
+    shapes: PaymentSheet.Shapes,
+    typography: PaymentSheet.Typography,
+): PrimaryButtonStyle {
+    return StripeThemeDefaults.primaryButtonStyle.copy(
+        colorsLight = this.colorsLight.toStripePrimaryButtonColors(fallbackBackground = colorsLight.primary),
+        colorsDark = this.colorsDark.toStripePrimaryButtonColors(fallbackBackground = colorsDark.primary),
+        shape = PrimaryButtonShape(
+            cornerRadius = shape.cornerRadiusDp ?: shapes.cornerRadiusDp,
+            borderStrokeWidth = shape.borderStrokeWidthDp ?: shapes.borderStrokeWidthDp,
+            height = shape.heightDp ?: StripeThemeDefaults.primaryButtonStyle.shape.height,
+        ),
+        typography = PrimaryButtonTypography(
+            fontFamily = this.typography.fontResId ?: typography.fontResId,
+            fontSize = this.typography.fontSizeSp?.sp
+                ?: (StripeThemeDefaults.typography.largeFontSize * typography.sizeScaleFactor),
+        ),
+    )
+}
+
+private fun PaymentSheet.PrimaryButtonColors.toStripePrimaryButtonColors(
+    fallbackBackground: Int,
+): PrimaryButtonColors {
+    return PrimaryButtonColors(
+        background = Color(background ?: fallbackBackground),
+        onBackground = Color(onBackground),
+        border = Color(border),
+        successBackground = Color(successBackgroundColor),
+        onSuccessBackground = Color(onSuccessBackgroundColor),
+    )
+}
+
+private fun PaymentSheet.Insets.toStripeFormInsets(): FormInsets {
+    return FormInsets(
+        start = startDp,
+        top = topDp,
+        end = endDp,
+        bottom = bottomDp,
+    )
+}
+
+@OptIn(AppearanceAPIAdditionsPreview::class)
+private fun PaymentSheet.IconStyle.toStripeIconStyle(): StripeIconStyle {
+    return when (this) {
+        PaymentSheet.IconStyle.Filled -> StripeIconStyle.Filled
+        PaymentSheet.IconStyle.Outlined -> StripeIconStyle.Outlined
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -14,9 +14,9 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
+import com.stripe.android.paymentsheet.ui.PaymentElementTheme
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.flow.filterNotNull
@@ -68,7 +68,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
 
         setContent {
-            StripeTheme {
+            PaymentElementTheme(appearance = starterArgs.config.appearance) {
                 val isProcessing by viewModel.processing.collectAsState()
 
                 val bottomSheetState = rememberStripeBottomSheetState(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -1,8 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -11,114 +8,22 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
-import com.stripe.android.uicore.FormInsets
-import com.stripe.android.uicore.IconStyle
-import com.stripe.android.uicore.PrimaryButtonColors
-import com.stripe.android.uicore.PrimaryButtonShape
-import com.stripe.android.uicore.PrimaryButtonTypography
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.StripeThemeDefaults
 
 @OptIn(AppearanceAPIAdditionsPreview::class)
 internal fun PaymentSheet.Appearance.parseAppearance() {
-    StripeTheme.colorsLightMutable = StripeThemeDefaults.colorsLight.copy(
-        component = Color(colorsLight.component),
-        componentBorder = Color(colorsLight.componentBorder),
-        componentDivider = Color(colorsLight.componentDivider),
-        onComponent = Color(colorsLight.onComponent),
-        subtitle = Color(colorsLight.subtitle),
-        placeholderText = Color(colorsLight.placeholderText),
-        appBarIcon = Color(colorsLight.appBarIcon),
-        materialColors = lightColors(
-            primary = Color(colorsLight.primary),
-            surface = Color(colorsLight.surface),
-            onSurface = Color(colorsLight.onSurface),
-            error = Color(colorsLight.error)
-        )
-    )
+    val values = toPaymentElementThemeValues()
 
-    StripeTheme.colorsDarkMutable = StripeThemeDefaults.colorsDark.copy(
-        component = Color(colorsDark.component),
-        componentBorder = Color(colorsDark.componentBorder),
-        componentDivider = Color(colorsDark.componentDivider),
-        onComponent = Color(colorsDark.onComponent),
-        subtitle = Color(colorsDark.subtitle),
-        placeholderText = Color(colorsDark.placeholderText),
-        appBarIcon = Color(colorsDark.appBarIcon),
-        materialColors = darkColors(
-            primary = Color(colorsDark.primary),
-            surface = Color(colorsDark.surface),
-            onSurface = Color(colorsDark.onSurface),
-            error = Color(colorsDark.error)
-        )
-    )
-
-    StripeTheme.shapesMutable = StripeThemeDefaults.shapes.copy(
-        cornerRadius = shapes.cornerRadiusDp,
-        bottomSheetCornerRadius = shapes.bottomSheetCornerRadiusDp,
-        borderStrokeWidth = shapes.borderStrokeWidthDp
-    )
-
-    StripeTheme.typographyMutable = StripeThemeDefaults.typography.copy(
-        fontFamily = typography.fontResId,
-        fontSizeMultiplier = typography.sizeScaleFactor,
-        h4 = typography.custom.h1?.toTextStyle(),
-    )
-
-    StripeTheme.primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle.copy(
-        colorsLight = PrimaryButtonColors(
-            background = Color(primaryButton.colorsLight.background ?: colorsLight.primary),
-            onBackground = Color(primaryButton.colorsLight.onBackground),
-            border = Color(primaryButton.colorsLight.border),
-            successBackground = Color(primaryButton.colorsLight.successBackgroundColor),
-            onSuccessBackground = Color(primaryButton.colorsLight.onSuccessBackgroundColor),
-        ),
-        colorsDark = PrimaryButtonColors(
-            background = Color(primaryButton.colorsDark.background ?: colorsDark.primary),
-            onBackground = Color(primaryButton.colorsDark.onBackground),
-            border = Color(primaryButton.colorsDark.border),
-            successBackground = Color(primaryButton.colorsDark.successBackgroundColor),
-            onSuccessBackground = Color(primaryButton.colorsDark.onSuccessBackgroundColor),
-        ),
-        shape = PrimaryButtonShape(
-            cornerRadius = primaryButton.shape.cornerRadiusDp ?: shapes.cornerRadiusDp,
-            borderStrokeWidth =
-            primaryButton.shape.borderStrokeWidthDp ?: shapes.borderStrokeWidthDp,
-            height = primaryButton.shape.heightDp ?: StripeThemeDefaults.primaryButtonStyle.shape.height
-        ),
-        typography = PrimaryButtonTypography(
-            fontFamily = primaryButton.typography.fontResId ?: typography.fontResId,
-            fontSize = primaryButton.typography.fontSizeSp?.sp
-                ?: (StripeThemeDefaults.typography.largeFontSize * typography.sizeScaleFactor)
-        )
-    )
-
-    StripeTheme.formInsets = StripeThemeDefaults.formInsets.copy(
-        start = formInsetValues.startDp,
-        top = formInsetValues.topDp,
-        end = formInsetValues.endDp,
-        bottom = formInsetValues.bottomDp
-    )
-
-    StripeTheme.customSectionSpacing = if (sectionSpacing.spacingDp >= 0f) {
-        sectionSpacing.spacingDp
-    } else {
-        null
-    }
-
-    StripeTheme.verticalModeRowPadding = verticalModeRowPadding
-
-    StripeTheme.textFieldInsets = FormInsets(
-        start = textFieldInsets.startDp,
-        end = textFieldInsets.endDp,
-        top = textFieldInsets.topDp,
-        bottom = textFieldInsets.bottomDp,
-    )
-
-    StripeTheme.iconStyle = when (iconStyle) {
-        PaymentSheet.IconStyle.Filled -> IconStyle.Filled
-        PaymentSheet.IconStyle.Outlined -> IconStyle.Outlined
-    }
+    StripeTheme.colorsLightMutable = values.colorsLight
+    StripeTheme.colorsDarkMutable = values.colorsDark
+    StripeTheme.shapesMutable = values.shapes
+    StripeTheme.typographyMutable = values.typography
+    StripeTheme.primaryButtonStyle = values.primaryButtonStyle
+    StripeTheme.formInsets = values.formInsets
+    StripeTheme.customSectionSpacing = values.sectionSpacing
+    StripeTheme.verticalModeRowPadding = values.verticalModeRowPadding
+    StripeTheme.textFieldInsets = values.textFieldInsets
+    StripeTheme.iconStyle = values.iconStyle
 }
 
 internal val WalletType.configType: PaymentSheet.WalletButtonsConfiguration.Wallet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -40,13 +40,13 @@ import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcompone
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldSection
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.text.annotatedStringResource
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.flow.collectLatest
@@ -250,7 +250,7 @@ internal fun AutocompleteScreenUI(
                 .padding(paddingValues)
         ) {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(top = StripeTheme.formInsets.top.dp)
+                modifier = Modifier.fillMaxWidth().padding(top = MaterialTheme.stripeFormInsets.top.dp)
             ) {
                 Box(
                     modifier = Modifier
@@ -259,7 +259,7 @@ internal fun AutocompleteScreenUI(
                 ) {
                     TextFieldSection(
                         textFieldController = queryController,
-                        modifier = Modifier.padding(StripeTheme.getOuterFormInsets())
+                        modifier = Modifier.padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
                     ) {
                         TextField(
                             modifier = Modifier
@@ -282,7 +282,9 @@ internal fun AutocompleteScreenUI(
                                 modifier = Modifier.padding(vertical = 8.dp)
                             )
                             Column(
-                                modifier = Modifier.fillMaxWidth().padding(StripeTheme.getOuterFormInsets())
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
                             ) {
                                 it.forEach { prediction ->
                                     val primaryText = prediction.primaryText
@@ -332,7 +334,7 @@ internal fun AutocompleteScreenUI(
                                 contentDescription = null,
                                 modifier = Modifier
                                     .padding(vertical = 16.dp)
-                                    .padding(StripeTheme.getOuterFormInsets())
+                                    .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
                                     .testTag(TEST_TAG_ATTRIBUTION_DRAWABLE)
                             )
                         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -23,10 +23,10 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.FormUI
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.stateFlowOf
 import javax.inject.Provider
@@ -63,7 +63,9 @@ internal fun InputAddressScreen(
             modifier = Modifier.padding(it)
         ) {
             Column(
-                Modifier.padding(StripeTheme.getOuterFormInsets()).padding(top = StripeTheme.formInsets.top.dp)
+                Modifier
+                    .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
+                    .padding(top = MaterialTheme.stripeFormInsets.top.dp)
             ) {
                 Text(
                     title,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.navigation
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -36,8 +37,8 @@ import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.CvcController
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getOuterFormInsets
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -319,7 +320,7 @@ internal sealed interface PaymentSheetScreen {
         override fun Content(modifier: Modifier) {
             PaymentMethodVerticalLayoutUI(
                 interactor,
-                modifier.padding(StripeTheme.getOuterFormInsets())
+                modifier.padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateButton.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.common.ui.PrimaryButton
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getComposeTextStyle
+import com.stripe.android.uicore.stripePrimaryButtonStyle
 
 @Composable
 internal fun BacsMandateButton(type: BacsMandateButtonType, label: String, onClick: () -> Unit) {
@@ -22,7 +22,7 @@ internal fun BacsMandateButton(type: BacsMandateButtonType, label: String, onCli
         )
         BacsMandateButtonType.Secondary -> {
             // Use the same text style as the primary button but a different color.
-            val textStyle = StripeTheme.primaryButtonStyle.getComposeTextStyle().copy(
+            val textStyle = MaterialTheme.stripePrimaryButtonStyle.getComposeTextStyle().copy(
                 color = MaterialTheme.colors.primary
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
@@ -36,6 +36,7 @@ import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.stripeTypography
 import com.stripe.android.uicore.text.Html
 import com.stripe.android.uicore.utils.collectAsState
@@ -59,7 +60,7 @@ internal fun BacsMandateConfirmationFormView(
     viewActionHandler: (action: BacsMandateConfirmationViewAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
 
     return Column(
         modifier = modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
@@ -56,6 +56,7 @@ import com.stripe.android.uicore.elements.TextFieldColors
 import com.stripe.android.uicore.elements.TrailingIcon
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable
@@ -69,7 +70,7 @@ internal fun CvcRecollectionScreen(
         Column(
             Modifier
                 .background(MaterialTheme.stripeColors.materialColors.surface)
-                .padding(StripeTheme.getOuterFormInsets())
+                .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
         ) {
             CvcRecollectionTopBar(isTestMode) {
                 viewActionHandler.invoke(CvcRecollectionViewAction.OnBackPressed)
@@ -100,7 +101,7 @@ internal fun CvcRecollectionPaymentSheetScreen(
         Column(
             Modifier
                 .background(MaterialTheme.stripeColors.materialColors.surface)
-                .padding(StripeTheme.getOuterFormInsets())
+                .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
         ) {
             CvcRecollectionTitle()
             CvcRecollectionField(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
@@ -38,6 +38,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -111,7 +112,7 @@ private fun ActivePolling(
         modifier = modifier
             .fillMaxSize()
             .padding(vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top))
-            .padding(StripeTheme.getOuterFormInsets())
+            .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
     ) {
         LoadingIndicator(
             modifier = Modifier.padding(bottom = Spacing.extended),
@@ -173,7 +174,7 @@ private fun FailedPolling(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top))
-                    .padding(StripeTheme.getOuterFormInsets())
+                    .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
             ) {
                 Image(
                     painter = painterResource(R.drawable.stripe_ic_paymentsheet_polling_failure),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/NewPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/NewPaymentMethodTabLayoutUI.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -22,10 +23,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
-import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.FormInsets
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.stripeFormInsets
 
 private object PaymentMethodsUISpacing {
     val carouselInnerPadding = 12.dp
@@ -77,7 +79,7 @@ internal fun NewPaymentMethodTabLayoutUI(
 
         LazyRow(
             state = state,
-            contentPadding = StripeTheme.getOuterFormInsets(),
+            contentPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets(),
             horizontalArrangement = Arrangement.spacedBy(innerPadding),
             userScrollEnabled = isEnabled,
             modifier = Modifier.testTag(TEST_TAG_LIST)
@@ -109,15 +111,19 @@ internal fun NewPaymentMethodTabLayoutUI(
 private fun rememberViewWidth(
     maxWidth: Dp,
     numberOfPaymentMethods: Int
-) = remember(maxWidth, numberOfPaymentMethods) {
-    calculateViewWidth(maxWidth, numberOfPaymentMethods)
+): Dp {
+    val formInsets = MaterialTheme.stripeFormInsets
+    return remember(maxWidth, numberOfPaymentMethods, formInsets) {
+        calculateViewWidth(maxWidth, numberOfPaymentMethods, formInsets)
+    }
 }
 
 internal fun calculateViewWidth(
     maxWidth: Dp,
-    numberOfPaymentMethods: Int
+    numberOfPaymentMethods: Int,
+    formInsets: FormInsets,
 ): Dp {
-    val targetWidth = maxWidth - (StripeTheme.formInsets.end + StripeTheme.formInsets.start).dp
+    val targetWidth = maxWidth - (formInsets.end + formInsets.start).dp
     val minItemWidth = 90.dp
 
     val minimumCardsWidth = minItemWidth * numberOfPaymentMethods

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,10 +32,10 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.utils.isOnlyOneNonCardPaymentMethod
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormHeaderUI
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
+import com.stripe.android.uicore.stripeFormInsets
 import java.util.UUID
 
 @Composable
@@ -57,7 +58,7 @@ internal fun PaymentElement(
         DefaultStripeImageLoader(context.applicationContext)
     }
 
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
 
     val selectedIndex = remember(selectedItemCode, supportedPaymentMethods) {
         supportedPaymentMethods.map { it.code }.indexOf(selectedItemCode)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElementTheme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElementTheme.kt
@@ -1,0 +1,97 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.view.ContextThemeWrapper
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.toPaymentElementThemeValues
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.StripeThemeDefaults
+
+@Composable
+internal fun PaymentElementTheme(
+    appearance: PaymentSheet.Appearance,
+    content: @Composable () -> Unit,
+) {
+    val isDark = appearance.themeMode.isDarkTheme(isSystemInDarkTheme())
+    val themeValues = remember(appearance) {
+        appearance.toPaymentElementThemeValues()
+    }
+    val baseContext = LocalContext.current
+    val inspectionMode = LocalInspectionMode.current
+    val styleContext = remember(baseContext, isDark, inspectionMode) {
+        baseContext.withUiMode(
+            uiMode = if (isDark) {
+                Configuration.UI_MODE_NIGHT_YES
+            } else {
+                Configuration.UI_MODE_NIGHT_NO
+            },
+            inspectionMode = inspectionMode,
+        )
+    }
+
+    CompositionLocalProvider(
+        LocalContext provides styleContext,
+    ) {
+        StripeTheme(
+            isDark = isDark,
+            colors = if (isDark) themeValues.colorsDark else themeValues.colorsLight,
+            shapes = themeValues.shapes,
+            typography = themeValues.typography,
+            primaryButtonStyle = themeValues.primaryButtonStyle,
+            formInsets = themeValues.formInsets,
+            sectionSpacing = themeValues.sectionSpacing,
+            sectionStyle = StripeThemeDefaults.sectionStyle,
+            textFieldInsets = themeValues.textFieldInsets,
+            iconStyle = themeValues.iconStyle,
+            verticalModeRowPadding = themeValues.verticalModeRowPadding,
+            content = content,
+        )
+    }
+}
+
+internal fun PaymentSheet.ThemeMode.isDarkTheme(isSystemDark: Boolean): Boolean {
+    return when (this) {
+        PaymentSheet.ThemeMode.Automatic -> isSystemDark
+        PaymentSheet.ThemeMode.AlwaysLight -> false
+        PaymentSheet.ThemeMode.AlwaysDark -> true
+    }
+}
+
+private fun Context.withUiMode(
+    uiMode: Int,
+    inspectionMode: Boolean,
+): Context {
+    if (uiMode == (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)) {
+        return this
+    }
+
+    val config = Configuration(resources.configuration).apply {
+        this.uiMode = (this.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or uiMode
+    }
+
+    return object : ContextThemeWrapper(this, theme) {
+        override fun getResources(): Resources {
+            @Suppress("DEPRECATION")
+            if (inspectionMode) {
+                val baseResources = this@withUiMode.resources
+                return Resources(
+                    baseResources.assets,
+                    baseResources.displayMetrics,
+                    config,
+                )
+            }
+
+            return super.getResources()
+        }
+    }.apply {
+        applyOverrideConfiguration(config)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -79,11 +79,13 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.CircularProgressIndicator
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.ui.core.elements.Mandate
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBackgroundColor
+import com.stripe.android.uicore.getComposeTextStyle
 import com.stripe.android.uicore.getOuterFormInsets
-import com.stripe.android.uicore.isSystemDarkTheme
 import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.stripeFormInsets
+import com.stripe.android.uicore.stripePrimaryButtonStyle
+import com.stripe.android.uicore.stripeThemeIsDark
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.delay
 
@@ -336,7 +338,7 @@ private fun PaymentSheetContent(
     mandateText: MandateText?,
     modifier: Modifier
 ) {
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
     Column(modifier = modifier.padding(bottom = currentScreen.bottomContentPadding)) {
         headerText?.let { text ->
             H4Text(
@@ -419,7 +421,7 @@ internal fun Wallet(
     cardBrandFilter: CardBrandFilter,
     cardFundingFilter: CardFundingFilter
 ) {
-    val padding = StripeTheme.getOuterFormInsets()
+    val padding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
 
     Column(modifier = modifier.padding(padding)) {
         WalletHeader(
@@ -498,7 +500,7 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
     val uiState by viewModel.primaryButtonUiState.collectAsState()
 
     val modifier = Modifier
-        .padding(StripeTheme.getOuterFormInsets())
+        .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
         .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
         .semantics {
             role = Role.Button
@@ -513,6 +515,9 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
     }
 
     val context = LocalContext.current
+    val primaryButtonStyle = MaterialTheme.stripePrimaryButtonStyle
+    val primaryButtonTextStyle = primaryButtonStyle.getComposeTextStyle()
+    val isDark = MaterialTheme.stripeThemeIsDark
 
     Box {
         AndroidViewBinding(
@@ -521,13 +526,14 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
                 val primaryButton = binding.primaryButton
                 button = primaryButton
                 primaryButton.setAppearanceConfiguration(
-                    StripeTheme.primaryButtonStyle,
+                    primaryButtonStyle = primaryButtonStyle,
+                    labelTextStyle = primaryButtonTextStyle,
                     tintList = ColorStateList.valueOf(
-                        if (context.isSystemDarkTheme()) {
+                        if (isDark) {
                             viewModel.config.appearance.primaryButton.colorsDark.background
                         } else {
                             viewModel.config.appearance.primaryButton.colorsLight.background
-                        } ?: StripeTheme.primaryButtonStyle.getBackgroundColor(context)
+                        } ?: primaryButtonStyle.getBackgroundColor(context)
                     )
                 )
                 binding

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -14,12 +14,16 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.withStyledAttributes
@@ -31,11 +35,9 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.StripeAndroidPrimaryButtonBinding
 import com.stripe.android.uicore.PrimaryButtonStyle
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.convertDpToPx
 import com.stripe.android.uicore.getBorderStrokeColor
-import com.stripe.android.uicore.getComposeTextStyle
 import com.stripe.android.uicore.getOnBackgroundColor
 import com.stripe.android.uicore.getOnSuccessBackgroundColor
 import com.stripe.android.uicore.getSuccessBackgroundColor
@@ -59,6 +61,7 @@ internal class PrimaryButton @JvmOverloads constructor(
     private var originalLabel: ResolvableString? = null
 
     private var defaultLabelColor: Int? = null
+    private var labelTextStyle by mutableStateOf(TextStyle.Default)
 
     @VisibleForTesting
     internal var externalLabel: ResolvableString? = null
@@ -103,8 +106,10 @@ internal class PrimaryButton @JvmOverloads constructor(
 
     fun setAppearanceConfiguration(
         primaryButtonStyle: PrimaryButtonStyle,
+        labelTextStyle: TextStyle,
         tintList: ColorStateList?
     ) {
+        this.labelTextStyle = labelTextStyle
         cornerRadius = context.convertDpToPx(primaryButtonStyle.shape.cornerRadius.dp)
         borderStrokeWidth = context.convertDpToPx(primaryButtonStyle.shape.borderStrokeWidth.dp)
         borderStrokeColor = primaryButtonStyle.getBorderStrokeColor(context)
@@ -170,6 +175,7 @@ internal class PrimaryButton @JvmOverloads constructor(
                 LabelUI(
                     label = text.resolve(),
                     color = defaultLabelColor,
+                    style = labelTextStyle,
                 )
             }
         }
@@ -316,21 +322,19 @@ internal class PrimaryButton @JvmOverloads constructor(
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-private fun LabelUI(label: String, color: Int?) {
-    StripeTheme {
-        Text(
-            text = label,
-            textAlign = TextAlign.Center,
-            color = color?.let { Color(it) } ?: Color.Unspecified,
-            style = StripeTheme.primaryButtonStyle.getComposeTextStyle(),
-            modifier = Modifier
-                .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
-                .semantics {
-                    // This shouldn't be visible for accessibility purposes
-                    // due to the content description and the click listener
-                    // being defined outside of compose, in PrimaryButton.
-                    hideFromAccessibility()
-                }
-        )
-    }
+private fun LabelUI(label: String, color: Int?, style: TextStyle) {
+    Text(
+        text = label,
+        textAlign = TextAlign.Center,
+        color = color?.let { Color(it) } ?: Color.Unspecified,
+        style = style,
+        modifier = Modifier
+            .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
+            .semantics {
+                // This shouldn't be visible for accessibility purposes
+                // due to the content description and the click listener
+                // being defined outside of compose, in PrimaryButton.
+                hideFromAccessibility()
+            }
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonTheme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonTheme.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
@@ -13,12 +14,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBackgroundColor
 import com.stripe.android.uicore.getBorderStrokeColor
 import com.stripe.android.uicore.getOnBackgroundColor
 import com.stripe.android.uicore.getOnSuccessBackgroundColor
 import com.stripe.android.uicore.getSuccessBackgroundColor
+import com.stripe.android.uicore.stripePrimaryButtonStyle
 
 internal data class PrimaryButtonColors(
     val background: Color = Color.Unspecified,
@@ -66,7 +67,7 @@ internal object PrimaryButtonTheme {
 
     @Composable
     private fun getPrimaryButtonColors(): PrimaryButtonColors {
-        val style = StripeTheme.primaryButtonStyle
+        val style = MaterialTheme.stripePrimaryButtonStyle
         val context = LocalContext.current
         val localColors = LocalPrimaryButtonColors.current
 
@@ -97,7 +98,7 @@ internal object PrimaryButtonTheme {
 
     @Composable
     private fun getPrimaryButtonShape(): PrimaryButtonShape {
-        val style = StripeTheme.primaryButtonStyle
+        val style = MaterialTheme.stripePrimaryButtonStyle
         val localShape = LocalPrimaryButtonShape.current
 
         return remember(style, localShape) {
@@ -117,7 +118,7 @@ internal object PrimaryButtonTheme {
 
     @Composable
     private fun getPrimaryButtonTypography(): PrimaryButtonTypography {
-        val style = StripeTheme.primaryButtonStyle
+        val style = MaterialTheme.stripePrimaryButtonStyle
         val localTypography = LocalPrimaryButtonTypography.current
 
         return remember(style, localTypography) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemoveButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemoveButton.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.ui.LoadingIndicator
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getComposeTextStyle
+import com.stripe.android.uicore.stripePrimaryButtonStyle
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val REMOVE_BUTTON_LOADING = "REMOVE_BUTTON_LOADING"
@@ -74,7 +74,7 @@ internal fun RemoveButton(
                         color = MaterialTheme.colors.error.copy(
                             LocalContentAlpha.current
                         ),
-                        style = StripeTheme.primaryButtonStyle.getComposeTextStyle(),
+                        style = MaterialTheme.stripePrimaryButtonStyle.getComposeTextStyle(),
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -60,7 +60,6 @@ import com.stripe.android.paymentsheet.toPaymentSelection
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.uicore.DefaultStripeTheme
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.SectionValidationMessage
@@ -68,6 +67,7 @@ import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
@@ -644,7 +644,7 @@ internal fun CvcRecollectionField(
         Column(
             Modifier
                 .padding(top = 20.dp)
-                .padding(StripeTheme.getOuterFormInsets())
+                .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
         ) {
             Text(
                 text = stringResource(R.string.stripe_paymentsheet_confirm_your_cvc),
@@ -675,9 +675,10 @@ internal fun CvcRecollectionField(
     }
 }
 
+@Composable
 private fun getSavedPaymentMethodTabLayoutPaddingValues() = PaddingValues(
-    start = (StripeTheme.formInsets.start - TAB_LAYOUT_EXTRA_PADDING).dp.coerceAtLeast(0.dp),
-    end = (StripeTheme.formInsets.end - TAB_LAYOUT_EXTRA_PADDING).dp.coerceAtLeast(0.dp)
+    start = (MaterialTheme.stripeFormInsets.start - TAB_LAYOUT_EXTRA_PADDING).dp.coerceAtLeast(0.dp),
+    end = (MaterialTheme.stripeFormInsets.end - TAB_LAYOUT_EXTRA_PADDING).dp.coerceAtLeast(0.dp)
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -32,12 +32,12 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.SavedPaymentMethod
 import com.stripe.android.paymentsheet.utils.testMetadata
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.paymentsheet.R as PaymentSheetR
@@ -45,7 +45,7 @@ import com.stripe.android.paymentsheet.R as PaymentSheetR
 @Composable
 internal fun UpdatePaymentMethodUI(interactor: UpdatePaymentMethodInteractor, modifier: Modifier) {
     val context = LocalContext.current
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
     val state by interactor.state.collectAsState()
     val shouldShowCardBrandDropdown = interactor.shouldShowCardBrandDropdown
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ComposeUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ComposeUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -9,11 +10,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
-import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.stripeFormInsets
 
 @Composable
 internal fun PaymentSheetContentPadding(subtractingExtraPadding: Dp = 0.dp) {
-    val bottomPadding = StripeTheme.formInsets.bottom.dp - subtractingExtraPadding
+    val bottomPadding = MaterialTheme.stripeFormInsets.bottom.dp - subtractingExtraPadding
     Spacer(modifier = Modifier.requiredHeight(bottomPadding.coerceAtLeast(0.dp)))
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -4,19 +4,20 @@ import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getOuterFormInsets
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable
 internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
 
     val state by interactor.state.collectAsState()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -29,10 +29,10 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeVerticalModeRowPadding
 import com.stripe.android.uicore.utils.collectAsState
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -133,7 +133,7 @@ internal fun PaymentMethodVerticalLayoutUI(
         val rowStyle = PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton.default.run {
             PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton.Builder()
                 .spacingDp(spacingDp)
-                .additionalInsetsDp(StripeTheme.verticalModeRowPadding)
+                .additionalInsetsDp(MaterialTheme.stripeVerticalModeRowPadding)
                 .build()
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmUI.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.verticalmode
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -11,15 +12,15 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.H4Text
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getOuterFormInsets
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable
 internal fun SavedPaymentMethodConfirmUI(
     savedPaymentMethodConfirmInteractor: SavedPaymentMethodConfirmInteractor,
 ) {
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
 
     Column(
         modifier = Modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -23,10 +23,10 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ui.FormElement
 import com.stripe.android.paymentsheet.ui.PaymentMethodIcon
 import com.stripe.android.paymentsheet.ui.PromoBadge
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.stripeFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -38,7 +38,7 @@ internal fun VerticalModeFormUI(
     showsWalletHeader: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val horizontalPadding = StripeTheme.getOuterFormInsets()
+    val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
 
     var hasSentInteractionEvent by remember { mutableStateOf(false) }
     val state by interactor.state.collectAsState()
@@ -89,7 +89,7 @@ internal fun VerticalModeFormHeaderUI(
     Row(
         modifier = Modifier
             .padding(bottom = 12.dp)
-            .padding(StripeTheme.getOuterFormInsets()),
+            .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets()),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (formHeaderInformation.shouldShowIcon) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.View.GONE
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.ui.text.TextStyle
 import androidx.core.view.isVisible
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -48,7 +49,11 @@ class PrimaryButtonTest {
 
     @Test
     fun `onFinishingState() should clear any tint and restore onReadyState()`() {
-        primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))
+        primaryButton.setAppearanceConfiguration(
+            primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle,
+            labelTextStyle = TextStyle.Default,
+            tintList = ColorStateList.valueOf(Color.BLACK),
+        )
         primaryButton.updateState(
             PrimaryButton.State.FinishProcessing({})
         )
@@ -62,7 +67,11 @@ class PrimaryButtonTest {
 
     @Test
     fun `onStartProcessing() and onFinishingState() should make button not clickable`() {
-        primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))
+        primaryButton.setAppearanceConfiguration(
+            primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle,
+            labelTextStyle = TextStyle.Default,
+            tintList = ColorStateList.valueOf(Color.BLACK),
+        )
         primaryButton.updateState(
             PrimaryButton.State.StartProcessing
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentElementThemeTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentElementThemeTest.kt
@@ -1,0 +1,205 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.os.Build
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.parseAppearance
+import com.stripe.android.paymentsheet.toPaymentElementThemeValues
+import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.uicore.FormInsets
+import com.stripe.android.uicore.IconStyle
+import com.stripe.android.uicore.LocalIconStyle
+import com.stripe.android.uicore.LocalSectionSpacing
+import com.stripe.android.uicore.LocalTextFieldInsets
+import com.stripe.android.uicore.PrimaryButtonStyle
+import com.stripe.android.uicore.StripeColors
+import com.stripe.android.uicore.StripeShapes
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.StripeTypography
+import com.stripe.android.uicore.isSystemDarkTheme
+import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeFormInsets
+import com.stripe.android.uicore.stripePrimaryButtonStyle
+import com.stripe.android.uicore.stripeShapes
+import com.stripe.android.uicore.stripeThemeIsDark
+import com.stripe.android.uicore.stripeTypography
+import com.stripe.android.uicore.stripeVerticalModeRowPadding
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(AppearanceAPIAdditionsPreview::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+internal class PaymentElementThemeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @Test
+    @Config(qualifiers = "notnight")
+    fun `always dark provides dark appearance independently of system theme`() = runScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysDark,
+    ) {
+        assertThat(isDark).isTrue()
+        assertThat(contextIsDark).isTrue()
+        assertThat(colors.materialColors.primary).isEqualTo(DARK_PRIMARY)
+        assertThat(shapes.cornerRadius).isEqualTo(12f)
+        assertThat(typography.fontSizeMultiplier).isEqualTo(1.5f)
+        assertThat(primaryButtonStyle.colorsDark.background).isEqualTo(DARK_BUTTON)
+        assertThat(primaryButtonStyle.shape.cornerRadius).isEqualTo(14f)
+        assertThat(formInsets).isEqualTo(FormInsets(start = 1f, top = 2f, end = 3f, bottom = 4f))
+        assertThat(sectionSpacing).isEqualTo(10f)
+        assertThat(textFieldInsets).isEqualTo(FormInsets(start = 5f, top = 6f, end = 7f, bottom = 8f))
+        assertThat(iconStyle).isEqualTo(IconStyle.Outlined)
+        assertThat(verticalModeRowPadding).isEqualTo(9f)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `always light provides light appearance independently of system theme`() = runScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysLight,
+    ) {
+        assertThat(isDark).isFalse()
+        assertThat(contextIsDark).isFalse()
+        assertThat(colors.materialColors.primary).isEqualTo(LIGHT_PRIMARY)
+        assertThat(primaryButtonStyle.colorsLight.background).isEqualTo(LIGHT_BUTTON)
+    }
+
+    @Test
+    fun `automatic follows dark system theme`() {
+        assertThat(PaymentSheet.ThemeMode.Automatic.isDarkTheme(isSystemDark = true)).isTrue()
+    }
+
+    @Test
+    fun `automatic follows light system theme`() {
+        assertThat(PaymentSheet.ThemeMode.Automatic.isDarkTheme(isSystemDark = false)).isFalse()
+    }
+
+    @Test
+    fun `parse appearance applies immutable values to legacy theme`() {
+        val appearance = createAppearance(PaymentSheet.ThemeMode.Automatic)
+        val expected = appearance.toPaymentElementThemeValues()
+
+        try {
+            appearance.parseAppearance()
+
+            assertThat(StripeTheme.colorsLightMutable.materialColors.primary)
+                .isEqualTo(expected.colorsLight.materialColors.primary)
+            assertThat(StripeTheme.colorsDarkMutable.materialColors.primary)
+                .isEqualTo(expected.colorsDark.materialColors.primary)
+            assertThat(StripeTheme.shapesMutable).isEqualTo(expected.shapes)
+            assertThat(StripeTheme.typographyMutable).isEqualTo(expected.typography)
+            assertThat(StripeTheme.primaryButtonStyle).isEqualTo(expected.primaryButtonStyle)
+            assertThat(StripeTheme.formInsets).isEqualTo(expected.formInsets)
+            assertThat(StripeTheme.customSectionSpacing).isEqualTo(expected.sectionSpacing)
+            assertThat(StripeTheme.textFieldInsets).isEqualTo(expected.textFieldInsets)
+            assertThat(StripeTheme.iconStyle).isEqualTo(expected.iconStyle)
+            assertThat(StripeTheme.verticalModeRowPadding).isEqualTo(expected.verticalModeRowPadding)
+        } finally {
+            PaymentSheet.Appearance().parseAppearance()
+        }
+    }
+
+    private fun runScenario(
+        themeMode: PaymentSheet.ThemeMode,
+        block: ThemeSnapshot.() -> Unit,
+    ) {
+        var snapshot: ThemeSnapshot? = null
+
+        composeRule.setContent {
+            PaymentElementTheme(appearance = createAppearance(themeMode)) {
+                snapshot = ThemeSnapshot(
+                    isDark = MaterialTheme.stripeThemeIsDark,
+                    contextIsDark = androidx.compose.ui.platform.LocalContext.current.isSystemDarkTheme(),
+                    colors = MaterialTheme.stripeColors,
+                    shapes = MaterialTheme.stripeShapes,
+                    typography = MaterialTheme.stripeTypography,
+                    primaryButtonStyle = MaterialTheme.stripePrimaryButtonStyle,
+                    formInsets = MaterialTheme.stripeFormInsets,
+                    sectionSpacing = LocalSectionSpacing.current,
+                    textFieldInsets = LocalTextFieldInsets.current,
+                    iconStyle = LocalIconStyle.current,
+                    verticalModeRowPadding = MaterialTheme.stripeVerticalModeRowPadding,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        requireNotNull(snapshot).apply(block)
+    }
+
+    private fun createAppearance(themeMode: PaymentSheet.ThemeMode): PaymentSheet.Appearance {
+        return PaymentSheet.Appearance(
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = LIGHT_PRIMARY),
+            colorsDark = PaymentSheet.Colors.configureDefaultDark(primary = DARK_PRIMARY),
+            themeMode = themeMode,
+            shapes = PaymentSheet.Shapes(
+                cornerRadiusDp = 12f,
+                borderStrokeWidthDp = 2f,
+                bottomSheetCornerRadiusDp = 16f,
+            ),
+            typography = PaymentSheet.Typography(
+                sizeScaleFactor = 1.5f,
+                fontResId = null,
+            ),
+            primaryButton = PaymentSheet.PrimaryButton(
+                colorsLight = PaymentSheet.PrimaryButtonColors(
+                    background = LIGHT_BUTTON.toArgb(),
+                    onBackground = Color.Black.toArgb(),
+                    border = Color.Blue.toArgb(),
+                ),
+                colorsDark = PaymentSheet.PrimaryButtonColors(
+                    background = DARK_BUTTON.toArgb(),
+                    onBackground = Color.White.toArgb(),
+                    border = Color.Cyan.toArgb(),
+                ),
+                shape = PaymentSheet.PrimaryButtonShape(
+                    cornerRadiusDp = 14f,
+                    borderStrokeWidthDp = 3f,
+                    heightDp = 50f,
+                ),
+                typography = PaymentSheet.PrimaryButtonTypography(
+                    fontResId = null,
+                    fontSizeSp = 18f,
+                ),
+            ),
+            embeddedAppearance = PaymentSheet.Appearance.Embedded.default,
+            formInsetValues = PaymentSheet.Insets(startDp = 1f, topDp = 2f, endDp = 3f, bottomDp = 4f),
+            sectionSpacing = PaymentSheet.Spacing(spacingDp = 10f),
+            textFieldInsets = PaymentSheet.Insets(startDp = 5f, topDp = 6f, endDp = 7f, bottomDp = 8f),
+            iconStyle = PaymentSheet.IconStyle.Outlined,
+            verticalModeRowPadding = 9f,
+        )
+    }
+
+    private data class ThemeSnapshot(
+        val isDark: Boolean,
+        val contextIsDark: Boolean,
+        val colors: StripeColors,
+        val shapes: StripeShapes,
+        val typography: StripeTypography,
+        val primaryButtonStyle: PrimaryButtonStyle,
+        val formInsets: FormInsets,
+        val sectionSpacing: Float?,
+        val textFieldInsets: FormInsets,
+        val iconStyle: IconStyle,
+        val verticalModeRowPadding: Float,
+    )
+
+    private companion object {
+        val LIGHT_PRIMARY = Color(0xFF123456)
+        val DARK_PRIMARY = Color(0xFF654321)
+        val LIGHT_BUTTON = Color(0xFFABCDEF)
+        val DARK_BUTTON = Color(0xFFFEDCBA)
+    }
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -488,7 +488,12 @@ val LocalSectionStyle = staticCompositionLocalOf { StripeTheme.sectionStyle }
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 val LocalTextFieldInsets = staticCompositionLocalOf { StripeTheme.textFieldInsets }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+private val LocalPrimaryButtonStyle = staticCompositionLocalOf { StripeTheme.primaryButtonStyle }
+
+private val LocalFormInsets = staticCompositionLocalOf { StripeTheme.formInsets }
+
+private val LocalVerticalModeRowPadding = staticCompositionLocalOf { StripeTheme.verticalModeRowPadding }
+
 private val LocalStripeThemeIsDark = staticCompositionLocalOf<Boolean?> { null }
 
 /**
@@ -513,10 +518,13 @@ fun StripeTheme(
         colors = colors,
         shapes = shapes,
         typography = typography,
+        primaryButtonStyle = StripeTheme.primaryButtonStyle,
+        formInsets = StripeTheme.formInsets,
         sectionSpacing = sectionSpacing,
         sectionStyle = sectionStyle,
         textFieldInsets = textFieldInsets,
         iconStyle = iconStyle,
+        verticalModeRowPadding = StripeTheme.verticalModeRowPadding,
         content = content,
     )
 }
@@ -531,10 +539,13 @@ fun StripeTheme(
     colors: StripeColors,
     shapes: StripeShapes,
     typography: StripeTypography,
+    primaryButtonStyle: PrimaryButtonStyle,
+    formInsets: FormInsets,
     sectionSpacing: Float?,
     sectionStyle: SectionStyle,
     textFieldInsets: FormInsets,
     iconStyle: IconStyle,
+    verticalModeRowPadding: Float,
     content: @Composable () -> Unit,
 ) {
     val isRobolectricTest = runCatching {
@@ -557,11 +568,14 @@ fun StripeTheme(
         LocalColors provides colors,
         LocalShapes provides shapes,
         LocalTypography provides typography,
+        LocalPrimaryButtonStyle provides primaryButtonStyle,
+        LocalFormInsets provides formInsets,
         LocalSectionSpacing provides sectionSpacing,
         LocalSectionStyle provides sectionStyle,
         LocalTextFieldInsets provides textFieldInsets,
         LocalStripeThemeIsDark provides isDark,
         LocalIconStyle provides iconStyle,
+        LocalVerticalModeRowPadding provides verticalModeRowPadding,
         LocalInspectionMode provides inspectionMode,
         LocalInstrumentationTest provides isInstrumentationTest,
         LocalStripeImageLoader provides DefaultStripeImageLoader(LocalContext.current.applicationContext),
@@ -628,6 +642,27 @@ val MaterialTheme.stripeTypography: StripeTypography
     @Composable
     @ReadOnlyComposable
     get() = LocalTypography.current
+
+@Suppress("UnusedReceiverParameter")
+val MaterialTheme.stripePrimaryButtonStyle: PrimaryButtonStyle
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalPrimaryButtonStyle.current
+
+@Suppress("UnusedReceiverParameter")
+val MaterialTheme.stripeFormInsets: FormInsets
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFormInsets.current
+
+@Suppress("UnusedReceiverParameter")
+val MaterialTheme.stripeVerticalModeRowPadding: Float
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalVerticalModeRowPadding.current
 
 @Suppress("UnusedReceiverParameter")
 val MaterialTheme.stripeThemeIsDark: Boolean
@@ -797,7 +832,7 @@ fun PrimaryButtonStyle.getBorderStrokeColor(context: Context): Int {
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun PrimaryButtonStyle.getComposeTextStyle(): TextStyle {
     val baseStyle = MaterialTheme.typography.h5.copy(
-        color = (if (isSystemInDarkTheme()) colorsDark else colorsLight).onBackground,
+        color = (if (MaterialTheme.stripeThemeIsDark) colorsDark else colorsLight).onBackground,
         fontSize = typography.fontSize
     )
     return if (typography.fontFamily != null) {
@@ -827,9 +862,12 @@ fun Color.darken(amount: Float): Color {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun StripeTheme.getOuterFormInsets(): PaddingValues = PaddingValues(
-    start = formInsets.start.dp,
-    end = formInsets.end.dp
+fun StripeTheme.getOuterFormInsets(): PaddingValues = formInsets.getOuterFormInsets()
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun FormInsets.getOuterFormInsets(): PaddingValues = PaddingValues(
+    start = start.dp,
+    end = end.dp,
 )
 
 private fun TextStyle.toCompat(): TextStyle {

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/StripeThemeScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/StripeThemeScreenshotTest.kt
@@ -50,10 +50,13 @@ internal class StripeThemeScreenshotTest {
                 colors = StripeThemeDefaults.colors(isDark),
                 shapes = StripeThemeDefaults.shapes,
                 typography = StripeThemeDefaults.typography,
+                primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle,
+                formInsets = StripeThemeDefaults.formInsets,
                 sectionSpacing = StripeThemeDefaults.sectionSpacing,
                 sectionStyle = StripeThemeDefaults.sectionStyle,
                 textFieldInsets = StripeThemeDefaults.textFieldInsets,
                 iconStyle = StripeThemeDefaults.iconStyle,
+                verticalModeRowPadding = StripeThemeDefaults.verticalModeRowPadding,
             ) {
                 ThemeContent()
             }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/StripeThemeTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/StripeThemeTest.kt
@@ -72,10 +72,13 @@ internal class StripeThemeTest {
                 colors = StripeThemeDefaults.colors(isDark),
                 shapes = StripeThemeDefaults.shapes,
                 typography = StripeThemeDefaults.typography,
+                primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle,
+                formInsets = StripeThemeDefaults.formInsets,
                 sectionSpacing = StripeThemeDefaults.sectionSpacing,
                 sectionStyle = StripeThemeDefaults.sectionStyle,
                 textFieldInsets = StripeThemeDefaults.textFieldInsets,
                 iconStyle = StripeThemeDefaults.iconStyle,
+                verticalModeRowPadding = StripeThemeDefaults.verticalModeRowPadding,
             ) {
                 providedIsDark = MaterialTheme.stripeThemeIsDark
             }


### PR DESCRIPTION
# Summary

Stacked on parent PR https://github.com/stripe/stripe-android/pull/13481.

- Adds `PaymentElementTheme`, which derives immutable theme values from `PaymentSheet.Appearance` and resolves its configured `ThemeMode`.
- Provides PaymentSheet appearance values through scoped Compose theme locals instead of reading from the mutable global `StripeTheme` singleton in PaymentSheet-owned views.
- Preserves `parseAppearance()` and the legacy `StripeTheme` overload for callers that have not migrated yet.
- Aligns the Android context UI mode with the selected PaymentSheet mode so Android Views and resource lookups use the same light or dark appearance.
- Leaves Link, Financial Connections, Connect, crypto, Identity, CustomerSheet, and the embedded Payment Element unchanged.

# Motivation

PaymentSheet appearance was parsed into process-wide mutable theme values. A composable could therefore read values written by a different PaymentSheet instance, and forced light or dark mode was not consistently available to every descendant. Scoping the converted appearance to the PaymentSheet composition makes the configured appearance the source of truth while retaining compatibility for unmigrated surfaces.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

Not included. Forced light/dark palette selection and Android context UI mode are covered by Robolectric Compose tests.

# Changelog

Not included in this internal implementation PR; the user-facing changelog will be handled with the completed stack.
