### PR TITLE
Scope form-screen interactors to their owning ViewModel lifecycle

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -14,14 +14,13 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.job
 import javax.inject.Inject
 
 internal class EmbeddedFormInteractorFactory @Inject constructor(
@@ -38,11 +37,10 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
         paymentMethodCode: PaymentMethodCode,
         hasSavedPaymentMethods: Boolean
     ): DefaultVerticalModeFormInteractor {
-        val formScope = CoroutineScope(
-            viewModelScope.coroutineContext + SupervisorJob(viewModelScope.coroutineContext.job)
-        )
+        val coroutineScope = viewModelScope.childScope(Dispatchers.Default)
+        val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
         val formHelper = embeddedFormHelperFactory.create(
-            coroutineScope = formScope,
+            coroutineScope = formHelperScope,
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
             automaticallyLaunchedCardScanFormDataHelper =
@@ -92,7 +90,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             ).displayedIncentive,
             // Embedded does not support validation at the moment. Should update here once it does.
             validationRequested = MutableSharedFlow(),
-            coroutineScope = formScope,
+            coroutineScope = coroutineScope,
             uiContext = Dispatchers.Main,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -12,12 +12,12 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -93,10 +93,10 @@ internal class DefaultAddPaymentMethodInteractor(
             paymentMethodMetadata: PaymentMethodMetadata,
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
         ): AddPaymentMethodInteractor {
-            val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+            val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
             val formHelper = DefaultFormHelper.create(
                 viewModel = viewModel,
-                coroutineScope = viewModel.viewModelScope,
+                coroutineScope = coroutineScope,
                 paymentMethodMetadata = paymentMethodMetadata,
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/CoroutineScopeExtensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/CoroutineScopeExtensions.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.paymentsheet.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
+
+internal fun CoroutineScope.childScope(context: CoroutineContext): CoroutineScope {
+    return CoroutineScope(context + SupervisorJob(coroutineContext[Job]))
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -11,12 +11,12 @@ import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -123,10 +123,11 @@ internal class DefaultVerticalModeFormInteractor(
             bankFormInteractor: BankFormInteractor,
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?
         ): VerticalModeFormInteractor {
-            val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
+            val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
             val formHelper = DefaultFormHelper.create(
                 viewModel = viewModel,
-                coroutineScope = viewModel.viewModelScope,
+                coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/CoroutineScopeExtensionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/CoroutineScopeExtensionsTest.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Test
+
+class CoroutineScopeExtensionsTest {
+    @Test
+    fun `childScope cancellation does not cancel the parent`() {
+        val parentScope = TestScope(UnconfinedTestDispatcher() + SupervisorJob())
+        val childScope = parentScope.childScope(Dispatchers.Unconfined)
+
+        childScope.cancel()
+
+        assertThat(parentScope.isActive).isTrue()
+    }
+
+    @Test
+    fun `parent cancellation cancels the childScope`() {
+        val parentScope = TestScope(UnconfinedTestDispatcher() + SupervisorJob())
+        val childScope = parentScope.childScope(Dispatchers.Unconfined)
+
+        parentScope.cancel()
+
+        assertThat(childScope.isActive).isFalse()
+    }
+}


### PR DESCRIPTION
# Summary
Added a `CoroutineScope.childScope(context)` utility and used it to give `AddPaymentMethodInteractor`, `VerticalModeFormInteractor`, and the embedded standalone form (`EmbeddedFormInteractorFactory`) properly parented coroutine scopes, replacing free-floating `CoroutineScope(dispatcher + SupervisorJob())` instances.

# Motivation
These interactors previously created their own unparented `CoroutineScope`, which is never cancelled when the owning `ViewModel` is cleared — a coroutine/collector leak on every screen exit. `childScope` builds a scope whose `SupervisorJob` is parented to the calling scope's `Job`, so:
- the parent being cancelled (e.g. the ViewModel clearing) cancels the child, fixing the leak, and
- the child failing/completing does not cancel the parent (that's what `SupervisorJob` buys us over a plain `Job`).

Each of the three interactors gets its own scope, and their form helpers get a Main-dispatcher child scope of that, so the form helper's lifecycle is nested under its owning interactor's lifecycle.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Added `CoroutineScopeExtensionsTest` covering the two lifecycle guarantees directly: cancelling a `childScope` does not cancel its parent, and cancelling the parent does cancel the `childScope`. Existing `DefaultVerticalModeFormInteractorTest` close/cancellation coverage continues to pass against the new scope hierarchy.

# Screenshots
N/A — no visual changes.
