### PR TITLE
Pass shipping address parameters from ECE to google pay confirmation option

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressButton.kt
@@ -65,6 +65,7 @@ internal sealed interface ExpressButton {
         val cardBrandFilter: CardBrandFilter,
         val cardFundingFilter: CardFundingFilter,
         val additionalEnabledNetworks: List<String>,
+        val shippingAddressRequired: Boolean,
     ) : ExpressButton {
 
         override fun toSelection(): PaymentSelection = PaymentSelection.GooglePay
@@ -75,6 +76,7 @@ internal sealed interface ExpressButton {
             fun create(
                 paymentMethodMetadata: PaymentMethodMetadata,
                 googlePayConfiguration: GooglePayConfiguration.State,
+                shippingAddressRequired: Boolean,
             ): GooglePay {
                 return GooglePay(
                     allowCreditCards = paymentMethodMetadata.cardFundingFilter.isAccepted(CardFunding.Credit),
@@ -84,6 +86,7 @@ internal sealed interface ExpressButton {
                     billingAddressParameters = paymentMethodMetadata.billingDetailsCollectionConfiguration
                         .toBillingAddressParameters(),
                     additionalEnabledNetworks = googlePayConfiguration.additionalEnabledNetworks,
+                    shippingAddressRequired = shippingAddressRequired,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.checkout.ece
 
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.core.injection.ViewModelScope
@@ -9,7 +10,6 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItems
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,11 +34,10 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             )
             return
         }
-        val paymentSelection = expressButton.toSelection()
 
         val confirmationArgs = getConfirmationArgs(
             state = state,
-            paymentSelection = paymentSelection,
+            expressButton = expressButton,
         ) ?: run {
             errorReporter.report(
                 ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
@@ -60,10 +59,19 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
 
     private fun getConfirmationArgs(
         state: CheckoutControllerState,
-        paymentSelection: PaymentSelection,
+        expressButton: ExpressButton,
     ): ConfirmationHandler.Args? {
         val configuration = state.commonConfiguration
-        val confirmationOption = paymentSelection.toConfirmationOption(
+        val shippingAddressRequired = (expressButton as? ExpressButton.GooglePay)?.shippingAddressRequired == true
+        val shippingAddressParameters = if (shippingAddressRequired) {
+            GooglePayJsonFactory.ShippingAddressParameters(
+                isRequired = true,
+                allowedCountryCodes = state.checkoutSessionResponse.allowedShippingCountries.orEmpty().toSet(),
+            )
+        } else {
+            null
+        }
+        val confirmationOption = expressButton.toSelection().toConfirmationOption(
             configuration = configuration,
             linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
@@ -72,6 +80,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
                 configuration = configuration,
                 paymentMethodMetadata = state.paymentMethodMetadata,
             ),
+            googlePayShippingAddressParameters = shippingAddressParameters,
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractor.kt
@@ -62,6 +62,8 @@ internal class DefaultExpressCheckoutElementInteractor @Inject constructor(
                     is ExpressButtonType.GooglePay -> ExpressButton.GooglePay.create(
                         paymentMethodMetadata = state.paymentMethodMetadata,
                         googlePayConfiguration = expressButtonType.googlePayConfiguration,
+                        shippingAddressRequired =
+                            state.configuration.expressCheckoutElementConfiguration.shippingAddressRequired,
                     )
                 }
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation
 
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkLaunchMode
@@ -22,6 +23,7 @@ internal fun PaymentSelection.toConfirmationOption(
     googlePayDisplayItems: List<GooglePayDisplayItem> = emptyList(),
     googlePayIsEmailRequired: Boolean = configuration.billingDetailsCollectionConfiguration.collectsEmail,
     googlePayBillingEmailOverride: String? = null,
+    googlePayShippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters? = null,
 ): ConfirmationHandler.Option? {
     return when (this) {
         is PaymentSelection.Saved -> toConfirmationOption(linkConfiguration)
@@ -36,6 +38,7 @@ internal fun PaymentSelection.toConfirmationOption(
             googlePayDisplayItems,
             isEmailRequired = googlePayIsEmailRequired,
             billingEmailOverride = googlePayBillingEmailOverride,
+            shippingAddressParameters = googlePayShippingAddressParameters,
         )
         is PaymentSelection.Link -> toConfirmationOption(linkConfiguration)
     }
@@ -130,6 +133,7 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
     displayItems: List<GooglePayDisplayItem>,
     isEmailRequired: Boolean,
     billingEmailOverride: String?,
+    shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,
 ): GooglePayConfirmationOption? {
     return configuration.googlePay?.let { googlePay ->
         GooglePayConfirmationOption(
@@ -147,6 +151,7 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
                 displayItems = displayItems,
                 isEmailRequired = isEmailRequired,
                 billingEmailOverride = billingEmailOverride,
+                shippingAddressParameters = shippingAddressParameters,
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout.ece
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateFactory
@@ -77,7 +78,35 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
 
             val args = confirmationHandler.startTurbine.awaitItem()
             assertThat(args.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
+            val option = args.confirmationOption as GooglePayConfirmationOption
+            assertThat(option.config.shippingAddressParameters).isNull()
             assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
+        }
+    }
+
+    @Test
+    fun `confirm requests a Google Pay shipping address for allowed countries`() {
+        val state = googlePayState(
+            allowedShippingCountries = listOf("US", "CA"),
+        )
+
+        runScenario(
+            state = state,
+            expressButton = createGooglePayExpressButton(
+                paymentMethodMetadata = state.paymentMethodMetadata,
+                shippingAddressRequired = true,
+            ),
+        ) {
+            performer.confirm(expressButton)
+
+            val args = confirmationHandler.startTurbine.awaitItem()
+            val option = args.confirmationOption as GooglePayConfirmationOption
+            assertThat(option.config.shippingAddressParameters).isEqualTo(
+                GooglePayJsonFactory.ShippingAddressParameters(
+                    isRequired = true,
+                    allowedCountryCodes = setOf("US", "CA"),
+                )
+            )
         }
     }
 
@@ -147,23 +176,30 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         assertThat(failureCall.error.cause.message).isEqualTo("Payment failed")
     }
 
-    private fun googlePayState(): CheckoutControllerState {
+    private fun googlePayState(
+        allowedShippingCountries: List<String>? = null,
+    ): CheckoutControllerState {
         return CheckoutControllerStateFactory.create(
             configuration = CheckoutController.Configuration()
                 .googlePayConfiguration(GooglePayConfiguration(GooglePayConfiguration.Environment.Test))
                 .build(),
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = "US"),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                merchantCountry = "US",
+                allowedShippingCountries = allowedShippingCountries,
+            ),
         )
     }
 
     private fun createGooglePayExpressButton(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        shippingAddressRequired: Boolean = false,
     ): ExpressButton.GooglePay {
         return ExpressButton.GooglePay.create(
             paymentMethodMetadata = paymentMethodMetadata,
             googlePayConfiguration = GooglePayConfiguration(
                 GooglePayConfiguration.Environment.Test,
             ).build(),
+            shippingAddressRequired = shippingAddressRequired,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementEventReporterTest.kt
@@ -171,6 +171,7 @@ internal class DefaultExpressCheckoutElementEventReporterTest {
                 googlePayButton = ExpressButton.GooglePay.create(
                     paymentMethodMetadata = paymentMethodMetadata,
                     googlePayConfiguration = googlePayConfiguration,
+                    shippingAddressRequired = false,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -51,9 +51,23 @@ internal class DefaultExpressCheckoutElementInteractorTest {
             ),
             ExpressButton.GooglePay.create(
                 paymentMethodMetadata = paymentMethodMetadata,
-                googlePayConfiguration = googlePayConfiguration
+                googlePayConfiguration = googlePayConfiguration,
+                shippingAddressRequired = false,
             ),
         )
+    }
+
+    @Test
+    fun `state propagates shipping address requirement to Google Pay button`() = runScenario(
+        configuration = ExpressCheckoutElement.Configuration()
+            .shippingAddressRequired(true),
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            availableWallets = listOf(WalletType.GooglePay),
+        ),
+    ) {
+        val googlePayButton = interactor.state.value.expressButtons.single() as ExpressButton.GooglePay
+
+        assertThat(googlePayButton.shippingAddressRequired).isTrue()
     }
 
     @Test
@@ -131,6 +145,7 @@ internal class DefaultExpressCheckoutElementInteractorTest {
                 ExpressButton.GooglePay.create(
                     paymentMethodMetadata = paymentMethodMetadata,
                     googlePayConfiguration = googlePayConfiguration,
+                    shippingAddressRequired = false,
                 ),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressButtonTest.kt
@@ -153,6 +153,15 @@ internal class ExpressButtonTest {
     }
 
     @Test
+    fun `GooglePay create uses shipping address requirement`() {
+        val button = createGooglePayExpressButton(
+            shippingAddressRequired = true,
+        )
+
+        assertThat(button.shippingAddressRequired).isTrue()
+    }
+
+    @Test
     fun `GooglePay create uses card brand filter from payment method metadata`() {
         val cardBrandFilter = PaymentSheetCardBrandFilter(
             cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.Allowed(
@@ -225,11 +234,13 @@ internal class ExpressButtonTest {
 
     private fun createGooglePayExpressButton(
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-        googlePayConfiguration: GooglePayConfiguration.State = createGooglePayConfiguration()
+        googlePayConfiguration: GooglePayConfiguration.State = createGooglePayConfiguration(),
+        shippingAddressRequired: Boolean = false,
     ): ExpressButton.GooglePay {
         return ExpressButton.GooglePay.create(
             paymentMethodMetadata = paymentMethodMetadata,
-            googlePayConfiguration = googlePayConfiguration
+            googlePayConfiguration = googlePayConfiguration,
+            shippingAddressRequired = shippingAddressRequired,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractorStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/ExpressCheckoutElementInteractorStateFactory.kt
@@ -23,6 +23,7 @@ internal object ExpressCheckoutElementInteractorStateFactory {
                 googlePayConfiguration = GooglePayConfiguration(
                     GooglePayConfiguration.Environment.Test,
                 ).build(),
+                shippingAddressRequired = false,
             ),
         ),
     ): ExpressCheckoutElementInteractor.State {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Pass shipping address parameters from ECE to google pay confirmation option

Discussed taking this approach in this [doc](https://docs.google.com/document/d/1av6OqID78te2xKT6yo2BV9upciQiLe1RKjAjvHAaozs/edit?tab=t.0#heading=h.470blygygy1k)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Progress towards collecting shipping address within ECE
https://jira.corp.stripe.com/browse/MOBILESDK-4721

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Manually verified that setting `shippingAddressRequired` on the ECE config led to GooglePay collecting shipping address

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>