### PR TITLE
Gate checkout confirmation against mutations

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -20,7 +20,7 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val arguments = operationCoordinator.beginConfirmation(::confirmationArgs) ?: return
+        val arguments = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
         viewModelScope.launch {
             try {
                 confirmationHandler.start(arguments)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -67,7 +67,7 @@ class CheckoutController @Inject internal constructor(
         get() = stateHolder.session
 
     /**
-     * Whether a mutation is currently in progress.
+     * Whether a mutation or confirmation is currently in progress or queued.
      */
     val isUpdating: StateFlow<Boolean> = operationCoordinator.isUpdating
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -3,6 +3,7 @@
 package com.stripe.android.checkout
 
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,6 +15,7 @@ import javax.inject.Singleton
 @Singleton
 internal class CheckoutOperationCoordinator @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
+    private val sheetStateHolder: SheetStateHolder,
     private val resultCallback: CheckoutController.ResultCallback,
 ) {
     private val admissionLock = Any()
@@ -21,9 +23,9 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
         confirmationHandler.state.value is ConfirmationHandler.State.Confirming
     private var confirmationCompletionClaimed = false
-    private val mutex = Mutex()
+    private val mutex = Mutex(locked = confirmationInFlight)
 
-    private val _isUpdating = MutableStateFlow(false)
+    private val _isUpdating = MutableStateFlow(confirmationInFlight)
     val isUpdating: StateFlow<Boolean> = _isUpdating.asStateFlow()
 
     suspend fun <T> runMutation(
@@ -46,13 +48,37 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    fun beginConfirmation(
+    fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
     ): ConfirmationHandler.Args? {
-        return synchronized(admissionLock) {
-            val confirmationArguments = arguments() ?: return@synchronized null
-            confirmationInFlight = true
-            confirmationArguments
+        val admission = synchronized(admissionLock) {
+            when {
+                sheetStateHolder.sheetIsOpen -> ConfirmationAdmission.Rejected(
+                    IllegalStateException("Cannot confirm checkout session while a payment flow is presented.")
+                )
+                pendingMutations > 0 || confirmationInFlight -> ConfirmationAdmission.Rejected(
+                    IllegalStateException("Cannot confirm checkout session while another mutation is in progress.")
+                )
+                else -> {
+                    val confirmationArguments = arguments()
+                        ?: return@synchronized ConfirmationAdmission.NoArguments
+                    check(mutex.tryLock()) {
+                        "Checkout operation gate should be available after confirmation admission."
+                    }
+                    confirmationInFlight = true
+                    updateIsUpdating()
+                    ConfirmationAdmission.Accepted(confirmationArguments)
+                }
+            }
+        }
+
+        return when (admission) {
+            is ConfirmationAdmission.Accepted -> admission.arguments
+            is ConfirmationAdmission.Rejected -> {
+                resultCallback.onResult(CheckoutController.Result.Failed(admission.error))
+                null
+            }
+            is ConfirmationAdmission.NoArguments -> null
         }
     }
 
@@ -85,13 +111,20 @@ internal class CheckoutOperationCoordinator @Inject constructor(
             synchronized(admissionLock) {
                 confirmationInFlight = false
                 confirmationCompletionClaimed = false
+                mutex.unlock()
                 updateIsUpdating()
             }
         }
     }
 
     private fun updateIsUpdating() {
-        _isUpdating.value = pendingMutations > 0
+        _isUpdating.value = confirmationInFlight || pendingMutations > 0
+    }
+
+    private sealed interface ConfirmationAdmission {
+        data class Accepted(val arguments: ConfirmationHandler.Args) : ConfirmationAdmission
+        data class Rejected(val error: Throwable) : ConfirmationAdmission
+        data object NoArguments : ConfirmationAdmission
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -31,12 +31,12 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val confirmationArgs = operationCoordinator.beginConfirmation {
+        val confirmationArgs = operationCoordinator.tryBeginConfirmation {
             val state = stateHolder.state ?: run {
                 errorReporter.report(
                     ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
                 )
-                return@beginConfirmation null
+                return@tryBeginConfirmation null
             }
             getConfirmationArgs(
                 state = state,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
@@ -95,10 +96,12 @@ internal class CheckoutConfirmationPerformerTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
-        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
+            sheetStateHolder = SheetStateHolder(savedStateHandle),
             resultCallback = {},
         )
         val performer = CheckoutConfirmationPerformer(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -2,6 +2,7 @@
 
 package com.stripe.android.checkout
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -11,6 +12,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -203,15 +205,122 @@ internal class CheckoutOperationCoordinatorTest {
 
     @Test
     fun `confirmation does not start when arguments are unavailable`() = runScenario {
-        val arguments = coordinator.beginConfirmation { null }
+        val arguments = coordinator.tryBeginConfirmation { null }
 
         assertThat(arguments).isNull()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
+    fun `confirmation returns failure when a payment flow is presented`() = runScenario(
+        sheetIsOpen = true,
+    ) {
+        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        assertThat(arguments).isNull()
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        val failure = result as CheckoutController.Result.Failed
+        assertThat(failure.error).hasMessageThat()
+            .isEqualTo("Cannot confirm checkout session while a payment flow is presented.")
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `confirmation returns failure while a mutation is in flight`() = runScenario {
+        val mutationStarted = CompletableDeferred<Unit>()
+        val finishMutation = CompletableDeferred<Unit>()
+        val mutation = async {
+            coordinator.runMutation {
+                mutationStarted.complete(Unit)
+                finishMutation.await()
+                Result.success(Unit)
+            }
+        }
+        mutationStarted.await()
+
+        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        assertThat(arguments).isNull()
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        val failure = result as CheckoutController.Result.Failed
+        assertThat(failure.error).hasMessageThat()
+            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+
+        finishMutation.complete(Unit)
+        mutation.await()
+    }
+
+    @Test
+    fun `second confirmation returns failure while confirmation is in flight`() = runScenario {
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+
+        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        assertThat(arguments).isNull()
+        val result = resultTurbine.awaitItem()
+        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+        val failure = result as CheckoutController.Result.Failed
+        assertThat(failure.error).hasMessageThat()
+            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+    }
+
+    @Test
+    fun `second confirmation can start after first confirmation completes`() = runScenario {
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                ConfirmationHandler.Result.Canceled.Action.None
+            )
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(coordinator.isUpdating.value).isFalse()
+
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `mutation waits for confirmation to complete without loading state flicker`() = runScenario {
+        coordinator.isUpdating.test {
+            assertThat(awaitItem()).isFalse()
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+            assertThat(awaitItem()).isTrue()
+
+            val mutationStarted = CompletableDeferred<Unit>()
+            val mutation = async {
+                coordinator.runMutation {
+                    mutationStarted.complete(Unit)
+                    Result.success(Unit)
+                }
+            }
+            runCurrent()
+
+            assertThat(mutationStarted.isCompleted).isFalse()
+            expectNoEvents()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Canceled(
+                    ConfirmationHandler.Result.Canceled.Action.None
+                )
+            )
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+            mutation.await()
+
+            assertThat(mutationStarted.isCompleted).isTrue()
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
     fun `successful confirmation is delivered as completed`() = runScenario {
-        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
@@ -223,7 +332,7 @@ internal class CheckoutOperationCoordinatorTest {
 
     @Test
     fun `canceled confirmation is delivered as canceled`() = runScenario {
-        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
@@ -238,7 +347,7 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `failed confirmation preserves its cause`() = runScenario {
         val expected = IllegalStateException("Confirmation failed")
-        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Failed(
@@ -257,7 +366,7 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `confirmation start failure releases the operation gate`() = runScenario {
         val expected = IllegalStateException("Start failed")
-        coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         coordinator.failConfirmation(expected)
 
@@ -282,7 +391,7 @@ internal class CheckoutOperationCoordinatorTest {
             },
         ) {
             val expected = IllegalStateException("Start failed")
-            assertThat(coordinator.beginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
 
             val failureCompletion = async(Dispatchers.Default) {
                 coordinator.failConfirmation(expected)
@@ -306,17 +415,75 @@ internal class CheckoutOperationCoordinatorTest {
         }
     }
 
+    @Test
+    fun `restored confirmation blocks mutations until its result arrives`() = runScenario(
+        initialConfirmationState = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        ),
+        hasReloadedFromProcessDeath = true,
+    ) {
+        assertThat(coordinator.isUpdating.value).isTrue()
+
+        val mutationStarted = CompletableDeferred<Unit>()
+        val mutation = async {
+            coordinator.runMutation {
+                mutationStarted.complete(Unit)
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+        assertThat(mutationStarted.isCompleted).isFalse()
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                ConfirmationHandler.Result.Canceled.Action.None
+            )
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        mutation.await()
+
+        assertThat(mutationStarted.isCompleted).isTrue()
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `success after process death resets isUpdating and delivers completed`() = runScenario(
+        initialConfirmationState = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        ),
+        hasReloadedFromProcessDeath = true,
+    ) {
+        coordinator.isUpdating.test {
+            assertThat(awaitItem()).isTrue()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
     private fun runScenario(
+        sheetIsOpen: Boolean = false,
+        initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
+        hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationState = MutableStateFlow<ConfirmationHandler.State>(ConfirmationHandler.State.Idle)
+        val confirmationState = MutableStateFlow(initialConfirmationState)
         val confirmationHandler = FakeConfirmationHandler(
+            hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
             state = confirmationState,
         )
+        val sheetStateHolder = SheetStateHolder(SavedStateHandle()).apply {
+            this.sheetIsOpen = sheetIsOpen
+        }
         val resultTurbine = Turbine<CheckoutController.Result>()
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
+            sheetStateHolder = sheetStateHolder,
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
         )
         backgroundScope.launch {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
@@ -212,10 +213,12 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val confirmationHandler = FakeConfirmationHandler()
         val eventReporter = FakeExpressCheckoutElementEventReporter()
         val errorReporter = FakeErrorReporter()
-        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
+            sheetStateHolder = SheetStateHolder(savedStateHandle),
             resultCallback = {},
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(


### PR DESCRIPTION
# Summary
Give confirmation the same serialization gate as mutations. A confirmation now acquires the operation mutex on admission and is rejected (with a `Failed` result) when a payment flow is presented or another mutation or confirmation is already in flight; mutations queue behind an in-flight confirmation instead of racing it. `isUpdating` now reflects a confirmation in progress, and a confirmation restored after process death holds the gate until its result arrives.

# Motivation
Prevent overlapping confirmations/mutations from corrupting checkout session state, and surface a confirmation as a loading state. `beginConfirmation` becomes `tryBeginConfirmation` with admission control.

Stacked on #13828.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

`CheckoutOperationCoordinatorTest` gains gating coverage: reject while a sheet is open, reject while a mutation is in flight, reject a second concurrent confirmation, mutation waits for confirmation without loading flicker, restored-from-death confirmation blocks mutations, and a second confirmation succeeds after the first completes. `./gradlew :paymentsheet:testDebugUnitTest` (checkout tests) and `:paymentsheet:detekt` pass.

# Screenshots
N/A — no UI change.

# Changelog
N/A — internal, `@RestrictTo` / `@CheckoutSessionPreview` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)