### PR TITLE
Fallback to app name if merchant/business name unavailable during checkout.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.checkout
 
+import com.stripe.android.checkout.injection.AppName
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -7,13 +8,15 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
-internal class CheckoutCommonConfigurationFactory @Inject constructor() {
+internal class CheckoutCommonConfigurationFactory @Inject constructor(
+    @AppName private val appName: String,
+) {
     fun create(
         configuration: CheckoutController.Configuration.State,
         checkoutSessionResponse: CheckoutSessionResponse,
         collectedDetails: CheckoutCollectedDetails,
     ): CommonConfiguration = CommonConfiguration(
-        merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse),
+        merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse, appName),
         customer = ConfigurationDefaults.customer,
         googlePay = configuration.toGooglePayConfiguration(checkoutSessionResponse),
         link = ConfigurationDefaults.link,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -16,7 +16,8 @@ internal fun CheckoutController.Configuration.State.toBillingDetailsCollectionCo
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutController.Configuration.State.resolveMerchantDisplayName(
     checkoutSessionResponse: CheckoutSessionResponse,
-): String = merchantDisplayName ?: checkoutSessionResponse.businessName.orEmpty()
+    appName: String,
+): String = merchantDisplayName ?: checkoutSessionResponse.businessName ?: appName
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutController.Configuration.State.toGooglePayConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -839,7 +839,8 @@ class CheckoutController @Inject internal constructor(
         /**
          * Sets the merchant display name shown to the customer during checkout.
          *
-         * If not set, the business name from the checkout session is used.
+         * If not set, the business name from the checkout session is used, falling back to the
+         * name of your app.
          */
         fun merchantDisplayName(
             merchantDisplayName: String,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -1,18 +1,21 @@
 package com.stripe.android.checkout
 
+import com.stripe.android.checkout.injection.AppName
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
-internal class CheckoutEmbeddedConfigurationFactory @Inject constructor() {
+internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
+    @AppName private val appName: String,
+) {
     fun create(
         configuration: CheckoutController.Configuration.State,
         checkoutSessionResponse: CheckoutSessionResponse,
         collectedDetails: CheckoutCollectedDetails,
     ): EmbeddedPaymentElement.Configuration {
-        val merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse)
+        val merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse, appName)
         return EmbeddedPaymentElement.Configuration.Builder(merchantDisplayName)
             .embeddedViewDisplaysMandateText(
                 configuration.paymentElementConfiguration.embeddedViewDisplaysMandateText

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/AppName.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/AppName.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.checkout.injection
+
+import javax.inject.Qualifier
+
+@Qualifier
+internal annotation class AppName

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -232,6 +232,12 @@ internal interface CheckoutControllerModule {
         }
 
         @Provides
+        @AppName
+        fun provideAppName(application: Application): String {
+            return application.applicationInfo.loadLabel(application.packageManager).toString()
+        }
+
+        @Provides
         fun providesInternalRowSelectionCallback(
             @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
         ): InternalRowSelectionCallback? {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -48,7 +48,7 @@ internal class CheckoutCommonConfigurationFactoryTest {
             shippingAddress = address(),
         )
 
-        val expected = CheckoutEmbeddedConfigurationFactory()
+        val expected = CheckoutEmbeddedConfigurationFactory(appName = "Test App")
             .create(configuration, checkoutSessionResponse, collectedDetails)
             .asCommonConfiguration()
         val actual = factory()
@@ -81,6 +81,17 @@ internal class CheckoutCommonConfigurationFactoryTest {
         )
 
         assertThat(result.merchantDisplayName).isEqualTo("Session Biz")
+    }
+
+    @Test
+    fun `falls back to the app name when merchant display name and business name are unset`() {
+        val result = factory(appName = "My App").create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(businessName = null),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("My App")
     }
 
     @Test
@@ -159,7 +170,7 @@ internal class CheckoutCommonConfigurationFactoryTest {
         assertThat(result.googlePlacesApiKey).isNull()
     }
 
-    private fun factory() = CheckoutCommonConfigurationFactory()
+    private fun factory(appName: String = "Test App") = CheckoutCommonConfigurationFactory(appName)
 
     private fun controllerConfiguration(
         billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -26,7 +26,7 @@ internal object CheckoutControllerStateFactory {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration: CommonConfiguration = CheckoutCommonConfigurationFactory().create(
+        commonConfiguration: CommonConfiguration = CheckoutCommonConfigurationFactory(appName = "Example, Inc.").create(
             configuration = configuration,
             checkoutSessionResponse = checkoutSessionResponse,
             collectedDetails = collectedDetails,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -201,7 +201,7 @@ internal class CheckoutControllerStateHolderTest {
         collectedDetails = CheckoutCollectedDetails(),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration = CheckoutCommonConfigurationFactory().create(
+        commonConfiguration = CheckoutCommonConfigurationFactory(appName = "Example, Inc.").create(
             configuration = CheckoutController.Configuration().build(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = CheckoutCollectedDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -42,6 +42,17 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
+    fun `falls back to the app name when merchant display name and business name are unset`() {
+        val result = factory(appName = "My App").create(
+            configuration = controllerConfiguration(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(businessName = null),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.merchantDisplayName).isEqualTo("My App")
+    }
+
+    @Test
     fun `propagates embeddedViewDisplaysMandateText when true`() {
         val result = factory().create(
             configuration = controllerConfiguration(embeddedViewDisplaysMandateText = true),
@@ -230,7 +241,7 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         assertThat(result.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod).isTrue()
     }
 
-    private fun factory() = CheckoutEmbeddedConfigurationFactory()
+    private fun factory(appName: String = "Test App") = CheckoutEmbeddedConfigurationFactory(appName)
 
     private fun controllerConfiguration(
         embeddedViewDisplaysMandateText: Boolean = true,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -278,7 +278,7 @@ internal class CheckoutStateLoaderTest {
         collectedDetails = CheckoutCollectedDetails(),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration = CheckoutCommonConfigurationFactory().create(
+        commonConfiguration = CheckoutCommonConfigurationFactory(appName = "Example, Inc.").create(
             configuration = CheckoutController.Configuration().build(),
             checkoutSessionResponse = checkoutSessionResponse,
             collectedDetails = CheckoutCollectedDetails(),
@@ -343,8 +343,8 @@ internal class CheckoutStateLoaderTest {
             customer = customer,
         )
         val loader = CheckoutStateLoader(
-            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(),
-            commonConfigurationFactory = CheckoutCommonConfigurationFactory(),
+            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
+            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Example, Inc."),
             flagImageResolver = flagImageResolver,
             paymentElementLoader = paymentElementLoader,
             selectionChooser = chooser,


### PR DESCRIPTION
# Summary
Added fallback to use the app name as the merchant display name in checkout screens when merchantDisplayName and businessName are both unset.

# Motivation
Previously, if both merchantDisplayName and businessName were not provided, the display name during checkout could be empty or misleading. This change ensures that there is always a meaningful name shown to the user by falling back to the app's name.
