### PR TITLE
Deliver checkout confirmation results to ResultCallback

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmail
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -14,13 +15,20 @@ import javax.inject.Named
 internal class CheckoutConfirmationPerformer @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val stateHolder: CheckoutControllerStateHolder,
+    private val operationCoordinator: CheckoutOperationCoordinator,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val arguments = confirmationArgs() ?: return
+        val arguments = operationCoordinator.beginConfirmation(::confirmationArgs) ?: return
         viewModelScope.launch {
-            confirmationHandler.start(arguments)
+            try {
+                confirmationHandler.start(arguments)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                operationCoordinator.failConfirmation(error)
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -29,6 +29,7 @@ import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
 import java.util.WeakHashMap
@@ -48,9 +49,8 @@ private val SERVER_UPDATE_TIMEOUT_MS = 20.seconds.inWholeMilliseconds
 @Singleton
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Suppress("TooManyFunctions", "UnusedParameter")
+@Suppress("TooManyFunctions")
 class CheckoutController @Inject internal constructor(
-    resultCallback: ResultCallback,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     private val checkoutSessionRepository: CheckoutSessionRepository,
     private val checkoutStateLoader: CheckoutStateLoader,
@@ -70,6 +70,12 @@ class CheckoutController @Inject internal constructor(
      * Whether a mutation is currently in progress.
      */
     val isUpdating: StateFlow<Boolean> = operationCoordinator.isUpdating
+
+    init {
+        viewModelScope.launch {
+            operationCoordinator.observeConfirmationResults()
+        }
+    }
 
     /**
      * Loads the Checkout Session identified by [checkoutSessionClientSecret] and prepares the

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -1,5 +1,8 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
 package com.stripe.android.checkout
 
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -9,9 +12,15 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-internal class CheckoutOperationCoordinator @Inject constructor() {
+internal class CheckoutOperationCoordinator @Inject constructor(
+    private val confirmationHandler: ConfirmationHandler,
+    private val resultCallback: CheckoutController.ResultCallback,
+) {
     private val admissionLock = Any()
     private var pendingMutations = 0
+    private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
+        confirmationHandler.state.value is ConfirmationHandler.State.Confirming
+    private var confirmationCompletionClaimed = false
     private val mutex = Mutex()
 
     private val _isUpdating = MutableStateFlow(false)
@@ -37,7 +46,59 @@ internal class CheckoutOperationCoordinator @Inject constructor() {
         }
     }
 
+    fun beginConfirmation(
+        arguments: () -> ConfirmationHandler.Args?,
+    ): ConfirmationHandler.Args? {
+        return synchronized(admissionLock) {
+            val confirmationArguments = arguments() ?: return@synchronized null
+            confirmationInFlight = true
+            confirmationArguments
+        }
+    }
+
+    suspend fun observeConfirmationResults() {
+        confirmationHandler.state.collect { state ->
+            if (state is ConfirmationHandler.State.Complete) {
+                completeConfirmation(state.result.asCheckoutResult())
+            }
+        }
+    }
+
+    fun failConfirmation(error: Throwable) {
+        completeConfirmation(CheckoutController.Result.Failed(error))
+    }
+
+    private fun completeConfirmation(result: CheckoutController.Result) {
+        val shouldComplete = synchronized(admissionLock) {
+            if (!confirmationInFlight || confirmationCompletionClaimed) {
+                false
+            } else {
+                confirmationCompletionClaimed = true
+                true
+            }
+        }
+        if (!shouldComplete) return
+
+        try {
+            resultCallback.onResult(result)
+        } finally {
+            synchronized(admissionLock) {
+                confirmationInFlight = false
+                confirmationCompletionClaimed = false
+                updateIsUpdating()
+            }
+        }
+    }
+
     private fun updateIsUpdating() {
         _isUpdating.value = pendingMutations > 0
+    }
+}
+
+private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result {
+    return when (this) {
+        is ConfirmationHandler.Result.Succeeded -> CheckoutController.Result.Completed()
+        is ConfirmationHandler.Result.Canceled -> CheckoutController.Result.Canceled()
+        is ConfirmationHandler.Result.Failed -> CheckoutController.Result.Failed(cause)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout.ece
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.CheckoutOperationCoordinator
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
@@ -10,6 +11,7 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItems
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,37 +24,45 @@ internal interface ExpressCheckoutElementConfirmationPerformer {
 internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constructor(
     private val stateHolder: CheckoutControllerStateHolder,
     private val confirmationHandler: ConfirmationHandler,
+    private val operationCoordinator: CheckoutOperationCoordinator,
     private val eventReporter: ExpressCheckoutElementEventReporter,
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val state = stateHolder.state ?: run {
-            errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
-            )
-            return
-        }
-
-        val confirmationArgs = getConfirmationArgs(
-            state = state,
-            expressButton = expressButton,
-        ) ?: run {
-            errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
-            )
-            return
-        }
+        val confirmationArgs = operationCoordinator.beginConfirmation {
+            val state = stateHolder.state ?: run {
+                errorReporter.report(
+                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
+                )
+                return@beginConfirmation null
+            }
+            getConfirmationArgs(
+                state = state,
+                expressButton = expressButton,
+            ) ?: run {
+                errorReporter.report(
+                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
+                )
+                null
+            }
+        } ?: return
 
         viewModelScope.launch {
-            confirmationHandler.start(confirmationArgs)
+            try {
+                confirmationHandler.start(confirmationArgs)
 
-            when (val result = confirmationHandler.awaitResult()) {
-                is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
-                is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
-                is ConfirmationHandler.Result.Canceled,
-                null -> Unit
+                when (val result = confirmationHandler.awaitResult()) {
+                    is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
+                    is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
+                    is ConfirmationHandler.Result.Canceled,
+                    null -> Unit
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                operationCoordinator.failConfirmation(error)
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -97,9 +97,14 @@ internal class CheckoutConfirmationPerformerTest {
         val confirmationHandler = FakeConfirmationHandler()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         stateHolder.state = state
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            resultCallback = {},
+        )
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,
             stateHolder = stateHolder,
+            operationCoordinator = operationCoordinator,
             statusBarColor = statusBarColor,
             viewModelScope = backgroundScope,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -1,13 +1,29 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
 package com.stripe.android.checkout
 
+import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 internal class CheckoutOperationCoordinatorTest {
 
@@ -185,20 +201,151 @@ internal class CheckoutOperationCoordinatorTest {
             .isEqualTo("next")
     }
 
+    @Test
+    fun `confirmation does not start when arguments are unavailable`() = runScenario {
+        val arguments = coordinator.beginConfirmation { null }
+
+        assertThat(arguments).isNull()
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `successful confirmation is delivered as completed`() = runScenario {
+        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `canceled confirmation is delivered as canceled`() = runScenario {
+        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
+            )
+        )
+
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `failed confirmation preserves its cause`() = runScenario {
+        val expected = IllegalStateException("Confirmation failed")
+        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Failed(
+                cause = expected,
+                message = "Confirmation failed".resolvableString,
+                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            )
+        )
+
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `confirmation start failure releases the operation gate`() = runScenario {
+        val expected = IllegalStateException("Start failed")
+        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+
+        coordinator.failConfirmation(expected)
+
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `overlapping completion signals deliver exactly one result`() {
+        val callbackStarted = CountDownLatch(1)
+        val releaseCallback = CountDownLatch(1)
+        val deliveredResults = CopyOnWriteArrayList<CheckoutController.Result>()
+        runScenario(
+            resultCallback = CheckoutController.ResultCallback { result ->
+                deliveredResults += result
+                callbackStarted.countDown()
+                check(releaseCallback.await(5, TimeUnit.SECONDS)) {
+                    "Timed out waiting to release the result callback."
+                }
+            },
+        ) {
+            val expected = IllegalStateException("Start failed")
+            assertThat(coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+
+            val failureCompletion = async(Dispatchers.Default) {
+                coordinator.failConfirmation(expected)
+            }
+            assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+            runCurrent()
+
+            assertThat(deliveredResults).hasSize(1)
+            releaseCallback.countDown()
+            failureCompletion.await()
+
+            assertThat(deliveredResults).hasSize(1)
+            val result = deliveredResults.single()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+            assertThat(coordinator.isUpdating.value).isFalse()
+        }
+    }
+
     private fun runScenario(
+        resultCallback: CheckoutController.ResultCallback? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
+        val confirmationState = MutableStateFlow<ConfirmationHandler.State>(ConfirmationHandler.State.Idle)
+        val confirmationHandler = FakeConfirmationHandler(
+            state = confirmationState,
+        )
+        val resultTurbine = Turbine<CheckoutController.Result>()
+        val coordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+        )
+        backgroundScope.launch {
+            coordinator.observeConfirmationResults()
+        }
+        testScheduler.runCurrent()
+
         Scenario(
-            coordinator = CheckoutOperationCoordinator(),
+            coordinator = coordinator,
+            confirmationState = confirmationState,
+            resultTurbine = resultTurbine,
             testScope = this,
         ).block()
+
+        confirmationHandler.validate()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val coordinator: CheckoutOperationCoordinator,
+        val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
+        val resultTurbine: Turbine<CheckoutController.Result>,
         private val testScope: TestScope,
-    ) {
+    ) : CoroutineScope by testScope {
         val backgroundScope = testScope.backgroundScope
         val testScheduler = testScope.testScheduler
+
+        fun runCurrent() {
+            testScheduler.runCurrent()
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.CheckoutOperationCoordinator
 import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
@@ -213,9 +214,14 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val errorReporter = FakeErrorReporter()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         stateHolder.state = state
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            resultCallback = {},
+        )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
             stateHolder = stateHolder,
             confirmationHandler = confirmationHandler,
+            operationCoordinator = operationCoordinator,
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             statusBarColor = null,


### PR DESCRIPTION
# Summary
Deliver checkout confirmation results to the integrator. The `CheckoutController.ResultCallback` was wired through DI but never invoked, so confirmation outcomes never reached the integrator. The coordinator now observes the `ConfirmationHandler` state, maps a completed confirmation to a `CheckoutController.Result`, and delivers it exactly once (deduping against an explicit failure signal). Both confirmation performers arm delivery via `beginConfirmation` and report a thrown start failure through `failConfirmation`.

# Motivation
Close the gap where the merchant's `ResultCallback` was dead code — confirmations completed with no way for the integrator to observe success/cancel/failure.

A confirmation still runs concurrently with mutations at this layer; mutual exclusion is added in the next PR (#13829).

Stacked on #13827.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

New `CheckoutOperationCoordinatorTest` covers delivery (completed/canceled/failed), explicit failure, and exactly-once dedup for overlapping completion signals. Performer tests updated to construct the coordinator. `./gradlew :paymentsheet:testDebugUnitTest` (checkout tests) and `:paymentsheet:detekt` pass.

# Screenshots
N/A — no UI change.

# Changelog
N/A — internal, `@RestrictTo` / `@CheckoutSessionPreview` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)