### PR TITLE
StripeCryptoOnramp: Adds Request ID When Available to Error Analytics

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsEvent.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsEvent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.crypto.onramp.analytics
 
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.crypto.onramp.model.CryptoNetwork
 import com.stripe.android.crypto.onramp.model.PaymentMethodType
@@ -181,8 +182,9 @@ internal sealed class OnrampAnalyticsEvent(
         name = "error_occurred",
         params = mapOf(
             "operation_name" to operation.value,
-            "error_message" to error.safeAnalyticsMessage
-        )
+            "error_message" to error.safeAnalyticsMessage,
+            "request_id" to (error as? StripeException)?.requestId,
+        ).filterNotNullValues()
     ) {
         enum class Operation(val value: String) {
             Configure("configure"),

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsEventTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsEventTest.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.crypto.onramp.analytics
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.exception.APIException
+import org.junit.Test
+
+class OnrampAnalyticsEventTest {
+    @Test
+    fun `error occurred includes request ID when available`() {
+        val event = OnrampAnalyticsEvent.ErrorOccurred(
+            operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.HasLinkAccount,
+            error = APIException(requestId = "req_123"),
+        )
+
+        assertThat(event.params?.get("operation_name")).isEqualTo("has_link_account")
+        assertThat(event.params?.get("error_message")).isEqualTo("apiError")
+        assertThat(event.params?.get("request_id")).isEqualTo("req_123")
+    }
+
+    @Test
+    fun `error occurred omits request ID when unavailable`() {
+        val event = OnrampAnalyticsEvent.ErrorOccurred(
+            operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.HasLinkAccount,
+            error = APIException(),
+        )
+
+        assertThat(event.params).doesNotContainKey("request_id")
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `request_id` parameter to analytics error logs if the error originated from an API failure.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Discussed the addition of this parameter at yesterday's CryptoOnramp sync meeting.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
1. Ran the new tests.
2. Tested manually with a rich mapped error

Here is an analytics log from an error occurring which now include `request_id`:

```
V2 LOG ANALYTICS: onramp.error_occurred
{
  "app_name": "Crypto Onramp Example",
  "app_version": 11,
  "client_id": "mobile-onramp-sdk",
  "created": 1785947147.9262772,
  "device_id": "a1b2c3d4e5f67890",
  "device_type": "Google_google_sdk_gphone64_arm64",
  "error_message": "invalidRequestError",
  "event_id": "5adf4bf6-3eab-4bd6-aa6f-8a827ca1aecf",
  "event_name": "onramp.error_occurred",
  "mobile_session_id": "612eeae6-2f19-463d-8187-47a326842928",
  "operation_name": "submit_wallet_ownership_signature",
  "os_version": 36,
  "platform_info": {
    "package_name": "com.stripe.android.crypto.onramp.example"
  },
  "plugin_type": "native",
  "request_id": "req_yTmyDmoIZrrFM9",
  "sdk_platform": "android",
  "sdk_version": "23.14.0",
  "session_id": "elements_session_1JO8U9VWx8T"
}
```

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A