### PR TITLE
Test automatic tax billing field policy

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFieldsTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFieldsTest.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.ui.core.elements
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.uicore.elements.IdentifierSpec
+import org.junit.Test
+
+class AutomaticTaxBillingFieldsTest {
+    @Test
+    fun `US requires line 1 city state and postal code`() {
+        assertThat(automaticTaxRequiredFields("US")).containsExactly(
+            IdentifierSpec.Line1,
+            IdentifierSpec.City,
+            IdentifierSpec.State,
+            IdentifierSpec.PostalCode,
+        )
+    }
+
+    @Test
+    fun `CA requires postal code`() {
+        assertThat(automaticTaxRequiredFields("CA")).containsExactly(IdentifierSpec.PostalCode)
+    }
+
+    @Test
+    fun `GB requires postal code`() {
+        assertThat(automaticTaxRequiredFields("GB")).containsExactly(IdentifierSpec.PostalCode)
+    }
+
+    @Test
+    fun `IN requires postal code`() {
+        assertThat(automaticTaxRequiredFields("IN")).containsExactly(IdentifierSpec.PostalCode)
+    }
+
+    @Test
+    fun `PR requires line 1 city and postal code`() {
+        assertThat(automaticTaxRequiredFields("PR")).containsExactly(
+            IdentifierSpec.Line1,
+            IdentifierSpec.City,
+            IdentifierSpec.PostalCode,
+        )
+    }
+
+    @Test
+    fun `country absent from policy requires only country`() {
+        assertThat(automaticTaxRequiredFields("DE")).isEmpty()
+    }
+}


### PR DESCRIPTION
# Summary

Adds unit coverage for `automaticTaxRequiredFields`, the country-to-required-fields policy that already ships on `master`. The policy had no direct tests, so a country's field set could change without any test failing.

The cases pin the distinct shapes the policy returns: US (line 1, city, state, postal code), Puerto Rico (line 1, city, postal code), the postal-code-only countries CA, GB, and IN, and a negative control for a country absent from the policy, which requires country only.

Test-only. No production code, no public API change, and no changelog entry.

# Motivation

`automaticTaxRequiredFields` decides which billing fields an automatic-tax form must collect per country. It is the narrowest place to pin that behavior, and pinning it here keeps the assertions independent of any form-construction or resolver work layered on top.

# Testing

- [x] ./gradlew :payments-ui-core:testDebugUnitTest --tests com.stripe.android.ui.core.elements.AutomaticTaxBillingFieldsTest :payments-ui-core:detekt

# Screenshots

Not applicable. Test-only change.

# Changelog

Not applicable.
