### PR TITLE
Fix managed device IME show race

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ManagedDeviceImeSmokeTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ManagedDeviceImeSmokeTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -47,7 +48,13 @@ internal class ManagedDeviceImeSmokeTest {
             imeBottomInset() == 0
         }
 
-        composeTestRule.onNodeWithTag(TEXT_FIELD_TAG).performClick()
+        composeTestRule.onNodeWithTag(TEXT_FIELD_TAG)
+            .performClick()
+            .assertIsFocused()
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+                .show(WindowInsetsCompat.Type.ime())
+        }
         composeTestRule.waitUntil(IME_TRANSITION_TIMEOUT_MS) {
             imeBottomInset() > 0
         }


### PR DESCRIPTION
# Summary

Stabilize `ManagedDeviceImeSmokeTest` by verifying that the test text field is focused and explicitly requesting the IME before waiting for a nonzero inset. This is the only layer in the stack and targets `master`.

# Motivation

The managed-device smoke test intermittently timed out waiting for a nonzero IME inset. A focused 50-iteration reproduction failed at iteration 2: Gboard completed its hide transition, but the subsequent Compose semantics click emitted neither an `InsetsController.show` event nor an `InputMethodManager.showSoftInput` event.

The test now synchronizes on the focused editor and explicitly requests the IME show transition. This preserves the existing timeout and nonzero-inset assertion while removing reliance on the click implicitly producing the system show request.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- Reproduced the original `ComposeTimeoutException` at iteration 2 of a focused 50-iteration Shampoo run.
- Passed 2 focused Shampoo iterations with the fix.
- Passed all 50 focused Shampoo iterations with the fix (`0` through `49`) with no failed-iteration, timeout, or assertion lines.
- Restored the normal Compose rule and passed the focused managed-device test in 39 seconds:

  `CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.paymentsheet.ManagedDeviceImeSmokeTest#focusedTextFieldExposesNonzeroImeInset' :paymentsheet:pixel2api33imeDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`

No tests were ignored. Shampoo was diagnostic-only and is absent from the submitted diff.

# Screenshots

Not applicable; this changes instrumentation-test synchronization only and has no user-visible UI effect.

# Changelog

Not applicable; this is an internal test-stability fix with no SDK behavior change.
