### PR TITLE
Pass shipping address parameters to Google Pay during confirmation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -275,6 +275,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
             publishableKey = publishableKey,
             displayItems = displayItems,
             billingEmailOverride = billingEmailOverride,
+            shippingAddressParameters = null,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -60,6 +60,7 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val publishableKey: String? = null,
         internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
         internal val billingEmailOverride: String? = null,
+        internal val shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,
     ) : Parcelable {
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -75,6 +75,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
                 )
             ),
             billingAddressParameters = args.config.billingAddressConfig.convert(),
+            shippingAddressParameters = args.shippingAddressParameters,
             isEmailRequired = args.config.isEmailRequired,
             allowCreditCards = args.config.allowCreditCards
         )

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
@@ -59,6 +59,7 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
         publishableKey: String?,
         displayItems: List<GooglePayJsonFactory.DisplayItem>,
         billingEmailOverride: String?,
+        shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,
     ) {
         activityResultLauncher.launch(
             GooglePayPaymentMethodLauncherContractV2.Args(
@@ -74,6 +75,7 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
                 publishableKey = publishableKey,
                 displayItems = displayItems,
                 billingEmailOverride = billingEmailOverride,
+                shippingAddressParameters = shippingAddressParameters,
             )
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -177,7 +177,8 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                         merchantName = "Widget, Inc."
                     ),
                     currencyCode = "usd",
-                    amount = 0
+                    amount = 0,
+                    shippingAddressParameters = null,
                 )
             )
             assertThat(transactionInfo)
@@ -205,7 +206,8 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                         merchantName = "Widget, Inc."
                     ),
                     currencyCode = "usd",
-                    amount = 0
+                    amount = 0,
+                    shippingAddressParameters = null,
                 )
             )
             assertThat(transactionInfo)
@@ -285,6 +287,35 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     @Test
+    fun `createPaymentDataRequest() should include shipping address parameters`() {
+        val viewModel = GooglePayPaymentMethodLauncherViewModel(
+            ApplicationProvider.getApplicationContext(),
+            paymentsClient,
+            REQUEST_OPTIONS,
+            ARGS.copy(
+                shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
+                    isRequired = true,
+                    allowedCountryCodes = setOf("US", "CA"),
+                    phoneNumberRequired = true,
+                ),
+            ),
+            stripeRepository,
+            googlePayJsonFactory,
+            googlePayRepository,
+            SavedStateHandle()
+        ).also { viewModelStoreRule.track(it) }
+
+        val paymentDataRequest = viewModel.createPaymentDataRequest()
+
+        assertThat(paymentDataRequest.getBoolean("shippingAddressRequired")).isTrue()
+        val shippingAddressParameters = paymentDataRequest.getJSONObject("shippingAddressParameters")
+        val allowedCountryCodes = shippingAddressParameters.getJSONArray("allowedCountryCodes")
+        assertThat(listOf(allowedCountryCodes.getString(0), allowedCountryCodes.getString(1)))
+            .containsExactly("US", "CA")
+        assertThat(shippingAddressParameters.getBoolean("phoneNumberRequired")).isTrue()
+    }
+
+    @Test
     fun `Factory gets initialized with fallback when no Injector is available`() {
         scenario.onFragment { fragment ->
             val application = ApplicationProvider.getApplicationContext<Application>()
@@ -302,6 +333,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     amount = 1099,
                     label = null,
                     transactionId = null,
+                    shippingAddressParameters = null,
                 )
             )
 
@@ -352,7 +384,8 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                 paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
                 paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
                 checkoutSessionId = null,
-            )
+            ),
+            shippingAddressParameters = null,
         )
         val REQUEST_OPTIONS = ApiRequest.Options(
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -104,6 +104,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             publishableKey = null,
             displayItems = config.displayItems.map { it.resolve(context) },
             billingEmailOverride = config.billingEmailOverride,
+            shippingAddressParameters = config.shippingAddressParameters,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.gpay
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
@@ -26,5 +27,6 @@ internal data class GooglePayConfirmationOption(
         val displayItems: List<GooglePayDisplayItem> = emptyList(),
         val isEmailRequired: Boolean = billingDetailsCollectionConfiguration.collectsEmail,
         val billingEmailOverride: String? = null,
+        val shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters? = null,
     ) : Parcelable
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -56,6 +56,7 @@ import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import com.stripe.android.R as PaymentsCoreR
 
+@Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class GooglePayConfirmationDefinitionTest {
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
@@ -385,6 +386,7 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = emptyList(),
             billingEmailOverride = null,
+            shippingAddressParameters = null,
         )
     }
 
@@ -421,6 +423,7 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = emptyList(),
             billingEmailOverride = null,
+            shippingAddressParameters = null,
         )
     }
 
@@ -458,6 +461,7 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = emptyList(),
             billingEmailOverride = null,
+            shippingAddressParameters = null,
         )
     }
 
@@ -496,6 +500,7 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = emptyList(),
             billingEmailOverride = null,
+            shippingAddressParameters = null,
         )
     }
 
@@ -550,6 +555,45 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = resolvedDisplayItems,
             billingEmailOverride = null,
+            shippingAddressParameters = null,
+        )
+    }
+
+    @Test
+    fun `On 'launch', should pass shipping address parameters to present`() = runTest {
+        val launcher = mock<InternalGooglePayPaymentMethodLauncher>()
+        val definition = createGooglePayConfirmationDefinition()
+        val shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
+            isRequired = true,
+            allowedCountryCodes = setOf("US", "CA"),
+            phoneNumberRequired = true,
+        )
+
+        definition.launch(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
+                config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
+                    shippingAddressParameters = shippingAddressParameters,
+                ),
+            ),
+            confirmationArgs = CONFIRMATION_PARAMETERS,
+            arguments = EmptyConfirmationLauncherArgs,
+            launcher = launcher,
+        )
+
+        verify(launcher).present(
+            currencyCode = "usd",
+            amount = 1000L,
+            config = launcherConfig(),
+            cardBrandFilter = DefaultCardBrandFilter,
+            cardFundingFilter = DefaultCardFundingFilter,
+            clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
+            transactionId = "pi_12345",
+            label = null,
+            isElements = true,
+            publishableKey = null,
+            displayItems = emptyList(),
+            billingEmailOverride = null,
+            shippingAddressParameters = shippingAddressParameters,
         )
     }
 
@@ -626,6 +670,7 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = emptyList(),
             billingEmailOverride = null,
+            shippingAddressParameters = null,
         )
     }
 
@@ -658,6 +703,7 @@ class GooglePayConfirmationDefinitionTest {
             publishableKey = null,
             displayItems = emptyList(),
             billingEmailOverride = null,
+            shippingAddressParameters = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -91,6 +91,7 @@ class GooglePayConfirmationFlowTest {
                     publishableKey = null,
                     displayItems = emptyList(),
                     billingEmailOverride = null,
+                    shippingAddressParameters = null,
                 )
             }
         }


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Pass shipping address parameters from GooglePayConfirmationOption -> Google Pay launch

Follow up PRs will generate shipping address parameters to populate the GooglePayConfirmationOption

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Progress towards collecting shipping address within ECE
https://jira.corp.stripe.com/browse/MOBILESDK-4721

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified