### PR TITLE
Pass shippingInformation from GooglePay to PaymentMethodConfirmationOption.Saved

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -28,6 +28,7 @@ import com.stripe.android.core.reactnative.registerForReactNativeActivityResult
 import com.stripe.android.googlepaylauncher.injection.GooglePayRepositoryFactory
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import dev.drewhamilton.poko.Poko
@@ -356,9 +357,18 @@ class GooglePayPaymentMethodLauncher internal constructor(
          */
         @Parcelize
         @Poko
-        class Completed(
-            val paymentMethod: PaymentMethod
-        ) : Result()
+        class Completed
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        constructor(
+            val paymentMethod: PaymentMethod,
+            @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            val shippingInformation: ShippingInformation?,
+        ) : Result() {
+            constructor(paymentMethod: PaymentMethod) : this(
+                paymentMethod = paymentMethod,
+                shippingInformation = null,
+            )
+        }
 
         /**
          * Represents a failed transaction.

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -20,6 +20,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.injection.DaggerGooglePayPaymentMethodLauncherViewModelFactoryComponent
+import com.stripe.android.model.GooglePayResult
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -142,16 +143,20 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
         paymentData: PaymentData
     ): GooglePayPaymentMethodLauncher.Result {
         val paymentDataJson = JSONObject(paymentData.toJson())
+        val googlePayResult = GooglePayResult.fromJson(paymentDataJson)
 
         val params = PaymentMethodCreateParams.createFromGooglePay(
-            googlePayPaymentData = paymentDataJson,
+            googlePayResult = googlePayResult,
             clientAttributionMetadata = args.clientAttributionMetadata,
             billingEmailOverride = args.billingEmailOverride,
         )
 
         return stripeRepository.createPaymentMethod(params, requestOptions).fold(
             onSuccess = {
-                GooglePayPaymentMethodLauncher.Result.Completed(it)
+                GooglePayPaymentMethodLauncher.Result.Completed(
+                    paymentMethod = it,
+                    shippingInformation = googlePayResult.shippingInformation,
+                )
             },
             onFailure = {
                 GooglePayPaymentMethodLauncher.Result.Failed(

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1045,7 +1045,7 @@ constructor(
             googlePayPaymentData: JSONObject
         ): PaymentMethodCreateParams {
             return createFromGooglePay(
-                googlePayPaymentData = googlePayPaymentData,
+                googlePayResult = GooglePayResult.fromJson(googlePayPaymentData),
                 clientAttributionMetadata = null,
                 billingEmailOverride = null,
             )
@@ -1053,11 +1053,10 @@ constructor(
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun createFromGooglePay(
-            googlePayPaymentData: JSONObject,
+            googlePayResult: GooglePayResult,
             clientAttributionMetadata: ClientAttributionMetadata?,
             billingEmailOverride: String?,
         ): PaymentMethodCreateParams {
-            val googlePayResult = GooglePayResult.fromJson(googlePayPaymentData)
             val token = googlePayResult.token
             val tokenId = token?.id.orEmpty()
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.GooglePayConfig
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.GooglePayFixtures
 import com.stripe.android.model.PaymentIntentCreationFlow
@@ -27,6 +28,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodSelectionFlow
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.testing.fakeCreationExtras
@@ -91,6 +93,27 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD
                 )
             )
+    }
+
+    @Test
+    fun `createPaymentMethod() should return shipping information`() = runTest {
+        val result = viewModel.createPaymentMethod(
+            PaymentData.fromJson(GooglePayFixtures.RESULT_WITH_SHIPPING_ADDRESS.toString())
+        ) as GooglePayPaymentMethodLauncher.Result.Completed
+
+        assertThat(result.shippingInformation).isEqualTo(
+            ShippingInformation(
+                name = "Jenny Rosen",
+                phone = "1-800-555-1234",
+                address = Address(
+                    line1 = "510 Townsend St",
+                    city = "San Francisco",
+                    state = "CA",
+                    postalCode = "94103",
+                    country = "US",
+                ),
+            )
+        )
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -28,7 +28,9 @@ class PaymentMethodCreateParamsTest {
     @Test
     fun createFromGooglePay_withBillingEmailOverride_overridesGooglePayEmail() {
         val params = PaymentMethodCreateParams.createFromGooglePay(
-            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            googlePayResult = GooglePayResult.fromJson(
+                GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS
+            ),
             clientAttributionMetadata = null,
             billingEmailOverride = "checkout@example.com",
         )
@@ -39,7 +41,9 @@ class PaymentMethodCreateParamsTest {
     @Test
     fun createFromGooglePay_withBillingEmailOverride_usedWhenGooglePayHasNoEmail() {
         val params = PaymentMethodCreateParams.createFromGooglePay(
-            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS,
+            googlePayResult = GooglePayResult.fromJson(
+                GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS
+            ),
             clientAttributionMetadata = null,
             billingEmailOverride = "checkout@example.com",
         )
@@ -50,7 +54,9 @@ class PaymentMethodCreateParamsTest {
     @Test
     fun createFromGooglePay_withNullOverride_keepsGooglePayEmail() {
         val params = PaymentMethodCreateParams.createFromGooglePay(
-            googlePayPaymentData = GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS,
+            googlePayResult = GooglePayResult.fromJson(
+                GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_FULL_BILLING_ADDRESS
+            ),
             clientAttributionMetadata = null,
             billingEmailOverride = null,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -210,6 +210,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     ): ConfirmationHandler.Args {
         return ConfirmationHandler.Args(
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -56,6 +56,7 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(): PaymentMe
         // For Instant Debits, we create the PaymentMethod inside the bank auth flow. Therefore,
         // we can just use the already created object here.
         PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = instantDebits.paymentMethod,
             optionsParams = paymentMethodOptionsParams,
         )
@@ -81,6 +82,7 @@ internal fun PaymentSelection.Saved.toConfirmationOption(
         )
     } else {
         PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = paymentMethod,
             optionsParams = paymentMethodOptionsParams,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.paymentelement.confirmation.utils.updatedWithPmoSfu
 import com.stripe.android.paymentelement.confirmation.utils.updatedWithProductUsage
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -22,6 +23,7 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
     data class Saved(
         val paymentMethod: com.stripe.android.model.PaymentMethod,
         override val optionsParams: PaymentMethodOptionsParams?,
+        val shippingInformation: ShippingInformation?,
         val originatedFromWallet: Boolean = false,
         override val confirmationChallengeState: ConfirmationChallengeState = ConfirmationChallengeState(),
         val newPMTransformedForConfirmation: Boolean = false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -119,6 +119,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                 val nextConfirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
+                    shippingInformation = null,
                     originatedFromWallet = true,
                 )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -119,7 +119,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                 val nextConfirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
-                    shippingInformation = null,
+                    shippingInformation = result.shippingInformation,
                     originatedFromWallet = true,
                 )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptor.kt
@@ -47,6 +47,7 @@ internal class DefaultCustomerSheetSetupIntentInterceptor(
                         .intercept(
                             intent = intent,
                             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                                shippingInformation = null,
                                 paymentMethod = paymentMethod,
                                 optionsParams = null,
                             ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -85,6 +85,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
             is LinkActivityResult.PaymentMethodObtained -> {
                 ConfirmationDefinition.Result.NextStep(
                     confirmationOption = PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = result.paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -90,6 +90,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
             requireNotNull(it.encodedPaymentMethod.parsePaymentMethod())
         }.map { paymentMethod ->
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = null,
                 originatedFromWallet = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -202,6 +202,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         savedConfirmationOption: LinkInlineSignupConfirmationOption.Saved?,
     ): PaymentMethodConfirmationOption.Saved {
         return PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = paymentMethod,
             optionsParams = savedConfirmationOption?.optionsParams,
             originatedFromWallet = false,
@@ -212,6 +213,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption?,
     ): PaymentMethodConfirmationOption.Saved {
         return PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = paymentMethod,
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession.takeIf {
@@ -253,6 +255,7 @@ internal class LinkInlineSignupConfirmationDefinition(
                 shouldSave = saveOption.shouldSave(),
             )
             is LinkInlineSignupConfirmationOption.Saved -> PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = optionsParams,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -182,6 +182,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             paymentMethod = paymentMethod,
             initialConfirmationState = ConfirmationHandler.State.Confirming(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),
@@ -224,6 +225,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
 
             confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Confirming(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),
@@ -454,6 +456,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
 
             confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Confirming(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -181,6 +181,7 @@ class ConfirmationHandlerOptionKtxTest {
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     cvc = "505"
@@ -590,6 +591,7 @@ class ConfirmationHandlerOptionKtxTest {
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
             )
@@ -610,6 +612,7 @@ class ConfirmationHandlerOptionKtxTest {
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationSaverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationSaverTest.kt
@@ -171,6 +171,7 @@ class ConfirmationSaverTest {
             paymentMethod = paymentMethod
         )
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = paymentMethod,
             optionsParams = null,
         )
@@ -200,6 +201,7 @@ class ConfirmationSaverTest {
             paymentMethod = paymentMethod
         )
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = paymentMethod,
             optionsParams = null,
         )
@@ -229,6 +231,7 @@ class ConfirmationSaverTest {
             paymentMethod = paymentMethod
         )
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = paymentMethod,
             optionsParams = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIsCardPaymentMethodForChallengeTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIsCardPaymentMethodForChallengeTest.kt
@@ -85,6 +85,7 @@ internal class DefaultIsCardPaymentMethodForChallengeTest {
     )
 
     private fun savedOption(paymentMethod: PaymentMethod) = PaymentMethodConfirmationOption.Saved(
+        shippingInformation = null,
         paymentMethod = paymentMethod,
         optionsParams = null,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -556,6 +556,7 @@ class IntentConfirmationDefinitionTest {
 
     private companion object {
         private val SAVED_PAYMENT_CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(
                 cvc = "505",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOptionTest.kt
@@ -13,6 +13,7 @@ class PaymentMethodConfirmationOptionTest {
     @Test
     fun `shouldSaveAsDefault returns false for Saved payment method`() {
         val option = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -656,6 +656,7 @@ internal class AttestationConfirmationDefinitionTest {
         )
 
         private val PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PAYMENT_INTENT.paymentMethod!!,
             optionsParams = null,
             originatedFromWallet = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -631,6 +631,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         )
 
         private val PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PAYMENT_INTENT.paymentMethod!!,
             optionsParams = null,
             originatedFromWallet = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -71,6 +71,7 @@ internal class CvcRecollectionConfirmationActivityTest {
             assertThat(confirmingWithSavedOptionWithCvc.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = PaymentMethodOptionsParams.Card(cvc = "444"),
                     )
@@ -109,6 +110,7 @@ internal class CvcRecollectionConfirmationActivityTest {
             assertThat(confirmingWithSavedOption.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = null,
                     )
@@ -173,6 +175,7 @@ internal class CvcRecollectionConfirmationActivityTest {
         val PAYMENT_METHOD = PaymentMethodFactory.card(random = true)
 
         val CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PAYMENT_METHOD,
             optionsParams = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -290,6 +290,7 @@ class CvcRecollectionConfirmationDefinitionTest {
         originatedFromWallet: Boolean = false,
     ): PaymentMethodConfirmationOption.Saved {
         return PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = optionsParams,
             originatedFromWallet = originatedFromWallet,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -78,6 +78,7 @@ internal class GooglePayConfirmationActivityTest {
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
@@ -151,6 +152,7 @@ internal class GooglePayConfirmationActivityTest {
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
@@ -211,6 +213,7 @@ internal class GooglePayConfirmationActivityTest {
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -19,8 +19,10 @@ import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLaunch
 import com.stripe.android.googlepaylauncher.injection.InternalGooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -135,6 +137,7 @@ class GooglePayConfirmationDefinitionTest {
             launcherArgs = EmptyConfirmationLauncherArgs,
             result = GooglePayPaymentMethodLauncher.Result.Completed(
                 paymentMethod = paymentMethod,
+                shippingInformation = SHIPPING_INFORMATION,
             ),
         )
 
@@ -150,6 +153,7 @@ class GooglePayConfirmationDefinitionTest {
 
         assertThat(savedOption.paymentMethod).isEqualTo(savedOption.paymentMethod)
         assertThat(savedOption.optionsParams).isNull()
+        assertThat(savedOption.shippingInformation).isEqualTo(SHIPPING_INFORMATION)
         assertThat(savedOption.originatedFromWallet).isTrue()
     }
 
@@ -813,5 +817,17 @@ class GooglePayConfirmationDefinitionTest {
 
         private val CONFIRMATION_PARAMETERS =
             com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
+
+        private val SHIPPING_INFORMATION = ShippingInformation(
+            name = "Jenny Rosen",
+            phone = "1-800-555-1234",
+            address = Address(
+                line1 = "510 Townsend St",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+                country = "US",
+            ),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -111,6 +111,7 @@ class GooglePayConfirmationFlowTest {
         launcherArgs = EmptyConfirmationLauncherArgs,
         definitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -440,6 +440,7 @@ class CheckoutSessionConfirmationInterceptorTest {
         )
 
         val SAVED_PM_OPTION = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptorTest.kt
@@ -75,6 +75,7 @@ class CustomerSheetConfirmationInterceptorTest {
         val result = interceptor.intercept(
             intent = SetupIntentFactory.create(),
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
@@ -82,6 +82,7 @@ internal suspend fun IntentConfirmationInterceptor.interceptDefaultSavedPaymentM
     ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> = intercept(
     intent = PaymentIntentFactory.create(),
     confirmationOption = PaymentMethodConfirmationOption.Saved(
+        shippingInformation = null,
         paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
         optionsParams = null,
     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -496,6 +496,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
             val nextStep = interceptor.intercept(
                 intent = PaymentIntentFactory.create(),
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = PaymentMethodFixtures.AU_BECS_DEBIT,
                     optionsParams = null,
                 ),
@@ -775,6 +776,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         )
 
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
             optionsParams = null,
         )
@@ -821,6 +823,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         )
 
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
         )
@@ -875,6 +878,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         )
 
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
         )
@@ -929,6 +933,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         )
 
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
         )
@@ -984,6 +989,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         )
 
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
         )
@@ -1094,6 +1100,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
             retrievedIntentStatus = StripeIntent.Status.RequiresConfirmation,
         ) { interceptor ->
             val confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 confirmationChallengeState = ConfirmationChallengeState(hCaptchaToken = "test_token"),
@@ -1201,6 +1208,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
             retrievedIntentStatus = StripeIntent.Status.RequiresConfirmation,
         ) { interceptor ->
             val confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 confirmationChallengeState = challengeState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -315,6 +315,7 @@ class DeferredIntentConfirmationInterceptorTest {
             interceptor.intercept(
                 intent = PaymentIntentFactory.create(),
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = paymentMethod,
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
@@ -456,6 +457,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val nextStep = interceptor.intercept(
             intent = PaymentIntentFactory.create(),
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = null,
                 confirmationChallengeState = challengeState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
@@ -91,6 +91,7 @@ class HCaptchaConfirmationInterceptorTest {
         val nextStep = interceptor.intercept(
             intent = SetupIntentFactory.create(),
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = null,
                 confirmationChallengeState = ConfirmationChallengeState(hCaptchaToken = hCaptchaToken),
@@ -134,6 +135,7 @@ class HCaptchaConfirmationInterceptorTest {
         val nextStep = interceptor.intercept(
             intent = PaymentIntentFactory.create(),
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = null,
                 confirmationChallengeState = ConfirmationChallengeState(hCaptchaToken = hCaptchaToken),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/IntentFirstConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/IntentFirstConfirmationInterceptorTest.kt
@@ -32,6 +32,7 @@ class IntentFirstConfirmationInterceptorTest {
             val nextStep = interceptor.intercept(
                 intent = PaymentIntentFactory.create(),
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),
@@ -75,6 +76,7 @@ class IntentFirstConfirmationInterceptorTest {
             val nextStep = interceptor.intercept(
                 intent = PaymentIntentFactory.create(),
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
@@ -243,6 +245,7 @@ class IntentFirstConfirmationInterceptorTest {
         val nextStep = interceptor.intercept(
             intent = PaymentIntentFactory.create(),
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 confirmationChallengeState = challengeState,
@@ -264,6 +267,7 @@ class IntentFirstConfirmationInterceptorTest {
         val nextStep = interceptor.intercept(
             intent = SetupIntentFactory.create(),
             confirmationOption = PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 confirmationChallengeState = challengeState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
@@ -59,6 +59,7 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             val nextStep = interceptor.intercept(
                 intent = intent,
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = providedPaymentMethod,
                     optionsParams = null,
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -119,6 +119,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
+                        shippingInformation = null,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -118,6 +118,7 @@ class LinkConfirmationFlowTest {
         assertThat(result).isEqualTo(
             ConfirmationDefinition.Result.NextStep(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -318,6 +318,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         val launcher = LinkInlineSignupConfirmationDefinition.Launcher(onResultScenario.onResult)
 
         val nextOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFactory.card(random = true),
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
@@ -343,6 +344,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         val definition = createLinkInlineSignupConfirmationDefinition(linkStore = storeScenario.linkStore)
 
         val nextOption = PaymentMethodConfirmationOption.Saved(
+            shippingInformation = null,
             paymentMethod = PaymentMethodFactory.card(random = true),
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -420,6 +420,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
@@ -494,6 +495,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
@@ -521,6 +523,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = SEPA_DEBIT_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false
@@ -990,6 +993,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
             )
@@ -1042,6 +1046,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
             )
@@ -1992,6 +1997,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false
@@ -2029,6 +2035,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false
@@ -2110,6 +2117,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = paymentMethod,
                 optionsParams = null,
             )
@@ -2143,6 +2151,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false
@@ -2180,6 +2189,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false
@@ -2217,6 +2227,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 PaymentMethodConfirmationOption.Saved(
+                    shippingInformation = null,
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false
@@ -3014,6 +3025,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1293,6 +1293,7 @@ internal class DefaultFlowControllerTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
             )
@@ -1354,6 +1355,7 @@ internal class DefaultFlowControllerTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
             )
@@ -1715,6 +1717,7 @@ internal class DefaultFlowControllerTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
             )
@@ -2287,6 +2290,7 @@ internal class DefaultFlowControllerTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
+                shippingInformation = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     cvc = "505"


### PR DESCRIPTION
committed by codex (not sure why it didn't note this in the PR description so adding it myself)

# Summary
Pass shippingInformation from GooglePay to PaymentMethodConfirmationOption.Saved

commits:
- Add shippingInformation to PaymentMethodConfirmationOption.Saved and set it to null everywhere
- Refactor PaymentMethodCreateParams.createGooglePay to use a GooglePayResult, so we can access the full GooglePayResult type in GooglePayConfirmationDefinition
- Update GooglePayConfirmationDefinition to set shippingInformation on PaymentMethodConfirmationOption.Saved when present

# Motivation

Support shipping address collection in ECE
https://jira.corp.stripe.com/browse/MOBILESDK-4721

We can access the PaymentMethodConfirmationOption.Saved in the CheckoutSessionConfirmationInterceptor and use its shippingInformation in the checkout session confirm call (will be done in the next PR in this stack)

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified