### PR TITLE
Add LPM tax address form primitives

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 data class AuBecsDebitMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("au_becs_mandate")
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
     fun transform(merchantName: String): FormElement =
         AuBecsDebitMandateTextElement(
             this.apiPath,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingAddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingAddressSpec.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Runtime-only form item that is resolved after server specs have been parsed and never serialized.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class AutomaticTaxBillingAddressSpec(
+    val allowedCountryCodes: Set<String>,
+) : FormItemSpec() {
+    @IgnoredOnParcel
+    override val apiPath: IdentifierSpec = IdentifierSpec.BillingAddress
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
@@ -19,7 +19,7 @@ data class CashAppPayMandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("cashapp_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_cash_app_pay_mandate,
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
 
     @IgnoredOnParcel
     @Transient

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaMandateTextSpec.kt
@@ -19,7 +19,7 @@ data class KlarnaMandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("klarna_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_klarna_mandate,
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
 
     @IgnoredOnParcel
     @Transient

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateSpec.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface MandateSpec

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
@@ -19,7 +19,7 @@ data class MandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("mandate"),
     @StringRes
     val stringResId: Int
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
 
     fun transform(vararg args: String): FormElement {
         return MandateTextElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
@@ -22,7 +22,7 @@ data class SepaMandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("sepa_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_sepa_mandate
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
     @IgnoredOnParcel
     @Transient
     private val mandateTextSpec = MandateTextSpec(apiPath, stringResId)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFieldsTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFieldsTest.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.ui.core.elements
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.uicore.elements.IdentifierSpec
+import org.junit.Test
+
+class AutomaticTaxBillingFieldsTest {
+    @Test
+    fun `US requires line 1 city state and postal code`() {
+        assertThat(automaticTaxRequiredFields("US")).containsExactly(
+            IdentifierSpec.Line1,
+            IdentifierSpec.City,
+            IdentifierSpec.State,
+            IdentifierSpec.PostalCode,
+        )
+    }
+
+    @Test
+    fun `CA requires postal code`() {
+        assertThat(automaticTaxRequiredFields("CA")).containsExactly(IdentifierSpec.PostalCode)
+    }
+
+    @Test
+    fun `GB requires postal code`() {
+        assertThat(automaticTaxRequiredFields("GB")).containsExactly(IdentifierSpec.PostalCode)
+    }
+
+    @Test
+    fun `IN requires postal code`() {
+        assertThat(automaticTaxRequiredFields("IN")).containsExactly(IdentifierSpec.PostalCode)
+    }
+
+    @Test
+    fun `PR requires line 1 city and postal code`() {
+        assertThat(automaticTaxRequiredFields("PR")).containsExactly(
+            IdentifierSpec.Line1,
+            IdentifierSpec.City,
+            IdentifierSpec.PostalCode,
+        )
+    }
+
+    @Test
+    fun `country absent from policy requires only country`() {
+        assertThat(automaticTaxRequiredFields("DE")).isEmpty()
+    }
+}


### PR DESCRIPTION
# Summary

This PR has no customer-visible form change. It introduces the internal runtime form markers required by the following server-form adapter PR.

## What changed

Adds a non-serialized tax-minimum address spec and marks each mandate spec so an adapter can insert an address before mandate text without relying on concrete mandate classes.

## What stays the same

No transformer consumes the new tax-address spec in this PR. Server and direct LPM output, card AVS, and address serialization are unchanged.

# Motivation

The marker types keep server-schema parsing separate from the runtime reconciliation that follows.

# Testing

- [x] Added country-to-required-tax-fields coverage for US, CA, GB, IN, PR, and an unsupported country.
- [x] ./gradlew :payments-ui-core:testDebugUnitTest --tests com.stripe.android.ui.core.elements.AutomaticTaxBillingFieldsTest

# Screenshots

Not applicable. This PR has no rendered-form change.

# Changelog

Not applicable. Internal groundwork only.