### PR TITLE
Model payment method billing address policy

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -3,7 +3,12 @@ package com.stripe.android.lpmfoundations.luxe
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.CountryElement
+import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 
 internal class FormElementsBuilder(
     private val arguments: UiDefinitionFactory.Arguments,
@@ -60,6 +65,24 @@ internal class FormElementsBuilder(
 
     fun element(formElement: FormElement): FormElementsBuilder = apply {
         uiFormElements += formElement
+    }
+
+    fun billingAddressPolicy(policy: PaymentMethodBillingAddressPolicy): FormElementsBuilder = apply {
+        when (policy) {
+            is PaymentMethodBillingAddressPolicy.CountryOnly -> {
+                element(
+                    formElement = SectionElement.wrap(
+                        sectionFieldElement = CountryElement(
+                            identifier = IdentifierSpec.Country,
+                            controller = DropdownFieldController(
+                                config = CountryConfig(policy.allowedCountryCodes),
+                                initialValue = arguments.initialValues[IdentifierSpec.Country],
+                            ),
+                        ),
+                    ),
+                )
+            }
+        }
     }
 
     fun ignoreBillingAddressRequirements() = apply {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodBillingAddressPolicy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/PaymentMethodBillingAddressPolicy.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.lpmfoundations.luxe
+
+/**
+ * Billing-address policy contributed by a payment-method definition.
+ */
+internal sealed interface PaymentMethodBillingAddressPolicy {
+    /**
+     * Requires a country value from [allowedCountryCodes], unless merchant settings promote collection to a
+     * full address.
+     */
+    data class CountryOnly(
+        val allowedCountryCodes: Set<String>,
+    ) : PaymentMethodBillingAddressPolicy
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.luxe.ContactInformationCollectionMode
 import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodBillingAddressPolicy
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -67,19 +68,10 @@ private object KlarnaUiDefinitionFactory : UiDefinitionFactory.Simple() {
             .overrideContactInformationPosition(ContactInformationCollectionMode.Email)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Phone)
             .ignoreBillingAddressRequirements()
-            .element(
-                formElement = SectionElement.wrap(
-                    sectionFieldElement = CountryElement(
-                        identifier = IdentifierSpec.Country,
-                        controller = DropdownFieldController(
-                            config = CountryConfig(
-                                onlyShowCountryCodes =
-                                metadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                            ),
-                            initialValue = arguments.initialValues[IdentifierSpec.Country],
-                        )
-                    )
-                )
+            .billingAddressPolicy(
+                PaymentMethodBillingAddressPolicy.CountryOnly(
+                    allowedCountryCodes = metadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
+                ),
             )
             .apply {
                 if (

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.lpmfoundations.luxe.ContactInformationCollectionMode
 import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
+import com.stripe.android.lpmfoundations.luxe.PaymentMethodBillingAddressPolicy
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -9,11 +10,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.CountryConfig
-import com.stripe.android.uicore.elements.CountryElement
-import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.SectionElement
 
 internal object WeroDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Wero
@@ -47,18 +43,8 @@ private object WeroUiDefinitionFactory : UiDefinitionFactory.Simple() {
         builder: FormElementsBuilder,
     ) {
         builder
-            .element(
-                formElement = SectionElement.wrap(
-                    sectionFieldElement = CountryElement(
-                        identifier = IdentifierSpec.Country,
-                        controller = DropdownFieldController(
-                            config = CountryConfig(
-                                onlyShowCountryCodes = setOf("DE", "BE", "FR"),
-                            ),
-                            initialValue = arguments.initialValues[IdentifierSpec.Country],
-                        )
-                    )
-                )
+            .billingAddressPolicy(
+                PaymentMethodBillingAddressPolicy.CountryOnly(allowedCountryCodes = setOf("DE", "BE", "FR")),
             )
             .overrideContactInformationPosition(ContactInformationCollectionMode.Name)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Email)


### PR DESCRIPTION
# Summary

Klarna and Wero keep their existing country-only billing forms. This PR names that payment-method-owned intent `PaymentMethodBillingAddressPolicy.CountryOnly` and exposes it through `FormElementsBuilder.billingAddressPolicy(...)`.

## What changed

- Payment-method definitions contribute a documented billing-address policy.
- Klarna and Wero use the policy entry point instead of constructing their country element directly.
- The policy carries the payment method's allowed-country payload.

## What stays the same

- Klarna and Wero render the same fields and ordering at this PR's head.
- Calls render immediately at this intermediate stack head. Centralized resolution with merchant settings belongs to #13862.
- Public APIs, changelog, and snapshots are unchanged.

# Testing

The focused builder, Klarna, and Wero coverage passed at the stack tip as part of the uncached 85-test billing-address suite.

# Screenshots

Not applicable. Output and ordering are unchanged at this PR's head.

# Changelog

Not applicable. This is an internal refactor.
