### PR TITLE
Make place_id optional and add source to autocomplete analytics events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteModels.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeAutocompleteModels.kt
@@ -8,7 +8,8 @@ import org.json.JSONObject
 
 @Parcelize
 internal data class AutocompletePredictionsResult(
-    val predictions: List<AutocompleteSuggestion>
+    val predictions: List<AutocompleteSuggestion>,
+    val source: String?,
 ) : StripeModel
 
 @Parcelize
@@ -38,6 +39,7 @@ internal object AutocompletePredictionsResponseJsonParser :
     ModelJsonParser<AutocompletePredictionsResult> {
     override fun parse(json: JSONObject): AutocompletePredictionsResult? {
         val suggestionsArray = json.optJSONArray("suggestions") ?: return null
+        val source = StripeJsonUtils.optString(json, "source")
         val predictions = (0 until suggestionsArray.length()).mapNotNull { i ->
             val suggestion = suggestionsArray.optJSONObject(i)
                 ?: return@mapNotNull null
@@ -59,7 +61,7 @@ internal object AutocompletePredictionsResponseJsonParser :
                     ?.let { parseAddress(it) },
             )
         }
-        return AutocompletePredictionsResult(predictions = predictions)
+        return AutocompletePredictionsResult(predictions = predictions, source = source)
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -18,6 +18,7 @@ internal class StripeHostedPlacesClientProxy(
     private var sessionToken: String = newSessionToken()
     private var lastQueryLength: Int = 0
     private var sessionStartReported: Boolean = false
+    private var lastSource: String? = null
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
 
     override fun resetSession() {
@@ -25,6 +26,7 @@ internal class StripeHostedPlacesClientProxy(
             sessionToken = newSessionToken()
             lastQueryLength = 0
             sessionStartReported = false
+            lastSource = null
             predictionCache.clear()
         }
     }
@@ -55,6 +57,7 @@ internal class StripeHostedPlacesClientProxy(
         ).map { result ->
             val limitedPredictions = result.predictions.take(limit)
             synchronized(lock) {
+                lastSource = result.source
                 limitedPredictions.forEach { predictionCache[it.placeId] = it }
             }
             FindAutocompletePredictionsResponse(
@@ -67,10 +70,12 @@ internal class StripeHostedPlacesClientProxy(
                 }
             )
         }.onSuccess { response ->
+            val source = synchronized(lock) { lastSource }
             eventReporter.onAutocompleteSuggestionsReturned(
                 sessionToken = token,
                 queryLength = q.length,
                 resultCount = response.autocompletePredictions.size,
+                source = source,
             )
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)
@@ -81,13 +86,20 @@ internal class StripeHostedPlacesClientProxy(
         val cached: AutocompleteSuggestion?
         val token: String
         val queryLength: Int
+        val source: String?
         synchronized(lock) {
             cached = predictionCache[placeId]
             token = sessionToken
             queryLength = lastQueryLength
+            source = lastSource
         }
         if (cached?.address != null) {
-            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
+            eventReporter.onAutocompleteSelected(
+                sessionToken = token,
+                queryLength = queryLength,
+                placeId = placeId,
+                source = source,
+            )
             return Result.success(
                 Address(
                     line1 = cached.address.line1,
@@ -122,7 +134,12 @@ internal class StripeHostedPlacesClientProxy(
                 country = result.address?.country,
             )
         }.onSuccess {
-            eventReporter.onAutocompleteSelected(sessionToken = token, queryLength = queryLength, placeId = placeId)
+            eventReporter.onAutocompleteSelected(
+                sessionToken = token,
+                queryLength = queryLength,
+                placeId = placeId,
+                source = source,
+            )
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -101,16 +101,7 @@ internal class StripeHostedPlacesClientProxy(
                 placeId = placeId,
                 source = source,
             )
-            return Result.success(
-                Address(
-                    line1 = cached.address.line1,
-                    line2 = cached.address.line2,
-                    city = cached.address.city,
-                    state = cached.address.state,
-                    postalCode = cached.address.postalCode,
-                    country = cached.address.country,
-                )
-            )
+            return Result.success(cached.address.toAddress())
         }
         eventReporter.onAutocompleteDetailsFetchStarted()
         return repository.fetchPlaceDetails(
@@ -125,16 +116,7 @@ internal class StripeHostedPlacesClientProxy(
                     }
                 }
             }
-        }.map { result ->
-            Address(
-                line1 = result.address?.line1,
-                line2 = result.address?.line2,
-                city = result.address?.city,
-                state = result.address?.state,
-                postalCode = result.address?.postalCode,
-                country = result.address?.country,
-            )
-        }.onSuccess {
+        }.map { it.address.toAddress() }.onSuccess {
             eventReporter.onAutocompleteSelected(
                 sessionToken = token,
                 queryLength = queryLength,
@@ -150,3 +132,12 @@ internal class StripeHostedPlacesClientProxy(
         fun newSessionToken(): String = UUID.randomUUID().toString()
     }
 }
+
+private fun StripeProxyAddress?.toAddress(): Address = Address(
+    line1 = this?.line1,
+    line2 = this?.line2,
+    city = this?.city,
+    state = this?.state,
+    postalCode = this?.postalCode,
+    country = this?.country,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -49,6 +49,7 @@ internal class StripeHostedPlacesClientProxy(
             eventReporter.onAutocompleteSessionStarted(token)
         }
         eventReporter.onAutocompleteFetchStarted()
+        var responseSource: String? = null
         return repository.findAutocompletePredictions(
             query = q,
             country = country,
@@ -56,6 +57,7 @@ internal class StripeHostedPlacesClientProxy(
             locale = locale.toLanguageTag(),
         ).map { result ->
             val limitedPredictions = result.predictions.take(limit)
+            responseSource = result.source
             synchronized(lock) {
                 lastSource = result.source
                 limitedPredictions.forEach { predictionCache[it.placeId] = it }
@@ -70,12 +72,11 @@ internal class StripeHostedPlacesClientProxy(
                 }
             )
         }.onSuccess { response ->
-            val source = synchronized(lock) { lastSource }
             eventReporter.onAutocompleteSuggestionsReturned(
                 sessionToken = token,
                 queryLength = q.length,
                 resultCount = response.autocompletePredictions.size,
-                source = source,
+                source = responseSource,
             )
         }.onFailure { error ->
             eventReporter.onAutocompleteError(sessionToken = token, error = error)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -64,6 +64,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         private val timeToFetch: Duration?,
         private val resultCount: Int,
         private val sessionElapsed: Duration?,
+        private val source: String?,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_suggestions"
         override val additionalParams: Map<String, Any>
@@ -73,6 +74,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                     FIELD_QUERY_LENGTH to queryLength,
                     FIELD_RESULT_COUNT to resultCount,
                 )
+                source?.let { data[FIELD_SOURCE] = it }
                 timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
                 sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
                 return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
@@ -82,7 +84,8 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
     class AutocompleteSelected(
         private val autocompleteSessionToken: String,
         private val queryLength: Int,
-        private val placeId: String,
+        private val placeId: String?,
+        private val source: String?,
         private val sessionElapsed: Duration?,
         private val timeToFetch: Duration?,
     ) : AddressLauncherEvent() {
@@ -92,8 +95,9 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                 val data = mutableMapOf<String, Any>(
                     FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
                     FIELD_QUERY_LENGTH to queryLength,
-                    FIELD_PLACE_ID to placeId,
                 )
+                placeId?.let { data[FIELD_PLACE_ID] = it }
+                source?.let { data[FIELD_SOURCE] = it }
                 sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
                 timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
                 return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
@@ -127,5 +131,6 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         const val FIELD_SESSION_ELAPSED = "session_elapsed"
         const val FIELD_QUERY_LENGTH = "query_length"
         const val FIELD_PLACE_ID = "place_id"
+        const val FIELD_SOURCE = "source"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -17,11 +17,12 @@ internal interface AddressLauncherEventReporter {
         sessionToken: String,
         queryLength: Int,
         resultCount: Int,
+        source: String?,
     )
 
     fun onAutocompleteDetailsFetchStarted()
 
-    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String)
+    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?)
 
     fun onAutocompleteError(sessionToken: String, error: Throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -64,6 +64,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         sessionToken: String,
         queryLength: Int,
         resultCount: Int,
+        source: String?,
     ) {
         val fetchDuration = durationProvider.end(DurationProvider.Key.AddressAutocompleteFetch)
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
@@ -74,11 +75,12 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
                 timeToFetch = fetchDuration,
                 resultCount = resultCount,
                 sessionElapsed = sessionElapsed,
+                source = source,
             )
         )
     }
 
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) {
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         val timeToFetch = durationProvider.end(DurationProvider.Key.AddressAutocompleteDetailsFetch)
         fireEvent(
@@ -86,6 +88,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
                 autocompleteSessionToken = sessionToken,
                 queryLength = queryLength,
                 placeId = placeId,
+                source = source,
                 sessionElapsed = sessionElapsed,
                 timeToFetch = timeToFetch,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -9,8 +9,13 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
     ) = Unit
     override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
     override fun onAutocompleteFetchStarted() = Unit
-    override fun onAutocompleteSuggestionsReturned(sessionToken: String, queryLength: Int, resultCount: Int) = Unit
+    override fun onAutocompleteSuggestionsReturned(
+        sessionToken: String,
+        queryLength: Int,
+        resultCount: Int,
+        source: String?,
+    ) = Unit
     override fun onAutocompleteDetailsFetchStarted() = Unit
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) = Unit
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) = Unit
     override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -16,6 +16,11 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
         source: String?,
     ) = Unit
     override fun onAutocompleteDetailsFetchStarted() = Unit
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) = Unit
+    override fun onAutocompleteSelected(
+        sessionToken: String,
+        queryLength: Int,
+        placeId: String?,
+        source: String?,
+    ) = Unit
     override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakeStripeAutocompleteRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FakeStripeAutocompleteRepository.kt
@@ -5,7 +5,7 @@ import app.cash.turbine.Turbine
 
 internal class FakeStripeAutocompleteRepository : StripeAutocompleteRepository {
     var predictionsResult: Result<AutocompletePredictionsResult> = Result.success(
-        AutocompletePredictionsResult(predictions = emptyList())
+        AutocompletePredictionsResult(predictions = emptyList(), source = null)
     )
     var detailsResult: Result<PlaceDetailsResult> = Result.failure(NotImplementedError())
     var onBeforeFindAutocompletePredictions: (suspend () -> Unit)? = null

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -37,7 +37,8 @@ class StripeHostedPlacesClientProxyTest {
                         AutocompleteSuggestion("p1", "Result 1", "City, CA", null),
                         AutocompleteSuggestion("p2", "Result 2", "City, CA", null),
                         AutocompleteSuggestion("p3", "Result 3", "City, CA", null),
-                    )
+                    ),
+                    source = "google",
                 )
             )
         }
@@ -125,7 +126,8 @@ class StripeHostedPlacesClientProxyTest {
                 AutocompletePredictionsResult(
                     predictions = listOf(
                         AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress)
-                    )
+                    ),
+                    source = "google",
                 )
             )
         }
@@ -163,7 +165,8 @@ class StripeHostedPlacesClientProxyTest {
                 AutocompletePredictionsResult(
                     predictions = listOf(
                         AutocompleteSuggestion("place_jp", "Kameido", "Koto City, Tokyo", inlineAddress)
-                    )
+                    ),
+                    source = "google",
                 )
             )
         }
@@ -194,7 +197,8 @@ class StripeHostedPlacesClientProxyTest {
         val repository = FakeStripeAutocompleteRepository().apply {
             predictionsResult = Result.success(
                 AutocompletePredictionsResult(
-                    predictions = listOf(AutocompleteSuggestion("place_123", "123 Main St", "", inlineAddress))
+                    predictions = listOf(AutocompleteSuggestion("place_123", "123 Main St", "", inlineAddress)),
+                    source = "google",
                 )
             )
         }
@@ -267,7 +271,8 @@ class StripeHostedPlacesClientProxyTest {
             AutocompletePredictionsResult(
                 predictions = listOf(
                     AutocompleteSuggestion("place_123", "123 Main St", "San Francisco, CA", null)
-                )
+                ),
+                source = "google",
             )
         )
         detailsResult = Result.success(
@@ -421,7 +426,8 @@ class StripeHostedPlacesClientProxyTest {
         val repository = FakeStripeAutocompleteRepository().apply {
             predictionsResult = Result.success(
                 AutocompletePredictionsResult(
-                    predictions = listOf(AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress))
+                    predictions = listOf(AutocompleteSuggestion("place_123", "123 Main St", "SF, CA", inlineAddress)),
+                    source = "google",
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -53,16 +53,19 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         sessionToken: String,
         queryLength: Int,
         resultCount: Int,
+        source: String?,
     ) {
-        _autocompleteSuggestionsReturnedCalls.add(SuggestionsReturnedCall(sessionToken, queryLength, resultCount))
+        _autocompleteSuggestionsReturnedCalls.add(
+            SuggestionsReturnedCall(sessionToken, queryLength, resultCount, source)
+        )
     }
 
     override fun onAutocompleteDetailsFetchStarted() {
         _autocompleteDetailsFetchStartedCalls.add(Unit)
     }
 
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String) {
-        _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId))
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) {
+        _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId, source))
     }
 
     override fun onAutocompleteError(sessionToken: String, error: Throwable) {
@@ -86,9 +89,14 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         val editDistance: Int?,
     )
 
-    data class SuggestionsReturnedCall(val sessionToken: String, val queryLength: Int, val resultCount: Int)
+    data class SuggestionsReturnedCall(
+        val sessionToken: String,
+        val queryLength: Int,
+        val resultCount: Int,
+        val source: String?,
+    )
 
-    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String)
+    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String?, val source: String?)
 
     data class ErrorCall(val sessionToken: String, val error: Throwable)
 }


### PR DESCRIPTION
## Summary

- Make `place_id` optional in `mc_address_autocomplete_selected` analytics event so it can be omitted when unavailable
- Add `source` field (parsed from the endpoint response) to both `mc_address_autocomplete_suggestions` and `mc_address_autocomplete_selected` analytics events

## Motivation

The autocomplete endpoint returns a `source` field indicating which provider fulfilled the request. This was not being forwarded to analytics events. Additionally, `place_id` should be optional to support future flows where it may not be available at selection time.

## Testing
- [x] Modified tests
- [x] Existing tests pass with updated signatures