### PR TITLE
Enable inline autocomplete by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ NEXT_VERSION_BUMP: MINOR
 ### PaymentSheet
 * [FIXED] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
 * [ADDED] Added support for the Agrobank, MBSB Bank, and Bank of China FPX banks, and the FPX bank list is now displayed in alphabetical order.
-* [ADDED] Inline address autocomplete is now enabled by default in PaymentSheet and FlowController.
+* [CHANGED] Inline address autocomplete is now enabled by default in PaymentSheet and FlowController.
 
 ### AddressElement
-* [ADDED] Inline address autocomplete is now enabled by default.
+* [CHANGED] Inline address autocomplete is now enabled by default.
 
 ### CryptoOnramp
 * [ADDED][13623](https://github.com/stripe/stripe-android/pull/13623) Added optional Samsung Pay support to Crypto Onramp, including availability checks, payment credential collection, and developer-facing error details. Integrators must provide the Samsung Pay SDK in their application.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ NEXT_VERSION_BUMP: MINOR
 ### PaymentSheet
 * [FIXED] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
 * [ADDED] Added support for the Agrobank, MBSB Bank, and Bank of China FPX banks, and the FPX bank list is now displayed in alphabetical order.
+* [ADDED] Inline address autocomplete is now enabled by default in PaymentSheet and FlowController.
+
+### AddressElement
+* [ADDED] Inline address autocomplete is now enabled by default.
 
 ## 23.14.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ NEXT_VERSION_BUMP: MINOR
 ### PaymentSheet
 * [FIXED] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
 * [ADDED] Added support for the Agrobank, MBSB Bank, and Bank of China FPX banks, and the FPX bank list is now displayed in alphabetical order.
+* [ADDED] Inline address autocomplete is now enabled by default in PaymentSheet and FlowController.
+
+### AddressElement
+* [ADDED] Inline address autocomplete is now enabled by default.
 
 ### CryptoOnramp
 * [ADDED][13623](https://github.com/stripe/stripe-android/pull/13623) Added optional Samsung Pay support to Crypto Onramp, including availability checks, payment credential collection, and developer-facing error details. Integrators must provide the Samsung Pay SDK in their application.

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -573,7 +573,6 @@ internal class PlaygroundSettings private constructor(
             CaptureMethodSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.enableNfcScanning),
             FeatureFlagSettingsDefinition(FeatureFlags.disableNfcScanningSecurity),
-            FeatureFlagSettingsDefinition(FeatureFlags.inlineAddressAutocompleteEnabled),
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
@@ -6,8 +6,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -15,23 +13,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.rememberAddressLauncher
@@ -74,20 +66,6 @@ private fun AddressElementExampleScreen(viewModel: AddressElementExampleViewMode
             is AddressElementExampleViewState.Content -> {
                 state.address?.let { address ->
                     Address(address)
-                }
-                var inlineAutocompleteEnabled by remember {
-                    mutableStateOf(FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled)
-                }
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("Inline autocomplete")
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Switch(
-                        checked = inlineAutocompleteEnabled,
-                        onCheckedChange = { enabled ->
-                            inlineAutocompleteEnabled = enabled
-                            FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(enabled)
-                        },
-                    )
                 }
                 val context = LocalContext.current
                 Button(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
@@ -152,6 +152,7 @@ internal class FlowControllerAnalyticsTest {
             hasQueryParam("duration"),
             query("intent_id", "pi_example"),
         )
+        validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 
         page.clickPrimaryButton()
         testContext.consumePaymentOptionEventForFlowController("card", "4242")
@@ -236,6 +237,7 @@ internal class FlowControllerAnalyticsTest {
             eventName = "mc_custom_payment_newpm_success",
             hasQueryParam("duration")
         )
+        validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 
         page.clickPrimaryButton()
         testContext.consumePaymentOptionEventForFlowController("card", "4242")
@@ -343,6 +345,7 @@ internal class FlowControllerAnalyticsTest {
             query("is_confirmation_tokens", "true"),
             query("intent_id", "pi_example"),
         )
+        validateAnalyticsRequest(eventName = "mc_billing_address_completed")
         page.clickPrimaryButton()
         testContext.consumePaymentOptionEventForFlowController("card", "4242")
         testContext.consumeNullPaymentOptionEventForFlowController()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -188,7 +188,7 @@ class PaymentSheetAddressAutocompleteTest {
     }
 
     private fun fillOutAutocompletePage() {
-        paymentSheetPage.fillOutFieldWithLabel(label = "Address", "Main Street")
+        paymentSheetPage.clickAndFillField(label = "Address", text = "Main Street")
         paymentSheetPage.waitForText(text = "Enter address manually")
 
         paymentSheetPage.waitForText(SELECTING_ADDRESS_SECONDARY_TEXT)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -107,9 +107,6 @@ class PaymentSheetAddressAutocompleteTest {
 
         clickAndFillOutCard()
 
-        paymentSheetPage.waitForContentDescription(description = "Search")
-        paymentSheetPage.clickViewWithContentDescription(description = "Search")
-
         fillOutAutocompletePage()
 
         enqueueConfirm()
@@ -191,8 +188,8 @@ class PaymentSheetAddressAutocompleteTest {
     }
 
     private fun fillOutAutocompletePage() {
-        paymentSheetPage.waitForText(text = "Enter address manually")
         paymentSheetPage.fillOutFieldWithLabel(label = "Address", "Main Street")
+        paymentSheetPage.waitForText(text = "Enter address manually")
 
         paymentSheetPage.waitForText(SELECTING_ADDRESS_SECONDARY_TEXT)
         paymentSheetPage.clickViewWithText(SELECTING_ADDRESS_SECONDARY_TEXT)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -189,7 +189,6 @@ class PaymentSheetAddressAutocompleteTest {
 
     private fun fillOutAutocompletePage() {
         paymentSheetPage.clickAndFillField(label = "Address", text = "Main Street")
-        paymentSheetPage.waitForText(text = "Enter address manually")
 
         paymentSheetPage.waitForText(SELECTING_ADDRESS_SECONDARY_TEXT)
         paymentSheetPage.clickViewWithText(SELECTING_ADDRESS_SECONDARY_TEXT)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -140,6 +140,7 @@ internal class PaymentSheetAnalyticsTest {
             hasQueryParam("duration"),
             query("intent_id", "pi_example"),
         )
+        validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 
         page.clickPrimaryButton()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.TappedConfirmButton("card"))
@@ -217,6 +218,7 @@ internal class PaymentSheetAnalyticsTest {
             eventName = "mc_complete_payment_newpm_success",
             hasQueryParam("duration")
         )
+        validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 
         page.clickPrimaryButton()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.TappedConfirmButton("card"))
@@ -316,6 +318,7 @@ internal class PaymentSheetAnalyticsTest {
             query("is_confirmation_tokens", "true"),
             query("intent_id", "pi_example"),
         )
+        validateAnalyticsRequest(eventName = "mc_billing_address_completed")
         page.clickPrimaryButton()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.TappedConfirmButton("card"))
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -126,10 +126,10 @@ internal class PaymentSheetPage(
         waitForText(label)
         composeTestRule.onNode(hasText(label))
             .performScrollTo()
-            .performTextReplacement(text)
-        composeTestRule.waitForIdle()
-        composeTestRule.onNode(hasText(text))
             .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNode(hasText(label))
+            .performTextReplacement(text)
     }
 
     fun clickSavedCard(last4: String) {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -122,6 +122,16 @@ internal class PaymentSheetPage(
         replaceText(label, text)
     }
 
+    fun clickAndFillField(label: String, text: String) {
+        waitForText(label)
+        composeTestRule.onNode(hasText(label))
+            .performScrollTo()
+            .performTextReplacement(text)
+        composeTestRule.waitForIdle()
+        composeTestRule.onNode(hasText(text))
+            .performClick()
+    }
+
     fun clickSavedCard(last4: String) {
         val savedCardTagMatcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
             .and(hasText(last4, substring = true))

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
@@ -209,8 +208,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                     autocompleteConfig = AutocompleteAddressInteractor.Config(
                                         googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
                                         autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-                                        isInlineAutocompleteEnabled =
-                                            FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
+                                        isInlineAutocompleteEnabled = true,
                                     ),
                                     placesClient = null,
                                     stripeAutocompleteRepository = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -24,7 +24,6 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
@@ -682,7 +681,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private fun persistBillingAnalytics(paymentSelection: PaymentSelection?) {
-        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
         val billingAddress = paymentSelection.billingDetails?.address ?: return
         val filledAddress = autocompleteFilledAddress
@@ -693,7 +691,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
-        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
         val countryCode = paymentSelection.billingDetails?.address?.country ?: return
         val autocompleteUsed = savedStateHandle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.model.CountryUtils
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.injection.AddressElementViewModelModule
@@ -71,7 +70,7 @@ internal class InputAddressViewModel @Inject constructor(
     )
     val collectedAddress: StateFlow<AddressDetails?> = _collectedAddress
 
-    private val isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled
+    private val isInlineAutocompleteEnabled = true
 
     override val autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
         googlePlacesApiKey = args.config?.googlePlacesApiKey,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -18,7 +18,6 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
@@ -786,7 +785,6 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     private fun persistBillingAnalytics(paymentSelection: PaymentSelection?) {
-        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
         val billingAddress = paymentSelection.billingDetails?.address ?: return
         val filledAddress = viewModel.autocompleteFilledAddress
@@ -797,7 +795,6 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
-        if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return
         if (paymentSelection !is PaymentSelection.New) return
         val countryCode = paymentSelection.billingDetails?.address?.country ?: return
         val autocompleteUsed = viewModel.handle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/InlineAutocompletePlacesClient.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.Address
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
@@ -14,7 +13,6 @@ internal fun createInlineAutocompletePlacesClient(
     errorReporter: ErrorReporter,
     isPlacesAvailable: Boolean,
 ): PlacesClientProxy? {
-    if (!FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled) return null
     if (!isPlacesAvailable) return null
     val apiKey = googlePlacesApiKey ?: return null
     return LazyPlacesClientProxy {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -9,7 +9,6 @@ import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
 import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
@@ -94,7 +93,7 @@ internal abstract class BaseSheetViewModel(
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = config.googlePlacesApiKey,
             autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-            isInlineAutocompleteEnabled = FeatureFlags.inlineAddressAutocompleteEnabled.isEnabled,
+            isInlineAutocompleteEnabled = true,
         ),
         placesClient = placesClient,
         stripeAutocompleteRepository = stripeAutocompleteRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -3321,49 +3320,39 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `reportBillingAddressCompleted fires on successful payment with new card`() = confirmationTest {
-        FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
-        try {
-            val eventReporter = FakeEventReporter()
-            val viewModel = createViewModel(eventReporter = eventReporter)
+        val eventReporter = FakeEventReporter()
+        val viewModel = createViewModel(eventReporter = eventReporter)
 
-            viewModel.updateSelection(CARD_PAYMENT_SELECTION)
-            viewModel.checkout()
+        viewModel.updateSelection(CARD_PAYMENT_SELECTION)
+        viewModel.checkout()
 
-            assertThat(startTurbine.awaitItem()).isNotNull()
+        assertThat(startTurbine.awaitItem()).isNotNull()
 
-            confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
-            )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+        )
 
-            val call = eventReporter.billingAddressCompletedCalls.awaitItem()
-            assertThat(call.addressCountryCode).isEqualTo("US")
-            assertThat(call.autocompleteResultSelected).isFalse()
-            assertThat(call.editDistance).isNull()
-        } finally {
-            FeatureFlags.inlineAddressAutocompleteEnabled.reset()
-        }
+        val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+        assertThat(call.addressCountryCode).isEqualTo("US")
+        assertThat(call.autocompleteResultSelected).isFalse()
+        assertThat(call.editDistance).isNull()
     }
 
     @Test
     fun `reportBillingAddressCompleted does not fire for saved payment methods`() = confirmationTest {
-        FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
-        try {
-            val eventReporter = FakeEventReporter()
-            val viewModel = createViewModel(eventReporter = eventReporter)
+        val eventReporter = FakeEventReporter()
+        val viewModel = createViewModel(eventReporter = eventReporter)
 
-            viewModel.updateSelection(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
-            viewModel.checkout()
+        viewModel.updateSelection(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
+        viewModel.checkout()
 
-            assertThat(startTurbine.awaitItem()).isNotNull()
+        assertThat(startTurbine.awaitItem()).isNotNull()
 
-            confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
-            )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+        )
 
-            eventReporter.billingAddressCompletedCalls.ensureAllEventsConsumed()
-        } finally {
-            FeatureFlags.inlineAddressAutocompleteEnabled.reset()
-        }
+        eventReporter.billingAddressCompletedCalls.ensureAllEventsConsumed()
     }
 
     @Test
@@ -3373,44 +3362,39 @@ internal class PaymentSheetViewModelTest {
             emitNullResults = false,
             consumeBootstrap = false,
         ) {
-            FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
-            try {
-                val eventReporter = FakeEventReporter()
-                val savedStateHandle = SavedStateHandle(
-                    mapOf(
-                        "IN_PROGRESS_PAYMENT_SELECTION" to CARD_PAYMENT_SELECTION,
-                        "BILLING_AUTOCOMPLETE_USED" to true,
-                        "BILLING_AUTOCOMPLETE_EDIT_DISTANCE" to 3,
-                    )
+            val eventReporter = FakeEventReporter()
+            val savedStateHandle = SavedStateHandle(
+                mapOf(
+                    "IN_PROGRESS_PAYMENT_SELECTION" to CARD_PAYMENT_SELECTION,
+                    "BILLING_AUTOCOMPLETE_USED" to true,
+                    "BILLING_AUTOCOMPLETE_EDIT_DISTANCE" to 3,
                 )
-                val stripeIntent = PaymentIntentFactory.create(
-                    status = StripeIntent.Status.Succeeded
+            )
+            val stripeIntent = PaymentIntentFactory.create(
+                status = StripeIntent.Status.Succeeded
+            )
+            val paymentSheetLoader = RelayingPaymentElementLoader()
+            val viewModel = createViewModel(
+                eventReporter = eventReporter,
+                savedStateHandle = savedStateHandle,
+                stripeIntent = stripeIntent,
+                paymentElementLoader = paymentSheetLoader,
+            )
+
+            viewModel.paymentSheetResult.test {
+                paymentSheetLoader.enqueueSuccess(stripeIntent = stripeIntent)
+
+                awaitResultTurbine.add(
+                    ConfirmationHandler.Result.Succeeded(intent = stripeIntent)
                 )
-                val paymentSheetLoader = RelayingPaymentElementLoader()
-                val viewModel = createViewModel(
-                    eventReporter = eventReporter,
-                    savedStateHandle = savedStateHandle,
-                    stripeIntent = stripeIntent,
-                    paymentElementLoader = paymentSheetLoader,
-                )
 
-                viewModel.paymentSheetResult.test {
-                    paymentSheetLoader.enqueueSuccess(stripeIntent = stripeIntent)
-
-                    awaitResultTurbine.add(
-                        ConfirmationHandler.Result.Succeeded(intent = stripeIntent)
-                    )
-
-                    assertThat(awaitItem()).isEqualTo(PaymentSheetResult.Completed())
-                }
-
-                val call = eventReporter.billingAddressCompletedCalls.awaitItem()
-                assertThat(call.addressCountryCode).isEqualTo("US")
-                assertThat(call.autocompleteResultSelected).isTrue()
-                assertThat(call.editDistance).isEqualTo(3)
-            } finally {
-                FeatureFlags.inlineAddressAutocompleteEnabled.reset()
+                assertThat(awaitItem()).isEqualTo(PaymentSheetResult.Completed())
             }
+
+            val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+            assertThat(call.addressCountryCode).isEqualTo("US")
+            assertThat(call.autocompleteResultSelected).isTrue()
+            assertThat(call.editDistance).isEqualTo(3)
         }
 
     private fun testConfirmationStateRestorationAfterPaymentSuccess(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -3333,49 +3332,39 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `reportBillingAddressCompleted fires on successful payment with new card`() = confirmationTest {
-        FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
-        try {
-            val eventReporter = FakeEventReporter()
-            val viewModel = createViewModel(eventReporter = eventReporter)
+        val eventReporter = FakeEventReporter()
+        val viewModel = createViewModel(eventReporter = eventReporter)
 
-            viewModel.updateSelection(CARD_PAYMENT_SELECTION)
-            viewModel.checkout()
+        viewModel.updateSelection(CARD_PAYMENT_SELECTION)
+        viewModel.checkout()
 
-            assertThat(startTurbine.awaitItem()).isNotNull()
+        assertThat(startTurbine.awaitItem()).isNotNull()
 
-            confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
-            )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+        )
 
-            val call = eventReporter.billingAddressCompletedCalls.awaitItem()
-            assertThat(call.addressCountryCode).isEqualTo("US")
-            assertThat(call.autocompleteResultSelected).isFalse()
-            assertThat(call.editDistance).isNull()
-        } finally {
-            FeatureFlags.inlineAddressAutocompleteEnabled.reset()
-        }
+        val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+        assertThat(call.addressCountryCode).isEqualTo("US")
+        assertThat(call.autocompleteResultSelected).isFalse()
+        assertThat(call.editDistance).isNull()
     }
 
     @Test
     fun `reportBillingAddressCompleted does not fire for saved payment methods`() = confirmationTest {
-        FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
-        try {
-            val eventReporter = FakeEventReporter()
-            val viewModel = createViewModel(eventReporter = eventReporter)
+        val eventReporter = FakeEventReporter()
+        val viewModel = createViewModel(eventReporter = eventReporter)
 
-            viewModel.updateSelection(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
-            viewModel.checkout()
+        viewModel.updateSelection(PaymentSelection.Saved(CARD_PAYMENT_METHOD))
+        viewModel.checkout()
 
-            assertThat(startTurbine.awaitItem()).isNotNull()
+        assertThat(startTurbine.awaitItem()).isNotNull()
 
-            confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
-            )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+        )
 
-            eventReporter.billingAddressCompletedCalls.ensureAllEventsConsumed()
-        } finally {
-            FeatureFlags.inlineAddressAutocompleteEnabled.reset()
-        }
+        eventReporter.billingAddressCompletedCalls.ensureAllEventsConsumed()
     }
 
     @Test
@@ -3385,44 +3374,39 @@ internal class PaymentSheetViewModelTest {
             emitNullResults = false,
             consumeBootstrap = false,
         ) {
-            FeatureFlags.inlineAddressAutocompleteEnabled.setEnabled(true)
-            try {
-                val eventReporter = FakeEventReporter()
-                val savedStateHandle = SavedStateHandle(
-                    mapOf(
-                        "IN_PROGRESS_PAYMENT_SELECTION" to CARD_PAYMENT_SELECTION,
-                        "BILLING_AUTOCOMPLETE_USED" to true,
-                        "BILLING_AUTOCOMPLETE_EDIT_DISTANCE" to 3,
-                    )
+            val eventReporter = FakeEventReporter()
+            val savedStateHandle = SavedStateHandle(
+                mapOf(
+                    "IN_PROGRESS_PAYMENT_SELECTION" to CARD_PAYMENT_SELECTION,
+                    "BILLING_AUTOCOMPLETE_USED" to true,
+                    "BILLING_AUTOCOMPLETE_EDIT_DISTANCE" to 3,
                 )
-                val stripeIntent = PaymentIntentFactory.create(
-                    status = StripeIntent.Status.Succeeded
+            )
+            val stripeIntent = PaymentIntentFactory.create(
+                status = StripeIntent.Status.Succeeded
+            )
+            val paymentSheetLoader = RelayingPaymentElementLoader()
+            val viewModel = createViewModel(
+                eventReporter = eventReporter,
+                savedStateHandle = savedStateHandle,
+                stripeIntent = stripeIntent,
+                paymentElementLoader = paymentSheetLoader,
+            )
+
+            viewModel.paymentSheetResult.test {
+                paymentSheetLoader.enqueueSuccess(stripeIntent = stripeIntent)
+
+                awaitResultTurbine.add(
+                    ConfirmationHandler.Result.Succeeded(intent = stripeIntent)
                 )
-                val paymentSheetLoader = RelayingPaymentElementLoader()
-                val viewModel = createViewModel(
-                    eventReporter = eventReporter,
-                    savedStateHandle = savedStateHandle,
-                    stripeIntent = stripeIntent,
-                    paymentElementLoader = paymentSheetLoader,
-                )
 
-                viewModel.paymentSheetResult.test {
-                    paymentSheetLoader.enqueueSuccess(stripeIntent = stripeIntent)
-
-                    awaitResultTurbine.add(
-                        ConfirmationHandler.Result.Succeeded(intent = stripeIntent)
-                    )
-
-                    assertThat(awaitItem()).isEqualTo(PaymentSheetResult.Completed())
-                }
-
-                val call = eventReporter.billingAddressCompletedCalls.awaitItem()
-                assertThat(call.addressCountryCode).isEqualTo("US")
-                assertThat(call.autocompleteResultSelected).isTrue()
-                assertThat(call.editDistance).isEqualTo(3)
-            } finally {
-                FeatureFlags.inlineAddressAutocompleteEnabled.reset()
+                assertThat(awaitItem()).isEqualTo(PaymentSheetResult.Completed())
             }
+
+            val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+            assertThat(call.addressCountryCode).isEqualTo("US")
+            assertThat(call.autocompleteResultSelected).isTrue()
+            assertThat(call.editDistance).isEqualTo(3)
         }
 
     private fun testConfirmationStateRestorationAfterPaymentSuccess(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.addresselement
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Address
 import com.stripe.android.paymentelement.AddressElementSameAsBillingPreview
@@ -11,7 +10,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
@@ -59,12 +57,6 @@ class InputAddressViewModelTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
-
-    @get:Rule
-    val inlineAutocompleteRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.inlineAddressAutocompleteEnabled,
-        isEnabled = false,
-    )
 
     @Test
     fun `onScreenShown fires onShow with initial country`() {
@@ -983,14 +975,7 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `isInlineAutocompleteEnabled is false when flag is disabled`() {
-        val viewModel = createViewModel()
-        assertThat(viewModel.autocompleteConfig.isInlineAutocompleteEnabled).isFalse()
-    }
-
-    @Test
-    fun `isInlineAutocompleteEnabled is true when flag is enabled`() {
-        inlineAutocompleteRule.setEnabled(true)
+    fun `isInlineAutocompleteEnabled is always true`() {
         val viewModel = createViewModel()
         assertThat(viewModel.autocompleteConfig.isInlineAutocompleteEnabled).isTrue()
     }
@@ -1003,7 +988,6 @@ class InputAddressViewModelTest {
         googlePlacesApiKey: String = "test_key",
         autocompleteCountries: Set<String> = emptySet(),
     ): InputAddressViewModel {
-        inlineAutocompleteRule.setEnabled(true)
         return InputAddressViewModel(
             AddressElementActivityContract.Args(
                 publishableKey = "pk_123",

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -24,7 +24,6 @@ object FeatureFlags {
     val disableNfcScanningSecurity = FeatureFlag("Disable NFC Scanning Security")
     val disablePassiveCaptchaWarmup = FeatureFlag("Disable Passive Captcha Warm-Up")
     val forceTapToAddWithTerminal = FeatureFlag("Tap to Add: Force Terminal integration to be available")
-    val inlineAddressAutocompleteEnabled = FeatureFlag("Address Element: inline autocomplete suggestions")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION


# Summary
<!-- Simple summary of what was changed. -->

Remove the inlineAddressAutocompleteEnabled feature flag and enable inline address autocomplete by default in PaymentSheet, FlowController, and AddressElement

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Inline address autocomplete is ready for launch. The feature was previously gated behind a debug-only feature flag that always returned false in release builds. Server-side routing (Stripe proxy endpoints vs Google Places) remains controlled by the shouldUseAutocompleteProxyEndpoints flag from ElementsSession.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

Removed flag enable/reset boilerplate from PaymentSheetViewModelTest and InputAddressViewModelTest.
Updated tests to reflect always-on behavior. Build, unit tests, and detekt all pass.

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->



https://github.com/user-attachments/assets/4cfbf183-1e9b-419a-926c-727bab4576b9


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

 ### PaymentSheet
  [CHANGED] Inline address autocomplete is now enabled by default in PaymentSheet and FlowController.

 ### AddressElement
[CHANGED] Inline address autocomplete is now enabled by default.


