### PR TITLE
Include shipping information in Checkout Session confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -66,6 +67,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     intent = intent,
                     paymentMethod = paymentMethod,
                     savePaymentMethod = confirmationOption.shouldSave.takeIf { isSaveEnabled },
+                    shippingInformation = null,
                 )
                 confirmCheckoutSession(params)
             },
@@ -89,6 +91,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             intent = intent,
             paymentMethod = confirmationOption.paymentMethod,
             savePaymentMethod = null,
+            shippingInformation = confirmationOption.shippingInformation,
         )
         return confirmCheckoutSession(params)
     }
@@ -97,6 +100,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
         intent: StripeIntent,
         paymentMethod: PaymentMethod,
         savePaymentMethod: Boolean?,
+        shippingInformation: ShippingInformation?,
     ): ConfirmCheckoutSessionParams = when (intent) {
         is PaymentIntent -> ConfirmCheckoutSessionParams(
             paymentMethodId = paymentMethod.id,
@@ -104,11 +108,13 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             returnUrl = returnUrl,
             expectedAmount = intent.amount,
             savePaymentMethod = savePaymentMethod,
+            shipping = shippingInformation.toCheckoutSessionShipping(),
         )
         else -> ConfirmCheckoutSessionParams(
             paymentMethodId = paymentMethod.id,
             clientAttributionMetadata = clientAttributionMetadata,
             returnUrl = returnUrl,
+            shipping = shippingInformation.toCheckoutSessionShipping(),
         )
     }
 
@@ -179,5 +185,14 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             customerMetadata: CustomerMetadata?,
             clientAttributionMetadata: ClientAttributionMetadata,
         ): CheckoutSessionConfirmationInterceptor
+    }
+}
+
+private fun ShippingInformation?.toCheckoutSessionShipping(): ConfirmCheckoutSessionParams.Shipping? {
+    return this?.let {
+        ConfirmCheckoutSessionParams.Shipping(
+            name = it.name,
+            address = it.address,
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParams.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParams.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
+import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 
 /**
@@ -15,6 +16,7 @@ internal data class ConfirmCheckoutSessionParams(
     private val returnUrl: String,
     private val expectedAmount: Long? = null,
     private val savePaymentMethod: Boolean? = null,
+    private val shipping: Shipping?,
 ) {
     fun toParamMap(): Map<String, Any> {
         return buildMap {
@@ -26,6 +28,25 @@ internal data class ConfirmCheckoutSessionParams(
             }
             if (savePaymentMethod != null) {
                 put("save_payment_method", savePaymentMethod)
+            }
+            if (shipping != null) {
+                put("shipping", shipping.toParamMap())
+            }
+        }
+    }
+
+    internal data class Shipping(
+        private val name: String?,
+        private val address: Address?,
+    ) {
+        fun toParamMap(): Map<String, Any> {
+            return buildMap {
+                if (name != null) {
+                    put("name", name)
+                }
+                if (address != null) {
+                    put("address", address.toParamMap())
+                }
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentCreationFlow
@@ -21,6 +22,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
@@ -340,6 +342,20 @@ class CheckoutSessionConfirmationInterceptorTest {
         interceptSavedPm()
     }
 
+    @Test
+    fun `intercept with saved payment method passes shipping information`() = runScenario {
+        networkRule.checkoutConfirm(
+            bodyPart("shipping[name]", "Jenny Rosen"),
+            bodyPart("shipping[address][line1]", "510 Townsend St"),
+            bodyPart("shipping[address][postal_code]", "94103"),
+            not(hasBodyPart("shipping[phone]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptSavedPm(shippingInformation = SHIPPING_INFORMATION)
+    }
+
     private fun runScenario(
         createPaymentMethodResult: Result<PaymentMethod> = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
         customerMetadata: CustomerMetadata? = null,
@@ -405,10 +421,11 @@ class CheckoutSessionConfirmationInterceptorTest {
 
         suspend fun interceptSavedPm(
             intent: StripeIntent = PaymentIntentFactory.create(),
+            shippingInformation: ShippingInformation? = null,
         ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> =
             interceptor.intercept(
                 intent = intent,
-                confirmationOption = SAVED_PM_OPTION,
+                confirmationOption = SAVED_PM_OPTION.copy(shippingInformation = shippingInformation),
                 shippingValues = null,
             )
     }
@@ -443,6 +460,18 @@ class CheckoutSessionConfirmationInterceptorTest {
             shippingInformation = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
+        )
+
+        val SHIPPING_INFORMATION = ShippingInformation(
+            name = "Jenny Rosen",
+            phone = "1-800-555-1234",
+            address = Address(
+                line1 = "510 Townsend St",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+                country = "US",
+            ),
         )
 
         val SAVE_ENABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParamsTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentMethodSelectionFlow
@@ -52,9 +53,36 @@ class ConfirmCheckoutSessionParamsTest {
         assertThat(params).doesNotContainKey("save_payment_method")
     }
 
+    @Test
+    fun `toParamMap includes shipping information when set`() {
+        val params = createParams(shipping = SHIPPING).toParamMap()
+
+        assertThat(params["shipping"]).isEqualTo(
+            mapOf(
+                "name" to "Jane Doe",
+                "address" to mapOf(
+                    "line1" to "354 Oyster Point Blvd",
+                    "line2" to "Suite 200",
+                    "city" to "South San Francisco",
+                    "state" to "CA",
+                    "postal_code" to "94080",
+                    "country" to "US",
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `toParamMap omits shipping information when null`() {
+        val params = createParams(shipping = null).toParamMap()
+
+        assertThat(params).doesNotContainKey("shipping")
+    }
+
     private fun createParams(
         expectedAmount: Long? = null,
         savePaymentMethod: Boolean? = null,
+        shipping: ConfirmCheckoutSessionParams.Shipping? = null,
     ): ConfirmCheckoutSessionParams {
         return ConfirmCheckoutSessionParams(
             paymentMethodId = "pm_test_123",
@@ -62,6 +90,7 @@ class ConfirmCheckoutSessionParamsTest {
             returnUrl = "stripesdk://return_url",
             expectedAmount = expectedAmount,
             savePaymentMethod = savePaymentMethod,
+            shipping = shipping,
         )
     }
 
@@ -71,6 +100,18 @@ class ConfirmCheckoutSessionParamsTest {
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
             checkoutSessionId = null,
+        )
+
+        val SHIPPING = ConfirmCheckoutSessionParams.Shipping(
+            name = "Jane Doe",
+            address = Address(
+                line1 = "354 Oyster Point Blvd",
+                line2 = "Suite 200",
+                city = "South San Francisco",
+                state = "CA",
+                postalCode = "94080",
+                country = "US",
+            ),
         )
     }
 }


### PR DESCRIPTION
committed by codex (not sure why it didn't note this in the PR description so adding it myself)

# Summary

Include shipping information in Checkout Session confirmation

# Motivation

Support shipping address collection in ECE
https://jira.corp.stripe.com/browse/MOBILESDK-4721

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified