### PR TITLE
 Fix country switch not reverting inline autocomplete to condensed mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -28,6 +28,7 @@ internal class InlineAutocompleteController(
 ) {
     private var lastPredictionLine1: String? = null
     private var lastObservedCountry: String? = null
+    private var predictionsPaused = false
     private var queryFlow: StateFlow<String>? = null
     private var countryFlow: StateFlow<String?>? = null
     private var observeJob: Job? = null
@@ -47,6 +48,7 @@ internal class InlineAutocompleteController(
         queryFlow = query
         countryFlow = country
         lastObservedCountry = country.value ?: ""
+        predictionsPaused = false
         observeJob = coroutineScope.launch {
             combine(query, country) { q, c -> q to (c ?: "") }
                 .debounce(AutocompleteViewModel.SEARCH_DEBOUNCE_MS)
@@ -60,7 +62,10 @@ internal class InlineAutocompleteController(
                     if (countryChanged) {
                         lastObservedCountry = c
                     }
-                    if (!isCountrySupported(c) || q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE) {
+                    if (predictionsPaused ||
+                        !isCountrySupported(c) ||
+                        q.length < AutocompleteViewModel.MIN_CHARS_AUTOCOMPLETE
+                    ) {
                         lastPredictionLine1 = null
                         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
                         if (countryChanged) {
@@ -120,11 +125,15 @@ internal class InlineAutocompleteController(
     }
 
     fun onFocusLost() {
-        observeJob?.cancel()
+        // Pause prediction fetching, but keep observing the country flow so switching between
+        // supported and unsupported countries still toggles the form's mode while the inline
+        // field is unfocused (e.g. after the form has expanded to manual entry).
+        predictionsPaused = true
         _inlinePredictionsState.value = AutocompleteAddressInteractor.InlinePredictionsState.Idle
     }
 
     fun onFocusGained() {
+        predictionsPaused = false
         if (observeJob?.isActive == true) return
         val q = queryFlow ?: return
         val c = countryFlow ?: return

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -616,6 +616,31 @@ class InlineAutocompleteControllerTest {
     }
 
     @Test
+    fun `country switches back to supported after focus loss re-emits OnValues`() = runScenario(
+        autocompleteCountries = setOf("US")
+    ) {
+        delegate.observeQueryChanges(queryFlow, countryFlow)
+
+        // Switching to an unsupported country expands the form.
+        countryFlow.value = "CA"
+        advanceTimeBy(500)
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnValues(mapOf(IdentifierSpec.Country to "CA"))
+        )
+
+        // Expanding removes the inline field from composition, so focus is lost. The country
+        // observation must survive this so the form can revert when a supported country returns.
+        delegate.onFocusLost()
+
+        // Switching back to a supported country must re-emit so the form returns to inline mode.
+        countryFlow.value = "US"
+        advanceTimeBy(500)
+        assertThat(eventCalls.awaitItem()).isEqualTo(
+            AutocompleteAddressInteractor.Event.OnValues(mapOf(IdentifierSpec.Country to "US"))
+        )
+    }
+
+    @Test
     fun `calling observeQueryChanges again cancels previous observation`() =
         runScenario {
             fakePlacesClient.findPredictionsResult = Result.success(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteCountrySwitchIntegrationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteCountrySwitchIntegrationTest.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.Address
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.uicore.elements.AddressFieldConfiguration
+import com.stripe.android.uicore.elements.AddressInputMode
+import com.stripe.android.uicore.elements.AutocompleteAddressController
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.DropdownFieldController
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// End-to-end: drives the real AutocompleteAddressController + BillingInlineAutocompleteAddressInteractor
+// (which uses the real InlineAutocompleteController) through a country-dropdown change, to verify the
+// form's input mode toggles in BOTH directions even across the focus loss that expansion triggers.
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class InlineAutocompleteCountrySwitchIntegrationTest {
+
+    @Test
+    fun `switching country unsupported then back to supported reverts to inline mode`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val fakePlaces = FakePlacesClientProxy(
+                findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
+                fetchPlaceResult = Result.success(Address()),
+            )
+            val config = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = null,
+                autocompleteCountries = setOf("US"),
+                isPlacesAvailable = false,
+                isInlineAutocompleteEnabled = true,
+                shouldUseStripeHostedAutocomplete = true,
+            )
+            val interactor = BillingInlineAutocompleteAddressInteractor(
+                placesClient = fakePlaces,
+                autocompleteConfig = config,
+                coroutineScope = backgroundScope,
+            )
+            val countryController = DropdownFieldController(CountryConfig(setOf("US", "JP")), "US")
+            val controller = AutocompleteAddressController(
+                identifier = IdentifierSpec.Generic("address"),
+                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                countryDropdownFieldController = countryController,
+                phoneNumberConfig = AddressFieldConfiguration.HIDDEN,
+                nameConfig = AddressFieldConfiguration.HIDDEN,
+                emailConfig = AddressFieldConfiguration.HIDDEN,
+                sameAsShippingElement = null,
+                shippingValuesMap = null,
+                interactorFactory = { interactor },
+            )
+
+            controller.addressElementFlow.test {
+                // Supported country -> inline ("condensed") autocomplete field.
+                assertThat(awaitItem().addressInputMode)
+                    .isInstanceOf<AddressInputMode.AutocompleteInline>()
+
+                // Unsupported country -> form expands to manual entry.
+                countryController.onRawValueChange("JP")
+                advanceTimeBy(600)
+                assertThat(awaitItem().addressInputMode)
+                    .isInstanceOf<AddressInputMode.NoAutocomplete>()
+
+                // Expansion removes the inline field, so it loses focus.
+                interactor.onFocusLost()
+
+                // Back to a supported country -> must revert to inline mode.
+                countryController.onRawValueChange("US")
+                advanceTimeBy(600)
+                assertThat(awaitItem().addressInputMode)
+                    .isInstanceOf<AddressInputMode.AutocompleteInline>()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}


### PR DESCRIPTION

# Summary
<!-- Simple summary of what was changed. -->

Fix country switching not reverting inline autocomplete from expanded (manual entry) mode back to
condensed (inline) mode when a supported country is re-selected.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
PR #13709 introduced onFocusLost() which cancelled the shared observeJob in
    InlineAutocompleteController. This job handled both prediction fetching AND country-change
    observation. When the form expanded to NoAutocomplete (unsupported country), the inline field was
    removed from composition → focus lost → observeJob cancelled → country changes were no longer
    observed. Switching back to a supported country produced no event, so the form stayed in expanded mode
    permanently. This affected both PaymentSheet billing address and standalone Address Element, since both use
    InlineAutocompleteController.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Added unit test (InlineAutocompleteControllerTest)


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A