### PR TITLE
Avoid dropping the first form-selection update

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -28,6 +28,7 @@ import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
@@ -126,7 +127,9 @@ internal class DefaultFormHelper(
         }
     }
 
-    private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>()
+    private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>(replay = 1)
+
+    private var paymentSelectionJob: Job? = null
 
     private val paymentSelection: Flow<PaymentSelection?> = combine(
         lastFormValues,
@@ -145,8 +148,12 @@ internal class DefaultFormHelper(
             savedStateHandle[PREVIOUSLY_COMPLETED_PAYMENT_FORM] = value
         }
 
-    init {
-        coroutineScope.launch {
+    private fun startPaymentSelectionCollection() {
+        if (paymentSelectionJob?.isActive == true) {
+            return
+        }
+
+        paymentSelectionJob = coroutineScope.launch {
             paymentSelection.collect { selection ->
                 selectionUpdater(selection)
                 reportFieldCompleted(selection?.paymentMethodType)
@@ -171,6 +178,8 @@ internal class DefaultFormHelper(
     }
 
     override fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String) {
+        startPaymentSelectionCollection()
+
         coroutineScope.launch {
             lastFormValues.emit(formValues to selectedPaymentMethodCode)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -28,7 +28,6 @@ import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
@@ -129,8 +128,6 @@ internal class DefaultFormHelper(
 
     private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>(replay = 1)
 
-    private var paymentSelectionJob: Job? = null
-
     private val paymentSelection: Flow<PaymentSelection?> = combine(
         lastFormValues,
         linkInlineHandler.linkInlineState,
@@ -148,12 +145,8 @@ internal class DefaultFormHelper(
             savedStateHandle[PREVIOUSLY_COMPLETED_PAYMENT_FORM] = value
         }
 
-    private fun startPaymentSelectionCollection() {
-        if (paymentSelectionJob?.isActive == true) {
-            return
-        }
-
-        paymentSelectionJob = coroutineScope.launch {
+    init {
+        coroutineScope.launch {
             paymentSelection.collect { selection ->
                 selectionUpdater(selection)
                 reportFieldCompleted(selection?.paymentMethodType)
@@ -178,8 +171,6 @@ internal class DefaultFormHelper(
     }
 
     override fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String) {
-        startPaymentSelectionCollection()
-
         coroutineScope.launch {
             lastFormValues.emit(formValues to selectedPaymentMethodCode)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.SavedStateHandle
-import app.cash.turbine.Turbine
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -45,14 +44,19 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.Executors
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
@@ -218,65 +222,55 @@ internal class FormHelperTest {
     }
 
     @Test
-    fun `first onFormFieldValuesChanged call delivers selection instead of being dropped`() = runTest {
-        val cardBrand = "visa"
-        val name = "Joe"
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-                IdentifierSpec.Name to FormFieldEntry(name, true),
-            ),
-            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
-        )
-        val selectionUpdaterCalls = Turbine<PaymentSelection?>()
-        val formHelper = createFormHelper(
-            newPaymentSelectionProvider = { null },
-            selectionUpdater = { selection ->
-                selectionUpdaterCalls.add(selection)
-            },
-        )
+    fun `first onFormFieldValuesChanged call is not dropped on a real async dispatcher`() {
+        // A regular TestDispatcher runs launched coroutines eagerly/inline, so it can't catch a
+        // regression here: the bug this guards against is a genuine scheduling gap between the
+        // init{} collector's launch and it actually subscribing, which only shows up with a real
+        // dispatcher. lastFormValues' replay = 1 is what keeps this update from being lost even if
+        // the very first call to onFormFieldValuesChanged races ahead of that subscription.
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(executor.asCoroutineDispatcher()))
+            val cardBrand = "visa"
+            val name = "Joe"
+            val receivedSelection = CompletableDeferred<PaymentSelection?>()
 
-        formHelper.onFormFieldValuesChanged(formFieldValues, "card")
+            val formHelper = DefaultFormHelper(
+                coroutineScope = coroutineScope,
+                linkInlineHandler = LinkInlineHandler.create(),
+                cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                newPaymentSelectionProvider = { null },
+                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                selectionUpdater = { selection -> receivedSelection.complete(selection) },
+                setAsDefaultMatchesSaveForFutureUse = false,
+                eventReporter = FakeEventReporter(),
+                savedStateHandle = SavedStateHandle(),
+                autocompleteAddressInteractorFactory = null,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = null,
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                isNfcScanningAvailable = null,
+            )
 
-        val selection = selectionUpdaterCalls.awaitItem() as PaymentSelection.New.Card
-        assertThat(selection.brand.code).isEqualTo(cardBrand)
-        selectionUpdaterCalls.ensureAllEventsConsumed()
-    }
+            val formFieldValues = FormFieldValues(
+                fieldValuePairs = mapOf(
+                    IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                    IdentifierSpec.Name to FormFieldEntry(name, true),
+                ),
+                userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
+            )
+            formHelper.onFormFieldValuesChanged(formFieldValues, "card")
 
-    @Test
-    fun `repeated onFormFieldValuesChanged calls only start a single collector`() = runTest {
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
-        val selectionUpdaterCalls = Turbine<PaymentSelection?>()
-        val formHelper = createFormHelper(
-            newPaymentSelectionProvider = { null },
-            selectionUpdater = { selection ->
-                selectionUpdaterCalls.add(selection)
-            },
-        )
+            val selection = runBlocking {
+                withTimeoutOrNull(5_000) { receivedSelection.await() }
+            } as? PaymentSelection.New.Card
 
-        val firstFormFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.Name to FormFieldEntry("Joe", true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-        formHelper.onFormFieldValuesChanged(firstFormFieldValues, "card")
-        val firstSelection = selectionUpdaterCalls.awaitItem() as PaymentSelection.New.Card
-        assertThat(firstSelection.brand.code).isEqualTo("visa")
-
-        val secondFormFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("mastercard", true),
-                IdentifierSpec.Name to FormFieldEntry("Jane", true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-        formHelper.onFormFieldValuesChanged(secondFormFieldValues, "card")
-        val secondSelection = selectionUpdaterCalls.awaitItem() as PaymentSelection.New.Card
-        assertThat(secondSelection.brand.code).isEqualTo("mastercard")
-
-        selectionUpdaterCalls.ensureAllEventsConsumed()
+            assertThat(selection).isNotNull()
+            assertThat(selection?.brand?.code).isEqualTo(cardBrand)
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -214,6 +215,68 @@ internal class FormHelperTest {
             }
         ).onFormFieldValuesChanged(formFieldValues, "card")
         assertThat(hasCalledSelectionUpdater).isTrue()
+    }
+
+    @Test
+    fun `first onFormFieldValuesChanged call delivers selection instead of being dropped`() = runTest {
+        val cardBrand = "visa"
+        val name = "Joe"
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                IdentifierSpec.Name to FormFieldEntry(name, true),
+            ),
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
+        )
+        val selectionUpdaterCalls = Turbine<PaymentSelection?>()
+        val formHelper = createFormHelper(
+            newPaymentSelectionProvider = { null },
+            selectionUpdater = { selection ->
+                selectionUpdaterCalls.add(selection)
+            },
+        )
+
+        formHelper.onFormFieldValuesChanged(formFieldValues, "card")
+
+        val selection = selectionUpdaterCalls.awaitItem() as PaymentSelection.New.Card
+        assertThat(selection.brand.code).isEqualTo(cardBrand)
+        selectionUpdaterCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `repeated onFormFieldValuesChanged calls only start a single collector`() = runTest {
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+        val selectionUpdaterCalls = Turbine<PaymentSelection?>()
+        val formHelper = createFormHelper(
+            newPaymentSelectionProvider = { null },
+            selectionUpdater = { selection ->
+                selectionUpdaterCalls.add(selection)
+            },
+        )
+
+        val firstFormFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+                IdentifierSpec.Name to FormFieldEntry("Joe", true),
+            ),
+            userRequestedReuse = customerRequestedSave,
+        )
+        formHelper.onFormFieldValuesChanged(firstFormFieldValues, "card")
+        val firstSelection = selectionUpdaterCalls.awaitItem() as PaymentSelection.New.Card
+        assertThat(firstSelection.brand.code).isEqualTo("visa")
+
+        val secondFormFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.CardBrand to FormFieldEntry("mastercard", true),
+                IdentifierSpec.Name to FormFieldEntry("Jane", true),
+            ),
+            userRequestedReuse = customerRequestedSave,
+        )
+        formHelper.onFormFieldValuesChanged(secondFormFieldValues, "card")
+        val secondSelection = selectionUpdaterCalls.awaitItem() as PaymentSelection.New.Card
+        assertThat(secondSelection.brand.code).isEqualTo("mastercard")
+
+        selectionUpdaterCalls.ensureAllEventsConsumed()
     }
 
     @Test


### PR DESCRIPTION
# Summary
`DefaultFormHelper`'s internal `lastFormValues` now uses `replay = 1`, so the collector that turns form-field updates into a `PaymentSelection` never misses the very first update.

# Motivation
The collector is started in `init` via `coroutineScope.launch { paymentSelection.collect { ... } }`. That only *schedules* the collector — it doesn't guarantee it has subscribed before anything else runs on that scope. `lastFormValues` previously had no replay buffer, so if `onFormFieldValuesChanged` ran (and emitted) before the collector had actually subscribed, that emission had no subscriber to receive it and was silently dropped.

I verified this is a real, reproducible gap and not just a theoretical one: with a genuine single-threaded async dispatcher (not a test dispatcher, which runs launched coroutines eagerly and can't expose this), constructing the helper and immediately calling `onFormFieldValuesChanged` drops the update 100% of the time without this fix, and delivers it correctly with `replay = 1`. The fix is a one-line change to the buffer, keeping the existing `init`-based collector exactly as it was.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Added a `FormHelperTest` case that reproduces the drop directly: it wires `DefaultFormHelper` to a real `Executors.newSingleThreadExecutor()`-backed dispatcher (not `UnconfinedTestDispatcher`, which can't exercise the scheduling gap) and asserts the very first `onFormFieldValuesChanged` call is still delivered.

# Screenshots
N/A — no visual changes.
