### PR TITLE
Use a deterministic clock in payment flow processor tests

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -30,6 +30,7 @@ import com.stripe.android.payments.PaymentFlowFailureMessageFactory
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
+import com.stripe.android.payments.SystemClock
 import com.stripe.android.payments.core.authentication.DefaultPaymentNextActionHandlerRegistry
 import com.stripe.android.payments.core.authentication.PaymentNextActionHandlerRegistry
 import com.stripe.android.polling.DefaultPollingAnalyticsEventReporter
@@ -72,6 +73,7 @@ constructor(
         Logger.getInstance(enableLogging),
         workContext,
         pollingAnalyticsEventReporter,
+        SystemClock,
     )
     private val setupIntentFlowResultProcessor = SetupIntentFlowResultProcessor(
         context,
@@ -80,6 +82,7 @@ constructor(
         Logger.getInstance(enableLogging),
         workContext,
         pollingAnalyticsEventReporter,
+        SystemClock,
     )
 
     private val defaultReturnUrl = DefaultReturnUrl.create(context)

--- a/payments-core/src/main/java/com/stripe/android/payments/Clock.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/Clock.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.payments
+
+/** Supplies wall-clock time for payment flow polling. */
+internal fun interface Clock {
+    fun currentTimeMillis(): Long
+}
+
+internal object SystemClock : Clock {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -37,6 +37,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
     private val logger: Logger,
     private val workContext: CoroutineContext,
     private val pollingAnalyticsEventReporter: PollingAnalyticsEventReporter,
+    private val clock: Clock,
 ) {
     private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
 
@@ -52,7 +53,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
             stripeAccount = result.stripeAccountId
         )
 
-        val initialRetrieveIntentStartTime = System.currentTimeMillis()
+        val initialRetrieveIntentStartTime = clock.currentTimeMillis()
 
         val requestId = unvalidatedResult.exception?.requestId
 
@@ -253,15 +254,15 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         }
 
         val timeRemaining = getPollingDurationForPaymentMethod(originalIntent) -
-            (System.currentTimeMillis() - initialRetrieveIntentStartTime)
+            (clock.currentTimeMillis() - initialRetrieveIntentStartTime)
 
         withTimeoutOrNull(timeRemaining) {
             stripeIntentResult = retrieveAndTrackStatus()
             while (shouldRetry(stripeIntentResult)) {
                 // We want to delay a maximum of 1s between requests, including the time the request took.
                 // e.g. if the previous request took 250ms, the delay will be 750ms
-                delay(POLLING_DELAY - (System.currentTimeMillis() - timeOfLastRequest))
-                timeOfLastRequest = System.currentTimeMillis()
+                delay(POLLING_DELAY - (clock.currentTimeMillis() - timeOfLastRequest))
+                timeOfLastRequest = clock.currentTimeMillis()
                 stripeIntentResult = retrieveAndTrackStatus()
             }
         }
@@ -331,6 +332,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
     logger: Logger,
     @IOContext workContext: CoroutineContext,
     pollingAnalyticsEventReporter: PollingAnalyticsEventReporter,
+    clock: Clock,
 ) : PaymentFlowResultProcessor<PaymentIntent, PaymentIntentResult>(
     context,
     publishableKeyProvider,
@@ -338,6 +340,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
     logger,
     workContext,
     pollingAnalyticsEventReporter,
+    clock,
 ) {
     override suspend fun retrieveStripeIntent(
         clientSecret: String,
@@ -397,6 +400,7 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
     logger: Logger,
     @IOContext workContext: CoroutineContext,
     pollingAnalyticsEventReporter: PollingAnalyticsEventReporter,
+    clock: Clock,
 ) : PaymentFlowResultProcessor<SetupIntent, SetupIntentResult>(
     context,
     publishableKeyProvider,
@@ -404,6 +408,7 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
     logger,
     workContext,
     pollingAnalyticsEventReporter,
+    clock,
 ) {
     override suspend fun retrieveStripeIntent(
         clientSecret: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -9,7 +9,9 @@ import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.payments.Clock
 import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.payments.SystemClock
 import com.stripe.android.payments.core.authentication.DefaultPaymentNextActionHandlerRegistry
 import com.stripe.android.payments.core.authentication.PaymentNextActionHandlerRegistry
 import dagger.Module
@@ -65,4 +67,7 @@ internal class PaymentLauncherModule {
     fun provideDurationProvider(): DurationProvider {
         return DefaultDurationProvider.instance
     }
+
+    @Provides
+    fun provideClock(): Clock = SystemClock
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -1181,6 +1181,7 @@ internal class PaymentIntentFlowResultProcessorTest {
         Logger.noop(),
         testDispatcher,
         pollingAnalyticsEventReporter,
+        Clock { testDispatcher.scheduler.currentTime },
     )
 
     private class FakeStripeRepository(

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -43,6 +43,7 @@ internal class SetupIntentFlowResultProcessorTest {
         Logger.noop(),
         testDispatcher,
         pollingAnalyticsEventReporter,
+        Clock { testDispatcher.scheduler.currentTime },
     )
 
     @Test


### PR DESCRIPTION
# Summary

This single-layer change, based directly on `master`, injects a typed `Clock` into `PaymentFlowResultProcessor` and uses a shared `SystemClock` for both manual and Dagger construction. `PaymentIntentFlowResultProcessorTest` and `SetupIntentFlowResultProcessorTest` instead use the test coroutine scheduler as their clock.

# Motivation

These processor tests run delays and timeouts on a virtual coroutine scheduler, but the polling calculations previously read `System.currentTimeMillis()`. That mixed two timelines: coroutine time advanced deterministically while elapsed request time depended on the machine's wall clock. Under CI load, real time could advance enough to reduce the remaining polling window or change retry behavior, making invocation counts and timeout assertions flaky.

Using the scheduler-backed clock keeps every test timing decision on the same deterministic timeline. The typed `Clock` also avoids an ambiguous raw `() -> Long` Dagger binding, and the shared `SystemClock` ensures the manual controller and dependency-injected paths cannot drift.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

`./gradlew :payments-core:testDebugUnitTest --tests 'com.stripe.android.payments.PaymentIntentFlowResultProcessorTest' --tests 'com.stripe.android.payments.SetupIntentFlowResultProcessorTest'`

Result: `BUILD SUCCESSFUL`; both targeted test classes passed. No tests were ignored.

# Screenshots

Not applicable — this changes internal polling clock injection and unit-test determinism only; there are no visual changes.

# Changelog

Not applicable — there are no public API or customer-visible behavior changes.
