### PR TITLE
Fix CheckoutSheetLauncherTest launch mode

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -461,9 +461,7 @@ internal class CheckoutSheetLauncherTest {
             selection = null,
             hasBeenConfirmed = false,
             shouldInvokeSelectionCallback = false,
-            launchMode = EmbeddedLaunchMode.PaymentOptions(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            ),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
 
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()


### PR DESCRIPTION
# Summary

Updates `CheckoutSheetLauncherTest` to use the parameterless `EmbeddedLaunchMode.PaymentOptions` data object.

Stack position: 1 of 5 (bottom).

# Motivation

The change that removed `paymentMethodLayout` from `EmbeddedLaunchMode.PaymentOptions` left this test constructing the old type. Updating the fixture keeps the test source compatible with the current launch-mode API.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutSheetLauncherTest`

No tests were ignored.

# Screenshots

Not applicable — this is a test-only compatibility fix with no UI changes.

# Changelog

Not applicable — this PR only repairs an existing test.
