### PR TITLE
Preserve configurable country field identifiers

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -85,6 +85,7 @@ data class AddressSpec(
                     identifier = apiPath,
                     initialValues = initialValues,
                     countryCodes = allowedCountryCodes,
+                    countryElementIdentifier = IdentifierSpec.Country,
                     sameAsShippingElement = sameAsShippingElement,
                     shippingValuesMap = shippingValues,
                     hideCountry = hideCountry,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
@@ -75,9 +75,10 @@ class BillingAddressElement(
     override val identifier: IdentifierSpec,
     rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
     countryCodes: Set<String> = emptySet(),
+    countryElementIdentifier: IdentifierSpec,
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
-        rawValuesMap[IdentifierSpec.Country]
+        rawValuesMap[countryElementIdentifier]
     ),
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     sameAsShippingElement: SameAsShippingElement?,
@@ -113,6 +114,7 @@ class BillingAddressElement(
             identifier = identifier,
             initialValues = rawValuesMap,
             countryCodes = countryCodes,
+            countryElementIdentifier = countryElementIdentifier,
             nameConfig = nameConfig,
             phoneNumberConfig = phoneNumberConfig,
             emailConfig = emailConfig,
@@ -132,7 +134,7 @@ class BillingAddressElement(
                 emailConfig = emailConfig,
             ),
             countryElement = CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = countryElementIdentifier,
                 controller = countryDropdownFieldController,
             ),
             shippingValuesMap = shippingValuesMap,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.utils.isInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -73,6 +74,27 @@ internal class CardBillingAddressElementTest {
             dropdownFieldController.onRawValueChange("US")
             expectMostRecentItem().verifyFieldsShown()
         }
+    }
+
+    @Test
+    fun `Country-only collection preserves a configured country identifier`() = runTest {
+        val countryIdentifier = IdentifierSpec.Generic("payment_method_data[future_lpm][country]")
+        val element = BillingAddressElement(
+            identifier = IdentifierSpec.Generic("billing_element"),
+            rawValuesMap = mapOf(countryIdentifier to "DE"),
+            countryCodes = setOf("DE"),
+            countryElementIdentifier = countryIdentifier,
+            autocompleteAddressInteractorFactory = null,
+            sameAsShippingElement = null,
+            shippingValuesMap = null,
+            addressCollectionMode = BillingAddressCollectionMode.Country(emptyMap()),
+        )
+
+        assertThat(element.countryElement.identifier).isEqualTo(countryIdentifier)
+        assertThat(element.countryElement.controller.rawFieldValue.value).isEqualTo("DE")
+        val formFieldIdentifiers = element.getFormFieldValueFlow().first().map { it.first }
+        assertThat(formFieldIdentifiers).contains(countryIdentifier)
+        assertThat(formFieldIdentifiers).doesNotContain(IdentifierSpec.Country)
     }
 
     @Test
