### PR TITLE
Refactor payment method title logic into a shared helper function.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -29,6 +28,7 @@ import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
 import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
+import com.stripe.android.paymentsheet.utils.addPaymentMethodTitle
 import com.stripe.android.paymentsheet.utils.isOnlyOneNonCardPaymentMethod
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenUI
@@ -48,7 +48,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.Closeable
 import javax.inject.Inject
-import com.stripe.android.R as PaymentsCoreR
 
 internal class EmbeddedNavigator private constructor(
     private val eventReporter: EventReporter,
@@ -338,11 +337,10 @@ internal class EmbeddedNavigator private constructor(
             )
 
             override fun title(): StateFlow<ResolvableString?> = interactor.state.mapAsStateFlow { state ->
-                when {
-                    state.supportedPaymentMethods.isOnlyOneNonCardPaymentMethod() -> null
-                    state.supportedPaymentMethods.singleOrNull()?.code == PaymentMethod.Type.Card.code ->
-                        PaymentsCoreR.string.stripe_title_add_a_card.resolvableString
-                    else -> R.string.stripe_paymentsheet_choose_payment_method.resolvableString
+                if (state.supportedPaymentMethods.isOnlyOneNonCardPaymentMethod()) {
+                    null
+                } else {
+                    state.supportedPaymentMethods.addPaymentMethodTitle()
                 }
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -9,7 +9,6 @@ import com.stripe.android.common.ui.BottomSheetLoadingIndicator
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
@@ -24,6 +23,7 @@ import com.stripe.android.paymentsheet.ui.SavedPaymentMethodsTopContentPadding
 import com.stripe.android.paymentsheet.ui.SelectSavedPaymentMethodsInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
+import com.stripe.android.paymentsheet.utils.addPaymentMethodTitle
 import com.stripe.android.paymentsheet.utils.isOnlyOneNonCardPaymentMethod
 import com.stripe.android.paymentsheet.verticalmode.DefaultSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.ManageScreenInteractor
@@ -42,7 +42,6 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 import java.io.Closeable
-import com.stripe.android.R as PaymentsCoreR
 
 internal val formBottomContentPadding = 20.dp
 internal val horizontalModeWalletsDividerSpacing = 16.dp
@@ -213,11 +212,7 @@ internal sealed interface PaymentSheetScreen {
                 if (isWalletEnabled || isCompleteFlow) {
                     null
                 } else {
-                    if (state.supportedPaymentMethods.singleOrNull()?.code == PaymentMethod.Type.Card.code) {
-                        PaymentsCoreR.string.stripe_title_add_a_card.resolvableString
-                    } else {
-                        R.string.stripe_paymentsheet_choose_payment_method.resolvableString
-                    }
+                    state.supportedPaymentMethods.addPaymentMethodTitle()
                 }
             }
         }
@@ -265,11 +260,7 @@ internal sealed interface PaymentSheetScreen {
                 } else if (isCompleteFlow) {
                     R.string.stripe_paymentsheet_add_payment_method_title.resolvableString
                 } else {
-                    if (state.supportedPaymentMethods.singleOrNull()?.code == PaymentMethod.Type.Card.code) {
-                        PaymentsCoreR.string.stripe_title_add_a_card.resolvableString
-                    } else {
-                        R.string.stripe_paymentsheet_choose_payment_method.resolvableString
-                    }
+                    state.supportedPaymentMethods.addPaymentMethodTitle()
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/SupportedPaymentMethodsUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/SupportedPaymentMethodsUtils.kt
@@ -1,7 +1,18 @@
 package com.stripe.android.paymentsheet.utils
 
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.R as PaymentsCoreR
 
 internal fun List<SupportedPaymentMethod>.isOnlyOneNonCardPaymentMethod() =
     this.size == 1 && this.first().code != PaymentMethod.Type.Card.code
+
+internal fun List<SupportedPaymentMethod>.addPaymentMethodTitle(): ResolvableString =
+    if (singleOrNull()?.code == PaymentMethod.Type.Card.code) {
+        PaymentsCoreR.string.stripe_title_add_a_card.resolvableString
+    } else {
+        R.string.stripe_paymentsheet_choose_payment_method.resolvableString
+    }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
@@ -23,6 +24,7 @@ import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.FakeUpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
@@ -48,8 +50,11 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import kotlin.test.Test
+import com.stripe.android.R as PaymentsCoreR
+import com.stripe.android.paymentsheet.R as PaymentSheetR
 import com.stripe.android.ui.core.R as PaymentsUiCoreR
 
+@Suppress("LargeClass")
 internal class EmbeddedNavigatorTest {
 
     @get:Rule
@@ -353,6 +358,80 @@ internal class EmbeddedNavigatorTest {
     }
 
     @Test
+    fun `HorizontalPaymentOptions topBarState hides test mode label in live mode`() {
+        val screen = createHorizontalPaymentOptionsScreen(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState(),
+                isLiveMode = true,
+            ),
+        )
+
+        val topBarState = screen.topBarState().value!!
+        assertThat(topBarState.showTestModeLabel).isFalse()
+        assertThat(topBarState.showEditMenu).isFalse()
+        assertThat(topBarState.isEditing).isFalse()
+    }
+
+    @Test
+    fun `HorizontalPaymentOptions topBarState shows test mode label in test mode`() {
+        val screen = createHorizontalPaymentOptionsScreen(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState(),
+                isLiveMode = false,
+            ),
+        )
+
+        val topBarState = screen.topBarState().value!!
+        assertThat(topBarState.showTestModeLabel).isTrue()
+        assertThat(topBarState.showEditMenu).isFalse()
+        assertThat(topBarState.isEditing).isFalse()
+    }
+
+    @Test
+    fun `HorizontalPaymentOptions title is null when only one non-card payment method`() {
+        val screen = createHorizontalPaymentOptionsScreen(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState().copy(
+                    supportedPaymentMethods = listOf(LpmRepositoryTestHelpers.usBankAccount),
+                ),
+            ),
+        )
+
+        assertThat(screen.title().value).isNull()
+    }
+
+    @Test
+    fun `HorizontalPaymentOptions title is add a card when only card is supported`() {
+        val screen = createHorizontalPaymentOptionsScreen(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState().copy(
+                    supportedPaymentMethods = listOf(LpmRepositoryTestHelpers.card),
+                ),
+            ),
+        )
+
+        assertThat(screen.title().value)
+            .isEqualTo(PaymentsCoreR.string.stripe_title_add_a_card.resolvableString)
+    }
+
+    @Test
+    fun `HorizontalPaymentOptions title is choose payment method when multiple methods supported`() {
+        val screen = createHorizontalPaymentOptionsScreen(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState().copy(
+                    supportedPaymentMethods = listOf(
+                        LpmRepositoryTestHelpers.card,
+                        LpmRepositoryTestHelpers.usBankAccount,
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(screen.title().value)
+            .isEqualTo(PaymentSheetR.string.stripe_paymentsheet_choose_payment_method.resolvableString)
+    }
+
+    @Test
     fun `initial back stack with a form on top starts on the form and can go back`() = runTest {
         val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
@@ -486,6 +565,36 @@ internal class EmbeddedNavigatorTest {
 
         formScreen.close()
         assertThat(formInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+        formInteractor.validate()
+    }
+
+    @Test
+    fun `Form topBarState hides test mode label in live mode`() {
+        val (formScreen, formInteractor) = createFormScreen(isLiveMode = true)
+
+        val topBarState = formScreen.topBarState().value!!
+        assertThat(topBarState.showTestModeLabel).isFalse()
+        assertThat(topBarState.showEditMenu).isFalse()
+        assertThat(topBarState.isEditing).isFalse()
+        formInteractor.validate()
+    }
+
+    @Test
+    fun `Form topBarState shows test mode label in test mode`() {
+        val (formScreen, formInteractor) = createFormScreen(isLiveMode = false)
+
+        val topBarState = formScreen.topBarState().value!!
+        assertThat(topBarState.showTestModeLabel).isTrue()
+        assertThat(topBarState.showEditMenu).isFalse()
+        assertThat(topBarState.isEditing).isFalse()
+        formInteractor.validate()
+    }
+
+    @Test
+    fun `Form title returns null`() {
+        val (formScreen, formInteractor) = createFormScreen()
+
+        assertThat(formScreen.title().value).isNull()
         formInteractor.validate()
     }
 
@@ -624,9 +733,12 @@ internal class EmbeddedNavigatorTest {
         )
     }
 
-    private fun createHorizontalPaymentOptionsScreen(): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
+    private fun createHorizontalPaymentOptionsScreen(
+        interactor: AddPaymentMethodInteractor =
+            FakeAddPaymentMethodInteractor(FakeAddPaymentMethodInteractor.createState()),
+    ): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
         return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
-            interactor = FakeAddPaymentMethodInteractor(FakeAddPaymentMethodInteractor.createState()),
+            interactor = interactor,
             eventReporter = FakeEventReporter(),
             sheetActivityState = stateFlowOf(
                 SheetActivityStateHolder.State(
@@ -642,8 +754,10 @@ internal class EmbeddedNavigatorTest {
         )
     }
 
-    private fun createFormScreen(): Pair<EmbeddedNavigator.Screen.Form, TestFormInteractor> {
-        val formInteractor = TestFormInteractor()
+    private fun createFormScreen(
+        isLiveMode: Boolean = true,
+    ): Pair<EmbeddedNavigator.Screen.Form, TestFormInteractor> {
+        val formInteractor = TestFormInteractor(isLiveMode = isLiveMode)
         val screen = EmbeddedNavigator.Screen.Form(
             formInteractor = formInteractor,
             eventReporter = FakeEventReporter(),
@@ -660,8 +774,9 @@ internal class EmbeddedNavigatorTest {
         return screen to formInteractor
     }
 
-    private class TestFormInteractor : VerticalModeFormInteractor {
-        override val isLiveMode: Boolean = true
+    private class TestFormInteractor(
+        override val isLiveMode: Boolean = true,
+    ) : VerticalModeFormInteractor {
         override val state: StateFlow<VerticalModeFormInteractor.State>
             get() = throw AssertionError("Not expected")
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -16,9 +16,9 @@ import org.mockito.kotlin.mock
 internal class FakeAddPaymentMethodInteractor(
     initialState: AddPaymentMethodInteractor.State,
     private val viewActionRecorder: ViewActionRecorder<AddPaymentMethodInteractor.ViewAction> = ViewActionRecorder(),
+    override val isLiveMode: Boolean = true,
 ) : AddPaymentMethodInteractor {
     override val state: StateFlow<AddPaymentMethodInteractor.State> = stateFlowOf(initialState)
-    override val isLiveMode: Boolean = true
 
     override fun handleViewAction(viewAction: AddPaymentMethodInteractor.ViewAction) {
         viewActionRecorder.record(viewAction)


### PR DESCRIPTION
# Summary
This PR refactors the logic for determining the "Add payment method" screen title into a shared utility function. This reduces duplication and centralizes the logic for deciding which title to show based on supported payment methods.

# Motivation
Previously, logic for which title to display was duplicated in several places and relied on hardcoded checks. By introducing a utility helper, future updates that affect the title only need to be made in one place, making the code easier to maintain and less error-prone.

Follow up to #13763

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
