### PR TITLE
Clear CheckoutController state after completion

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultHandler.kt
@@ -55,7 +55,7 @@ internal class CheckoutConfirmationResultHandler @Inject constructor(
         onSucceeded: suspend (CheckoutSessionResponse?) -> Unit,
     ) {
         // Synchronous confirmation carries the latest response. Next-action confirmation does not,
-        // so the controller retrieves the completed Checkout Session before delivering the result.
+        // so the controller retrieves the completed Checkout Session before clearing its state.
         onSucceeded(result.metadata[CheckoutSessionResponseKey])
         resultCallback.onResult(CheckoutController.Result.Completed())
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -69,7 +69,8 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
-     * The latest [Session] data, or `null` until [configure] has completed successfully.
+     * The latest [Session] data, or `null` until [configure] completes successfully and after a
+     * payment flow completes.
      */
     val session: StateFlow<Session?>
         get() = stateHolder.session
@@ -312,6 +313,7 @@ class CheckoutController @Inject internal constructor(
     ) {
         operationCoordinator.runMutation {
             confirmationStateUpdater.update(checkoutSessionResponse)
+            stateHolder.state = null
             kotlin.Result.success(Unit)
         }
     }
@@ -1095,7 +1097,8 @@ class CheckoutController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Result {
         /**
-         * The customer completed the payment flow.
+         * The customer completed the payment flow. The controller's loaded [session] is cleared
+         * before this result is delivered.
          */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -75,7 +75,8 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
-     * The latest [Session] data, or `null` until [configure] has completed successfully.
+     * The latest [Session] data, or `null` until [configure] completes successfully and after a
+     * payment flow completes.
      */
     val session: StateFlow<Session?>
         get() = stateHolder.session
@@ -303,6 +304,7 @@ class CheckoutController @Inject internal constructor(
     ) {
         runSerialized {
             confirmationStateUpdater.update(checkoutSessionResponse)
+            stateHolder.state = null
             kotlin.Result.success(Unit)
         }
     }
@@ -1006,7 +1008,8 @@ class CheckoutController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Result {
         /**
-         * The customer completed the payment flow.
+         * The customer completed the payment flow. The controller's loaded [session] is cleared
+         * before this result is delivered.
          */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -986,7 +986,7 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `successful confirmation waits for an in-flight mutation then refreshes state`() =
+    fun `successful confirmation waits for an in-flight mutation then clears state`() =
         runMutationScenario(assertLoadingConsumed = true) {
             val holdMutation = CountDownLatch(1)
             networkRule.checkoutUpdate(
@@ -1018,8 +1018,8 @@ internal class CheckoutControllerTest {
             confirmation.await()
 
             assertThat(isUpdatingTurbine.awaitItem()).isFalse()
-            assertThat(committedState().checkoutSessionResponse).isEqualTo(confirmedResponse)
-            assertThat(controller.session.value).isNotNull()
+            assertThat(committedStateOrNull()).isNull()
+            assertThat(controller.session.value).isNull()
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -1024,7 +1024,7 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `successful confirmation waits for an in-flight mutation then refreshes state`() =
+    fun `successful confirmation waits for an in-flight mutation then clears state`() =
         runMutationScenario(assertLoadingConsumed = true) {
             val holdMutation = CountDownLatch(1)
             networkRule.checkoutUpdate(
@@ -1056,8 +1056,8 @@ internal class CheckoutControllerTest {
             confirmation.await()
 
             assertThat(isUpdatingTurbine.awaitItem()).isFalse()
-            assertThat(committedState().checkoutSessionResponse).isEqualTo(confirmedResponse)
-            assertThat(controller.session.value).isNotNull()
+            assertThat(committedStateOrNull()).isNull()
+            assertThat(controller.session.value).isNull()
         }
 
     @Test


### PR DESCRIPTION
# Summary

- Clears `CheckoutController` state after the serialized confirmation refresh and before delivering `Result.Completed`.
- Documents that the public `session` flow returns to `null` after a completed payment flow.
- Updates the concurrency test to assert the completed session is cleared.

Stack position: 4 of 4 (top), based on #13803.

# Motivation

A successfully completed payment flow should not leave a stale Checkout Session available for further mutation or reuse. Clearing after the best-effort refresh preserves confirmation ordering while ensuring observers and the result callback see the controller in its terminal state.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutSheetLauncherTest --tests com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionConfirmationInterceptorTest --tests com.stripe.android.checkout.CheckoutConfirmationResultHandlerTest --tests com.stripe.android.checkout.CheckoutConfirmationStateUpdaterTest --tests com.stripe.android.checkout.CheckoutControllerTest`

No tests were ignored.

# Screenshots

Not applicable — there are no visual changes.

# Changelog

Not included — `CheckoutController` remains a preview API.