@@ -312,6 +334,7 @@ internal class CardBillingAddressElementTest {
             rawValuesMap = emptyMap(),
             countryCodes = emptySet(),
             countryDropdownFieldController = dropdownFieldController,
+            countryElementIdentifier = IdentifierSpec.Country,
             autocompleteAddressInteractorFactory = null,
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -382,6 +405,7 @@ internal class CardBillingAddressElementTest {
                 rawValuesMap = emptyMap(),
                 countryCodes = emptySet(),
                 countryDropdownFieldController = dropdownFieldController,
+                countryElementIdentifier = IdentifierSpec.Country,
                 autocompleteAddressInteractorFactory = {
                     object : AutocompleteAddressInteractor {
                         override val autocompleteConfig: AutocompleteAddressInteractor.Config =

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -290,6 +290,7 @@ private fun cardBillingElements(
         IdentifierSpec.Generic("credit_billing"),
         countryCodes = allowedCountries,
         rawValuesMap = initialValues,
+        countryElementIdentifier = IdentifierSpec.Country,
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = shippingValues,
         addressCollectionMode = cardBillingAddressCollectionMode(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
@@ -18,6 +18,7 @@ internal class AddressFormController(
         identifier = IdentifierSpec.Generic("address"),
         initialValues = initialValues,
         countryCodes = config?.allowedCountries ?: CountryUtils.supportedBillingCountries,
+        countryElementIdentifier = IdentifierSpec.Country,
         nameConfig = AddressFieldConfiguration.REQUIRED,
         phoneNumberConfig = parsePhoneNumberConfig(config?.additionalFields?.phone),
         shippingValuesMap = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -187,6 +187,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             identifier = IdentifierSpec.Generic("billing_details[address]"),
             initialValues = defaultAddress?.asFormFieldValues() ?: emptyMap(),
             countryCodes = collectionConfiguration.allowedBillingCountries,
+            countryElementIdentifier = IdentifierSpec.Country,
             sameAsShippingElement = sameAsShippingElement,
             interactorFactory = it,
             shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -44,6 +44,7 @@ internal class BillingDetailsForm(
         sameAsShippingElement = null,
         shippingValuesMap = null,
         countryCodes = allowedBillingCountries,
+        countryElementIdentifier = IdentifierSpec.Country,
         collectionConfiguration = BillingDetailsCollectionConfiguration(
             address = when (addressCollectionMode) {
                 AddressCollectionMode.Automatic ->

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -17,9 +17,10 @@ class AutocompleteAddressController(
     val initialValues: Map<IdentifierSpec, String?>,
     interactorFactory: AutocompleteAddressInteractor.Factory,
     countryCodes: Set<String> = emptySet(),
+    private val countryElementIdentifier: IdentifierSpec,
     private val countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
-        initialValues[IdentifierSpec.Country]
+        initialValues[countryElementIdentifier]
     ),
     private val phoneNumberConfig: AddressFieldConfiguration,
     private val nameConfig: AddressFieldConfiguration,
@@ -76,7 +77,7 @@ class AutocompleteAddressController(
     private val isValidating = MutableStateFlow(false)
 
     val countryElement = CountryElement(
-        IdentifierSpec.Country,
+        countryElementIdentifier,
         countryDropdownFieldController,
     )
 
@@ -125,7 +126,13 @@ class AutocompleteAddressController(
              * Merges the current and new values together. New value keys will override current
              * value keys if provided.
              */
-            val newValues = currentValues.plus(event.values ?: emptyMap())
+            val newValues = currentValues.plus(
+                event.values
+                    ?.mapKeys { (identifier, _) ->
+                        if (identifier == IdentifierSpec.Country) countryElementIdentifier else identifier
+                    }
+                    .orEmpty(),
+            )
 
             when (event) {
                 is AutocompleteAddressInteractor.Event.OnValues -> Unit
@@ -135,7 +142,7 @@ class AutocompleteAddressController(
             val newAddressInputMode = toAddressInputMode(expandForm, newValues)
 
             if (currentValues != newValues || newAddressInputMode != addressElementFlow.value.addressInputMode) {
-                newValues[IdentifierSpec.Country]?.let {
+                newValues[countryElementIdentifier]?.let {
                     countryDropdownFieldController.onRawValueChange(it)
                 }
 
@@ -177,7 +184,7 @@ class AutocompleteAddressController(
         values: Map<IdentifierSpec, String?>
     ): AddressInputMode {
         val googlePlacesApiKey = config.googlePlacesApiKey
-        val countrySupported = isCountrySupported(values[IdentifierSpec.Country])
+        val countrySupported = isCountrySupported(values[countryElementIdentifier])
 
         val showInline = inlineAutocompleteActive && !expandForm &&
             countrySupported && values[IdentifierSpec.Line1].isNullOrEmpty()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -9,9 +9,10 @@ class AutocompleteAddressElement(
     override val identifier: IdentifierSpec,
     initialValues: Map<IdentifierSpec, String?>,
     countryCodes: Set<String> = emptySet(),
+    countryElementIdentifier: IdentifierSpec,
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
-        initialValues[IdentifierSpec.Country]
+        initialValues[countryElementIdentifier]
     ),
     phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
     nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
@@ -26,6 +27,7 @@ class AutocompleteAddressElement(
             identifier = identifier,
             initialValues = initialValues,
             countryCodes = countryCodes,
+            countryElementIdentifier = countryElementIdentifier,
             countryDropdownFieldController = countryDropdownFieldController,
             phoneNumberConfig = phoneNumberConfig,
             nameConfig = nameConfig,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -296,6 +296,40 @@ class AutocompleteAddressControllerTest {
         }
 
     @Test
+    fun `Autocomplete preserves a configured country identifier`() = runTest {
+        TestAutocompleteAddressInteractor.test(
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = null,
+                autocompleteCountries = setOf("DE", "FR"),
+            ),
+        ) {
+            val countryIdentifier = IdentifierSpec.Generic("payment_method_data[future_lpm][country]")
+            val controller = createAutocompleteAddressController(
+                values = mapOf(countryIdentifier to "DE"),
+                countryElementIdentifier = countryIdentifier,
+                interactor = interactor,
+            )
+            val registerCall = registerCalls.awaitItem()
+
+            controller.addressElementFlow.test {
+                val initialElement = awaitItem()
+                assertThat(initialElement.countryElement.identifier).isEqualTo(countryIdentifier)
+                assertThat(initialElement.countryElement.controller.rawFieldValue.value).isEqualTo("DE")
+
+                registerCall.onEvent(
+                    AutocompleteAddressInteractor.Event.OnValues(
+                        values = mapOf(IdentifierSpec.Country to "FR"),
+                    ),
+                )
+
+                val updatedElement = awaitItem()
+                assertThat(updatedElement.countryElement.identifier).isEqualTo(countryIdentifier)
+                assertThat(updatedElement.countryElement.controller.rawFieldValue.value).isEqualTo("FR")
+            }
+        }
+    }
+
+    @Test
     fun `Element does not use full-screen autocomplete when stripe-hosted is enabled without inline autocomplete`() =
         noAutocompleteTest(
             autocompleteConfig = AutocompleteAddressInteractor.Config(
@@ -947,6 +981,7 @@ class AutocompleteAddressControllerTest {
 
     private fun createAutocompleteAddressController(
         values: Map<IdentifierSpec, String?> = emptyMap(),
+        countryElementIdentifier: IdentifierSpec = IdentifierSpec.Country,
         phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         emailConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
@@ -965,6 +1000,7 @@ class AutocompleteAddressControllerTest {
         return AutocompleteAddressController(
             identifier = IdentifierSpec.Generic("address"),
             initialValues = values,
+            countryElementIdentifier = countryElementIdentifier,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
             phoneNumberConfig = phoneNumberConfig,


### PR DESCRIPTION
# Summary

Preserve configurable nested country field identifiers while every existing form continues to use `IdentifierSpec.Country`. There is no customer-visible behavior change.

# Motivation

A schema-provided LPM country field can need to serialize at a nested API path. This preserves that infrastructure for a future schema-driven LPM integration, for example a future Sofort-style integration. It does not add or re-enable Sofort.

# Coverage

- Existing address, card, US Bank Account, and billing-details paths explicitly retain `IdentifierSpec.Country`.
- Country-only and autocomplete paths preserve a caller-provided nested country identifier.

# Testing

- `:payments-ui-core:testDebugUnitTest --tests CardBillingAddressElementTest`
- `:stripe-ui-core:testDebugUnitTest --tests AutocompleteAddressControllerTest`
- Focused PaymentSheet CountrySpec, Klarna, Klarna-no-form, and Wero tests
- `:payments-ui-core:detekt :payments-ui-core:apiCheck :stripe-ui-core:detekt :stripe-ui-core:apiCheck :paymentsheet:detekt :paymentsheet:apiCheck`
- `git diff --check`

# Screenshots

None. No visible change is expected.

# Changelog

N/A. No customer-visible behavior change.