### PR TITLE
Extract BillingAddressElement configuration

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
@@ -14,7 +14,6 @@ import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.AddressInputMode
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FieldValidationMessage
@@ -72,60 +71,63 @@ fun cardBillingAddressCollectionMode(
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BillingAddressElement(
-    override val identifier: IdentifierSpec,
-    rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
-    countryCodes: Set<String> = emptySet(),
-    countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
-        CountryConfig(countryCodes),
-        rawValuesMap[IdentifierSpec.Country]
-    ),
-    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    private val configuration: Configuration,
+    private val countryDropdownFieldController: DropdownFieldController,
     sameAsShippingElement: SameAsShippingElement?,
-    shippingValuesMap: Map<IdentifierSpec, String?>?,
-    private val addressCollectionMode: BillingAddressCollectionMode,
-    private val collectionConfiguration: BillingDetailsCollectionConfiguration =
-        BillingDetailsCollectionConfiguration(),
-    private val shouldHideCountryOnNoAddressCollection: Boolean = true,
 ) : AddressFieldsElement {
-    private val nameConfig = if (collectionConfiguration.collectName) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Configuration(
+        val identifier: IdentifierSpec,
+        val initialValues: Map<IdentifierSpec, String?>,
+        val countryCodes: Set<String>,
+        val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+        val shippingValues: Map<IdentifierSpec, String?>?,
+        val addressCollectionMode: BillingAddressCollectionMode,
+        val collectionConfiguration: BillingDetailsCollectionConfiguration,
+        val shouldHideCountryOnNoAddressCollection: Boolean,
+    )
+
+    override val identifier: IdentifierSpec = configuration.identifier
+
+    private val nameConfig = if (configuration.collectionConfiguration.collectName) {
         AddressFieldConfiguration.REQUIRED
     } else {
         AddressFieldConfiguration.HIDDEN
     }
 
-    private val emailConfig = if (collectionConfiguration.collectEmail) {
+    private val emailConfig = if (configuration.collectionConfiguration.collectEmail) {
         AddressFieldConfiguration.REQUIRED
     } else {
         AddressFieldConfiguration.HIDDEN
     }
 
-    private val phoneNumberConfig = if (collectionConfiguration.collectPhone) {
+    private val phoneNumberConfig = if (configuration.collectionConfiguration.collectPhone) {
         AddressFieldConfiguration.REQUIRED
     } else {
         AddressFieldConfiguration.HIDDEN
     }
 
     @VisibleForTesting
-    val addressElement = autocompleteAddressInteractorFactory?.takeIf {
-        addressCollectionMode == BillingAddressCollectionMode.Full
+    val addressElement = configuration.autocompleteAddressInteractorFactory?.takeIf {
+        configuration.addressCollectionMode == BillingAddressCollectionMode.Full
     }?.let { factory ->
         AutocompleteAddressElement(
             identifier = identifier,
-            initialValues = rawValuesMap,
-            countryCodes = countryCodes,
+            initialValues = configuration.initialValues,
+            countryCodes = configuration.countryCodes,
             nameConfig = nameConfig,
             phoneNumberConfig = phoneNumberConfig,
             emailConfig = emailConfig,
             countryDropdownFieldController = countryDropdownFieldController,
             interactorFactory = factory,
-            shippingValuesMap = shippingValuesMap,
+            shippingValuesMap = configuration.shippingValues,
             sameAsShippingElement = sameAsShippingElement,
         )
     } ?: run {
         AddressElement(
             _identifier = identifier,
-            rawValuesMap = rawValuesMap,
-            countryCodes = countryCodes,
+            rawValuesMap = configuration.initialValues,
+            countryCodes = configuration.countryCodes,
             addressInputMode = AddressInputMode.NoAutocomplete(
                 nameConfig = nameConfig,
                 phoneNumberConfig = phoneNumberConfig,
@@ -135,10 +137,10 @@ class BillingAddressElement(
                 identifier = IdentifierSpec.Country,
                 controller = countryDropdownFieldController,
             ),
-            shippingValuesMap = shippingValuesMap,
+            shippingValuesMap = configuration.shippingValues,
             sameAsShippingElement = sameAsShippingElement,
-            hideCountry = shouldHideCountryOnNoAddressCollection &&
-                addressCollectionMode == BillingAddressCollectionMode.Never,
+            hideCountry = configuration.shouldHideCountryOnNoAddressCollection &&
+                configuration.addressCollectionMode == BillingAddressCollectionMode.Never,
         )
     }
 
@@ -200,7 +202,7 @@ class BillingAddressElement(
     // card and achv2 uses save for future use
     val hiddenIdentifiers: StateFlow<Set<IdentifierSpec>> =
         countryDropdownFieldController.rawFieldValue.mapAsStateFlow { countryCode ->
-            when (val mode = addressCollectionMode) {
+            when (val mode = configuration.addressCollectionMode) {
                 BillingAddressCollectionMode.Never -> {
                     FieldType.entries
                         .filterNot { it == FieldType.Name }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -308,15 +308,18 @@ internal class CardBillingAddressElementTest {
         addressCollectionMode: BillingAddressCollectionMode,
     ): BillingAddressElement {
         return BillingAddressElement(
-            identifier = IdentifierSpec.Generic("billing_element"),
-            rawValuesMap = emptyMap(),
-            countryCodes = emptySet(),
+            configuration = BillingAddressElement.Configuration(
+                identifier = IdentifierSpec.Generic("billing_element"),
+                initialValues = emptyMap(),
+                countryCodes = emptySet(),
+                autocompleteAddressInteractorFactory = null,
+                shippingValues = null,
+                addressCollectionMode = addressCollectionMode,
+                collectionConfiguration = collectionConfiguration,
+                shouldHideCountryOnNoAddressCollection = true,
+            ),
             countryDropdownFieldController = dropdownFieldController,
-            autocompleteAddressInteractorFactory = null,
             sameAsShippingElement = null,
-            shippingValuesMap = null,
-            addressCollectionMode = addressCollectionMode,
-            collectionConfiguration = collectionConfiguration,
         )
     }
 
@@ -378,34 +381,37 @@ internal class CardBillingAddressElementTest {
     ) = runTest {
         block(
             BillingAddressElement(
-                identifier = IdentifierSpec.Generic("billing_element"),
-                rawValuesMap = emptyMap(),
-                countryCodes = emptySet(),
-                countryDropdownFieldController = dropdownFieldController,
-                autocompleteAddressInteractorFactory = {
-                    object : AutocompleteAddressInteractor {
-                        override val autocompleteConfig: AutocompleteAddressInteractor.Config =
-                            AutocompleteAddressInteractor.Config(
-                                googlePlacesApiKey = null,
-                                autocompleteCountries = emptySet()
-                            )
+                configuration = BillingAddressElement.Configuration(
+                    identifier = IdentifierSpec.Generic("billing_element"),
+                    initialValues = emptyMap(),
+                    countryCodes = emptySet(),
+                    autocompleteAddressInteractorFactory = {
+                        object : AutocompleteAddressInteractor {
+                            override val autocompleteConfig: AutocompleteAddressInteractor.Config =
+                                AutocompleteAddressInteractor.Config(
+                                    googlePlacesApiKey = null,
+                                    autocompleteCountries = emptySet()
+                                )
 
-                        override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
-                            // No-op
-                        }
+                            override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
+                                // No-op
+                            }
 
-                        override fun onAutocomplete(country: String) {
-                            error("Should not be called!")
+                            override fun onAutocomplete(country: String) {
+                                error("Should not be called!")
+                            }
                         }
-                    }
-                },
-                sameAsShippingElement = null,
-                shippingValuesMap = null,
-                addressCollectionMode = cardBillingAddressCollectionMode(
-                    addressCollectionMode = configuration.address,
-                    requiresBillingAddressForAutomaticTax = false,
+                    },
+                    shippingValues = null,
+                    addressCollectionMode = cardBillingAddressCollectionMode(
+                        addressCollectionMode = configuration.address,
+                        requiresBillingAddressForAutomaticTax = false,
+                    ),
+                    collectionConfiguration = configuration,
+                    shouldHideCountryOnNoAddressCollection = true,
                 ),
-                collectionConfiguration = configuration,
+                countryDropdownFieldController = dropdownFieldController,
+                sameAsShippingElement = null,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/CountrySpecBillingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/CountrySpecBillingAddressElement.kt
@@ -18,21 +18,24 @@ internal fun CountrySpec.toCountryOnlyBillingAddressSection(
     }
     return SectionElement.wrap(
         BillingAddressElement(
-            identifier = IdentifierSpec.Country,
-            rawValuesMap = countryInitialValues,
-            countryCodes = allowedCountryCodes,
+            configuration = BillingAddressElement.Configuration(
+                identifier = IdentifierSpec.Country,
+                initialValues = countryInitialValues,
+                countryCodes = allowedCountryCodes,
+                autocompleteAddressInteractorFactory = null,
+                shippingValues = null,
+                addressCollectionMode = BillingAddressCollectionMode.Country(emptyMap()),
+                collectionConfiguration = BillingDetailsCollectionConfiguration(
+                    address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                    allowedCountries = allowedCountryCodes,
+                ),
+                shouldHideCountryOnNoAddressCollection = true,
+            ),
             countryDropdownFieldController = DropdownFieldController(
                 CountryConfig(allowedCountryCodes),
                 initialValue = countryInitialValues[IdentifierSpec.Country],
             ),
-            autocompleteAddressInteractorFactory = null,
             sameAsShippingElement = null,
-            shippingValuesMap = null,
-            addressCollectionMode = BillingAddressCollectionMode.Country(emptyMap()),
-            collectionConfiguration = BillingDetailsCollectionConfiguration(
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
-                allowedCountries = allowedCountryCodes,
-            ),
         ),
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -36,6 +36,8 @@ import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.RenderableFormElement
 import com.stripe.android.ui.core.elements.cardBillingAddressCollectionMode
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingController
@@ -288,17 +290,24 @@ private fun cardBillingElements(
                 )
             }
     val addressElement = BillingAddressElement(
-        IdentifierSpec.Generic("credit_billing"),
-        countryCodes = allowedCountries,
-        rawValuesMap = initialValues,
-        sameAsShippingElement = sameAsShippingElement,
-        shippingValuesMap = shippingValues,
-        addressCollectionMode = cardBillingAddressCollectionMode(
-            addressCollectionMode = collectionConfiguration.address,
-            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
+        configuration = BillingAddressElement.Configuration(
+            identifier = IdentifierSpec.Generic("credit_billing"),
+            initialValues = initialValues,
+            countryCodes = allowedCountries,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            shippingValues = shippingValues,
+            addressCollectionMode = cardBillingAddressCollectionMode(
+                addressCollectionMode = collectionConfiguration.address,
+                requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
+            ),
+            collectionConfiguration = collectionConfiguration,
+            shouldHideCountryOnNoAddressCollection = true,
         ),
-        collectionConfiguration = collectionConfiguration,
-        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+        countryDropdownFieldController = DropdownFieldController(
+            CountryConfig(allowedCountries),
+            initialValues[IdentifierSpec.Country],
+        ),
+        sameAsShippingElement = sameAsShippingElement,
     )
 
     val title = when {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -9,6 +9,8 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.cardBillingAddressCollectionMode
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.SectionElement
@@ -39,34 +41,42 @@ internal class BillingDetailsForm(
         null
     }
 
+    private val initialAddressValues = rawAddressValues(billingDetails)
+
     private val cardBillingAddressElement: BillingAddressElement = BillingAddressElement(
-        identifier = IdentifierSpec.BillingAddress,
+        configuration = BillingAddressElement.Configuration(
+            identifier = IdentifierSpec.BillingAddress,
+            initialValues = initialAddressValues,
+            countryCodes = allowedBillingCountries,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            shippingValues = null,
+            addressCollectionMode = cardBillingAddressCollectionMode(
+                addressCollectionMode = when (addressCollectionMode) {
+                    AddressCollectionMode.Automatic ->
+                        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+                    AddressCollectionMode.Never -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                    AddressCollectionMode.Full -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+                },
+                requiresBillingAddressForAutomaticTax = false,
+            ),
+            collectionConfiguration = BillingDetailsCollectionConfiguration(
+                address = when (addressCollectionMode) {
+                    AddressCollectionMode.Automatic ->
+                        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+                    AddressCollectionMode.Never -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                    AddressCollectionMode.Full -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+                },
+                collectName = nameCollection == NameCollection.InBillingDetailsForm,
+                collectEmail = collectEmail,
+                collectPhone = collectPhone,
+            ),
+            shouldHideCountryOnNoAddressCollection = false,
+        ),
+        countryDropdownFieldController = DropdownFieldController(
+            CountryConfig(allowedBillingCountries),
+            initialAddressValues[IdentifierSpec.Country],
+        ),
         sameAsShippingElement = null,
-        shippingValuesMap = null,
-        countryCodes = allowedBillingCountries,
-        collectionConfiguration = BillingDetailsCollectionConfiguration(
-            address = when (addressCollectionMode) {
-                AddressCollectionMode.Automatic ->
-                    BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-                AddressCollectionMode.Never -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-                AddressCollectionMode.Full -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
-            },
-            collectName = nameCollection == NameCollection.InBillingDetailsForm,
-            collectEmail = collectEmail,
-            collectPhone = collectPhone,
-        ),
-        addressCollectionMode = cardBillingAddressCollectionMode(
-            addressCollectionMode = when (addressCollectionMode) {
-                AddressCollectionMode.Automatic ->
-                    BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-                AddressCollectionMode.Never -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-                AddressCollectionMode.Full -> BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
-            },
-            requiresBillingAddressForAutomaticTax = false,
-        ),
-        rawValuesMap = rawAddressValues(billingDetails),
-        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-        shouldHideCountryOnNoAddressCollection = false,
     )
 
     val addressSectionElement = SectionElement.wrap(


### PR DESCRIPTION
# Summary

Extracts `BillingAddressElement.Configuration`, an immutable value holder for the static inputs used to construct a billing-address element.

- Migrate the card, standalone billing-details, and `CountrySpec` callers without changing their inputs.
- Keep `DropdownFieldController` and `SameAsShippingElement` as constructor inputs because they own live form state.
- Leave automatic-tax policy and field widening out of this change.

# Motivation

#13713 needs to replace a billing-address element when automatic tax widens a country-only form. A copyable configuration makes that replacement explicit without mutating an element whose nested address and section controllers have already captured live state.

```kotlin
BillingAddressElement(
    configuration = BillingAddressElement.Configuration(/* static construction policy */),
    countryDropdownFieldController = /* live country state */,
    sameAsShippingElement = /* live checkbox state */,
)
```

The `CountrySpec` path continues to initialize its controller from `initialValues[spec.apiPath]`. Card and standalone billing-details paths continue to use `IdentifierSpec.Country`.

This is behavior-neutral prework between #13737 and #13713. It intentionally does not add `withAdditionalFields()`, automatic-tax constants, gates, or finalization.

| Path | Approve only if | Evidence |
| --- | --- | --- |
| `CountrySpec` | The custom API path and initial country remain on the same controller. | `TransformSpecToElementsTest` |
| Card | The country controller uses the allowed countries and `IdentifierSpec.Country` initial value. | `CardDefinitionTest` |
| Standalone billing details | Initial values and Automatic/Never visibility stay unchanged. | `BillingDetailsFormTest` |
| Scope | No finalizer, widening method, or automatic-tax decision is introduced. | Diff review |

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Passed:

- `./gradlew :payments-ui-core:testDebugUnitTest --tests com.stripe.android.ui.core.elements.CardBillingAddressElementTest`
- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.lpmfoundations.luxe.TransformSpecToElementsTest --tests com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinitionTest --tests com.stripe.android.paymentsheet.ui.BillingDetailsFormTest`
- `./gradlew :payments-ui-core:lintRelease :payments-ui-core:detekt :payments-ui-core:apiCheck :paymentsheet:detekt :paymentsheet:apiCheck`

# Screenshots

Not applicable. The rendered form behavior is unchanged.

# Changelog

Not applicable. This is an internal behavior-neutral refactor.
