### PR TITLE
Fix custom payment method failure test flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -8,7 +8,6 @@ import android.util.Log
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasTestTag
@@ -851,9 +850,15 @@ internal class PlaygroundTestDriver(
             selectors.customPaymentMethodFailButton,
         )
 
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG))
-            .assertIsDisplayed()
-            .assertTextEquals(CustomPaymentMethodActivity.FAILED_DISPLAY_MESSAGE)
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            composeTestRule
+                .onAllNodes(
+                    hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG)
+                        .and(hasText(CustomPaymentMethodActivity.FAILED_DISPLAY_MESSAGE))
+                )
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
 
         teardown()
     }


### PR DESCRIPTION
# Summary

Stabilize the custom payment method failure E2E test by waiting for the exact PaymentSheet error node while allowing Compose roots to be temporarily detached. This is a single-layer PR targeting `master`.

# Motivation

`CustomPaymentMethodActivity` finishes immediately after the failure button is tapped. During the transition back to PaymentSheet, the activity's Compose root can detach before PaymentSheet's root is available, causing the immediate assertion to fail with `No compose hierarchies found in the app` on `pixel2api33chrome_0`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Ran the focused `TestCustomPaymentMethod#testCustomPaymentMethod_Fail` managed-device test on Pixel 2/API 33 with Chrome:

- 2 Shampoo iterations passed.
- 50 Shampoo iterations passed, with logcat confirming iterations 0 through 49 and no failed iteration.
- The focused test passed once more after restoring the normal `RetryRule` configuration.

No tests were newly ignored.

# Screenshots

Not applicable: this is a test synchronization change with no UI changes.

# Changelog

Not applicable: this only stabilizes an instrumentation test and does not change user-facing behavior.
