### PR TITLE
Refresh CheckoutController state after confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultHandler.kt
@@ -3,6 +3,8 @@ package com.stripe.android.checkout
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
@@ -24,24 +26,38 @@ internal class CheckoutConfirmationResultHandler @Inject constructor(
      * per confirmation and never restores a stale completion across process death, so this single
      * collector delivers each result exactly once.
      */
-    fun register() {
+    fun register(
+        onSucceeded: suspend (CheckoutSessionResponse?) -> Unit,
+    ) {
         confirmationHandler.state
             .filterIsInstance<ConfirmationHandler.State.Complete>()
-            .onEach { handle(it.result) }
+            .onEach { handle(it.result, onSucceeded) }
             .launchIn(viewModelScope)
     }
 
-    private fun handle(result: ConfirmationHandler.Result) {
+    private suspend fun handle(
+        result: ConfirmationHandler.Result,
+        onSucceeded: suspend (CheckoutSessionResponse?) -> Unit,
+    ) {
         val isProcessDeathResult = isAwaitingProcessDeathResult
         isAwaitingProcessDeathResult = false
 
         when (result) {
-            is ConfirmationHandler.Result.Succeeded ->
-                resultCallback.onResult(CheckoutController.Result.Completed())
+            is ConfirmationHandler.Result.Succeeded -> handleSucceeded(result, onSucceeded)
             is ConfirmationHandler.Result.Failed ->
                 resultCallback.onResult(CheckoutController.Result.Failed(result.cause))
             is ConfirmationHandler.Result.Canceled -> handleCanceled(result, isProcessDeathResult)
         }
+    }
+
+    private suspend fun handleSucceeded(
+        result: ConfirmationHandler.Result.Succeeded,
+        onSucceeded: suspend (CheckoutSessionResponse?) -> Unit,
+    ) {
+        // Synchronous confirmation carries the latest response. Next-action confirmation does not,
+        // so the controller retrieves the completed Checkout Session before delivering the result.
+        onSucceeded(result.metadata[CheckoutSessionResponseKey])
+        resultCallback.onResult(CheckoutController.Result.Completed())
     }
 
     private fun handleCanceled(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationStateUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationStateUpdater.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutConfirmationStateUpdater internal constructor(
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val fetchResponse: suspend (sessionId: String, adaptivePricingAllowed: Boolean) ->
+        Result<CheckoutSessionResponse>,
+    private val reloadState: suspend (CheckoutControllerState) -> Unit,
+) {
+    @Inject
+    constructor(
+        stateHolder: CheckoutControllerStateHolder,
+        checkoutSessionRepository: CheckoutSessionRepository,
+        checkoutStateLoader: CheckoutStateLoader,
+    ) : this(
+        stateHolder = stateHolder,
+        fetchResponse = checkoutSessionRepository::init,
+        reloadState = checkoutStateLoader::reload,
+    )
+
+    suspend fun update(checkoutSessionResponse: CheckoutSessionResponse?) {
+        // The controller invokes this inside runSerialized, so the snapshot remains current across
+        // the fetch and reload suspensions and cannot overwrite a concurrently committed mutation.
+        val state = stateHolder.state ?: return
+        val response = checkoutSessionResponse ?: runCatching {
+            fetchResponse(
+                state.checkoutSessionResponse.id,
+                state.configuration.adaptivePricingAllowed,
+            ).getOrThrow()
+        }.getOrNull() ?: return
+
+        // Reloading keeps every field derived from the response in sync. A refresh failure must not
+        // turn a successfully completed payment into a failed result or prevent its callback.
+        runCatching {
+            reloadState(state.copy(checkoutSessionResponse = response))
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -54,6 +54,7 @@ private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 class CheckoutController @Inject internal constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     confirmationResultHandler: CheckoutConfirmationResultHandler,
+    private val confirmationStateUpdater: CheckoutConfirmationStateUpdater,
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
@@ -64,7 +65,7 @@ class CheckoutController @Inject internal constructor(
     private val savedState: CheckoutControllerSavedState,
 ) {
     init {
-        confirmationResultHandler.register()
+        confirmationResultHandler.register(::handleConfirmationSucceeded)
     }
 
     /**
@@ -305,6 +306,15 @@ class CheckoutController @Inject internal constructor(
     private fun integrationLaunchedFailure(): kotlin.Result<Nothing> = kotlin.Result.failure(
         IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
     )
+
+    internal suspend fun handleConfirmationSucceeded(
+        checkoutSessionResponse: CheckoutSessionResponse?,
+    ) {
+        operationCoordinator.runMutation {
+            confirmationStateUpdater.update(checkoutSessionResponse)
+            kotlin.Result.success(Unit)
+        }
+    }
 
     internal suspend fun updateCurrency(currency: String): kotlin.Result<Unit> {
         return withCheckoutState { sessionId ->

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -57,6 +57,7 @@ private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 class CheckoutController @Inject internal constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     confirmationResultHandler: CheckoutConfirmationResultHandler,
+    private val confirmationStateUpdater: CheckoutConfirmationStateUpdater,
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
     private val stateHolder: CheckoutControllerStateHolder,
@@ -70,7 +71,7 @@ class CheckoutController @Inject internal constructor(
     private val _isUpdating = MutableStateFlow(false)
 
     init {
-        confirmationResultHandler.register()
+        confirmationResultHandler.register(::handleConfirmationSucceeded)
     }
 
     /**
@@ -296,6 +297,15 @@ class CheckoutController @Inject internal constructor(
     private fun integrationLaunchedFailure(): kotlin.Result<Nothing> = kotlin.Result.failure(
         IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
     )
+
+    internal suspend fun handleConfirmationSucceeded(
+        checkoutSessionResponse: CheckoutSessionResponse?,
+    ) {
+        runSerialized {
+            confirmationStateUpdater.update(checkoutSessionResponse)
+            kotlin.Result.success(Unit)
+        }
+    }
 
     /**
      * Serializes [block] behind [mutex] so configuration and mutations run in sequence, and toggles

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultHandlerTest.kt
@@ -9,6 +9,10 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
@@ -18,30 +22,73 @@ import org.junit.Test
 internal class CheckoutConfirmationResultHandlerTest {
 
     @Test
-    fun `register handles current complete result`() {
-        runScenario(initialResult = succeeded()) {
-            assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    fun `register handles current complete response before invoking callback`() {
+        val response = response(status = CheckoutSessionResponse.Status.COMPLETE)
+
+        runScenario(initialResult = succeeded(response)) {
+            val callbackCall = callbackCalls.awaitItem()
+            assertThat(callbackCall.result).isInstanceOf<CheckoutController.Result.Completed>()
+            assertThat(callbackCall.succeededCallCount).isEqualTo(1)
+            assertThat(callbackCall.succeededResponse).isEqualTo(response)
         }
     }
 
     @Test
-    fun `succeeded result invokes Completed`() = runScenario {
-        emit(succeeded())
+    fun `succeeded with open response passes it to success handler and invokes Completed`() = runScenario {
+        val response = response(status = CheckoutSessionResponse.Status.OPEN)
 
-        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        emit(succeeded(response))
+
+        val callbackCall = callbackCalls.awaitItem()
+        assertThat(callbackCall.result).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(callbackCall.succeededResponse).isEqualTo(response)
+    }
+
+    @Test
+    fun `succeeded with unknown response passes it to success handler and invokes Completed`() = runScenario {
+        val response = response(status = CheckoutSessionResponse.Status.UNKNOWN)
+
+        emit(succeeded(response))
+
+        val callbackCall = callbackCalls.awaitItem()
+        assertThat(callbackCall.result).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(callbackCall.succeededResponse).isEqualTo(response)
+    }
+
+    @Test
+    fun `succeeded with expired response passes it to success handler and invokes Completed`() = runScenario {
+        val response = response(status = CheckoutSessionResponse.Status.EXPIRED)
+
+        emit(succeeded(response))
+
+        val callbackCall = callbackCalls.awaitItem()
+        assertThat(callbackCall.result).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(callbackCall.succeededResponse).isEqualTo(response)
+    }
+
+    @Test
+    fun `succeeded result without response invokes success handler before Completed`() = runScenario {
+        emit(ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED))
+
+        val callbackCall = callbackCalls.awaitItem()
+        assertThat(callbackCall.result).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(callbackCall.succeededCallCount).isEqualTo(1)
+        assertThat(callbackCall.succeededResponse).isNull()
     }
 
     @Test
     fun `each confirmation completion delivers its own callback`() = runScenario {
-        emit(succeeded())
-        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        val response = response(status = CheckoutSessionResponse.Status.COMPLETE)
+
+        emit(succeeded(response))
+        assertThat(callbackCalls.awaitItem().result).isInstanceOf<CheckoutController.Result.Completed>()
 
         // A second confirmation returns to Confirming before completing again. The interleaved
         // Confirming breaks the state flow's de-duplication, so an identical result still delivers.
         emitConfirming()
-        emit(succeeded())
+        emit(succeeded(response))
 
-        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(callbackCalls.awaitItem().result).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test
@@ -56,7 +103,7 @@ internal class CheckoutConfirmationResultHandlerTest {
             )
         )
 
-        val result = callbackCalls.awaitItem()
+        val result = callbackCalls.awaitItem().result
         assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
         assertThat((result as CheckoutController.Result.Failed).error).isEqualTo(cause)
     }
@@ -69,7 +116,7 @@ internal class CheckoutConfirmationResultHandlerTest {
             )
         )
 
-        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(callbackCalls.awaitItem().result).isInstanceOf<CheckoutController.Result.Canceled>()
     }
 
     @Test
@@ -104,7 +151,7 @@ internal class CheckoutConfirmationResultHandlerTest {
             )
         )
 
-        assertThat(callbackCalls.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(callbackCalls.awaitItem().result).isInstanceOf<CheckoutController.Result.Canceled>()
     }
 
     private fun runScenario(
@@ -112,7 +159,9 @@ internal class CheckoutConfirmationResultHandlerTest {
         hasReloadedFromProcessDeath: Boolean = false,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val callbackCalls = Turbine<CheckoutController.Result>()
+        val callbackCalls = Turbine<CallbackCall>()
+        var succeededCallCount = 0
+        var succeededResponse: CheckoutSessionResponse? = null
         val initialConfirmationState: ConfirmationHandler.State =
             initialResult?.let(ConfirmationHandler.State::Complete)
                 ?: ConfirmationHandler.State.Idle
@@ -122,10 +171,21 @@ internal class CheckoutConfirmationResultHandlerTest {
         )
         val handler = CheckoutConfirmationResultHandler(
             confirmationHandler = confirmationHandler,
-            resultCallback = CheckoutController.ResultCallback(callbackCalls::add),
+            resultCallback = CheckoutController.ResultCallback { result ->
+                callbackCalls.add(
+                    CallbackCall(
+                        result = result,
+                        succeededCallCount = succeededCallCount,
+                        succeededResponse = succeededResponse,
+                    )
+                )
+            },
             viewModelScope = backgroundScope,
         )
-        handler.register()
+        handler.register { response ->
+            succeededCallCount += 1
+            succeededResponse = response
+        }
         testScheduler.runCurrent()
 
         Scenario(
@@ -138,13 +198,29 @@ internal class CheckoutConfirmationResultHandlerTest {
         callbackCalls.ensureAllEventsConsumed()
     }
 
-    private fun succeeded(): ConfirmationHandler.Result.Succeeded {
-        return ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+    private fun response(
+        status: CheckoutSessionResponse.Status,
+    ): CheckoutSessionResponse {
+        return CheckoutSessionResponseFactory.create(
+            id = "cs_confirmed",
+            status = status,
+        )
+    }
+
+    private fun succeeded(
+        response: CheckoutSessionResponse,
+    ): ConfirmationHandler.Result.Succeeded {
+        return ConfirmationHandler.Result.Succeeded(
+            intent = PaymentIntentFixtures.PI_SUCCEEDED,
+            metadata = MutableConfirmationMetadata().apply {
+                set(CheckoutSessionResponseKey, response)
+            },
+        )
     }
 
     private class Scenario(
         val confirmationHandler: FakeConfirmationHandler,
-        val callbackCalls: Turbine<CheckoutController.Result>,
+        val callbackCalls: Turbine<CallbackCall>,
         val testScheduler: TestCoroutineScheduler,
     ) {
         fun emit(result: ConfirmationHandler.Result) {
@@ -158,4 +234,10 @@ internal class CheckoutConfirmationResultHandlerTest {
             testScheduler.runCurrent()
         }
     }
+
+    private data class CallbackCall(
+        val result: CheckoutController.Result,
+        val succeededCallCount: Int,
+        val succeededResponse: CheckoutSessionResponse?,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationStateUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationStateUpdaterTest.kt
@@ -1,0 +1,151 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutConfirmationStateUpdaterTest {
+
+    @Test
+    fun `provided response reloads state without fetching`() = runScenario {
+        val response = response(id = "cs_confirmed")
+
+        updater.update(response)
+
+        assertThat(reloadCalls.awaitItem().checkoutSessionResponse).isEqualTo(response)
+        fetchCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `missing response fetches session and reloads state`() {
+        val response = response(id = "cs_refreshed")
+
+        runScenario(fetchResult = Result.success(response)) {
+            updater.update(checkoutSessionResponse = null)
+
+            val initialState = requireNotNull(initialState)
+            assertThat(fetchCalls.awaitItem()).isEqualTo(
+                FetchCall(
+                    sessionId = initialState.checkoutSessionResponse.id,
+                    adaptivePricingAllowed = initialState.configuration.adaptivePricingAllowed,
+                )
+            )
+            assertThat(reloadCalls.awaitItem().checkoutSessionResponse).isEqualTo(response)
+        }
+    }
+
+    @Test
+    fun `failed refresh leaves state unchanged`() {
+        val error = IllegalStateException("Failed to refresh")
+
+        runScenario(fetchResult = Result.failure(error)) {
+            updater.update(checkoutSessionResponse = null)
+
+            val initialState = requireNotNull(initialState)
+            assertThat(fetchCalls.awaitItem().sessionId).isEqualTo(initialState.checkoutSessionResponse.id)
+            reloadCalls.expectNoEvents()
+            assertThat(stateHolder.state).isEqualTo(initialState)
+        }
+    }
+
+    @Test
+    fun `provided response swallows reload failure and leaves state unchanged`() {
+        val error = IllegalStateException("Failed to reload")
+
+        runScenario(reloadError = error) {
+            val initialState = requireNotNull(initialState)
+
+            updater.update(response(id = "cs_confirmed"))
+
+            // Reload was attempted with the confirmed response but threw; update must swallow it so a
+            // completed payment is never turned into a failed result.
+            assertThat(reloadCalls.awaitItem().checkoutSessionResponse.id).isEqualTo("cs_confirmed")
+            fetchCalls.expectNoEvents()
+            assertThat(stateHolder.state).isEqualTo(initialState)
+        }
+    }
+
+    @Test
+    fun `fetched response swallows reload failure and leaves state unchanged`() {
+        val fetchedResponse = response(id = "cs_refreshed")
+        val error = IllegalStateException("Failed to reload")
+
+        runScenario(fetchResult = Result.success(fetchedResponse), reloadError = error) {
+            val initialState = requireNotNull(initialState)
+
+            updater.update(checkoutSessionResponse = null)
+
+            assertThat(fetchCalls.awaitItem().sessionId).isEqualTo(initialState.checkoutSessionResponse.id)
+            assertThat(reloadCalls.awaitItem().checkoutSessionResponse).isEqualTo(fetchedResponse)
+            assertThat(stateHolder.state).isEqualTo(initialState)
+        }
+    }
+
+    @Test
+    fun `missing state does not fetch or reload`() = runScenario(state = null) {
+        updater.update(response(id = "cs_confirmed"))
+
+        fetchCalls.expectNoEvents()
+        reloadCalls.expectNoEvents()
+    }
+
+    private fun runScenario(
+        state: CheckoutControllerState? = CheckoutControllerStateFactory.create(),
+        fetchResult: Result<CheckoutSessionResponse> = Result.failure(
+            IllegalStateException("Unexpected fetch")
+        ),
+        reloadError: Throwable? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val fetchCalls = Turbine<FetchCall>()
+        val reloadCalls = Turbine<CheckoutControllerState>()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        stateHolder.state = state
+        val updater = CheckoutConfirmationStateUpdater(
+            stateHolder = stateHolder,
+            fetchResponse = { sessionId, adaptivePricingAllowed ->
+                fetchCalls.add(FetchCall(sessionId, adaptivePricingAllowed))
+                fetchResult
+            },
+            reloadState = { updatedState ->
+                reloadCalls.add(updatedState)
+                reloadError?.let { throw it }
+                stateHolder.state = updatedState
+            },
+        )
+
+        Scenario(
+            updater = updater,
+            initialState = state,
+            stateHolder = stateHolder,
+            fetchCalls = fetchCalls,
+            reloadCalls = reloadCalls,
+        ).block()
+
+        fetchCalls.ensureAllEventsConsumed()
+        reloadCalls.ensureAllEventsConsumed()
+    }
+
+    private fun response(id: String): CheckoutSessionResponse {
+        return CheckoutSessionResponseFactory.create(id = id)
+    }
+
+    private class Scenario(
+        val updater: CheckoutConfirmationStateUpdater,
+        val initialState: CheckoutControllerState?,
+        val stateHolder: CheckoutControllerStateHolder,
+        val fetchCalls: Turbine<FetchCall>,
+        val reloadCalls: Turbine<CheckoutControllerState>,
+    )
+
+    private data class FetchCall(
+        val sessionId: String,
+        val adaptivePricingAllowed: Boolean,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
@@ -345,6 +346,11 @@ internal class CheckoutControllerTest {
         val confirmationHandler = FakeConfirmationHandler()
         val results = mutableListOf<CheckoutController.Result>()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val confirmationStateUpdater = CheckoutConfirmationStateUpdater(
+            stateHolder = stateHolder,
+            fetchResponse = { _, _ -> Result.failure(AssertionError("Unexpected fetch")) },
+            reloadState = { _ -> },
+        )
         val resultHandler = CheckoutConfirmationResultHandler(
             confirmationHandler = confirmationHandler,
             resultCallback = CheckoutController.ResultCallback { results.add(it) },
@@ -356,6 +362,7 @@ internal class CheckoutControllerTest {
         CheckoutController(
             viewModelScope = backgroundScope,
             confirmationResultHandler = resultHandler,
+            confirmationStateUpdater = confirmationStateUpdater,
             checkoutSessionRepository = mock(),
             checkoutStateLoader = mock(),
             stateHolder = stateHolder,
@@ -1017,6 +1024,43 @@ internal class CheckoutControllerTest {
         }
 
     @Test
+    fun `successful confirmation waits for an in-flight mutation then refreshes state`() =
+        runMutationScenario(assertLoadingConsumed = true) {
+            val holdMutation = CountDownLatch(1)
+            networkRule.checkoutUpdate(
+                bodyPart("promotion_code", "10OFF"),
+            ) { response ->
+                holdMutation.await(10, TimeUnit.SECONDS)
+                successResponseFactory().invoke(response)
+            }
+            val confirmedResponse = committedState().checkoutSessionResponse.copy(
+                status = CheckoutSessionResponse.Status.COMPLETE,
+            )
+
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+
+            val mutation = async { controller.applyPromotionCode("10OFF") }
+            testScheduler.advanceUntilIdle()
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+
+            val confirmation = async {
+                controller.handleConfirmationSucceeded(confirmedResponse)
+            }
+            testScheduler.advanceUntilIdle()
+
+            assertThat(confirmation.isCompleted).isFalse()
+            assertThat(committedStateOrNull()).isNotNull()
+
+            holdMutation.countDown()
+            assertThat(mutation.await().isSuccess).isTrue()
+            confirmation.await()
+
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+            assertThat(committedState().checkoutSessionResponse).isEqualTo(confirmedResponse)
+            assertThat(controller.session.value).isNotNull()
+        }
+
+    @Test
     fun `configure toggles isUpdating true then false`() = runTest {
         networkRule.defaultInit()
         val controller = createController()
@@ -1362,7 +1406,9 @@ internal class CheckoutControllerTest {
 
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
-        fun committedState(): CheckoutControllerState = requireNotNull(stateHolder.state)
+        fun committedState(): CheckoutControllerState = requireNotNull(committedStateOrNull())
+
+        fun committedStateOrNull(): CheckoutControllerState? = stateHolder.state
 
         // Simulates a presented payment flow by opening the sheet through the SheetStateHolder backed
         // by the shared SavedStateHandle, which the mutation guard reads back through the same holder.

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
@@ -390,6 +391,11 @@ internal class CheckoutControllerTest {
         val confirmationHandler = FakeConfirmationHandler()
         val results = mutableListOf<CheckoutController.Result>()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val confirmationStateUpdater = CheckoutConfirmationStateUpdater(
+            stateHolder = stateHolder,
+            fetchResponse = { _, _ -> Result.failure(AssertionError("Unexpected fetch")) },
+            reloadState = { _ -> },
+        )
         val resultHandler = CheckoutConfirmationResultHandler(
             confirmationHandler = confirmationHandler,
             resultCallback = CheckoutController.ResultCallback { results.add(it) },
@@ -401,6 +407,7 @@ internal class CheckoutControllerTest {
         CheckoutController(
             viewModelScope = backgroundScope,
             confirmationResultHandler = resultHandler,
+            confirmationStateUpdater = confirmationStateUpdater,
             checkoutSessionRepository = mock(),
             checkoutStateLoader = mock(),
             stateHolder = stateHolder,
@@ -979,6 +986,43 @@ internal class CheckoutControllerTest {
         }
 
     @Test
+    fun `successful confirmation waits for an in-flight mutation then refreshes state`() =
+        runMutationScenario(assertLoadingConsumed = true) {
+            val holdMutation = CountDownLatch(1)
+            networkRule.checkoutUpdate(
+                bodyPart("promotion_code", "10OFF"),
+            ) { response ->
+                holdMutation.await(10, TimeUnit.SECONDS)
+                successResponseFactory().invoke(response)
+            }
+            val confirmedResponse = committedState().checkoutSessionResponse.copy(
+                status = CheckoutSessionResponse.Status.COMPLETE,
+            )
+
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+
+            val mutation = async { controller.applyPromotionCode("10OFF") }
+            testScheduler.advanceUntilIdle()
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+
+            val confirmation = async {
+                controller.handleConfirmationSucceeded(confirmedResponse)
+            }
+            testScheduler.advanceUntilIdle()
+
+            assertThat(confirmation.isCompleted).isFalse()
+            assertThat(committedStateOrNull()).isNotNull()
+
+            holdMutation.countDown()
+            assertThat(mutation.await().isSuccess).isTrue()
+            confirmation.await()
+
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+            assertThat(committedState().checkoutSessionResponse).isEqualTo(confirmedResponse)
+            assertThat(controller.session.value).isNotNull()
+        }
+
+    @Test
     fun `configure is serialized behind an in-flight mutation and shares its loading window`() =
         runMutationScenario(assertLoadingConsumed = true) {
             val holdMutation = CountDownLatch(1)
@@ -1316,7 +1360,9 @@ internal class CheckoutControllerTest {
 
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
-        fun committedState(): CheckoutControllerState = requireNotNull(stateHolder.state)
+        fun committedState(): CheckoutControllerState = requireNotNull(committedStateOrNull())
+
+        fun committedStateOrNull(): CheckoutControllerState? = stateHolder.state
     }
 
     private companion object {


### PR DESCRIPTION
# Summary

- Adds a confirmation-state updater that uses the response returned by synchronous confirmation or refetches after a next action.
- Reloads all response-derived controller state before delivering `Completed`.
- Serializes confirmation refreshes through `CheckoutOperationCoordinator` while keeping refresh failures from changing a successful payment result.

At this layer the refreshed session remains loaded; the final PR clears it after refresh.

Stack position: 3 of 4, based on #13802.

# Motivation

Confirmation can finish while another controller mutation is still in flight, and next-action results do not carry a Checkout Session response. Refreshing through the controller's existing serialization path prevents stale writes and ensures derived state is synchronized without converting a completed payment into a failure when refresh work fails.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutConfirmationResultHandlerTest --tests com.stripe.android.checkout.CheckoutConfirmationStateUpdaterTest --tests com.stripe.android.checkout.CheckoutControllerTest`

No tests were ignored.

# Screenshots

Not applicable — there are no visual changes.

# Changelog

Not included — `CheckoutController` remains a preview API.
