### PR TITLE
Close saved-payment-method confirmation interactors when they leave composition

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -39,21 +41,28 @@ internal fun FormScreenContent(
     savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
 ) {
     val interactorState by interactor.state.collectAsState()
+    val savedPaymentSelectionToConfirm = state.savedPaymentSelectionToConfirm
+    val latestUpdateSelection by rememberUpdatedState(updateSelection)
+    val savedPaymentMethodConfirmInteractor = remember(savedPaymentSelectionToConfirm) {
+        savedPaymentSelectionToConfirm?.let {
+            savedPaymentMethodConfirmInteractorFactory.create(
+                initialSelection = it,
+                updateSelection = { selection -> latestUpdateSelection(selection) },
+            )
+        }
+    }
 
     DismissKeyboardOnProcessing(interactorState.isProcessing)
 
     EventReporterProvider(eventReporter) {
-        if (state.savedPaymentSelectionToConfirm == null) {
+        if (savedPaymentMethodConfirmInteractor == null) {
             VerticalModeFormUI(
                 interactor = interactor,
                 showsWalletHeader = false
             )
         } else {
             SavedPaymentMethodConfirmUI(
-                savedPaymentMethodConfirmInteractor = savedPaymentMethodConfirmInteractorFactory.create(
-                    initialSelection = state.savedPaymentSelectionToConfirm,
-                    updateSelection = updateSelection,
-                ),
+                savedPaymentMethodConfirmInteractor = savedPaymentMethodConfirmInteractor,
             )
         }
         USBankAccountMandate(state)


### PR DESCRIPTION
# Summary
`SavedPaymentMethodConfirmInteractor` now exposes `close()`, which cancels its internal selection-collecting job. `PaymentSheetScreen.SavedPaymentMethodConfirm` implements `Closeable` and delegates to it. In the embedded form, `FormScreenContent` now `remember`s the interactor keyed on the selection being confirmed and closes it via `DisposableEffect` when it leaves composition or the selection changes.

# Motivation
`DefaultSavedPaymentMethodConfirmInteractor` launched a `coroutineScope.launch { selection.collectLatest { updateSelection(it) } }` job in `init` with no way to stop it — every time the saved-payment confirmation screen/composable was shown, that collector leaked for the life of the underlying scope. This adds an explicit disposal hook and wires it up at both places the interactor is created: the standalone `PaymentSheetScreen.SavedPaymentMethodConfirm` screen and the embedded `FormActivityUI`'s `FormScreenContent` composable.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- Added a `DefaultSavedPaymentMethodConfirmInteractorTest` case verifying that after `close()`, selection updates stop being delivered. Wired a `CleanupTestRule` so every interactor built by the test helper gets closed during test cleanup.
- Added `FormScreenContentTest` covering the `remember`/`DisposableEffect` semantics in the embedded form: the interactor is reused across unrelated recompositions of the same selection, closed exactly once when the confirmation is dismissed, and recreated (with the old one closed) when the selection changes.
- Added a `PaymentSheetScreen` test verifying `SavedPaymentMethodConfirm.close()` delegates to the interactor's `close()`.
- `FakeSavedPaymentMethodConfirmInteractor` got a no-op `close()` to satisfy the interface.

# Screenshots
N/A — no visual changes.
