### PR TITLE
Remove APDU data from `ApduResponseError`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
@@ -93,7 +93,7 @@ internal abstract class ApduCommand<TResponseData> {
                 } ?: Result.failure(ApduResponseError.Invalid(rawData))
             },
             onFailure = { cause ->
-                Result.failure(ApduResponseError.Parsing(rawData, cause))
+                Result.failure(ApduResponseError.Parsing(cause))
             }
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
@@ -81,10 +81,9 @@ internal sealed class ApduResponseError(
     }
 
     class Parsing(
-        val data: ByteArray,
         override val cause: Throwable?,
     ) : ApduResponseError(
-        message = "Failed to parse response data: ${data.toHexString()}"
+        message = "Failed to parse response data!"
     ) {
         override val errorCode: String = "apduParsingIssue"
         override val userMessage: ResolvableString = R.string.stripe_nfc_scan_internal_error_message.resolvableString

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
@@ -119,7 +119,6 @@ internal class ApduCommandTest {
             assertThat(error).isInstanceOf<ApduResponseError.Parsing>()
 
             val parsingError = error as ApduResponseError.Parsing
-            assertThat(parsingError.data.contentEquals(malformedResponseData)).isTrue()
             assertThat(parsingError.cause).isInstanceOf<IndexOutOfBoundsException>()
 
             assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()


### PR DESCRIPTION
# Summary
Remove APDU data from `ApduResponseError`

# Motivation
Prevent potentially logging sensitive byte data if error is caught unexpectedly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified