### PR TITLE
Deliver CheckoutController confirmation results

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -41,6 +41,9 @@ internal class CheckoutControllerExampleViewModel(
         savedStateHandle = savedStateHandle,
     ).resultCallback { result ->
         Log.d(TAG, "Result: $result")
+        if (result is CheckoutController.Result.Completed) {
+            _sessionComplete.tryEmit(Unit)
+        }
     }.build()
 
     init {
@@ -50,9 +53,6 @@ internal class CheckoutControllerExampleViewModel(
         viewModelScope.launch {
             controller.session.collect { session ->
                 updateConfiguredState { it.copy(session = session) }
-                if (session?.status == Session.Status.Complete) {
-                    _sessionComplete.tryEmit(Unit)
-                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultHandler.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutConfirmationResultHandler @Inject constructor(
+    private val confirmationHandler: ConfirmationHandler,
+    private val resultCallback: CheckoutController.ResultCallback,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
+) {
+    private var isAwaitingProcessDeathResult = confirmationHandler.hasReloadedFromProcessDeath
+
+    /**
+     * Observes the shared [ConfirmationHandler] for the controller's lifetime and forwards each
+     * terminal confirmation result to [resultCallback]. This is registered exactly once (from
+     * [CheckoutController]'s init); the handler emits [ConfirmationHandler.State.Complete] at most once
+     * per confirmation and never restores a stale completion across process death, so this single
+     * collector delivers each result exactly once.
+     */
+    fun register() {
+        confirmationHandler.state
+            .filterIsInstance<ConfirmationHandler.State.Complete>()
+            .onEach { handle(it.result) }
+            .launchIn(viewModelScope)
+    }
+
+    private fun handle(result: ConfirmationHandler.Result) {
+        val isProcessDeathResult = isAwaitingProcessDeathResult
+        isAwaitingProcessDeathResult = false
+
+        when (result) {
+            is ConfirmationHandler.Result.Succeeded ->
+                resultCallback.onResult(CheckoutController.Result.Completed())
+            is ConfirmationHandler.Result.Failed ->
+                resultCallback.onResult(CheckoutController.Result.Failed(result.cause))
+            is ConfirmationHandler.Result.Canceled -> handleCanceled(result, isProcessDeathResult)
+        }
+    }
+
+    private fun handleCanceled(
+        result: ConfirmationHandler.Result.Canceled,
+        isProcessDeathResult: Boolean,
+    ) {
+        // None normally keeps the customer in the payment UI. After process death, however, it means
+        // the pending next-action result did not return, so checkout must report the interrupted flow.
+        val shouldInformMerchant =
+            result.action == ConfirmationHandler.Result.Canceled.Action.InformCancellation ||
+                result.action == ConfirmationHandler.Result.Canceled.Action.None && isProcessDeathResult
+
+        if (shouldInformMerchant) {
+            resultCallback.onResult(CheckoutController.Result.Canceled())
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -53,10 +53,10 @@ private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 @Singleton
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Suppress("TooManyFunctions", "UnusedParameter")
+@Suppress("TooManyFunctions")
 class CheckoutController @Inject internal constructor(
-    resultCallback: ResultCallback,
     @ViewModelScope private val viewModelScope: CoroutineScope,
+    confirmationResultHandler: CheckoutConfirmationResultHandler,
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
@@ -64,16 +64,20 @@ class CheckoutController @Inject internal constructor(
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
 ) {
+    private val mutex = Mutex()
+    private val pendingMutations = AtomicInteger(0)
+
+    private val _isUpdating = MutableStateFlow(false)
+
+    init {
+        confirmationResultHandler.register()
+    }
+
     /**
      * The latest [Session] data, or `null` until [configure] has completed successfully.
      */
     val session: StateFlow<Session?>
         get() = stateHolder.session
-
-    private val mutex = Mutex()
-    private val pendingMutations = AtomicInteger(0)
-
-    private val _isUpdating = MutableStateFlow(false)
 
     /**
      * Whether a mutation is currently in progress.

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -53,6 +53,7 @@ private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 @Suppress("TooManyFunctions")
 class CheckoutController @Inject internal constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
+    confirmationResultHandler: CheckoutConfirmationResultHandler,
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
@@ -62,6 +63,15 @@ class CheckoutController @Inject internal constructor(
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
     private val savedState: CheckoutControllerSavedState,
 ) {
+    private val mutex = Mutex()
+    private val pendingMutations = AtomicInteger(0)
+
+    private val _isUpdating = MutableStateFlow(false)
+
+    init {
+        confirmationResultHandler.register()
+    }
+
     /**
      * The latest [Session] data, or `null` until [configure] has completed successfully.
      */

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -63,11 +63,6 @@ class CheckoutController @Inject internal constructor(
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
     private val savedState: CheckoutControllerSavedState,
 ) {
-    private val mutex = Mutex()
-    private val pendingMutations = AtomicInteger(0)
-
-    private val _isUpdating = MutableStateFlow(false)
-
     init {
         confirmationResultHandler.register()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultHandlerTest.kt
@@ -1,0 +1,162 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutConfirmationResultHandlerTest {
+
+    @Test
+    fun `register handles current complete result`() {
+        runScenario(initialResult = succeeded()) {
+            assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        }
+    }
+
+    @Test
+    fun `succeeded result invokes Completed`() = runScenario {
+        emit(succeeded())
+
+        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `each confirmation completion delivers its own callback`() = runScenario {
+        emit(succeeded())
+        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+
+        // A second confirmation returns to Confirming before completing again. The interleaved
+        // Confirming breaks the state flow's de-duplication, so an identical result still delivers.
+        emitConfirming()
+        emit(succeeded())
+
+        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `failed result invokes Failed with the confirmation cause`() = runScenario {
+        val cause = IllegalStateException("Failed")
+
+        emit(
+            ConfirmationHandler.Result.Failed(
+                cause = cause,
+                message = "Failed".resolvableString,
+                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            )
+        )
+
+        val result = callbackCalls.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        assertThat((result as CheckoutController.Result.Failed).error).isEqualTo(cause)
+    }
+
+    @Test
+    fun `canceled with InformCancellation invokes Canceled`() = runScenario {
+        emit(
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+            )
+        )
+
+        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+    }
+
+    @Test
+    fun `canceled with ModifyPaymentDetails does not invoke callback`() = runScenario {
+        emit(
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails,
+            )
+        )
+
+        callbackCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `canceled with None does not invoke callback`() = runScenario {
+        emit(
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.None,
+            )
+        )
+
+        callbackCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `canceled with None after process death invokes Canceled`() = runScenario(
+        hasReloadedFromProcessDeath = true,
+    ) {
+        emit(
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.None,
+            )
+        )
+
+        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+    }
+
+    private fun runScenario(
+        initialResult: ConfirmationHandler.Result? = null,
+        hasReloadedFromProcessDeath: Boolean = false,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val callbackCalls = Turbine<CheckoutController.Result>()
+        val initialConfirmationState: ConfirmationHandler.State =
+            initialResult?.let(ConfirmationHandler.State::Complete)
+                ?: ConfirmationHandler.State.Idle
+        val confirmationHandler = FakeConfirmationHandler(
+            hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
+            state = MutableStateFlow(initialConfirmationState),
+        )
+        val handler = CheckoutConfirmationResultHandler(
+            confirmationHandler = confirmationHandler,
+            resultCallback = CheckoutController.ResultCallback(callbackCalls::add),
+            viewModelScope = backgroundScope,
+        )
+        handler.register()
+        testScheduler.runCurrent()
+
+        Scenario(
+            confirmationHandler = confirmationHandler,
+            callbackCalls = callbackCalls,
+            testScheduler = testScheduler,
+        ).block()
+
+        confirmationHandler.validate()
+        callbackCalls.ensureAllEventsConsumed()
+    }
+
+    private fun succeeded(): ConfirmationHandler.Result.Succeeded {
+        return ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+    }
+
+    private class Scenario(
+        val confirmationHandler: FakeConfirmationHandler,
+        val callbackCalls: Turbine<CheckoutController.Result>,
+        val testScheduler: TestCoroutineScheduler,
+    ) {
+        fun emit(result: ConfirmationHandler.Result) {
+            confirmationHandler.state.value = ConfirmationHandler.State.Complete(result)
+            testScheduler.runCurrent()
+        }
+
+        fun emitConfirming() {
+            confirmationHandler.state.value =
+                ConfirmationHandler.State.Confirming(FakeConfirmationOption())
+            testScheduler.runCurrent()
+        }
+    }
+
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultHandlerTest.kt
@@ -158,5 +158,4 @@ internal class CheckoutConfirmationResultHandlerTest {
             testScheduler.runCurrent()
         }
     }
-
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -405,8 +405,10 @@ internal class CheckoutControllerTest {
             checkoutStateLoader = mock(),
             stateHolder = stateHolder,
             sheetStateHolder = SheetStateHolder(SavedStateHandle()),
+            operationCoordinator = mock(),
             checkoutPresenterSubcomponentFactory = mock(),
             paymentElementCallbackIdentifier = DEFAULT_INTEGRATION_NAME,
+            savedState = mock(),
         )
 
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -22,6 +22,8 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -44,6 +46,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -335,6 +338,41 @@ internal class CheckoutControllerTest {
 
         assertThat(committedState).isNull()
         assertThat(controller.session.value).isNull()
+    }
+
+    @Test
+    fun `constructing the controller registers the confirmation result handler`() = runTest {
+        val confirmationHandler = FakeConfirmationHandler()
+        val results = mutableListOf<CheckoutController.Result>()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val resultHandler = CheckoutConfirmationResultHandler(
+            confirmationHandler = confirmationHandler,
+            resultCallback = CheckoutController.ResultCallback { results.add(it) },
+            viewModelScope = backgroundScope,
+        )
+
+        // Constructing the controller must start the collector in init; otherwise the emission below
+        // is dropped and no callback fires. Deps the constructor only stores are inert mocks.
+        CheckoutController(
+            viewModelScope = backgroundScope,
+            confirmationResultHandler = resultHandler,
+            checkoutSessionRepository = mock(),
+            checkoutStateLoader = mock(),
+            stateHolder = stateHolder,
+            sheetStateHolder = SheetStateHolder(SavedStateHandle()),
+            checkoutPresenterSubcomponentFactory = mock(),
+            paymentElementCallbackIdentifier = DEFAULT_INTEGRATION_NAME,
+        )
+
+        confirmationHandler.state.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+            )
+        )
+        testScheduler.runCurrent()
+
+        assertThat(results.single()).isInstanceOf(CheckoutController.Result.Canceled::class.java)
+        confirmationHandler.validate()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -24,6 +24,8 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -45,6 +47,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -380,6 +383,41 @@ internal class CheckoutControllerTest {
         assertThat(controller.session.value).isNull()
         assertThat(savedStateHandle.keys()).doesNotContain(DEFAULT_INTEGRATION_NAME)
         assertThat(createController(savedStateHandle.simulateProcessDeath()).session.value).isNull()
+    }
+
+    @Test
+    fun `constructing the controller registers the confirmation result handler`() = runTest {
+        val confirmationHandler = FakeConfirmationHandler()
+        val results = mutableListOf<CheckoutController.Result>()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val resultHandler = CheckoutConfirmationResultHandler(
+            confirmationHandler = confirmationHandler,
+            resultCallback = CheckoutController.ResultCallback { results.add(it) },
+            viewModelScope = backgroundScope,
+        )
+
+        // Constructing the controller must start the collector in init; otherwise the emission below
+        // is dropped and no callback fires. Deps the constructor only stores are inert mocks.
+        CheckoutController(
+            viewModelScope = backgroundScope,
+            confirmationResultHandler = resultHandler,
+            checkoutSessionRepository = mock(),
+            checkoutStateLoader = mock(),
+            stateHolder = stateHolder,
+            sheetStateHolder = SheetStateHolder(SavedStateHandle()),
+            checkoutPresenterSubcomponentFactory = mock(),
+            paymentElementCallbackIdentifier = DEFAULT_INTEGRATION_NAME,
+        )
+
+        confirmationHandler.state.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+            )
+        )
+        testScheduler.runCurrent()
+
+        assertThat(results.single()).isInstanceOf(CheckoutController.Result.Canceled::class.java)
+        confirmationHandler.validate()
     }
 
     @Test


### PR DESCRIPTION
# Summary

- Adds a controller-scoped handler that converts terminal confirmation states into `CheckoutController.Result` callbacks.
- Delivers completed and failed results, reports applicable cancellations, and handles interrupted next actions after process death.
- Registers result observation when the controller is constructed and updates the playground to use `Result.Completed` for completion.

Stack position: 2 of 4, based on #13801.

# Motivation

`CheckoutController.Builder.resultCallback` was bound into the component but terminal confirmation results were not forwarded to it. Centralizing the mapping gives the controller one exactly-once result path and preserves the distinction between merchant-visible cancellation and returning to payment details.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutConfirmationResultHandlerTest --tests com.stripe.android.checkout.CheckoutControllerTest`
- `./gradlew :paymentsheet-example:compileBaseDebugKotlin`

No tests were ignored.

# Screenshots

Not applicable — there are no visual changes.

# Changelog

Not included — `CheckoutController` remains a preview API.
