### PR TITLE
Harden checkout confirmation result delivery

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -20,14 +20,14 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val arguments = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
+        val operation = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
         viewModelScope.launch {
             try {
-                confirmationHandler.start(arguments)
+                confirmationHandler.start(operation.arguments)
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                operationCoordinator.failConfirmation(error)
+                operationCoordinator.failConfirmation(operation, error)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -29,7 +29,6 @@ import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
 import java.util.WeakHashMap
@@ -70,12 +69,6 @@ class CheckoutController @Inject internal constructor(
      * Whether a mutation or confirmation is currently in progress or queued.
      */
     val isUpdating: StateFlow<Boolean> = operationCoordinator.isUpdating
-
-    init {
-        viewModelScope.launch {
-            operationCoordinator.observeConfirmationResults()
-        }
-    }
 
     /**
      * Loads the Checkout Session identified by [checkoutSessionClientSecret] and prepares the

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -31,7 +31,6 @@ import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -72,12 +71,6 @@ class CheckoutController @Inject internal constructor(
      * Whether a mutation or confirmation is currently in progress or queued.
      */
     val isUpdating: StateFlow<Boolean> = operationCoordinator.isUpdating
-
-    init {
-        viewModelScope.launch {
-            operationCoordinator.observeConfirmationResults()
-        }
-    }
 
     /**
      * Loads the Checkout Session identified by [checkoutSessionClientSecret] and prepares the

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -2,11 +2,14 @@
 
 package com.stripe.android.checkout
 
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -17,16 +20,24 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val sheetStateHolder: SheetStateHolder,
     private val resultCallback: CheckoutController.ResultCallback,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     private val admissionLock = Any()
     private var pendingMutations = 0
-    private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
+    private val confirmationRestored = confirmationHandler.hasReloadedFromProcessDeath ||
         confirmationHandler.state.value is ConfirmationHandler.State.Confirming
-    private var confirmationCompletionClaimed = false
-    private val mutex = Mutex(locked = confirmationInFlight)
+    private var nextConfirmationId = if (confirmationRestored) 1L else 0L
+    private var activeConfirmationId: Long? = if (confirmationRestored) 0L else null
+    private val mutex = Mutex(locked = activeConfirmationId != null)
 
-    private val _isUpdating = MutableStateFlow(confirmationInFlight)
+    private val _isUpdating = MutableStateFlow(activeConfirmationId != null)
     val isUpdating: StateFlow<Boolean> = _isUpdating.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            observeConfirmationResults()
+        }
+    }
 
     suspend fun <T> runMutation(
         block: suspend () -> Result<T>,
@@ -53,7 +64,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     ): Result<T> {
         return synchronized(admissionLock) {
             when {
-                confirmationInFlight -> Result.failure(
+                activeConfirmationId != null -> Result.failure(
                     IllegalStateException("Cannot mutate checkout session while confirmation is in progress.")
                 )
                 pendingMutations > 0 -> Result.failure(
@@ -75,82 +86,81 @@ internal class CheckoutOperationCoordinator @Inject constructor(
 
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
-    ): ConfirmationHandler.Args? {
-        val admission = synchronized(admissionLock) {
-            when {
-                sheetStateHolder.sheetIsOpen -> ConfirmationAdmission.Rejected(
-                    IllegalStateException("Cannot confirm checkout session while a payment flow is presented.")
-                )
-                pendingMutations > 0 || confirmationInFlight -> ConfirmationAdmission.Rejected(
-                    IllegalStateException("Cannot confirm checkout session while another mutation is in progress.")
-                )
-                else -> {
-                    val confirmationArguments = arguments()
-                        ?: return@synchronized ConfirmationAdmission.NoArguments
-                    check(mutex.tryLock()) {
-                        "Checkout operation gate should be available after confirmation admission."
-                    }
-                    confirmationInFlight = true
-                    updateIsUpdating()
-                    ConfirmationAdmission.Accepted(confirmationArguments)
-                }
+    ): ConfirmationOperation? {
+        return synchronized(admissionLock) {
+            if (
+                sheetStateHolder.sheetIsOpen ||
+                pendingMutations > 0 ||
+                activeConfirmationId != null ||
+                confirmationHandler.state.value is ConfirmationHandler.State.Confirming
+            ) {
+                return@synchronized null
             }
-        }
-
-        return when (admission) {
-            is ConfirmationAdmission.Accepted -> admission.arguments
-            is ConfirmationAdmission.Rejected -> {
-                resultCallback.onResult(CheckoutController.Result.Failed(admission.error))
-                null
+            val confirmationArguments = arguments() ?: return@synchronized null
+            check(mutex.tryLock()) {
+                "Checkout operation gate should be available after confirmation admission."
             }
-            is ConfirmationAdmission.NoArguments -> null
+            val operation = ConfirmationOperation(
+                id = nextConfirmationId++,
+                arguments = confirmationArguments,
+            )
+            activeConfirmationId = operation.id
+            updateIsUpdating()
+            operation
         }
     }
 
-    suspend fun observeConfirmationResults() {
+    fun failConfirmation(
+        operation: ConfirmationOperation,
+        error: Throwable,
+    ) {
+        completeConfirmation(
+            result = CheckoutController.Result.Failed(error),
+            expectedConfirmationId = operation.id,
+        )
+    }
+
+    private suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation(state.result.asCheckoutResult())
+                completeConfirmation(
+                    result = state.result.asCheckoutResult(),
+                    expectedConfirmationId = null,
+                )
             }
         }
     }
 
-    fun failConfirmation(error: Throwable) {
-        completeConfirmation(CheckoutController.Result.Failed(error))
-    }
-
-    private fun completeConfirmation(result: CheckoutController.Result) {
+    private fun completeConfirmation(
+        result: CheckoutController.Result,
+        expectedConfirmationId: Long?,
+    ) {
         val shouldComplete = synchronized(admissionLock) {
-            if (!confirmationInFlight || confirmationCompletionClaimed) {
+            val activeId = activeConfirmationId
+            val completionIsStale = expectedConfirmationId != null && expectedConfirmationId != activeId
+            if (activeId == null || completionIsStale) {
                 false
             } else {
-                confirmationCompletionClaimed = true
+                activeConfirmationId = null
+                mutex.unlock()
+                updateIsUpdating()
                 true
             }
         }
         if (!shouldComplete) return
 
-        try {
-            resultCallback.onResult(result)
-        } finally {
-            synchronized(admissionLock) {
-                confirmationInFlight = false
-                confirmationCompletionClaimed = false
-                mutex.unlock()
-                updateIsUpdating()
-            }
-        }
+        // The completed operation no longer owns the gate, so the callback may synchronously start another one.
+        resultCallback.onResult(result)
     }
 
     private fun updateIsUpdating() {
-        _isUpdating.value = confirmationInFlight || pendingMutations > 0
+        _isUpdating.value = activeConfirmationId != null || pendingMutations > 0
     }
 
-    private sealed interface ConfirmationAdmission {
-        data class Accepted(val arguments: ConfirmationHandler.Args) : ConfirmationAdmission
-        data class Rejected(val error: Throwable) : ConfirmationAdmission
-        data object NoArguments : ConfirmationAdmission
-    }
+    internal class ConfirmationOperation(
+        internal val id: Long,
+        internal val arguments: ConfirmationHandler.Args,
+    )
 }
 
 private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -31,7 +31,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val confirmationArgs = operationCoordinator.tryBeginConfirmation {
+        val operation = operationCoordinator.tryBeginConfirmation {
             val state = stateHolder.state ?: run {
                 errorReporter.report(
                     ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
@@ -50,19 +50,22 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         } ?: return
 
         viewModelScope.launch {
-            try {
-                confirmationHandler.start(confirmationArgs)
-
-                when (val result = confirmationHandler.awaitResult()) {
-                    is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
-                    is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
-                    is ConfirmationHandler.Result.Canceled,
-                    null -> Unit
-                }
+            val result = try {
+                confirmationHandler.start(operation.arguments)
+                confirmationHandler.awaitResult()
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                operationCoordinator.failConfirmation(error)
+                operationCoordinator.failConfirmation(operation, error)
+                return@launch
+            }
+
+            // Analytics failures must not be reported to the integrator as confirmation failures.
+            when (result) {
+                is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
+                is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
+                is ConfirmationHandler.Result.Canceled,
+                null -> Unit
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -78,6 +79,22 @@ internal class CheckoutConfirmationPerformerTest {
         assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
     }
 
+    @Test
+    fun `confirm delivers failure when confirmation start throws`() {
+        val expected = IllegalStateException("Start failed")
+        runScenario(
+            state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+            startError = expected,
+        ) {
+            performer.confirm()
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
     private fun googlePayState(
         paymentSelection: PaymentSelection?,
     ): CheckoutControllerState {
@@ -93,16 +110,19 @@ internal class CheckoutConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         statusBarColor: Int? = null,
+        startError: Throwable? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
+        val confirmationHandler = FakeConfirmationHandler(startError = startError)
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
-            resultCallback = {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
+            viewModelScope = backgroundScope,
         )
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,
@@ -116,15 +136,18 @@ internal class CheckoutConfirmationPerformerTest {
             performer = performer,
             confirmationHandler = confirmationHandler,
             stateHolder = stateHolder,
+            resultTurbine = resultTurbine,
         ).block()
 
         confirmationHandler.validate()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val performer: CheckoutConfirmationPerformer,
         val confirmationHandler: FakeConfirmationHandler,
         val stateHolder: CheckoutControllerStateHolder,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -212,22 +211,18 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `confirmation returns failure when a payment flow is presented`() = runScenario(
+    fun `confirmation is ignored when a payment flow is presented`() = runScenario(
         sheetIsOpen = true,
     ) {
-        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
-        assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while a payment flow is presented.")
+        assertThat(operation).isNull()
+        resultTurbine.expectNoEvents()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
-    fun `confirmation returns failure while a mutation is in flight`() = runScenario {
+    fun `confirmation is ignored while a mutation is in flight`() = runScenario {
         val mutationStarted = CompletableDeferred<Unit>()
         val finishMutation = CompletableDeferred<Unit>()
         val mutation = async {
@@ -239,31 +234,28 @@ internal class CheckoutOperationCoordinatorTest {
         }
         mutationStarted.await()
 
-        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
-        assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+        assertThat(operation).isNull()
+        resultTurbine.expectNoEvents()
 
         finishMutation.complete(Unit)
         mutation.await()
     }
 
     @Test
-    fun `second confirmation returns failure while confirmation is in flight`() = runScenario {
+    fun `second confirmation is ignored while confirmation is in flight`() = runScenario {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
 
-        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
-        assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+        assertThat(operation).isNull()
+        resultTurbine.expectNoEvents()
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test
@@ -284,6 +276,61 @@ internal class CheckoutOperationCoordinatorTest {
 
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
         assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `result callback can synchronously start another confirmation`() = runScenario {
+        lateinit var secondOperation: CheckoutOperationCoordinator.ConfirmationOperation
+        resultCallbackInterceptor.afterResult = { result ->
+            if (result is CheckoutController.Result.Canceled) {
+                assertThat(coordinator.isUpdating.value).isFalse()
+                secondOperation = checkNotNull(
+                    coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+                )
+            }
+        }
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(secondOperation).isNotNull()
+
+        confirmationState.value = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `stale failure does not complete a newer confirmation`() = runScenario {
+        resultCallbackInterceptor.afterResult = { result ->
+            if (result is CheckoutController.Result.Canceled) {
+                checkNotNull(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS })
+            }
+        }
+        val firstOperation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+
+        coordinator.failConfirmation(firstOperation, IllegalStateException("Stale failure"))
+
+        resultTurbine.expectNoEvents()
+        confirmationState.value = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test
@@ -366,9 +413,11 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `confirmation start failure releases the operation gate`() = runScenario {
         val expected = IllegalStateException("Start failed")
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
 
-        coordinator.failConfirmation(expected)
+        coordinator.failConfirmation(operation, expected)
 
         val result = resultTurbine.awaitItem()
         assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
@@ -391,10 +440,12 @@ internal class CheckoutOperationCoordinatorTest {
             },
         ) {
             val expected = IllegalStateException("Start failed")
-            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+            val operation = checkNotNull(
+                coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            )
 
             val failureCompletion = async(Dispatchers.Default) {
-                coordinator.failConfirmation(expected)
+                coordinator.failConfirmation(operation, expected)
             }
             assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
 
@@ -517,20 +568,22 @@ internal class CheckoutOperationCoordinatorTest {
             this.sheetIsOpen = sheetIsOpen
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
+        val resultCallbackInterceptor = ResultCallbackInterceptor(resultTurbine)
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
-            resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+            resultCallback = resultCallback ?: CheckoutController.ResultCallback(
+                resultCallbackInterceptor::onResult
+            ),
+            viewModelScope = backgroundScope,
         )
-        backgroundScope.launch {
-            coordinator.observeConfirmationResults()
-        }
         testScheduler.runCurrent()
 
         Scenario(
             coordinator = coordinator,
             confirmationState = confirmationState,
             resultTurbine = resultTurbine,
+            resultCallbackInterceptor = resultCallbackInterceptor,
             testScope = this,
         ).block()
 
@@ -542,6 +595,7 @@ internal class CheckoutOperationCoordinatorTest {
         val coordinator: CheckoutOperationCoordinator,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
+        val resultCallbackInterceptor: ResultCallbackInterceptor,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
         val backgroundScope = testScope.backgroundScope
@@ -549,6 +603,17 @@ internal class CheckoutOperationCoordinatorTest {
 
         fun runCurrent() {
             testScheduler.runCurrent()
+        }
+    }
+
+    private class ResultCallbackInterceptor(
+        private val resultTurbine: Turbine<CheckoutController.Result>,
+    ) {
+        var afterResult: (CheckoutController.Result) -> Unit = {}
+
+        fun onResult(result: CheckoutController.Result) {
+            resultTurbine.add(result)
+            afterResult(result)
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -212,22 +211,18 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `confirmation returns failure when a payment flow is presented`() = runScenario(
+    fun `confirmation is ignored when a payment flow is presented`() = runScenario(
         sheetIsOpen = true,
     ) {
-        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
-        assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while a payment flow is presented.")
+        assertThat(operation).isNull()
+        resultTurbine.expectNoEvents()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
-    fun `confirmation returns failure while a mutation is in flight`() = runScenario {
+    fun `confirmation is ignored while a mutation is in flight`() = runScenario {
         val mutationStarted = CompletableDeferred<Unit>()
         val finishMutation = CompletableDeferred<Unit>()
         val mutation = async {
@@ -239,31 +234,28 @@ internal class CheckoutOperationCoordinatorTest {
         }
         mutationStarted.await()
 
-        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
-        assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+        assertThat(operation).isNull()
+        resultTurbine.expectNoEvents()
 
         finishMutation.complete(Unit)
         mutation.await()
     }
 
     @Test
-    fun `second confirmation returns failure while confirmation is in flight`() = runScenario {
+    fun `second confirmation is ignored while confirmation is in flight`() = runScenario {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
 
-        val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
-        assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+        assertThat(operation).isNull()
+        resultTurbine.expectNoEvents()
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test
@@ -284,6 +276,61 @@ internal class CheckoutOperationCoordinatorTest {
 
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
         assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `result callback can synchronously start another confirmation`() = runScenario {
+        lateinit var secondOperation: CheckoutOperationCoordinator.ConfirmationOperation
+        resultCallbackInterceptor.afterResult = { result ->
+            if (result is CheckoutController.Result.Canceled) {
+                assertThat(coordinator.isUpdating.value).isFalse()
+                secondOperation = checkNotNull(
+                    coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+                )
+            }
+        }
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        assertThat(secondOperation).isNotNull()
+
+        confirmationState.value = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `stale failure does not complete a newer confirmation`() = runScenario {
+        resultCallbackInterceptor.afterResult = { result ->
+            if (result is CheckoutController.Result.Canceled) {
+                checkNotNull(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS })
+            }
+        }
+        val firstOperation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+
+        coordinator.failConfirmation(firstOperation, IllegalStateException("Stale failure"))
+
+        resultTurbine.expectNoEvents()
+        confirmationState.value = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test
@@ -366,9 +413,11 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `confirmation start failure releases the operation gate`() = runScenario {
         val expected = IllegalStateException("Start failed")
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
 
-        coordinator.failConfirmation(expected)
+        coordinator.failConfirmation(operation, expected)
 
         val result = resultTurbine.awaitItem()
         assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
@@ -391,10 +440,12 @@ internal class CheckoutOperationCoordinatorTest {
             },
         ) {
             val expected = IllegalStateException("Start failed")
-            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+            val operation = checkNotNull(
+                coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            )
 
             val failureCompletion = async(Dispatchers.Default) {
-                coordinator.failConfirmation(expected)
+                coordinator.failConfirmation(operation, expected)
             }
             assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
 
@@ -536,20 +587,22 @@ internal class CheckoutOperationCoordinatorTest {
             this.sheetIsOpen = sheetIsOpen
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
+        val resultCallbackInterceptor = ResultCallbackInterceptor(resultTurbine)
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
-            resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+            resultCallback = resultCallback ?: CheckoutController.ResultCallback(
+                resultCallbackInterceptor::onResult
+            ),
+            viewModelScope = backgroundScope,
         )
-        backgroundScope.launch {
-            coordinator.observeConfirmationResults()
-        }
         testScheduler.runCurrent()
 
         Scenario(
             coordinator = coordinator,
             confirmationState = confirmationState,
             resultTurbine = resultTurbine,
+            resultCallbackInterceptor = resultCallbackInterceptor,
             testScope = this,
         ).block()
 
@@ -561,6 +614,7 @@ internal class CheckoutOperationCoordinatorTest {
         val coordinator: CheckoutOperationCoordinator,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
+        val resultCallbackInterceptor: ResultCallbackInterceptor,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
         val backgroundScope = testScope.backgroundScope
@@ -568,6 +622,17 @@ internal class CheckoutOperationCoordinatorTest {
 
         fun runCurrent() {
             testScheduler.runCurrent()
+        }
+    }
+
+    private class ResultCallbackInterceptor(
+        private val resultTurbine: Turbine<CheckoutController.Result>,
+    ) {
+        var afterResult: (CheckoutController.Result) -> Unit = {}
+
+        fun onResult(result: CheckoutController.Result) {
+            resultTurbine.add(result)
+            afterResult(result)
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout.ece
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.checkout.CheckoutController
@@ -26,6 +27,11 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFacto
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -178,6 +184,62 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         assertThat(failureCall.error.cause.message).isEqualTo("Payment failed")
     }
 
+    @Test
+    fun `confirm delivers failure when confirmation start throws`() {
+        val expected = IllegalStateException("Start failed")
+        runScenario(
+            state = googlePayState(),
+            expressButton = createGooglePayExpressButton(),
+            startError = expected,
+        ) {
+            performer.confirm(expressButton)
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
+    @Test
+    fun `confirm delivers failure when awaiting confirmation result throws`() {
+        val expected = IllegalStateException("Await failed")
+        runScenario(
+            state = googlePayState(),
+            expressButton = createGooglePayExpressButton(),
+            awaitResultError = expected,
+        ) {
+            performer.confirm(expressButton)
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
+    @Test
+    fun `ECE reporting failure is not delivered as a confirmation failure`() {
+        val expected = IllegalStateException("Reporting failed")
+        runScenario(
+            state = googlePayState(),
+            expressButton = createGooglePayExpressButton(),
+            paymentSuccessError = expected,
+        ) {
+            confirmationHandler.awaitResultTurbine.add(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+
+            performer.confirm(expressButton)
+
+            confirmationHandler.startTurbine.awaitItem()
+            assertThat(eventReporter.calls.awaitItem())
+                .isEqualTo(FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentSuccess(expressButton))
+            assertThat(uncaughtErrors.awaitItem()).isSameInstanceAs(expected)
+            resultTurbine.expectNoEvents()
+        }
+    }
+
     private fun googlePayState(
         allowedShippingCountries: List<String>? = null,
     ): CheckoutControllerState {
@@ -208,18 +270,34 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         expressButton: ExpressButton,
+        startError: Throwable? = null,
+        awaitResultError: Throwable? = null,
+        paymentSuccessError: Throwable? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
-        val eventReporter = FakeExpressCheckoutElementEventReporter()
+        val confirmationHandler = FakeConfirmationHandler(
+            startError = startError,
+            awaitResultError = awaitResultError,
+        )
+        val eventReporter = FakeExpressCheckoutElementEventReporter(
+            paymentSuccessError = paymentSuccessError,
+        )
         val errorReporter = FakeErrorReporter()
+        val resultTurbine = Turbine<CheckoutController.Result>()
+        val uncaughtErrors = Turbine<Throwable>()
+        val performerScope = CoroutineScope(
+            SupervisorJob() + StandardTestDispatcher(testScheduler) + CoroutineExceptionHandler { _, error ->
+                uncaughtErrors.add(error)
+            }
+        )
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
-            resultCallback = {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
+            viewModelScope = backgroundScope,
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
             stateHolder = stateHolder,
@@ -228,7 +306,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             statusBarColor = null,
-            viewModelScope = backgroundScope,
+            viewModelScope = performerScope,
         )
 
         Scenario(
@@ -238,11 +316,16 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             errorReporter = errorReporter,
             stateHolder = stateHolder,
             expressButton = expressButton,
+            resultTurbine = resultTurbine,
+            uncaughtErrors = uncaughtErrors,
         ).block()
 
+        performerScope.cancel()
         confirmationHandler.validate()
         eventReporter.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
+        resultTurbine.ensureAllEventsConsumed()
+        uncaughtErrors.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -252,5 +335,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val errorReporter: FakeErrorReporter,
         val stateHolder: CheckoutControllerStateHolder,
         val expressButton: ExpressButton,
+        val resultTurbine: Turbine<CheckoutController.Result>,
+        val uncaughtErrors: Turbine<Throwable>,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/FakeExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/FakeExpressCheckoutElementEventReporter.kt
@@ -3,7 +3,9 @@ package com.stripe.android.checkout.ece
 import app.cash.turbine.Turbine
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 
-internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementEventReporter {
+internal class FakeExpressCheckoutElementEventReporter(
+    private val paymentSuccessError: Throwable? = null,
+) : ExpressCheckoutElementEventReporter {
     val calls = Turbine<Call>()
 
     override fun onEceDisplayed() {
@@ -16,6 +18,7 @@ internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementE
 
     override fun onEcePaymentSuccess(expressButton: ExpressButton) {
         calls.add(Call.OnEcePaymentSuccess(expressButton))
+        paymentSuccessError?.let { throw it }
     }
 
     override fun onEcePaymentFailure(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class FakeConfirmationHandler(
     override val hasReloadedFromProcessDeath: Boolean = false,
-    override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle)
+    override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle),
+    private val startError: Throwable? = null,
+    private val awaitResultError: Throwable? = null,
 ) : ConfirmationHandler {
     val registerTurbine: Turbine<RegisterCall> = Turbine()
     val startTurbine: Turbine<ConfirmationHandler.Args> = Turbine()
@@ -30,9 +32,11 @@ internal class FakeConfirmationHandler(
 
     override suspend fun start(arguments: ConfirmationHandler.Args) {
         startTurbine.add(arguments)
+        startError?.let { throw it }
     }
 
     override suspend fun awaitResult(): ConfirmationHandler.Result? {
+        awaitResultError?.let { throw it }
         return awaitResultTurbine.awaitItem()
     }
 


### PR DESCRIPTION
# Summary

Hardens confirmation result delivery as a standalone CheckoutSessionPreview change. It follows merged PR #13830 and is independent of the CheckoutController result-delivery stack in #13801–#13804.

- Scopes confirmation completion and failures to an admitted operation token.
- Silently ignores duplicate and conflicting confirmation attempts.
- Releases the operation gate before invoking the result callback so reentrant confirmation is safe.
- Moves confirmation-state observation into `CheckoutOperationCoordinator` and narrows Express Checkout exception handling around confirmation only.

# Motivation

Confirmation attempts could previously produce callbacks even when they were rejected by the coordinator, stale failures could affect a newer operation, and callbacks ran while the gate was still armed. Express Checkout analytics failures could also be reported as payment failures. This change makes the coordinator the single owner of admission and completion so each admitted operation produces at most one result without blocking a synchronous follow-up confirmation.

# Testing

- [x] Added tests
- [x] Modified tests
- [x] Manually verified

- Focused confirmation test run: 39 tests passed.
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:detekt`
- `git diff --check`

# Screenshots

Not applicable — no UI changes.

# Changelog

Not applicable — internal CheckoutSessionPreview hardening.
