### PR TITLE
Stabilize PaymentSheet E2E tests on fresh Chrome installs.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiSelector
@@ -204,8 +205,11 @@ internal class Selectors(
             }
         }
 
-        if (browser == BrowserUI.Chrome && launchedActivity?.contains(CHROME_FIRST_RUN_ACTIVITY) == true) {
-            dismissChromeFirstRunWithInput()
+        if (browser == BrowserUI.Chrome) {
+            sleep(CHROME_ACTIVITY_TRANSITION_MS)
+            if (currentTopActivity()?.contains(CHROME_FIRST_RUN_ACTIVITY) == true) {
+                dismissChromeFirstRunWithInput()
+            }
         }
     }
 
@@ -218,31 +222,31 @@ internal class Selectors(
     }
 
     private fun dismissChromeFirstRunWithInput() {
-        // The API 33 google_apis image has two fixed first-run screens. Accessibility remains
-        // attached to the PaymentSheet window while Chrome is foreground, so use proportional
-        // coordinates for its bottom action buttons.
-        val (displayWidth, displayHeight) = physicalDisplaySize()
-        val buttonY = displayHeight * 9 / 10
-        device.click(displayWidth / 2, buttonY)
-        sleep(CHROME_FIRST_RUN_SCREEN_TRANSITION_MS)
-        device.click(displayWidth / 8, buttonY)
-    }
+        val chrome = BrowserUI.Chrome.packageName
+        repeat(CHROME_FIRST_RUN_MAX_SCREENS) {
+            if (currentTopActivity()?.contains(CHROME_FIRST_RUN_ACTIVITY) == false) {
+                return
+            }
 
-    private fun physicalDisplaySize(): Pair<Int, Int> {
-        val dimensions = runCatching {
-            device.executeShellCommand("wm size")
-                .lineSequence()
-                .first { it.startsWith("Physical size:") }
-                .substringAfter(':')
-                .trim()
-                .split('x')
-        }.getOrNull()
-        val width = dimensions?.getOrNull(0)?.toIntOrNull()
-        val height = dimensions?.getOrNull(1)?.toIntOrNull()
-        return if (width != null && height != null) {
-            width to height
-        } else {
-            device.displayWidth to device.displayHeight
+            var buttonId: String? = null
+            composeTestRule.waitUntil(
+                conditionDescription = "Chrome first-run dismissal button to appear",
+                timeoutMillis = BROWSER_LAUNCH_TIMEOUT_MS,
+            ) {
+                buttonId = CHROME_FIRST_RUN_BUTTON_IDS.firstOrNull { id ->
+                    device.hasObject(By.res("$chrome:id/$id"))
+                }
+                buttonId != null
+            }
+            device.findObject(By.res("$chrome:id/${checkNotNull(buttonId)}")).click()
+            sleep(CHROME_ACTIVITY_TRANSITION_MS)
+        }
+
+        composeTestRule.waitUntil(
+            conditionDescription = "Chrome first-run onboarding to close",
+            timeoutMillis = BROWSER_LAUNCH_TIMEOUT_MS,
+        ) {
+            currentTopActivity()?.contains(CHROME_FIRST_RUN_ACTIVITY) == false
         }
     }
 
@@ -460,9 +464,17 @@ internal class Selectors(
 
     companion object {
         private const val BROWSER_LAUNCH_TIMEOUT_MS = 60_000L
-        private const val CHROME_FIRST_RUN_SCREEN_TRANSITION_MS = 2_000L
+        private const val CHROME_ACTIVITY_TRANSITION_MS = 2_000L
+        private const val CHROME_FIRST_RUN_MAX_SCREENS = 8
         private const val CHROME_FIRST_RUN_ACTIVITY =
             "com.android.chrome/org.chromium.chrome.browser.firstrun.FirstRunActivity"
+        private val CHROME_FIRST_RUN_BUTTON_IDS = listOf(
+            "signin_fre_dismiss_button",
+            "negative_button",
+            "button_secondary",
+            "terms_accept",
+            "next_button",
+        )
 
         fun browserWindow(device: UiDevice, browser: BrowserUI): UiObject? =
             device.findObject(


### PR DESCRIPTION
## Summary

  - Wait for Chrome’s launch activity to settle before checking for first-run onboarding.
  - Dismiss each Chrome first-run screen using stable resource IDs.
  - Wait until `FirstRunActivity` closes before continuing the Financial Connections flow.

  ## Why this works

  Chrome initially launches through a transient activity before redirecting to
  `FirstRunActivity`. Previously, we inspected the first activity too early and
  sometimes concluded that onboarding was absent.

  The fallback coordinate taps were also based on an older Chrome layout. On the
  API 33 image, those coordinates landed outside “Use without an account,” leaving
  Chrome open while the test waited for Financial Connections’
  `connect_account_button`.

  The new approach:

  1. Lets Chrome finish its activity transition.
  2. Finds the visible dismiss/secondary button by resource ID.
  3. Handles multiple onboarding screens.
  4. Proceeds only after `FirstRunActivity` actually exits.

  This ensures the authorization flow returns to Financial Connections before
  Compose assertions resume.

  ## Validation

  Temporarily added `ShampooRule` immediately inside the Compose rule. This keeps
  Compose’s coroutine test scope running once while repeating timeout and cleanup
  rules for every iteration.

  The complete `TestUSBankAccount` suite passed at:

  - 2 iterations: 18/18 executions
  - 5 iterations: 45/45 executions
  - 10 iterations: 90/90 executions
  - 20 iterations: 180/180 executions

