### PR TITLE
Make updateBillingAddress function internal in CheckoutController.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -182,18 +182,7 @@ class CheckoutController @Inject internal constructor(
         checkoutSessionRepository.updateEmail(sessionId, email?.trim().orEmpty())
     }
 
-    /**
-     * Sets the billing address for this checkout.
-     *
-     * The address is stored locally and used when presenting payment UI. If automatic tax is
-     * enabled and the tax address source is billing, the address is also sent to the server
-     * to compute updated tax amounts.
-     *
-     * @param name The billing name.
-     * @param phoneNumber The billing phone number.
-     * @param address The billing address.
-     */
-    suspend fun updateBillingAddress(
+    internal suspend fun updateBillingAddress(
         name: String?,
         phoneNumber: String?,
         address: Address,


### PR DESCRIPTION
# Summary
Changed the visibility of the updateBillingAddress function in CheckoutController from public `suspend` to `internal suspend`.

# Motivation
Preparing for API review. This will not be part of the public API, but will be used for internally setting billing details.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified