### PR TITLE
[Embedded horizontal 6] Drop redundant paymentMethodLayout from EmbeddedLaunchMode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -24,14 +24,12 @@ import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.state.CustomerState
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
-    private val paymentElementConfigurationProvider: Provider<PaymentElement.Configuration.State>,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
@@ -145,7 +143,6 @@ internal class CheckoutSheetLauncher @Inject constructor(
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = paymentElementConfigurationProvider.get().paymentMethodLayout.asPaymentSheet(),
             ),
         )
         activityLauncher.launch(args)
@@ -202,9 +199,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = paymentElementConfigurationProvider.get().paymentMethodLayout.asPaymentSheet(),
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         activityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedLaunchMode.kt
@@ -2,21 +2,17 @@ package com.stripe.android.paymentelement.embedded
 
 import android.os.Parcelable
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
 
 internal sealed interface EmbeddedLaunchMode : Parcelable {
     @Parcelize
     data class Form(
         val selectedPaymentMethodCode: PaymentMethodCode,
-        val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
     ) : EmbeddedLaunchMode
 
     @Parcelize
     data object Manage : EmbeddedLaunchMode
 
     @Parcelize
-    data class PaymentOptions(
-        val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
-    ) : EmbeddedLaunchMode
+    data object PaymentOptions : EmbeddedLaunchMode
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.state.CustomerState
@@ -187,7 +186,6 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         activityLauncher.launch(args)
@@ -244,9 +242,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         activityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedFormScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedFormScreenFactory.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentsheet.PaymentSheet
 import javax.inject.Inject
 
 internal fun interface EmbeddedFormScreenFactory {
@@ -16,7 +15,6 @@ internal class DefaultEmbeddedFormScreenFactory @Inject constructor(
         return formFactory.create(
             EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -30,7 +30,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
@@ -247,9 +246,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         setActivityResult(
             EmbeddedActivityResult.Cancelled(
                 customerState = customerStateHolder.customer.value,
-                launchMode = EmbeddedLaunchMode.PaymentOptions(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                ),
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -16,7 +16,6 @@ import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.FormHelper.FormType
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -98,9 +97,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
                 hasBeenConfirmed = false,
                 customerState = customerStateHolder.customer.value,
                 shouldInvokeSelectionCallback = false,
-                launchMode = EmbeddedLaunchMode.PaymentOptions(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                ),
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -75,7 +74,6 @@ internal class CheckoutSheetLauncherTest {
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
             ),
         )
 
@@ -92,29 +90,6 @@ internal class CheckoutSheetLauncherTest {
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
         assertThat(selectionHolder.temporarySelection.value).isEqualTo(code)
-    }
-
-    @Test
-    fun `launchForm uses configured payment method layout`() = testScenario(
-        paymentElementConfiguration = PaymentElement.Configuration()
-            .paymentMethodLayout(PaymentElement.PaymentMethodLayout.Horizontal)
-            .build()
-    ) {
-        sheetLauncher.launchForm(
-            code = "test_code",
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-            configuration = EmbeddedConfigurationFactory.create(),
-            customerState = createCustomerState(),
-            promotion = null,
-        )
-
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.launchMode).isEqualTo(
-            EmbeddedLaunchMode.Form(
-                selectedPaymentMethodCode = "test_code",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            )
-        )
     }
 
     @Test
@@ -221,7 +196,6 @@ internal class CheckoutSheetLauncherTest {
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -243,7 +217,6 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -263,7 +236,6 @@ internal class CheckoutSheetLauncherTest {
         val result = EmbeddedActivityResult.Error(
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -284,7 +256,6 @@ internal class CheckoutSheetLauncherTest {
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -417,9 +388,7 @@ internal class CheckoutSheetLauncherTest {
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         sheetLauncher.launchPaymentOptions(
@@ -432,27 +401,6 @@ internal class CheckoutSheetLauncherTest {
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
-    }
-
-    @Test
-    fun `launchPaymentOptions uses configured payment method layout`() = testScenario(
-        paymentElementConfiguration = PaymentElement.Configuration()
-            .paymentMethodLayout(PaymentElement.PaymentMethodLayout.Horizontal)
-            .build()
-    ) {
-        sheetLauncher.launchPaymentOptions(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
-            selection = PaymentSelection.GooglePay,
-            configuration = EmbeddedConfigurationFactory.create(),
-        )
-
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            )
-        )
     }
 
     @Test
@@ -511,9 +459,7 @@ internal class CheckoutSheetLauncherTest {
             selection = selection,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -530,9 +476,7 @@ internal class CheckoutSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val result = EmbeddedActivityResult.Cancelled(
             customerState = customerState,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -551,9 +495,7 @@ internal class CheckoutSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         val result = EmbeddedActivityResult.Cancelled(
             customerState = createCustomerState(paymentMethods = emptyList()),
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
         callback.onActivityResult(result)
@@ -572,9 +514,7 @@ internal class CheckoutSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         val result = EmbeddedActivityResult.Cancelled(
             customerState = createCustomerState(paymentMethods = listOf(paymentMethod)),
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
         callback.onActivityResult(result)
@@ -588,9 +528,7 @@ internal class CheckoutSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         customerStateHolder.setCustomerState(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
         val result = EmbeddedActivityResult.Error(
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
 
@@ -612,7 +550,6 @@ internal class CheckoutSheetLauncherTest {
     }
 
     private fun testScenario(
-        paymentElementConfiguration: PaymentElement.Configuration.State = PaymentElement.Configuration().build(),
         block: suspend Scenario.() -> Unit
     ) = runTest {
         val lifecycleOwner = TestLifecycleOwner()
@@ -633,7 +570,6 @@ internal class CheckoutSheetLauncherTest {
                 activityResultCaller = activityResultCaller,
                 lifecycleOwner = lifecycleOwner,
                 selectionHolder = selectionHolder,
-                paymentElementConfigurationProvider = { paymentElementConfiguration },
                 customerStateHolder = customerStateHolder,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -83,7 +82,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             promotion = promotion,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
 
@@ -215,7 +213,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -243,7 +240,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -273,7 +269,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 shouldInvokeSelectionCallback = false,
                 launchMode = EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 ),
             )
             val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -299,7 +294,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 shouldInvokeSelectionCallback = false,
                 launchMode = EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 ),
             )
             val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -320,7 +314,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = null,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -344,7 +337,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 customerState = null,
                 launchMode = EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 ),
             )
             val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -368,7 +360,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -386,7 +377,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = createCustomerState(),
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -542,7 +532,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -561,7 +550,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = null,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -587,9 +575,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
             promotion = null,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         sheetLauncher.launchPaymentOptions(
@@ -661,9 +647,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = null,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -684,9 +668,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = selection,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -706,9 +688,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = null,
             hasBeenConfirmed = true,
             shouldInvokeSelectionCallback = false,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -724,9 +704,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val result = EmbeddedActivityResult.Cancelled(
             customerState = customerState,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
@@ -746,9 +724,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         val result = EmbeddedActivityResult.Cancelled(
             customerState = createCustomerState(paymentMethods = emptyList()),
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
         callback.onActivityResult(result)
@@ -767,9 +743,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         val result = EmbeddedActivityResult.Cancelled(
             customerState = createCustomerState(paymentMethods = listOf(paymentMethod)),
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
         callback.onActivityResult(result)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -98,7 +97,6 @@ internal class EmbeddedSheetActivityTest {
                     shouldInvokeSelectionCallback = false,
                     launchMode = EmbeddedLaunchMode.Form(
                         selectedPaymentMethodCode = "card",
-                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                     ),
                 )
             )
@@ -124,7 +122,6 @@ internal class EmbeddedSheetActivityTest {
             .isEqualTo(
                 EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 )
             )
     }
@@ -147,7 +144,6 @@ internal class EmbeddedSheetActivityTest {
             .isEqualTo(
                 EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "cashapp",
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 )
             )
     }
@@ -173,7 +169,6 @@ internal class EmbeddedSheetActivityTest {
                     promotion = null,
                     launchMode = EmbeddedLaunchMode.Form(
                         selectedPaymentMethodCode = selectedPaymentMethodCode,
-                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                     ),
                 ),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
@@ -136,7 +135,6 @@ internal class FormActivityScreenShotTest {
             customerStateHolder = FakeCustomerStateHolder(),
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val formHelperFactory = EmbeddedFormHelperFactory(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentelement.embedded.sheet.FakeSheetActivityConfirm
 import com.stripe.android.paymentelement.embedded.sheet.FakeSheetActivityStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.FakeUpdatePaymentMethodInteractor
@@ -498,7 +497,6 @@ internal class EmbeddedNavigatorTest {
         val screen = factory.create(
             EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             )
         )
 
@@ -517,7 +515,6 @@ internal class EmbeddedNavigatorTest {
         val screen = factory.create(
             EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             )
         )
 
@@ -543,7 +540,6 @@ internal class EmbeddedNavigatorTest {
         val screen = factory.create(
             EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "cashapp",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             )
         )
 
@@ -562,7 +558,6 @@ internal class EmbeddedNavigatorTest {
         val screen = factory.create(
             EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             )
         )
 
@@ -654,7 +649,6 @@ internal class EmbeddedNavigatorTest {
             customerStateHolder = FakeCustomerStateHolder(),
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         return screen to formInteractor

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
@@ -91,7 +90,6 @@ internal class DefaultSheetActivityConfirmationHelperTest {
                 shouldInvokeSelectionCallback = false,
                 launchMode = EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                 ),
             )
         )
@@ -131,7 +129,6 @@ internal class DefaultSheetActivityConfirmationHelperTest {
             coroutineScope = backgroundScope,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
             statusBarColor = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentelement.embedded.form.confirmationStateComplete
 import com.stripe.android.paymentelement.embedded.form.confirmationStateConfirming
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -109,9 +108,7 @@ class DefaultSheetActivityStateHolderTest {
     @Test
     fun `PaymentOptions mode always uses continue label regardless of formSheetAction`() {
         testScenario(
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         ) {
             stateHolder.state.test {
                 val state = awaitItem()
@@ -355,7 +352,6 @@ class DefaultSheetActivityStateHolderTest {
                         shouldInvokeSelectionCallback = false,
                         launchMode = EmbeddedLaunchMode.Form(
                             selectedPaymentMethodCode = "card",
-                            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                         ),
                     )
                 )
@@ -383,7 +379,6 @@ class DefaultSheetActivityStateHolderTest {
                         shouldInvokeSelectionCallback = false,
                         launchMode = EmbeddedLaunchMode.Form(
                             selectedPaymentMethodCode = "card",
-                            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                         ),
                     )
                 )
@@ -417,7 +412,6 @@ class DefaultSheetActivityStateHolderTest {
                         shouldInvokeSelectionCallback = false,
                         launchMode = EmbeddedLaunchMode.Form(
                             selectedPaymentMethodCode = "card",
-                            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
                         ),
                     )
                 )
@@ -467,7 +461,6 @@ class DefaultSheetActivityStateHolderTest {
         customerStateHolder: FakeCustomerStateHolder = FakeCustomerStateHolder(),
         launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.Form(
             selectedPaymentMethodCode = "card",
-            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
         block: suspend Scenario.() -> Unit
     ) = runTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -48,7 +48,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
         val cancelled = result as EmbeddedActivityResult.Cancelled
         assertThat(cancelled.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions(paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical)
+            EmbeddedLaunchMode.PaymentOptions
         )
     }
 
@@ -62,9 +62,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                     hasBeenConfirmed = false,
                     customerState = null,
                     shouldInvokeSelectionCallback = false,
-                    launchMode = EmbeddedLaunchMode.PaymentOptions(
-                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                    ),
+                    launchMode = EmbeddedLaunchMode.PaymentOptions,
                 )
             )
         }
@@ -76,7 +74,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         assertThat(result).isInstanceOf<EmbeddedActivityResult.Complete>()
         val complete = result as EmbeddedActivityResult.Complete
         assertThat(complete.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions(paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical)
+            EmbeddedLaunchMode.PaymentOptions
         )
     }
 
@@ -93,7 +91,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
         val cancelled = result as EmbeddedActivityResult.Cancelled
         assertThat(cancelled.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions(paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical)
+            EmbeddedLaunchMode.PaymentOptions
         )
     }
 
@@ -160,9 +158,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                     previousNewSelections = previousNewSelections,
                     customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                     promotion = null,
-                    launchMode = EmbeddedLaunchMode.PaymentOptions(
-                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                    ),
+                    launchMode = EmbeddedLaunchMode.PaymentOptions,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -325,7 +325,6 @@ internal class DefaultVerticalModeFormInteractorTest {
             customerStateHolder = FakeCustomerStateHolder(),
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = paymentMethodCode,
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
             ),
         )
         val formHelperFactory = EmbeddedFormHelperFactory(


### PR DESCRIPTION
# Summary
Remove the redundant `paymentMethodLayout` property from `EmbeddedLaunchMode.Form` and `EmbeddedLaunchMode.PaymentOptions`.

This also converts `PaymentOptions` to a data object, removes the now-unneeded payment element configuration provider from `CheckoutSheetLauncher`, and updates affected callers and tests.

# Motivation
`EmbeddedLaunchMode` only needs to identify how the embedded sheet was opened. Its `paymentMethodLayout` value was not consumed; layout continues to come from the existing configuration and state-loading path. Removing the duplicate state simplifies launch arguments and avoids threading configuration through the launcher solely to populate an unused field.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Updated existing launcher and embedded sheet test expectations for the simplified launch modes. Automated CI is running.

# Screenshots
N/A — no visual changes.

# Changelog
No changelog entry. This is an internal refactor with no user-facing API or behavior change.