### PR TITLE
Fix confirmation token bank account test flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
@@ -106,7 +106,7 @@ internal class TestConfirmationToken : BasePlaygroundTest() {
             settings[CheckoutModeSettingsDefinition] = CheckoutMode.SETUP
             settings[InitializationTypeSettingsDefinition] = InitializationType.DeferredClientSideConfirmation
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
-        }
+        }.copy(resetCustomer = true)
 
         testDriver.confirmCustomUSBankAccountAndBuy(
             testParameters = testParameters,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1261,7 +1261,10 @@ internal class PlaygroundTestDriver(
         Espresso.onIdle()
         selectors.composeTestRule.waitForIdle()
 
-        selectors.multiStepSelect.waitForEnabled()
+        selectors.multiStepSelect.waitForEnabled(
+            requireClickAction = true,
+            timeout = CHECKOUT_PREPARATION_TIMEOUT,
+        )
         if (clickMultiStep) {
             selectors.multiStepSelect.click()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.model
 import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.paymentelement.ExtendedLabelsInPaymentOptionPreview
@@ -96,7 +97,10 @@ class PaymentOption internal constructor(
      */
     val iconPainter: Painter
         @Composable
-        get() = rememberDrawablePainter(icon())
+        get() {
+            val drawable = remember(this) { icon() }
+            return rememberDrawablePainter(drawable)
+        }
 
     /**
      * Fetches the icon associated with this [PaymentOption].


### PR DESCRIPTION
# Summary

Stabilize `TestConfirmationToken.testBankAccountWithConfirmationTokenInCustomFlow_withCSC` by isolating customer state between executions, using the existing bounded checkout-preparation timeout for custom FlowController launches, and retaining the `PaymentOption` icon drawable across Compose recompositions.

The temporary `ShampooRule` used for diagnosis was restored to the normal `RetryRule` configuration after the focused 50-iteration soak passed, so this PR does not multiply the full PaymentSheet example E2E suite in CI.

# Motivation

The test intermittently timed out after 90 seconds on `pixel2api33chrome`. Focused Shampoo runs exposed three interacting sources of instability:

1. The test creates a new CustomerSession customer on each execution, while PaymentSheet retains process-level customer state. Setting `resetCustomer = true` clears that state before the new playground activity is launched, preventing a previous iteration's customer and payment selection from leaking into the next one.
2. Custom FlowController setup used the generic 15-second UI wait even though it performs the same asynchronous checkout preparation as the complete-flow path. Reusing the existing 45-second `CHECKOUT_PREPARATION_TIMEOUT` keeps the wait state-based and bounded while allowing legitimate backend/configuration latency.
3. `PaymentOption.iconPainter` called `icon()` during every recomposition. Because `icon()` returns a new asynchronously loading `DelegateDrawable`, the changing drawable key could repeatedly replace the remembered painter and keep Compose busy after the bank account selection. Remembering the drawable by `PaymentOption` instance allows the image load to complete once and lets Compose settle.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

- Temporarily replaced `RetryRule` with `ShampooRule(2)` and verified the focused test passed twice after the fixes.
- Increased the temporary Shampoo count to 50 and verified all 50 focused executions passed on `pixel2api33chrome` in 11m31s:
  `CI=true ./gradlew :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest -PSTRIPE_PAYMENTSHEET_EXAMPLE_PROXY_IP_ADDRESS= -Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestConfirmationToken#testBankAccountWithConfirmationTokenInCustomFlow_withCSC`
- Restored the normal `RetryRule` configuration and verified the focused test passed on `pixel2api33chrome_0` in 2m14s:
  `CI=true ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_PROXY_IP_ADDRESS= -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestConfirmationToken#testBankAccountWithConfirmationTokenInCustomFlow_withCSC' :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`

No tests were ignored or quarantined.

# Screenshots

Not applicable — this changes test synchronization and painter lifetime without changing the rendered UI.

# Changelog

Not applicable — this is a test-stability fix and corrects the lifetime of an existing Compose painter without changing the public API.
