### PR TITLE
Fix custom payment method cancel test flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -835,6 +835,7 @@ internal class PlaygroundTestDriver(
         )
 
         isSelectPaymentMethodScreen()
+        selectors.buyButton.waitProcessingComplete()
         selectors.buyButton.isEnabled()
 
         teardown()


### PR DESCRIPTION
# Summary

Wait for the PaymentSheet primary button to finish processing after canceling a custom payment method before asserting that it is enabled.

# Motivation

`TestCustomPaymentMethod.testCustomPaymentMethod_Cancel` can query Compose semantics while the custom payment method activity is finishing and the PaymentSheet hierarchy is temporarily detached. This race fails with `IllegalStateException: No compose hierarchies found in the app`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- Ran `TestCustomPaymentMethod#testCustomPaymentMethod_Cancel` for 2 diagnostic Shampoo iterations on `pixel2api33chrome`; all passed.
- Ran the same test for 50 diagnostic Shampoo iterations; iterations 0 through 49 passed with no failed iteration.
- Restored the normal `RetryRule` configuration and ran the focused test once more; it passed.

# Screenshots

Not applicable — this changes test synchronization only and does not affect UI.

# Changelog

Not applicable — this changes instrumentation test code only and does not affect the SDK's user-facing behavior.
