### PR TITLE
Use canonical country identifier

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountrySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountrySpec.kt
@@ -19,8 +19,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 @Parcelize
 data class CountrySpec(
-    @SerialName("api_path")
-    override val apiPath: IdentifierSpec = IdentifierSpec.Country,
     @SerialName("allowed_country_codes")
     val allowedCountryCodes: Set<String> = CountryUtils.supportedBillingCountries
 ) : FormItemSpec() {
@@ -28,10 +26,10 @@ data class CountrySpec(
         initialValues: Map<IdentifierSpec, String?>
     ) = createSectionElement(
         CountryElement(
-            this.apiPath,
+            IdentifierSpec.Country,
             DropdownFieldController(
-                CountryConfig(this.allowedCountryCodes),
-                initialValue = initialValues[this.apiPath]
+                CountryConfig(allowedCountryCodes),
+                initialValue = initialValues[IdentifierSpec.Country]
             )
         )
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -21,7 +21,8 @@ import kotlinx.serialization.json.jsonPrimitive
 @Serializable(with = FormItemSpecSerializer::class)
 sealed class FormItemSpec : Parcelable {
     @SerialName("api_path")
-    abstract val apiPath: IdentifierSpec
+    open val apiPath: IdentifierSpec
+        get() = IdentifierSpec.Country
 
     internal fun createSectionElement(
         sectionFieldElement: SectionFieldElement,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/LpmSerializerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/LpmSerializerTest.kt
@@ -173,7 +173,7 @@ class LpmSerializerTest {
     }
 
     @Test
-    fun `Verify all types api_path parsed correctly`() {
+    fun `Verify all API-path-backed types parse correctly`() {
         val types = listOf(
             "billing_address",
             "affirm_header",
@@ -181,10 +181,8 @@ class LpmSerializerTest {
             "au_becs_bsb_number",
             "au_becs_account_number",
             "au_becs_mandate",
-            "country",
             "email",
             "iban",
-            "klarna_country",
             "klarna_header",
             "static_text",
             "name",
@@ -218,7 +216,7 @@ class LpmSerializerTest {
     }
 
     @Test
-    fun `Verify all specs have default api_path parsed correctly`() {
+    fun `Verify all API-path-backed specs have default paths`() {
         val types = mapOf(
             "billing_address" to "billing_details[address]",
             "affirm_header" to "affirm_header",
@@ -226,10 +224,8 @@ class LpmSerializerTest {
             "au_becs_bsb_number" to "au_becs_debit[bsb_number]",
             "au_becs_account_number" to "au_becs_debit[account_number]",
             "au_becs_mandate" to "au_becs_mandate",
-            "country" to "billing_details[address][country]",
             "email" to "billing_details[email]",
             "iban" to "sepa_debit[iban]",
-            "klarna_country" to "billing_details[address][country]",
             "klarna_header" to "klarna_header_text",
             "name" to "billing_details[name]",
             "mandate" to "mandate",


### PR DESCRIPTION
# Summary

`CountrySpec` now collects country values under the canonical `IdentifierSpec.Country` key. A schema-provided `api_path` is no longer used as the runtime country-field identifier.

JIRA: [MOBILESDK-4667](https://jira.corp.stripe.com/browse/MOBILESDK-4667)

## What changed

- `CountrySpec.transform()` creates its country field with `IdentifierSpec.Country`.
- Its initial country value also comes from `IdentifierSpec.Country`.
- `CountrySpec` no longer declares an `api_path`; only API-path-backed specifications retain that field.

## What stays the same

- Country allowlists and the country control's visible behavior are unchanged.
- Existing forms that already use the canonical country key are unchanged.
- This does not re-enable Sofort or add a new payment method.

# Motivation

Current Android payment-method forms collect country at `billing_details[address][country]`. Removing the unused configurable runtime path keeps that contract explicit before the shared billing-address migration in #13723.

# Coverage

- `LpmSerializerTest` limits custom and default API-path assertions to specifications that actually own an API path.
- `TransformSpecToElementsTest` asserts CountrySpec's canonical country-only collection, while the dependent migration tests cover Klarna, Klarna without a form, Wero, payment-method metadata, and FormViewModel behavior.

# Testing

- `./gradlew :payments-ui-core:testDebugUnitTest --tests 'com.stripe.android.ui.core.elements.LpmSerializerTest' :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.lpmfoundations.luxe.TransformSpecToElementsTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinitionTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinitionNoFormTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.WeroDefinitionTest' --tests 'com.stripe.android.paymentsheet.forms.FormViewModelTest'` passed.
- `./gradlew :payments-ui-core:detekt :payments-ui-core:apiCheck :paymentsheet:detekt :paymentsheet:apiCheck` passed.
- `git diff --check` passed.

# Screenshots

None. No visual change is expected.

# Changelog

N/A. No customer-visible change.
