### PR TITLE
Disable Link in ECE when shipping address is required

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/AvailableExpressButtonTypesFactory.kt
@@ -35,8 +35,8 @@ internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constr
                 }
                 WalletType.Link -> ExpressButtonType.Link.takeIf {
                     expressCheckoutElementConfiguration.linkVisibility !=
-                        ExpressCheckoutElement.Configuration.LinkVisibility.Never
-                        && !expressCheckoutElementConfiguration.shippingAddressRequired
+                        ExpressCheckoutElement.Configuration.LinkVisibility.Never &&
+                        !expressCheckoutElementConfiguration.shippingAddressRequired
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/AvailableExpressButtonTypesFactory.kt
@@ -36,6 +36,7 @@ internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constr
                 WalletType.Link -> ExpressButtonType.Link.takeIf {
                     expressCheckoutElementConfiguration.linkVisibility !=
                         ExpressCheckoutElement.Configuration.LinkVisibility.Never
+                        && !expressCheckoutElementConfiguration.shippingAddressRequired
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
@@ -56,6 +56,30 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
         )
     }
 
+    @Test
+    fun `create keeps google pay when shipping address is required`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.GooglePay),
+            configuration = ExpressCheckoutElement.Configuration()
+                .shippingAddressRequired(true),
+        )
+
+        assertThat(availableExpressButtonTypes).containsExactly(
+            ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
+        )
+    }
+
+    @Test
+    fun `create filters out link when shipping address is required`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.Link),
+            configuration = ExpressCheckoutElement.Configuration()
+                .shippingAddressRequired(true),
+        )
+
+        assertThat(availableExpressButtonTypes).isEmpty()
+    }
+
     private fun create(
         availableWallets: List<WalletType>,
         configuration: ExpressCheckoutElement.Configuration = ExpressCheckoutElement.Configuration(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Disable Link in ECE when shipping address is required

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Shipping address collection isn't supported by Link yet
https://jira.corp.stripe.com/browse/MOBILESDK-4721

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>