### PR TITLE
Stabilize managed device IME smoke test

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ManagedDeviceImeSmokeTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ManagedDeviceImeSmokeTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -18,7 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val KEYBOARD_VISIBILITY_TIMEOUT_MS = 5_000L
+private const val IME_TRANSITION_TIMEOUT_MS = 5_000L
 
 /** Verifies that the managed device used for keyboard-dependent tests has a working IME. */
 @RequiresIme
@@ -38,10 +39,16 @@ internal class ManagedDeviceImeSmokeTest {
                     modifier = Modifier.testTag(TEXT_FIELD_TAG),
                 )
             }
+            // Managed devices can retain IME visibility between activity launches.
+            WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+                .hide(WindowInsetsCompat.Type.ime())
+        }
+        composeTestRule.waitUntil(IME_TRANSITION_TIMEOUT_MS) {
+            imeBottomInset() == 0
         }
 
         composeTestRule.onNodeWithTag(TEXT_FIELD_TAG).performClick()
-        composeTestRule.waitUntil(KEYBOARD_VISIBILITY_TIMEOUT_MS) {
+        composeTestRule.waitUntil(IME_TRANSITION_TIMEOUT_MS) {
             imeBottomInset() > 0
         }
 


### PR DESCRIPTION
# Summary
Stabilize `ManagedDeviceImeSmokeTest` by explicitly hiding the software keyboard and waiting for its inset to reach zero before focusing the test text field. Rename the timeout to describe both IME transitions.

# Motivation
Google APIs managed devices can retain an in-progress or visible IME across activity launches. Previously, the test could focus its text field while the prior IME hide transition was still running. That races the new show request against the stale hide request and can leave the IME inset at zero until the test times out.

The test now establishes a known baseline before exercising the behavior under test:

1. Request that the IME hide.
2. Wait until the root IME inset is zero.
3. Focus the text field.
4. Wait for and assert a nonzero IME inset.

This makes the assertion a deterministic `hidden -> visible` transition instead of depending on emulator state left by an earlier activity.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- Stress-tested with `ShampooRule`: 50 isolated iterations passed with no failures.
- Ran the same managed-device task as CI against the final code; it passed in 1m 8s:

  `./gradlew -Pandroid.testInstrumentationRunnerArguments.annotation=com.stripe.android.paymentsheet.RequiresIme :paymentsheet:pixel2api33imeDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`

No tests were ignored.

# Screenshots
Not applicable; this changes instrumentation-test synchronization only and has no user-visible UI effect.

# Changelog
Not applicable; this is an internal test-stability fix with no SDK behavior change.
