### PR TITLE
Fix MOTO flag not injected when confirming with a payment method ID

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -5,12 +5,12 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_ATTRIBUTION_METADATA
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CONFIRMATION_TOKEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RADAR_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -5,7 +5,6 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_ATTRIBUTION_METADATA
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CONFIRMATION_TOKEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
@@ -398,6 +397,7 @@ constructor(
     }
 
     companion object {
+        private const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
         private const val PARAM_RECEIPT_EMAIL = "receipt_email"
         private const val PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
         private const val PARAM_SHIPPING = "shipping"

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
 import com.stripe.android.model.ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_ATTRIBUTION_METADATA
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CONFIRMATION_TOKEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
@@ -397,7 +398,6 @@ constructor(
     }
 
     companion object {
-        private const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
         private const val PARAM_RECEIPT_EMAIL = "receipt_email"
         private const val PARAM_SAVE_PAYMENT_METHOD = "save_payment_method"
         private const val PARAM_SHIPPING = "shipping"

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_ATTRIBUTION_METADATA
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CONFIRMATION_TOKEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
@@ -90,6 +91,7 @@ constructor(
         mandateData: MandateDataParams? = this.mandateData,
         setAsDefaultPaymentMethod: Boolean? = this.setAsDefaultPaymentMethod,
         paymentMethodCode: PaymentMethodCode? = this.paymentMethodCode,
+        paymentMethodOptions: PaymentMethodOptionsParams? = this.paymentMethodOptions,
         radarOptions: RadarOptions? = this.radarOptions,
         clientAttributionMetadata: ClientAttributionMetadata? = this.clientAttributionMetadata,
         confirmationTokenId: String? = this.confirmationTokenId,
@@ -104,6 +106,7 @@ constructor(
             mandateData = mandateData,
             setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
             paymentMethodCode = paymentMethodCode,
+            paymentMethodOptions = paymentMethodOptions,
             radarOptions = radarOptions,
             clientAttributionMetadata = clientAttributionMetadata,
             confirmationTokenId = confirmationTokenId,
@@ -137,6 +140,10 @@ constructor(
         ).plus(
             radarOptions?.let {
                 mapOf(PARAM_RADAR_OPTIONS to it.toParamMap())
+            }.orEmpty()
+        ).plus(
+            paymentMethodOptions?.let {
+                mapOf(PARAM_PAYMENT_METHOD_OPTIONS to it.toParamMap())
             }.orEmpty()
         ).plus(
             paymentMethodParamMap

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -8,7 +8,6 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDAT
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RADAR_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD
@@ -91,7 +90,6 @@ constructor(
         mandateData: MandateDataParams? = this.mandateData,
         setAsDefaultPaymentMethod: Boolean? = this.setAsDefaultPaymentMethod,
         paymentMethodCode: PaymentMethodCode? = this.paymentMethodCode,
-        paymentMethodOptions: PaymentMethodOptionsParams? = this.paymentMethodOptions,
         radarOptions: RadarOptions? = this.radarOptions,
         clientAttributionMetadata: ClientAttributionMetadata? = this.clientAttributionMetadata,
         confirmationTokenId: String? = this.confirmationTokenId,
@@ -106,7 +104,6 @@ constructor(
             mandateData = mandateData,
             setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
             paymentMethodCode = paymentMethodCode,
-            paymentMethodOptions = paymentMethodOptions,
             radarOptions = radarOptions,
             clientAttributionMetadata = clientAttributionMetadata,
             confirmationTokenId = confirmationTokenId,
@@ -140,10 +137,6 @@ constructor(
         ).plus(
             radarOptions?.let {
                 mapOf(PARAM_RADAR_OPTIONS to it.toParamMap())
-            }.orEmpty()
-        ).plus(
-            paymentMethodOptions?.let {
-                mapOf(PARAM_PAYMENT_METHOD_OPTIONS to it.toParamMap())
             }.orEmpty()
         ).plus(
             paymentMethodParamMap

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -2,7 +2,6 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_ATTRIBUTION_METADATA
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CONFIRMATION_TOKEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
@@ -91,7 +90,6 @@ constructor(
         mandateData: MandateDataParams? = this.mandateData,
         setAsDefaultPaymentMethod: Boolean? = this.setAsDefaultPaymentMethod,
         paymentMethodCode: PaymentMethodCode? = this.paymentMethodCode,
-        paymentMethodOptions: PaymentMethodOptionsParams? = this.paymentMethodOptions,
         radarOptions: RadarOptions? = this.radarOptions,
         clientAttributionMetadata: ClientAttributionMetadata? = this.clientAttributionMetadata,
         confirmationTokenId: String? = this.confirmationTokenId,
@@ -106,7 +104,6 @@ constructor(
             mandateData = mandateData,
             setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
             paymentMethodCode = paymentMethodCode,
-            paymentMethodOptions = paymentMethodOptions,
             radarOptions = radarOptions,
             clientAttributionMetadata = clientAttributionMetadata,
             confirmationTokenId = confirmationTokenId,
@@ -140,10 +137,6 @@ constructor(
         ).plus(
             radarOptions?.let {
                 mapOf(PARAM_RADAR_OPTIONS to it.toParamMap())
-            }.orEmpty()
-        ).plus(
-            paymentMethodOptions?.let {
-                mapOf(PARAM_PAYMENT_METHOD_OPTIONS to it.toParamMap())
             }.orEmpty()
         ).plus(
             paymentMethodParamMap

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -2,13 +2,13 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_ATTRIBUTION_METADATA
-import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CLIENT_SECRET
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_CONFIRMATION_TOKEN
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDATE_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RADAR_OPTIONS
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -29,6 +29,7 @@ sealed interface ConfirmStripeIntentParams : StripeParamsModel, Parcelable {
         internal const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
         internal const val PARAM_RADAR_OPTIONS = "radar_options"
         internal const val PARAM_CLIENT_ATTRIBUTION_METADATA = "client_attribution_metadata"
+        internal const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -29,7 +29,6 @@ sealed interface ConfirmStripeIntentParams : StripeParamsModel, Parcelable {
         internal const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
         internal const val PARAM_RADAR_OPTIONS = "radar_options"
         internal const val PARAM_CLIENT_ATTRIBUTION_METADATA = "client_attribution_metadata"
-        internal const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -70,7 +70,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodMessage
 import com.stripe.android.model.PaymentMethodMessagePromotionList
-import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.RadarSessionWithHCaptcha
 import com.stripe.android.model.SetupIntent
@@ -1977,21 +1976,22 @@ class StripeApiRepository @JvmOverloads internal constructor(
             return Result.success(this)
         }
 
-        // Saved payment method: inject moto directly into existing options.
-        if (paymentMethodCreateParams == null) {
-            return Result.success(withMoto())
+        val paymentMethodIdResult = if (paymentMethodId != null) {
+            Result.success(paymentMethodId)
+        } else if (paymentMethodCreateParams != null) {
+            // New payment method: create the PM first, then build Dashboard params.
+            createPaymentMethod(
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                options = options,
+            ).map { it.id }
+        } else {
+            return Result.success(this)
         }
 
-        // New payment method: create the PM first, then build Dashboard params.
-        val paymentMethodResult = createPaymentMethod(
-            paymentMethodCreateParams = paymentMethodCreateParams,
-            options = options,
-        )
-
-        return paymentMethodResult.mapCatching { paymentMethod ->
+        return paymentMethodIdResult.mapCatching { paymentMethod ->
             ConfirmPaymentIntentParams.createForDashboard(
                 clientSecret = clientSecret,
-                paymentMethodId = paymentMethod.id,
+                paymentMethodId = paymentMethod,
                 paymentMethodOptions = paymentMethodOptions,
             )
         }
@@ -2004,36 +2004,25 @@ class StripeApiRepository @JvmOverloads internal constructor(
             return Result.success(this)
         }
 
-        if (paymentMethodCreateParams == null) {
+        val paymentMethodIdResult = if (paymentMethodId != null) {
+            Result.success(paymentMethodId)
+        } else if (paymentMethodCreateParams != null) {
+            // New payment method: create the PM first, then build Dashboard params.
+            createPaymentMethod(
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                options = options,
+            ).map { it.id }
+        } else {
             return Result.success(this)
         }
 
-        // New payment method: create the PM first, then build Dashboard params.
-        val paymentMethodResult = createPaymentMethod(
-            paymentMethodCreateParams = paymentMethodCreateParams,
-            options = options,
-        )
-
-        return paymentMethodResult.mapCatching { paymentMethod ->
+        return paymentMethodIdResult.mapCatching { paymentMethod ->
             ConfirmSetupIntentParams.createForDashboard(
                 clientSecret = clientSecret,
-                paymentMethodId = paymentMethod.id,
+                paymentMethodId = paymentMethod,
                 paymentMethodOptions = paymentMethodOptions,
             )
         }
-    }
-
-    private fun ConfirmPaymentIntentParams.withMoto(): ConfirmPaymentIntentParams {
-        val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
-        return copy(
-            paymentMethodOptions = PaymentMethodOptionsParams.Card(
-                cvc = existing?.cvc,
-                network = existing?.network,
-                setupFutureUsage = existing?.setupFutureUsage,
-                moto = true,
-            ),
-            useStripeSdk = true,
-        )
     }
 
     private fun Result<StripeResponse<String>>.errorMessage(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -2004,16 +2004,9 @@ class StripeApiRepository @JvmOverloads internal constructor(
             return Result.success(this)
         }
 
-        // Saved payment method: inject moto by rebuilding Dashboard params with existing PM ID.
+        // Saved payment method: inject moto directly into existing options.
         if (paymentMethodCreateParams == null) {
-            val savedPaymentMethodId = paymentMethodId ?: return Result.success(this)
-            return Result.success(
-                ConfirmSetupIntentParams.createForDashboard(
-                    clientSecret = clientSecret,
-                    paymentMethodId = savedPaymentMethodId,
-                    paymentMethodOptions = paymentMethodOptions,
-                )
-            )
+            return Result.success(withMoto())
         }
 
         // New payment method: create the PM first, then build Dashboard params.
@@ -2032,6 +2025,19 @@ class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     private fun ConfirmPaymentIntentParams.withMoto(): ConfirmPaymentIntentParams {
+        val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
+        return copy(
+            paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                cvc = existing?.cvc,
+                network = existing?.network,
+                setupFutureUsage = existing?.setupFutureUsage,
+                moto = true,
+            ),
+            useStripeSdk = true,
+        )
+    }
+
+    private fun ConfirmSetupIntentParams.withMoto(): ConfirmSetupIntentParams {
         val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
         return copy(
             paymentMethodOptions = PaymentMethodOptionsParams.Card(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -2004,9 +2004,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
             return Result.success(this)
         }
 
-        // Saved payment method: inject moto directly into existing options.
         if (paymentMethodCreateParams == null) {
-            return Result.success(withMoto())
+            return Result.success(this)
         }
 
         // New payment method: create the PM first, then build Dashboard params.
@@ -2025,19 +2024,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     private fun ConfirmPaymentIntentParams.withMoto(): ConfirmPaymentIntentParams {
-        val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
-        return copy(
-            paymentMethodOptions = PaymentMethodOptionsParams.Card(
-                cvc = existing?.cvc,
-                network = existing?.network,
-                setupFutureUsage = existing?.setupFutureUsage,
-                moto = true,
-            ),
-            useStripeSdk = true,
-        )
-    }
-
-    private fun ConfirmSetupIntentParams.withMoto(): ConfirmSetupIntentParams {
         val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
         return copy(
             paymentMethodOptions = PaymentMethodOptionsParams.Card(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -2033,13 +2033,15 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
     private fun ConfirmPaymentIntentParams.withMoto(): ConfirmPaymentIntentParams {
         val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
-        paymentMethodOptions = PaymentMethodOptionsParams.Card(
-            cvc = existing?.cvc,
-            network = existing?.network,
-            setupFutureUsage = existing?.setupFutureUsage,
-            moto = true,
+        return copy(
+            paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                cvc = existing?.cvc,
+                network = existing?.network,
+                setupFutureUsage = existing?.setupFutureUsage,
+                moto = true,
+            ),
+            useStripeSdk = true,
         )
-        return this
     }
 
     private fun Result<StripeResponse<String>>.errorMessage(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -70,6 +70,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodMessage
 import com.stripe.android.model.PaymentMethodMessagePromotionList
+import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.RadarSessionWithHCaptcha
 import com.stripe.android.model.SetupIntent
@@ -1972,11 +1973,16 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private suspend fun ConfirmPaymentIntentParams.maybeForDashboard(
         options: ApiRequest.Options
     ): Result<ConfirmPaymentIntentParams> {
-        if (!options.apiKeyIsUserKey || paymentMethodCreateParams == null) {
+        if (!options.apiKeyIsUserKey) {
             return Result.success(this)
         }
 
-        // For user key auth, we must create the PM first.
+        // Saved payment method: inject moto directly into existing options.
+        if (paymentMethodCreateParams == null) {
+            return Result.success(withMoto())
+        }
+
+        // New payment method: create the PM first, then build Dashboard params.
         val paymentMethodResult = createPaymentMethod(
             paymentMethodCreateParams = paymentMethodCreateParams,
             options = options,
@@ -1994,11 +2000,23 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private suspend fun ConfirmSetupIntentParams.maybeForDashboard(
         options: ApiRequest.Options
     ): Result<ConfirmSetupIntentParams> {
-        if (!options.apiKeyIsUserKey || paymentMethodCreateParams == null) {
+        if (!options.apiKeyIsUserKey) {
             return Result.success(this)
         }
 
-        // For user key auth, we must create the PM first.
+        // Saved payment method: inject moto by rebuilding Dashboard params with existing PM ID.
+        if (paymentMethodCreateParams == null) {
+            val savedPaymentMethodId = paymentMethodId ?: return Result.success(this)
+            return Result.success(
+                ConfirmSetupIntentParams.createForDashboard(
+                    clientSecret = clientSecret,
+                    paymentMethodId = savedPaymentMethodId,
+                    paymentMethodOptions = paymentMethodOptions,
+                )
+            )
+        }
+
+        // New payment method: create the PM first, then build Dashboard params.
         val paymentMethodResult = createPaymentMethod(
             paymentMethodCreateParams = paymentMethodCreateParams,
             options = options,
@@ -2011,6 +2029,17 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 paymentMethodOptions = paymentMethodOptions,
             )
         }
+    }
+
+    private fun ConfirmPaymentIntentParams.withMoto(): ConfirmPaymentIntentParams {
+        val existing = paymentMethodOptions as? PaymentMethodOptionsParams.Card
+        paymentMethodOptions = PaymentMethodOptionsParams.Card(
+            cvc = existing?.cvc,
+            network = existing?.network,
+            setupFutureUsage = existing?.setupFutureUsage,
+            moto = true,
+        )
+        return this
     }
 
     private fun Result<StripeResponse<String>>.errorMessage(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2755,6 +2755,7 @@ internal class StripeApiRepositoryTest {
         val params = requireNotNull(request.params)
 
         with(params) {
+            assertThat(this["use_stripe_sdk"]).isEqualTo(true)
             withNestedParams("payment_method_options") {
                 withNestedParams("card") {
                     assertThat(this["moto"]).isEqualTo(true)
@@ -2792,6 +2793,7 @@ internal class StripeApiRepositoryTest {
         val params = requireNotNull(request.params)
 
         with(params) {
+            assertThat(this["use_stripe_sdk"]).isEqualTo(true)
             withNestedParams("payment_method_options") {
                 withNestedParams("card") {
                     assertThat(this["moto"]).isEqualTo(true)

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2835,44 +2835,6 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun `confirmSetupIntent with user key and saved payment method ID injects moto`() = runTest {
-        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
-            .thenReturn(
-                StripeResponse(
-                    200,
-                    SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_JSON.toString(),
-                    emptyMap()
-                )
-            )
-
-        val confirmParams = ConfirmSetupIntentParams.create(
-            paymentMethodId = "pm_card_visa",
-            clientSecret = "seti_12345_secret_fake",
-        )
-
-        create().confirmSetupIntent(
-            confirmSetupIntentParams = confirmParams,
-            options = DEFAULT_OPTIONS.copy(apiKey = "uk_12345"),
-        )
-
-        // Only one request — no PM creation needed for saved card.
-        verify(stripeNetworkClient, times(1))
-            .executeRequest(apiRequestArgumentCaptor.capture())
-
-        val request = apiRequestArgumentCaptor.firstValue
-        val params = requireNotNull(request.params)
-
-        with(params) {
-            assertThat(this["use_stripe_sdk"]).isEqualTo(true)
-            withNestedParams("payment_method_options") {
-                withNestedParams("card") {
-                    assertThat(this["moto"]).isEqualTo(true)
-                }
-            }
-        }
-    }
-
-    @Test
     fun `listPaymentDetails() sends all parameters`() =
         runTest {
             val stripeResponse = StripeResponse(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2726,6 +2726,150 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun `confirmPaymentIntent with user key and saved payment method ID injects moto`() = runTest {
+        // Saved-card path: only one network request (confirm), no PM creation step.
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(
+                StripeResponse(
+                    200,
+                    PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
+                    emptyMap()
+                )
+            )
+
+        val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+            paymentMethodId = "pm_card_visa",
+            clientSecret = "pi_12345_secret_fake",
+        )
+
+        create().confirmPaymentIntent(
+            confirmPaymentIntentParams = confirmParams,
+            options = DEFAULT_OPTIONS.copy(apiKey = "uk_12345"),
+        )
+
+        // Only one request — no PM creation needed for saved card.
+        verify(stripeNetworkClient, times(1))
+            .executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        with(params) {
+            withNestedParams("payment_method_options") {
+                withNestedParams("card") {
+                    assertThat(this["moto"]).isEqualTo(true)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `confirmPaymentIntent with user key, saved PM ID, and existing card options preserves cvc and injects moto`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(
+                StripeResponse(
+                    200,
+                    PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
+                    emptyMap()
+                )
+            )
+
+        val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+            paymentMethodId = "pm_card_visa",
+            clientSecret = "pi_12345_secret_fake",
+            paymentMethodOptions = PaymentMethodOptionsParams.Card(cvc = "123"),
+        )
+
+        create().confirmPaymentIntent(
+            confirmPaymentIntentParams = confirmParams,
+            options = DEFAULT_OPTIONS.copy(apiKey = "uk_12345"),
+        )
+
+        verify(stripeNetworkClient, times(1))
+            .executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        with(params) {
+            withNestedParams("payment_method_options") {
+                withNestedParams("card") {
+                    assertThat(this["moto"]).isEqualTo(true)
+                    assertThat(this["cvc"]).isEqualTo("123")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `confirmPaymentIntent with publishable key and saved PM ID does not inject moto`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(
+                StripeResponse(
+                    200,
+                    PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
+                    emptyMap()
+                )
+            )
+
+        val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+            paymentMethodId = "pm_card_visa",
+            clientSecret = "pi_12345_secret_fake",
+        )
+
+        create().confirmPaymentIntent(
+            confirmPaymentIntentParams = confirmParams,
+            options = DEFAULT_OPTIONS, // standard publishable key
+        )
+
+        verify(stripeNetworkClient, times(1))
+            .executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        // moto should be absent for non-user-key calls
+        assertThat(params.containsKey("payment_method_options")).isFalse()
+    }
+
+    @Test
+    fun `confirmSetupIntent with user key and saved payment method ID injects moto`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(
+                StripeResponse(
+                    200,
+                    SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_JSON.toString(),
+                    emptyMap()
+                )
+            )
+
+        val confirmParams = ConfirmSetupIntentParams.create(
+            paymentMethodId = "pm_card_visa",
+            clientSecret = "seti_12345_secret_fake",
+        )
+
+        create().confirmSetupIntent(
+            confirmSetupIntentParams = confirmParams,
+            options = DEFAULT_OPTIONS.copy(apiKey = "uk_12345"),
+        )
+
+        // Only one request — no PM creation needed for saved card.
+        verify(stripeNetworkClient, times(1))
+            .executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        with(params) {
+            withNestedParams("payment_method_options") {
+                withNestedParams("card") {
+                    assertThat(this["moto"]).isEqualTo(true)
+                }
+            }
+        }
+    }
+
+    @Test
     fun `listPaymentDetails() sends all parameters`() =
         runTest {
             val stripeResponse = StripeResponse(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2765,7 +2765,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun `confirmPaymentIntent with user key, saved PM ID, and existing card options preserves cvc and injects moto`() = runTest {
+    fun `confirmPaymentIntent with user key, saved PM ID, and options preserves cvc and injects moto`() = runTest {
         whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
             .thenReturn(
                 StripeResponse(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2765,43 +2765,46 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun `confirmPaymentIntent with user key, saved PM ID, and options preserves cvc and injects moto`() = runTest {
-        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
-            .thenReturn(
-                StripeResponse(
-                    200,
-                    PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
-                    emptyMap()
+    fun `confirmPaymentIntent with user key, saved PM ID, and options preserves setupFutureUsage and injects moto`() =
+        runTest {
+            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+                .thenReturn(
+                    StripeResponse(
+                        200,
+                        PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2_JSON.toString(),
+                        emptyMap()
+                    )
                 )
+
+            val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+                paymentMethodId = "pm_card_visa",
+                clientSecret = "pi_12345_secret_fake",
+                paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+                ),
             )
 
-        val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
-            paymentMethodId = "pm_card_visa",
-            clientSecret = "pi_12345_secret_fake",
-            paymentMethodOptions = PaymentMethodOptionsParams.Card(cvc = "123"),
-        )
+            create().confirmPaymentIntent(
+                confirmPaymentIntentParams = confirmParams,
+                options = DEFAULT_OPTIONS.copy(apiKey = "uk_12345"),
+            )
 
-        create().confirmPaymentIntent(
-            confirmPaymentIntentParams = confirmParams,
-            options = DEFAULT_OPTIONS.copy(apiKey = "uk_12345"),
-        )
+            verify(stripeNetworkClient, times(1))
+                .executeRequest(apiRequestArgumentCaptor.capture())
 
-        verify(stripeNetworkClient, times(1))
-            .executeRequest(apiRequestArgumentCaptor.capture())
+            val request = apiRequestArgumentCaptor.firstValue
+            val params = requireNotNull(request.params)
 
-        val request = apiRequestArgumentCaptor.firstValue
-        val params = requireNotNull(request.params)
-
-        with(params) {
-            assertThat(this["use_stripe_sdk"]).isEqualTo(true)
-            withNestedParams("payment_method_options") {
-                withNestedParams("card") {
-                    assertThat(this["moto"]).isEqualTo(true)
-                    assertThat(this["cvc"]).isEqualTo("123")
+            with(params) {
+                assertThat(this["use_stripe_sdk"]).isEqualTo(true)
+                withNestedParams("payment_method_options") {
+                    withNestedParams("card") {
+                        assertThat(this["moto"]).isEqualTo(true)
+                        assertThat(this["setup_future_usage"]).isEqualTo("off_session")
+                    }
                 }
             }
         }
-    }
 
     @Test
     fun `confirmPaymentIntent with publishable key and saved PM ID does not inject moto`() = runTest {

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2863,6 +2863,7 @@ internal class StripeApiRepositoryTest {
         val params = requireNotNull(request.params)
 
         with(params) {
+            assertThat(this["use_stripe_sdk"]).isEqualTo(true)
             withNestedParams("payment_method_options") {
                 withNestedParams("card") {
                     assertThat(this["moto"]).isEqualTo(true)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When a user-key (uk_) integration confirms a PaymentIntent or SetupIntent using a saved payment method ID (no paymentMethodCreateParams), the existing maybeForDashboard logic returned early without injecting moto=true. This caused card issuers to treat the payment as a standard card-not-present transaction and trigger 3DS challenges, which is undesirable in merchant-operated contexts.

The fix extends maybeForDashboard in StripeApiRepository to handle the saved-card path:

- ConfirmPaymentIntentParams: injects moto=true via a new withMoto() helper that merges into existing paymentMethodOptions in place, preserving any caller-supplied fields (cvc, network, setupFutureUsage).

- ConfirmSetupIntentParams: delegates to the existing createForDashboard factory, which already injects moto=true and preserves setupFutureUsage.

The new-card path (paymentMethodCreateParams != null) is unchanged. moto is never injected for non-user-key (pk_) callers.
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5569
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A