### PR TITLE
Add LPM billing address source policy

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSourceResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSourceResolver.kt
@@ -1,0 +1,83 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal object BillingAddressSourceResolver {
+    sealed interface Source {
+        data object Absent : Source
+
+        data class CountryOnly(
+            val allowedCountryCodes: Set<String>,
+        ) : Source
+
+        data class NormalAddress(
+            val hidesCountry: Boolean,
+        ) : Source
+    }
+
+    sealed interface Result {
+        data object PreserveExisting : Result
+
+        data object UseExistingNormalAddress : Result
+
+        data class CountryOnly(
+            val allowedCountryCodes: Set<String>,
+        ) : Result
+
+        data class TaxMinimum(
+            val allowedCountryCodes: Set<String>,
+        ) : Result
+
+        data class Full(
+            val allowedCountryCodes: Set<String>,
+        ) : Result
+    }
+
+    /**
+     * Selects one billing-country input before either adapter creates form elements.
+     *
+     * [source] describes the LPM's configured address input. [addressCollectionMode] and
+     * [requiresBillingAddressForAutomaticTax] add merchant and billing-sourced tax requirements.
+     * Country-only sources keep their allowlist when they are promoted. Normal addresses are
+     * preserved, but Full or tax-minimum collection exposes a hidden country and removes a separate
+     * country input. Missing sources remain missing unless Full or tax-minimum collection requires one.
+     */
+    fun resolve(
+        source: Source,
+        addressCollectionMode: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode,
+        requiresBillingAddressForAutomaticTax: Boolean,
+        allowedBillingCountries: Set<String>,
+    ): Result {
+        val requiresTaxMinimum =
+            addressCollectionMode ==
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic &&
+                requiresBillingAddressForAutomaticTax
+
+        return when (source) {
+            Source.Absent -> when {
+                addressCollectionMode ==
+                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                    Result.Full(allowedBillingCountries)
+                }
+                requiresTaxMinimum -> Result.TaxMinimum(allowedBillingCountries)
+                else -> Result.PreserveExisting
+            }
+            is Source.CountryOnly -> when {
+                addressCollectionMode ==
+                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                    Result.Full(source.allowedCountryCodes)
+                }
+                requiresTaxMinimum -> Result.TaxMinimum(source.allowedCountryCodes)
+                else -> Result.CountryOnly(source.allowedCountryCodes)
+            }
+            is Source.NormalAddress -> when {
+                source.hidesCountry && (
+                    addressCollectionMode ==
+                        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full ||
+                        requiresTaxMinimum
+                    ) -> Result.UseExistingNormalAddress
+                else -> Result.PreserveExisting
+            }
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSourceResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSourceResolverTest.kt
@@ -1,0 +1,132 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Test
+
+class BillingAddressSourceResolverTest {
+    @Test
+    fun `absent source is preserved in Never`() {
+        assertThat(resolve(ABSENT, NEVER, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `absent source is preserved in tax-disabled Automatic`() {
+        assertThat(resolve(ABSENT, AUTOMATIC, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `absent source emits tax minimum in billing-tax Automatic`() {
+        assertThat(resolve(ABSENT, AUTOMATIC, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.TaxMinimum(MERCHANT_COUNTRIES))
+    }
+
+    @Test
+    fun `absent source emits full address in Full`() {
+        assertThat(resolve(ABSENT, FULL, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.Full(MERCHANT_COUNTRIES))
+    }
+
+    @Test
+    fun `country-only source remains country-only in Never`() {
+        assertThat(resolve(COUNTRY_ONLY, NEVER, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.CountryOnly(LPM_COUNTRIES))
+    }
+
+    @Test
+    fun `country-only source remains country-only in tax-disabled Automatic`() {
+        assertThat(resolve(COUNTRY_ONLY, AUTOMATIC, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.CountryOnly(LPM_COUNTRIES))
+    }
+
+    @Test
+    fun `country-only source emits tax minimum in billing-tax Automatic`() {
+        assertThat(resolve(COUNTRY_ONLY, AUTOMATIC, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.TaxMinimum(LPM_COUNTRIES))
+    }
+
+    @Test
+    fun `country-only source emits full address in Full`() {
+        assertThat(resolve(COUNTRY_ONLY, FULL, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.Full(LPM_COUNTRIES))
+    }
+
+    @Test
+    fun `visible normal address is preserved in Never`() {
+        assertThat(resolve(NORMAL_ADDRESS, NEVER, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `visible normal address is preserved in tax-disabled Automatic`() {
+        assertThat(resolve(NORMAL_ADDRESS, AUTOMATIC, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `visible normal address is preserved in billing-tax Automatic`() {
+        assertThat(resolve(NORMAL_ADDRESS, AUTOMATIC, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `visible normal address is preserved in Full`() {
+        assertThat(resolve(NORMAL_ADDRESS, FULL, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `hidden-country normal address is preserved in Never`() {
+        assertThat(resolve(HIDDEN_COUNTRY_ADDRESS, NEVER, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `hidden-country normal address is preserved in tax-disabled Automatic`() {
+        assertThat(resolve(HIDDEN_COUNTRY_ADDRESS, AUTOMATIC, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.PreserveExisting)
+    }
+
+    @Test
+    fun `hidden-country normal address provides country in billing-tax Automatic`() {
+        assertThat(resolve(HIDDEN_COUNTRY_ADDRESS, AUTOMATIC, requiresTaxAddress = true))
+            .isEqualTo(BillingAddressSourceResolver.Result.UseExistingNormalAddress)
+    }
+
+    @Test
+    fun `hidden-country normal address provides country in Full`() {
+        assertThat(resolve(HIDDEN_COUNTRY_ADDRESS, FULL, requiresTaxAddress = false))
+            .isEqualTo(BillingAddressSourceResolver.Result.UseExistingNormalAddress)
+    }
+
+    private fun resolve(
+        source: BillingAddressSourceResolver.Source,
+        mode: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode,
+        requiresTaxAddress: Boolean,
+    ): BillingAddressSourceResolver.Result {
+        return BillingAddressSourceResolver.resolve(
+            source = source,
+            addressCollectionMode = mode,
+            requiresBillingAddressForAutomaticTax = requiresTaxAddress,
+            allowedBillingCountries = MERCHANT_COUNTRIES,
+        )
+    }
+
+    private companion object {
+        val MERCHANT_COUNTRIES = setOf("US", "CA")
+        val LPM_COUNTRIES = setOf("DE", "FR")
+        val ABSENT = BillingAddressSourceResolver.Source.Absent
+        val COUNTRY_ONLY = BillingAddressSourceResolver.Source.CountryOnly(LPM_COUNTRIES)
+        val NORMAL_ADDRESS = BillingAddressSourceResolver.Source.NormalAddress(
+            hidesCountry = false,
+        )
+        val HIDDEN_COUNTRY_ADDRESS = BillingAddressSourceResolver.Source.NormalAddress(
+            hidesCountry = true,
+        )
+        val NEVER = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+        val AUTOMATIC = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+        val FULL = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+    }
+}


### PR DESCRIPTION
# Summary

With every current configuration, this PR leaves rendered forms unchanged. It adds the pure policy that later PRs use to select one billing-country owner.

## What changed

Adds a source-by-mode decision table for absent, country-only, and normal address sources. The result expresses preserve, promote to tax minimum, promote to Full, or expose an existing hidden country.

## What stays the same

No factory consumes this policy yet. Card AVS, server-defined LPMs, direct LPMs, saved payment methods, Link, and U.S. Bank Account are unchanged.

# Motivation

Separating the decision from rendering makes the automatic-tax gate and one-country-owner rule reviewable before adapters are changed.

# Testing

- [x] Added decision-table tests for source shape, Never, Automatic with and without billing-sourced tax, and Full.
- [x] ./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.lpmfoundations.luxe.BillingAddressSourceResolverTest

# Screenshots

Not applicable. This PR has no rendered-form change.

# Changelog

Not applicable. Internal groundwork only.