### PR TITLE
Resolve billing addresses in server-defined LPM forms

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextSpec.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 data class AuBecsDebitMandateTextSpec(
     @SerialName("api_path")
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("au_becs_mandate")
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
     fun transform(merchantName: String): FormElement =
         AuBecsDebitMandateTextElement(
             this.apiPath,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingAddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingAddressSpec.kt
@@ -1,11 +1,18 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 
 /**
- * Runtime-only form item for automatic-tax billing address collection. It is never serialized.
+ * Runtime-only form item that is resolved after server specs have been parsed and never serialized.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
 data class AutomaticTaxBillingAddressSpec(
     val allowedCountryCodes: Set<String>,
-)
+) : FormItemSpec() {
+    @IgnoredOnParcel
+    override val apiPath: IdentifierSpec = IdentifierSpec.BillingAddress
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CashAppPayMandateTextSpec.kt
@@ -19,7 +19,7 @@ data class CashAppPayMandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("cashapp_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_cash_app_pay_mandate,
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
 
     @IgnoredOnParcel
     @Transient

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaMandateTextSpec.kt
@@ -19,7 +19,7 @@ data class KlarnaMandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("klarna_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_klarna_mandate,
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
 
     @IgnoredOnParcel
     @Transient

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateSpec.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface MandateSpec

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextSpec.kt
@@ -19,7 +19,7 @@ data class MandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("mandate"),
     @StringRes
     val stringResId: Int
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
 
     fun transform(vararg args: String): FormElement {
         return MandateTextElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SepaMandateTextSpec.kt
@@ -22,7 +22,7 @@ data class SepaMandateTextSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("sepa_mandate"),
     @StringRes
     val stringResId: Int = R.string.stripe_sepa_mandate
-) : FormItemSpec() {
+) : FormItemSpec(), MandateSpec {
     @IgnoredOnParcel
     @Transient
     private val mandateTextSpec = MandateTextSpec(apiPath, stringResId)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/AutomaticTaxBillingAddressFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/AutomaticTaxBillingAddressFactory.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.lpmfoundations.luxe
 
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
-import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
 import com.stripe.android.ui.core.elements.BillingAddressCollectionMode
 import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.additionalAutomaticTaxFieldsByCountry
@@ -15,7 +14,7 @@ internal class AutomaticTaxBillingAddressFactory(
     private val arguments: UiDefinitionFactory.Arguments,
 ) {
     fun create(
-        spec: AutomaticTaxBillingAddressSpec,
+        allowedCountryCodes: Set<String>,
     ): List<FormElement> {
         val sameAsShippingElement = arguments.shippingValues
             ?.get(IdentifierSpec.SameAsShipping)
@@ -29,7 +28,7 @@ internal class AutomaticTaxBillingAddressFactory(
         val billingAddressElement = BillingAddressElement(
             identifier = IdentifierSpec.BillingAddress,
             rawValuesMap = arguments.initialValues,
-            countryCodes = spec.allowedCountryCodes,
+            countryCodes = allowedCountryCodes,
             autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = arguments.shippingValues,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSpecResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSpecResolver.kt
@@ -1,0 +1,88 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
+import com.stripe.android.ui.core.elements.CountrySpec
+import com.stripe.android.ui.core.elements.FormItemSpec
+import com.stripe.android.ui.core.elements.MandateSpec
+
+internal object BillingAddressSpecResolver {
+    /**
+     * Reconciles authored country and address specs before element creation.
+     *
+     * Authored full addresses are preserved. Country specs are replaced in place, and a missing address is
+     * inserted before the first mandate. The result contains at most one billing-country owner.
+     */
+    fun resolve(
+        specs: List<FormItemSpec>,
+        addressCollectionMode: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode,
+        requiresBillingAddressForAutomaticTax: Boolean,
+        allowedBillingCountries: Set<String>,
+    ): List<FormItemSpec> {
+        val addressSpec = specs.filterIsInstance<AddressSpec>().firstOrNull()
+        val countrySpec = specs.filterIsInstance<CountrySpec>().firstOrNull()
+        val requiresTaxMinimum =
+            addressCollectionMode ==
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic &&
+                requiresBillingAddressForAutomaticTax
+
+        if (addressSpec != null) {
+            return if (
+                addressSpec.hideCountry &&
+                (
+                    addressCollectionMode ==
+                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full ||
+                        requiresTaxMinimum
+                    )
+            ) {
+                specs.mapNotNull { spec ->
+                    when (spec) {
+                        is CountrySpec -> null
+                        is AddressSpec -> spec.copy(hideCountry = false)
+                        else -> spec
+                    }
+                }
+            } else {
+                specs
+            }
+        }
+
+        val replacement = when {
+            addressCollectionMode ==
+                PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                AddressSpec(
+                    allowedCountryCodes = countrySpec?.allowedCountryCodes ?: allowedBillingCountries,
+                )
+            }
+            requiresTaxMinimum -> AutomaticTaxBillingAddressSpec(
+                allowedCountryCodes = countrySpec?.allowedCountryCodes ?: allowedBillingCountries,
+            )
+            else -> return specs
+        }
+
+        return specs.replaceCountryOrInsertAddress(replacement)
+    }
+
+    private fun List<FormItemSpec>.replaceCountryOrInsertAddress(
+        addressSpec: FormItemSpec,
+    ): List<FormItemSpec> {
+        val firstCountryIndex = indexOfFirst { it is CountrySpec }
+        if (firstCountryIndex >= 0) {
+            return mapIndexedNotNull { index, spec ->
+                when {
+                    index == firstCountryIndex -> addressSpec
+                    spec is CountrySpec -> null
+                    else -> spec
+                }
+            }
+        }
+
+        val firstMandateIndex = indexOfFirst { it is MandateSpec }
+            .takeIf { it >= 0 }
+            ?: size
+        return toMutableList().apply {
+            add(firstMandateIndex, addressSpec)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpmfoundations.luxe
 
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.ui.core.elements.AddressSpec
-import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
@@ -115,7 +114,7 @@ internal class FormElementsBuilder(
                 autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
             )
             is ResolvedBillingAddress.TaxMinimum -> AutomaticTaxBillingAddressFactory(arguments).create(
-                spec = AutomaticTaxBillingAddressSpec(allowedCountryCodes),
+                allowedCountryCodes = allowedCountryCodes,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -10,6 +10,7 @@ import com.stripe.android.ui.core.elements.AffirmTextSpec
 import com.stripe.android.ui.core.elements.AfterpayClearpayTextSpec
 import com.stripe.android.ui.core.elements.AuBankAccountNumberSpec
 import com.stripe.android.ui.core.elements.AuBecsDebitMandateTextSpec
+import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
 import com.stripe.android.ui.core.elements.BacsDebitBankAccountSpec
 import com.stripe.android.ui.core.elements.BacsDebitConfirmSpec
 import com.stripe.android.ui.core.elements.BsbSpec
@@ -50,43 +51,60 @@ internal class TransformSpecToElements(
         placeholderOverrideList: List<IdentifierSpec> = emptyList(),
         termsDisplay: PaymentSheet.TermsDisplay,
     ): List<FormElement> {
-        return specsForConfiguration(
+        val configuredSpecs = specsForConfiguration(
             configuration = arguments.billingDetailsCollectionConfiguration,
             placeholderOverrideList = placeholderOverrideList,
             requiresMandate = arguments.requiresMandate,
             specs = specs,
             termsDisplay = termsDisplay,
-        ).flatMap { spec ->
-            when (spec) {
-                is StaticTextSpec -> listOf(spec.transform())
-                is AfterpayClearpayTextSpec -> listOf(spec.transform(metadata?.stripeIntent?.currency))
-                is AffirmTextSpec -> listOf(spec.transform())
-                is EmptyFormSpec -> listOf(EmptyFormElement())
-                is MandateTextSpec -> listOf(spec.transform(arguments.merchantName))
-                is AuBecsDebitMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
-                is BacsDebitBankAccountSpec -> listOf(spec.transform(arguments.initialValues))
-                is BacsDebitConfirmSpec -> listOf(spec.transform(arguments.merchantName, arguments.initialValues))
-                is BsbSpec -> listOf(spec.transform(arguments.initialValues))
-                is OTPSpec -> listOf(spec.transform())
-                is NameSpec -> listOf(spec.transform(arguments.initialValues))
-                is EmailSpec -> listOf(spec.transform(arguments.initialValues))
-                is PhoneSpec -> listOf(spec.transform(arguments.initialValues))
-                is SimpleTextSpec -> listOf(spec.transform(arguments.initialValues))
-                is AuBankAccountNumberSpec -> listOf(spec.transform(arguments.initialValues))
-                is IbanSpec -> listOf(spec.transform(arguments.initialValues))
-                is KlarnaHeaderStaticTextSpec -> listOf(spec.transform())
-                is DropdownSpec -> listOf(spec.transform(arguments.initialValues))
-                is CountrySpec -> listOf(spec.transform(arguments.initialValues))
-                is AddressSpec -> spec.transform(
-                    arguments.initialValues,
-                    arguments.shippingValues,
-                    arguments.autocompleteAddressInteractorFactory,
-                )
-                is SepaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
-                is PlaceholderSpec -> listOf() // Placeholders should be processed before calling transform.
-                is CashAppPayMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
-                is KlarnaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
-            }
+        )
+        val resolvedSpecs = BillingAddressSpecResolver.resolve(
+            specs = configuredSpecs,
+            addressCollectionMode = arguments.billingDetailsCollectionConfiguration.address,
+            requiresBillingAddressForAutomaticTax = arguments.requiresBillingAddressForAutomaticTax,
+            allowedBillingCountries = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
+        )
+
+        return resolvedSpecs.flatMap { spec -> transform(spec, metadata) }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun transform(
+        spec: FormItemSpec,
+        metadata: PaymentMethodMetadata?,
+    ): List<FormElement> {
+        return when (spec) {
+            is AutomaticTaxBillingAddressSpec -> AutomaticTaxBillingAddressFactory(arguments).create(
+                allowedCountryCodes = spec.allowedCountryCodes,
+            )
+            is StaticTextSpec -> listOf(spec.transform())
+            is AfterpayClearpayTextSpec -> listOf(spec.transform(metadata?.stripeIntent?.currency))
+            is AffirmTextSpec -> listOf(spec.transform())
+            is EmptyFormSpec -> listOf(EmptyFormElement())
+            is MandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+            is AuBecsDebitMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+            is BacsDebitBankAccountSpec -> listOf(spec.transform(arguments.initialValues))
+            is BacsDebitConfirmSpec -> listOf(spec.transform(arguments.merchantName, arguments.initialValues))
+            is BsbSpec -> listOf(spec.transform(arguments.initialValues))
+            is OTPSpec -> listOf(spec.transform())
+            is NameSpec -> listOf(spec.transform(arguments.initialValues))
+            is EmailSpec -> listOf(spec.transform(arguments.initialValues))
+            is PhoneSpec -> listOf(spec.transform(arguments.initialValues))
+            is SimpleTextSpec -> listOf(spec.transform(arguments.initialValues))
+            is AuBankAccountNumberSpec -> listOf(spec.transform(arguments.initialValues))
+            is IbanSpec -> listOf(spec.transform(arguments.initialValues))
+            is KlarnaHeaderStaticTextSpec -> listOf(spec.transform())
+            is DropdownSpec -> listOf(spec.transform(arguments.initialValues))
+            is CountrySpec -> listOf(spec.transform(arguments.initialValues))
+            is AddressSpec -> spec.transform(
+                arguments.initialValues,
+                arguments.shippingValues,
+                arguments.autocompleteAddressInteractorFactory,
+            )
+            is SepaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+            is PlaceholderSpec -> listOf() // Placeholders should be processed before calling transform.
+            is CashAppPayMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
+            is KlarnaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSpecResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressSpecResolverTest.kt
@@ -1,0 +1,161 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
+import com.stripe.android.ui.core.elements.CountrySpec
+import com.stripe.android.ui.core.elements.FormItemSpec
+import com.stripe.android.ui.core.elements.MandateTextSpec
+import com.stripe.android.ui.core.elements.NameSpec
+import com.stripe.android.uicore.elements.IdentifierSpec
+import org.junit.Test
+
+class BillingAddressSpecResolverTest {
+    @Test
+    fun `resolve replaces country with any API path in place and preserves allowed countries`() {
+        val countrySpec = CountrySpec(
+            apiPath = IdentifierSpec.Generic("server_country"),
+            allowedCountryCodes = setOf("DE", "FR"),
+        )
+        val mandate = MandateTextSpec(stringResId = R.string.stripe_sepa_mandate)
+
+        val result = resolve(
+            specs = listOf(
+                NameSpec(),
+                countrySpec,
+                mandate,
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            NameSpec(),
+            AutomaticTaxBillingAddressSpec(
+                allowedCountryCodes = setOf("DE", "FR"),
+            ),
+            mandate,
+        ).inOrder()
+        assertThat(result.filterIsInstance<CountrySpec>()).isEmpty()
+    }
+
+    @Test
+    fun `resolve replaces multiple countries with one automatic tax billing address`() {
+        val result = resolve(
+            specs = listOf(
+                CountrySpec(allowedCountryCodes = setOf("US", "CA")),
+                NameSpec(),
+                CountrySpec(allowedCountryCodes = setOf("US")),
+            ),
+        )
+
+        assertThat(result.filterIsInstance<CountrySpec>()).isEmpty()
+        assertThat(result.filterIsInstance<AutomaticTaxBillingAddressSpec>()).hasSize(1)
+    }
+
+    @Test
+    fun `resolve preserves normal address, exposes its country, and removes separate country`() {
+        val normalAddress = AddressSpec(
+            allowedCountryCodes = setOf("GB"),
+            hideCountry = true,
+        )
+        val mandate = MandateTextSpec(stringResId = R.string.stripe_sepa_mandate)
+
+        val result = resolve(
+            specs = listOf(
+                CountrySpec(apiPath = IdentifierSpec.Generic("server_country")),
+                NameSpec(),
+                normalAddress,
+                mandate,
+            ),
+        )
+
+        assertThat(result).containsExactly(
+            NameSpec(),
+            normalAddress.copy(hideCountry = false),
+            mandate,
+        ).inOrder()
+        assertThat(result.filterIsInstance<CountrySpec>()).isEmpty()
+        assertThat(result.filterIsInstance<AutomaticTaxBillingAddressSpec>()).isEmpty()
+    }
+
+    @Test
+    fun `resolve preserves visible normal address without adding another address`() {
+        val addressSpec = AddressSpec(allowedCountryCodes = setOf("GB"))
+        val mandate = MandateTextSpec(stringResId = R.string.stripe_sepa_mandate)
+
+        val result = resolve(
+            specs = listOf(
+                NameSpec(),
+                addressSpec,
+                mandate,
+            ),
+        )
+
+        assertThat(result).containsExactly(NameSpec(), addressSpec, mandate).inOrder()
+        assertThat(result.filterIsInstance<AutomaticTaxBillingAddressSpec>()).isEmpty()
+    }
+
+    @Test
+    fun `resolve adds missing address after fields without mandate`() {
+        val result = resolve(specs = listOf(NameSpec()))
+
+        assertThat(result).containsExactly(
+            NameSpec(),
+            AutomaticTaxBillingAddressSpec(allowedCountryCodes = setOf("US", "CA")),
+        ).inOrder()
+    }
+
+    @Test
+    fun `resolve leaves country unchanged in Never`() {
+        val countrySpec = CountrySpec(allowedCountryCodes = setOf("US"))
+
+        val result = BillingAddressSpecResolver.resolve(
+            specs = listOf(countrySpec),
+            addressCollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+            requiresBillingAddressForAutomaticTax = true,
+            allowedBillingCountries = setOf("US"),
+        )
+
+        assertThat(result).containsExactly(countrySpec)
+    }
+
+    @Test
+    fun `resolve leaves country unchanged in tax-disabled Automatic`() {
+        val countrySpec = CountrySpec(allowedCountryCodes = setOf("US"))
+
+        val result = BillingAddressSpecResolver.resolve(
+            specs = listOf(countrySpec),
+            addressCollectionMode =
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            requiresBillingAddressForAutomaticTax = false,
+            allowedBillingCountries = setOf("US"),
+        )
+
+        assertThat(result).containsExactly(countrySpec)
+    }
+
+    @Test
+    fun `resolve replaces country with full address in Full`() {
+        val result = BillingAddressSpecResolver.resolve(
+            specs = listOf(CountrySpec(allowedCountryCodes = setOf("DE", "FR"))),
+            addressCollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            requiresBillingAddressForAutomaticTax = false,
+            allowedBillingCountries = setOf("US"),
+        )
+
+        assertThat(result).containsExactly(AddressSpec(allowedCountryCodes = setOf("DE", "FR")))
+    }
+
+    private fun resolve(
+        specs: List<FormItemSpec>,
+    ): List<FormItemSpec> {
+        return BillingAddressSpecResolver.resolve(
+            specs = specs,
+            addressCollectionMode =
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            requiresBillingAddressForAutomaticTax = true,
+            allowedBillingCountries = setOf("US", "CA"),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AutomaticTaxPaymentMethodRegistryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AutomaticTaxPaymentMethodRegistryTest.kt
@@ -16,7 +16,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class AutomaticTaxPaymentMethodRegistryTest {
     @Test
-    fun `direct registry definitions have one billing country controller for automatic tax`() {
+    fun `normal registry definitions have one billing country controller for automatic tax`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = PaymentMethodRegistry.all.map { it.type.code },
@@ -33,7 +33,7 @@ class AutomaticTaxPaymentMethodRegistryTest {
 
         PaymentMethodRegistry.all.forEach { definition ->
             val uiDefinitionFactory = definition.uiDefinitionFactory(metadata)
-            if (uiDefinitionFactory !is UiDefinitionFactory.Simple) {
+            if (uiDefinitionFactory is UiDefinitionFactory.Custom) {
                 return@forEach
             }
             val formElements = requireNotNull(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ServerDefinedBillingAddressTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ServerDefinedBillingAddressTest.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.ui.core.elements.AuBecsDebitMandateTextElement
+import com.stripe.android.ui.core.elements.BillingAddressElement
+import com.stripe.android.uicore.elements.SectionElement
+import org.junit.Test
+
+/**
+ * Production coverage for billing-address resolution in server-defined payment method forms.
+ *
+ * OXXO exercises the no-mandate path, while AU BECS exercises ordering before a real mandate.
+ */
+class ServerDefinedBillingAddressTest {
+    @Test
+    fun `OXXO appends the tax address when no mandate exists`() {
+        val formElements = OxxoDefinition.formElements(
+            metadata = createMetadata(
+                paymentMethodType = PaymentMethod.Type.Oxxo,
+                automaticTaxEnabled = true,
+            ),
+        )
+
+        val billingAddressElements = formElements.billingAddressElements()
+
+        assertThat(billingAddressElements).hasSize(1)
+        assertThat((formElements.last() as SectionElement).fields.single())
+            .isInstanceOf(BillingAddressElement::class.java)
+    }
+
+    @Test
+    fun `OXXO remains address-free when automatic tax is disabled`() {
+        val formElements = OxxoDefinition.formElements(
+            metadata = createMetadata(
+                paymentMethodType = PaymentMethod.Type.Oxxo,
+                automaticTaxEnabled = false,
+            ),
+        )
+
+        assertThat(formElements.billingAddressElements()).isEmpty()
+    }
+
+    @Test
+    fun `AU BECS inserts the tax address immediately before its real mandate`() {
+        val formElements = AuBecsDebitDefinition.formElements(
+            metadata = createMetadata(
+                paymentMethodType = PaymentMethod.Type.AuBecsDebit,
+                automaticTaxEnabled = true,
+            ),
+        )
+
+        val billingAddressElements = formElements.billingAddressElements()
+
+        assertThat(billingAddressElements).hasSize(1)
+        val billingAddressSectionIndex = formElements.indexOfFirst { element ->
+            element is SectionElement && billingAddressElements.single() in element.fields
+        }
+        assertThat(billingAddressSectionIndex).isAtLeast(0)
+        assertThat(formElements[billingAddressSectionIndex + 1])
+            .isInstanceOf(AuBecsDebitMandateTextElement::class.java)
+    }
+
+    private fun createMetadata(
+        paymentMethodType: PaymentMethod.Type,
+        automaticTaxEnabled: Boolean,
+    ) = PaymentMethodMetadataFactory.create(
+        stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf(paymentMethodType.code),
+        ),
+        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+        ),
+        checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = automaticTaxEnabled,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        ),
+    )
+
+    private fun List<Any>.billingAddressElements(): List<BillingAddressElement> {
+        return filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<BillingAddressElement>()
+    }
+}


### PR DESCRIPTION
# Summary

Server-defined non-card payment-method forms now reconcile authored country and address specs before element creation. With Automatic billing collection and billing-sourced tax, they collect the country-specific tax minimum without creating a second billing-country owner.

## What changed

- When Full collection or billing-sourced automatic tax requires an address, `BillingAddressSpecResolver` preserves authored full-address shapes, exposes a hidden country when needed, replaces country specs in place, and inserts a missing address before the first mandate.
- Its contract now distinguishes authored-spec reconciliation from payment-method policy resolution.
- `MandateSpec` classifies existing mandate variants so the resolver can insert a missing address before the first mandate. The resolver is its first production consumer.
- `TransformSpecToElements.transform()` resolves the authored specs before constructing form elements.

## What stays the same

- Visible full addresses remain unchanged.
- Hidden-country addresses expose their existing country input only when Full or billing-sourced automatic tax requires it.
- In Never and tax-disabled Automatic, country-only and absent authored specs preserve their configured form.
- Direct definitions remain owned by #13860. Public APIs, card AVS, Link, U.S. Bank Account, and the changelog are unchanged.

## Coverage

`BillingAddressSpecResolverTest` covers authored country, visible and hidden full-address, absent no-mandate, disabled-tax, Never, and Full cases. `ServerDefinedBillingAddressTest` covers OXXO enabled and disabled no-mandate paths plus AU BECS insertion immediately before a real mandate.

# Testing

- At the final stack tip, the uncached focused 85-test billing-address suite passed.
- At the final stack tip, `:paymentsheet:detekt`, `:paymentsheet:apiCheck`, `:payments-ui-core:detekt`, and `:payments-ui-core:apiCheck` passed.

# Screenshots

At the final stack tip, the selected OXXO automatic-tax snapshot passed verification without recording.

# Changelog

Not applicable. This behavior is not public yet.
