### PR TITLE
Stabilize US bank account Lite tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1533,24 +1533,38 @@ internal class PlaygroundTestDriver(
     private fun executeUsBankAccountLiteFlow() {
         awaitActivityClass(FINANCIAL_CONNECTIONS_LITE_ACTIVITY)
 
+        val firstPane = onWebView().withElementByAnyTestId(
+            testIds = FINANCIAL_CONNECTIONS_LITE_INITIAL_PANE_TEST_IDS,
+            timeout = WEBVIEW_ELEMENT_TIMEOUT,
+        )
+        firstPane.interaction.perform(webClick())
+
         onWebView()
-            .withElementByTestId("institution-default")
+            .withElementByTestId(
+                testId = FINANCIAL_CONNECTIONS_LITE_INITIAL_PANE_TEST_IDS.first { it != firstPane.testId },
+                timeout = WEBVIEW_ELEMENT_TIMEOUT,
+            )
             .perform(webClick())
 
         onWebView()
-            .withElementByTestId("agree-button")
+            .withElementByTestId(
+                testId = "select-button",
+                timeout = WEBVIEW_ELEMENT_TIMEOUT,
+            )
             .perform(webClick())
 
         onWebView()
-            .withElementByTestId(testId = "select-button")
+            .withElementByTestId(
+                testId = "link-not-now-button",
+                timeout = WEBVIEW_ELEMENT_TIMEOUT,
+            )
             .perform(webClick())
 
         onWebView()
-            .withElementByTestId("link-not-now-button")
-            .perform(webClick())
-
-        onWebView()
-            .withElementByTestId("done-button")
+            .withElementByTestId(
+                testId = "done-button",
+                timeout = WEBVIEW_ELEMENT_TIMEOUT,
+            )
             .perform(webClick())
     }
 
@@ -1625,9 +1639,10 @@ internal class PlaygroundTestDriver(
     private fun cancelAchLiteFlowOnLaunch() {
         awaitActivityClass(FINANCIAL_CONNECTIONS_LITE_ACTIVITY)
 
-        onWebView()
-            .withElementByTestId("agree-button")
-            .perform(webClick())
+        onWebView().withElementByAnyTestId(
+            testIds = FINANCIAL_CONNECTIONS_LITE_INITIAL_PANE_TEST_IDS,
+            timeout = WEBVIEW_ELEMENT_TIMEOUT,
+        )
 
         if (testParameters.authorizationAction == AuthorizeAction.Cancel) {
             selectors.authorizeAction?.click()
@@ -1787,6 +1802,10 @@ internal class PlaygroundTestDriver(
         val CHECKOUT_PREPARATION_TIMEOUT: Duration = 45.seconds
         val FINANCIAL_CONNECTIONS_COMPLETION_TIMEOUT: Duration = 60.seconds
         val FINANCIAL_CONNECTIONS_UI_TIMEOUT: Duration = 45.seconds
+        val FINANCIAL_CONNECTIONS_LITE_INITIAL_PANE_TEST_IDS = listOf(
+            "institution-default",
+            "agree-button",
+        )
         const val ACTIVITY_POLL_INTERVAL_MS = 250L
 
         const val ADD_PAYMENT_METHOD_NODE_TAG = "${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_+ Add"

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/WebviewInteraction.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/WebviewInteraction.kt
@@ -8,20 +8,58 @@ import androidx.test.espresso.web.webdriver.Locator
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+internal val WEBVIEW_ELEMENT_TIMEOUT: Duration = 30.seconds
+
+internal class WebElementMatch(
+    val testId: String,
+    val interaction: WebInteraction<Void>,
+)
+
 /**
  * Find a button in a web view using its `data-testid` ID (commonly used in Stripe frontend surfaces).
  *
- * The default [timeout] is generous because the first lookup after a web-based auth activity opens
+ * The [timeout] should be generous because the first lookup after a web-based auth activity opens
  * absorbs the full cost of navigating to, bootstrapping, and rendering a remote single-page app whose
  * content only appears after an async data fetch. This mirrors the equally generous activity and
  * idling-resource timeouts elsewhere in the driver and stays well under the 90s per-test timeout.
  */
 internal fun WebInteraction<Void>.withElementByTestId(
     testId: String,
-    timeout: Duration = 30.seconds,
-): WebInteraction<Void> = retryUntil(timeout = timeout) {
-    runCatching { withElement(findElement(Locator.CSS_SELECTOR, "[data-testid='$testId']")) }
-        .getOrNull()
+    timeout: Duration,
+): WebInteraction<Void> = withElementByAnyTestId(
+    testIds = listOf(testId),
+    timeout = timeout,
+).interaction
+
+/**
+ * Finds the first available element from [testIds] without spending the full timeout on a selector for a
+ * different server-controlled flow variant.
+ */
+internal fun WebInteraction<Void>.withElementByAnyTestId(
+    testIds: List<String>,
+    timeout: Duration,
+): WebElementMatch {
+    require(testIds.isNotEmpty()) { "testIds must not be empty" }
+
+    var lastFailure: Throwable? = null
+    return retryUntil(
+        timeout = timeout,
+        pollInterval = 1.seconds,
+        failureMessage = "No WebView element found with data-testid in " +
+            testIds.joinToString(prefix = "[", postfix = "]") { "'$it'" },
+        failureCause = { lastFailure },
+    ) {
+        testIds.firstNotNullOfOrNull { testId ->
+            runCatching {
+                WebElementMatch(
+                    testId = testId,
+                    interaction = withElement(findElement(Locator.CSS_SELECTOR, "[data-testid='$testId']")),
+                )
+            }.onFailure {
+                lastFailure = it
+            }.getOrNull()
+        }
+    }
 }
 
 /**
@@ -29,14 +67,19 @@ internal fun WebInteraction<Void>.withElementByTestId(
  * the target is detected promptly once it renders rather than up to a full [pollInterval] later.
  */
 private fun <T> retryUntil(
-    timeout: Duration = 30.seconds,
-    pollInterval: Duration = 1.seconds,
-    block: () -> T?
+    timeout: Duration,
+    pollInterval: Duration,
+    failureMessage: String,
+    failureCause: () -> Throwable?,
+    block: () -> T?,
 ): T {
     val endTime = elapsedRealtime() + timeout.inWholeMilliseconds
     while (elapsedRealtime() < endTime) {
         block()?.let { return it }
         sleep(pollInterval.inWholeMilliseconds)
     }
-    throw AssertionError("Condition not met within $timeout")
+
+    val error = AssertionError("$failureMessage within $timeout")
+    failureCause()?.let(error::initCause)
+    throw error
 }


### PR DESCRIPTION
# Summary

- Make the Financial Connections Lite test driver support either server-controlled initial pane order.
- Poll all valid WebView test IDs together and return the selector that matched.
- Include the attempted selectors and final Espresso exception when WebView polling times out.

# Motivation

`TestUSBankAccount#testUSBankAccountLiteSuccess` intermittently failed after 30 seconds while waiting for `institution-default`.

The Financial Connections frontend flag `bank_connections_enable_select_institution_first` controls whether `institution-default` or `agree-button` is rendered first. The Android test driver hard-coded `institution-default` followed by `agree-button`, so runs assigned the opposite flow variant waited for an element that was not expected to exist on that pane.

This fix works by polling both valid initial selectors during the same timeout. Once one appears, the driver records which selector matched, clicks it, and waits for the other pane. The cancellation flow similarly waits until either valid initial pane is ready before pressing Back. This follows the actual server-selected ordering instead of trying to hide the mismatch with a longer timeout.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

- Temporarily wrapped `TestRules` with `ShampooRule(20)` and ran `testUSBankAccountLiteSuccess` on `pixel2api33chrome`: 20/20 iterations passed.
- Removed the temporary Shampoo rule and reran `testUSBankAccountLiteSuccess` plus `testUSBankAccountLiteCancelAllowsUserToContinue`: 2/2 tests passed.
- `git diff --check`

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots

| Before | After |
| --- | --- |
| Not applicable; test infrastructure only. | Not applicable; test infrastructure only. |

# Changelog

Not applicable; this only changes Android test infrastructure.
