### PR TITLE
Refactor result handling to centralize customer state, selection updates.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -65,25 +65,15 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-                selectionHolder.setSelection(result.selection)
-            }
-            is EmbeddedActivityResult.Cancelled -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-            }
+            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
+            is EmbeddedActivityResult.Cancelled -> applyCustomerState(result.customerState)
             is EmbeddedActivityResult.Error -> Unit
         }
     }
 
     private fun handleManageResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-                selectionHolder.setSelection(result.selection)
-            }
+            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
             is EmbeddedActivityResult.Cancelled -> Unit
             is EmbeddedActivityResult.Error -> Unit
         }
@@ -91,17 +81,23 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handlePaymentOptionsResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-                selectionHolder.setSelection(result.selection)
-            }
+            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
             is EmbeddedActivityResult.Cancelled -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                applyCustomerState(result.customerState)
                 clearStaleSelection()
             }
             is EmbeddedActivityResult.Error -> Unit
         }
+    }
+
+    private fun applyCompleteResult(result: EmbeddedActivityResult.Complete) {
+        applyCustomerState(result.customerState)
+        selectionHolder.setPreviousNewSelections(result.previousNewSelections)
+        selectionHolder.setSelection(result.selection)
+    }
+
+    private fun applyCustomerState(customerState: CustomerState?) {
+        customerState?.let { customerStateHolder.setCustomerState(it) }
     }
 
     private fun clearStaleSelection() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -90,9 +90,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
             is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-                selectionHolder.setSelection(result.selection)
+                applyCompleteResult(result)
                 if (result.hasBeenConfirmed) {
                     embeddedResultCallbackHelper.setResult(
                         EmbeddedPaymentElement.Result.Completed()
@@ -102,7 +100,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
                 }
             }
             is EmbeddedActivityResult.Cancelled -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                applyCustomerState(result.customerState)
                 embeddedResultCallbackHelper.setResult(
                     EmbeddedPaymentElement.Result.Canceled()
                 )
@@ -114,9 +112,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private fun handleManageResult(result: EmbeddedActivityResult) {
         when (result) {
             is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-                selectionHolder.setSelection(result.selection)
+                applyCompleteResult(result)
                 if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
                     rowSelectionImmediateActionHandler.invoke()
                 }
@@ -129,9 +125,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private fun handlePaymentOptionsResult(result: EmbeddedActivityResult) {
         when (result) {
             is EmbeddedActivityResult.Complete -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
-                selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-                selectionHolder.setSelection(result.selection)
+                applyCompleteResult(result)
                 if (result.hasBeenConfirmed) {
                     embeddedResultCallbackHelper.setResult(
                         EmbeddedPaymentElement.Result.Completed()
@@ -139,11 +133,21 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
                 }
             }
             is EmbeddedActivityResult.Cancelled -> {
-                result.customerState?.let { customerStateHolder.setCustomerState(it) }
+                applyCustomerState(result.customerState)
                 clearStaleSelection()
             }
             is EmbeddedActivityResult.Error -> Unit
         }
+    }
+
+    private fun applyCompleteResult(result: EmbeddedActivityResult.Complete) {
+        applyCustomerState(result.customerState)
+        selectionHolder.setPreviousNewSelections(result.previousNewSelections)
+        selectionHolder.setSelection(result.selection)
+    }
+
+    private fun applyCustomerState(customerState: CustomerState?) {
+        customerState?.let { customerStateHolder.setCustomerState(it) }
     }
 
     private fun clearStaleSelection() {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
+import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -498,6 +499,30 @@ internal class CheckoutSheetLauncherTest {
             selection = null,
             configuration = EmbeddedConfigurationFactory.create(),
         )
+    }
+
+    @Test
+    fun `paymentOptionsResult merges returned previous new selections into selection holder`() = testScenario {
+        sheetStateHolder.sheetIsOpen = true
+        val returnedSelections = Bundle().apply {
+            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        }
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = returnedSelections,
+            customerState = null,
+            selection = null,
+            hasBeenConfirmed = false,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.PaymentOptions(
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+            ),
+        )
+
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+        callback.onActivityResult(result)
+
+        assertThat(selectionHolder.getPreviousNewSelection("cashapp"))
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 
     @Test


### PR DESCRIPTION
# Summary
Refactored result handling in sheet launcher classes to consolidate customer state and selection update logic. Added test validating proper merging of previous new selections.

# Motivation
Reduces duplication and improves consistency when updating customer state and new selection bundles from activity results.

Follow up to #13617

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog