### PR TITLE
Use SupervisorJob for reusable coroutine scopes

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
@@ -8,6 +8,7 @@ import android.webkit.DownloadListener
 import com.stripe.android.connect.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -15,7 +16,7 @@ internal class StripeDownloadListener(
     private val context: Context,
     private val stripeDownloadManager: StripeDownloadManager = StripeDownloadManagerImpl(context),
     private val stripeToastManager: StripeToastManager = StripeToastManagerImpl(),
-    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
 ) : DownloadListener {
 
     override fun onDownloadStart(

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
@@ -23,6 +23,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 
 @Module(includes = [PaymentConfigurationModule::class])
@@ -78,7 +79,7 @@ internal interface PaymentMethodMessagingModule {
         @Provides
         @ViewModelScope
         fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/cards/CardAccountRangeService.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/CardAccountRangeService.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardFunding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -83,7 +84,7 @@ class DefaultCardAccountRangeService(
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
     private val accountRangeResultListener: CardAccountRangeService.AccountRangeResultListener? = null,
-    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext)
+    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext + SupervisorJob())
 ) : CardAccountRangeService {
 
     private val needsRemoteQueryForFunding = CardFunding.entries.any {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -43,6 +43,7 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -79,7 +80,7 @@ internal class DefaultCardNumberController(
     cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
-    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext),
+    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext + SupervisorJob()),
     private val accountRangeService: CardAccountRangeService = DefaultCardAccountRangeService(
         cardAccountRangeRepository,
         uiContext,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -86,6 +86,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
 import javax.inject.Singleton
@@ -218,7 +219,7 @@ internal interface CheckoutControllerModule {
         @Singleton
         @ViewModelScope
         fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -16,6 +16,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 @Component(
     modules = [NfcScanningViewModelModule::class]
@@ -49,7 +50,7 @@ internal interface NfcScanningViewModelModule {
         @Provides
         @ViewModelScope
         fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -80,6 +80,7 @@ import dagger.Provides
 import dagger.Subcomponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -244,7 +245,7 @@ internal interface TapToAddViewModelModule {
         @Singleton
         @ViewModelScope
         fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
 
         @OptIn(ExperimentalAnalyticEventCallbackApi::class)

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -27,6 +27,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -86,7 +87,7 @@ internal interface LinkControllerModule {
         @Singleton
         @ViewModelScope
         fun provideCoroutineScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -59,6 +59,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
 import javax.inject.Singleton
@@ -129,7 +130,7 @@ internal interface EmbeddedActivityModule {
         @Singleton
         @ViewModelScope
         fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -55,6 +55,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
 import javax.inject.Singleton
@@ -227,7 +228,7 @@ internal interface EmbeddedPaymentElementViewModelModule {
         @Singleton
         @ViewModelScope
         fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(Dispatchers.Main)
+            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -17,6 +17,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -46,7 +47,7 @@ internal class PaymentOptionsViewModelModule {
     @Provides
     @ViewModelScope
     fun provideViewModelScope(): CoroutineScope {
-        return CoroutineScope(Dispatchers.Main)
+        return CoroutineScope(SupervisorJob() + Dispatchers.Main)
     }
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -14,6 +14,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -39,7 +40,7 @@ internal class PaymentSheetViewModelModule {
     @Provides
     @ViewModelScope
     fun provideViewModelScope(): CoroutineScope {
-        return CoroutineScope(Dispatchers.Main)
+        return CoroutineScope(SupervisorJob() + Dispatchers.Main)
     }
 
     @Provides


### PR DESCRIPTION
# Summary

Use `SupervisorJob` for reusable, manually constructed coroutine scopes throughout PaymentSheet, Payment Method Messaging, card-number handling, and Connect download monitoring.

This updates all custom scopes annotated with `@ViewModelScope` and the three additional reusable scope defaults in `DefaultCardNumberController`, `DefaultCardAccountRangeService`, and `StripeDownloadListener`.

# Motivation

Constructing a scope with only a dispatcher or dispatcher context automatically adds a regular root `Job`. These scopes launch multiple concurrent or sequential children and are reused for the lifetime of their owner. If any child fails, a regular `Job` cancels the root and its sibling coroutines; because that root remains canceled, every future launch in the same scope is immediately canceled as well.

This can turn an isolated failure into unrelated behavior stopping permanently. For example, a failed card-account-range lookup can prevent later lookups, one derived card-number flow can stop its sibling collectors, or one download-monitoring failure can cancel other and subsequent download jobs. The shared `@ViewModelScope` providers have the same risk for their long-lived collectors and later controller or configuration operations.

Adding `SupervisorJob` fixes this by preventing a failed child from canceling the supervisor or its siblings. The exception itself is still propagated to its normal handler or caller; it is not swallowed. Explicit owner cancellation still propagates from the supervisor to all children, preserving existing lifecycle cleanup behavior.

The existing dispatchers remain unchanged. Generic injected contexts add `SupervisorJob` last so it remains the scope's root job even if a supplied context unexpectedly contains another `Job`.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Verified all affected modules compile successfully:

```text
./gradlew :paymentsheet:compileDebugKotlin :payment-method-messaging:compileDebugKotlin
./gradlew :payments-core:compileDebugKotlin :payments-ui-core:compileDebugKotlin :connect:compileDebugKotlin
```

No tests were newly ignored.

# Screenshots

Not applicable — this changes coroutine failure isolation and has no visual impact.

# Changelog

Not applicable — this is an internal resilience fix with no public API change.
