### PR TITLE
Prevent Google Pay analytics event flake in tests and improve waiting logic.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -399,6 +399,11 @@ class GooglePayPaymentMethodLauncher internal constructor(
         internal const val PRODUCT_USAGE_TOKEN = "GooglePayPaymentMethodLauncher"
         internal var HAS_SENT_INIT_ANALYTIC_EVENT: Boolean = false
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun setHasSentInitAnalyticEvent(hasSent: Boolean) {
+            HAS_SENT_INIT_ANALYTIC_EVENT = hasSent
+        }
+
         // Generic internal error
         const val INTERNAL_ERROR = 1
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -69,7 +69,7 @@ internal class EmbeddedFormPage(
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule
                 .onAllNodes(hasTestTag(FORM_ELEMENT_TEST_TAG))
-                .fetchSemanticsNodes()
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isEmpty()
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -392,6 +392,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         testContext.consumePaymentOptionEvent("card", "4242")
 
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
+        embeddedContentPage.waitUntilVisible()
 
         validateAnalyticsRequest(eventName = "mc_embedded_manage_savedpm_show")
         embeddedContentPage.clickViewMore()
@@ -451,6 +452,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         }
         testContext.consumePaymentOptionEvent("card", "4242")
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
+        embeddedContentPage.waitUntilVisible()
 
         validateAnalyticsRequest(eventName = "mc_embedded_manage_savedpm_show")
         embeddedContentPage.clickViewMore()
@@ -467,12 +469,14 @@ internal class EmbeddedPaymentElementAnalyticsTest {
 
         validateAnalyticsRequest(eventName = "mc_embedded_paymentoption_removed")
         editPage.clickRemove()
-//        assertThat(testContext.paymentOptionTurbine.awaitItem()).isNull()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.RemovedSavedPaymentMethod("card"))
 
         managePage.waitUntilVisible()
         managePage.waitUntilGone(card1.id)
+        validateAnalyticsRequest(eventName = "mc_dismiss")
         managePage.clickDone()
+        Espresso.pressBack()
+        assertThat(testContext.paymentOptionTurbine.awaitItem()).isNull()
 
         testContext.markTestSucceeded()
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/GooglePayRepositoryTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/GooglePayRepositoryTestRule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.utils
 import com.google.android.gms.wallet.IsReadyToPayRequest
 import com.google.android.gms.wallet.PaymentsClient
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
@@ -10,6 +11,9 @@ import org.junit.runner.Description
 class GooglePayRepositoryTestRule : TestWatcher() {
     override fun starting(description: Description?) {
         super.starting(description)
+        // The launcher's init analytic fires once per process, so it lands on whichever test runs
+        // first and pollutes strict analytics expectations. Disable it for the whole test process.
+        GooglePayPaymentMethodLauncher.setHasSentInitAnalyticEvent(hasSent = true)
         GooglePayRepository.googlePayAvailabilityClientFactory = createFakeGooglePayAvailabilityClient()
     }
 


### PR DESCRIPTION
# Summary
Prevent Google Pay analytic event flakes by providing a way to set `HAS_SENT_INIT_ANALYTIC_EVENT` in tests, and improve waiting logic in analytics tests.

# Motivation
Google Pay analytic event fires once per process and could cause analytics tests to flake depending on test order. This change allows explicitly controlling the analytic event flag to avoid pollution across tests, and fixes timing issues in the analytics test suite.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog