### PR TITLE
Resolve automatic-tax billing addresses

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingAddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingAddressSpec.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Runtime-only form item for automatic-tax billing address collection. It is never serialized.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class AutomaticTaxBillingAddressSpec(
+    val allowedCountryCodes: Set<String>,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/AutomaticTaxBillingAddressFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/AutomaticTaxBillingAddressFactory.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.lpmfoundations.luxe
+
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
+import com.stripe.android.ui.core.elements.BillingAddressCollectionMode
+import com.stripe.android.ui.core.elements.BillingAddressElement
+import com.stripe.android.ui.core.elements.additionalAutomaticTaxFieldsByCountry
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SameAsShippingController
+import com.stripe.android.uicore.elements.SameAsShippingElement
+import com.stripe.android.uicore.elements.SectionElement
+
+internal class AutomaticTaxBillingAddressFactory(
+    private val arguments: UiDefinitionFactory.Arguments,
+) {
+    fun create(
+        spec: AutomaticTaxBillingAddressSpec,
+    ): List<FormElement> {
+        val sameAsShippingElement = arguments.shippingValues
+            ?.get(IdentifierSpec.SameAsShipping)
+            ?.toBooleanStrictOrNull()
+            ?.let { sameAsShipping ->
+                SameAsShippingElement(
+                    identifier = IdentifierSpec.SameAsShipping,
+                    controller = SameAsShippingController(sameAsShipping),
+                )
+            }
+        val billingAddressElement = BillingAddressElement(
+            identifier = IdentifierSpec.BillingAddress,
+            rawValuesMap = arguments.initialValues,
+            countryCodes = spec.allowedCountryCodes,
+            autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+            sameAsShippingElement = sameAsShippingElement,
+            shippingValuesMap = arguments.shippingValues,
+            addressCollectionMode = BillingAddressCollectionMode.Country(
+                additionalFieldsByCountry = additionalAutomaticTaxFieldsByCountry,
+            ),
+        )
+
+        return listOfNotNull(
+            SectionElement.wrap(billingAddressElement),
+            sameAsShippingElement,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.luxe
 
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.AutomaticTaxBillingAddressSpec
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
@@ -11,6 +12,7 @@ import com.stripe.android.uicore.elements.SectionElement
 
 internal class FormElementsBuilder(
     private val arguments: UiDefinitionFactory.Arguments,
+    private val supportsAutomaticTaxBillingAddress: Boolean,
 ) {
     private val headerFormElements: MutableList<FormElement> = mutableListOf()
     private val uiFormElements: MutableList<FormElement> = mutableListOf()
@@ -68,6 +70,8 @@ internal class FormElementsBuilder(
         val resolvedBillingAddress = BillingAddressPolicyResolver(
             policy = paymentMethodBillingAddressPolicy,
             addressCollectionMode = arguments.billingDetailsCollectionConfiguration.address,
+            requiresBillingAddressForAutomaticTax = supportsAutomaticTaxBillingAddress &&
+                arguments.requiresBillingAddressForAutomaticTax,
             merchantAllowedCountryCodes =
                 arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
         ).resolve()
@@ -109,6 +113,9 @@ internal class FormElementsBuilder(
                 initialValues = arguments.initialValues,
                 shippingValues = arguments.shippingValues,
                 autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+            )
+            is ResolvedBillingAddress.TaxMinimum -> AutomaticTaxBillingAddressFactory(arguments).create(
+                spec = AutomaticTaxBillingAddressSpec(allowedCountryCodes),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/ResolvedBillingAddress.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/ResolvedBillingAddress.kt
@@ -21,6 +21,13 @@ internal sealed interface ResolvedBillingAddress {
         val allowedCountryCodes: Set<String>,
     ) : ResolvedBillingAddress
 
+    /**
+     * Renders the country-specific minimum address required by automatic tax, restricted to [allowedCountryCodes].
+     */
+    data class TaxMinimum(
+        val allowedCountryCodes: Set<String>,
+    ) : ResolvedBillingAddress
+
     /** Renders no address fields and prevents every later resolution stage from promoting address collection. */
     data object Suppressed : ResolvedBillingAddress
 }
@@ -34,9 +41,10 @@ internal sealed interface ResolvedBillingAddress {
 internal class BillingAddressPolicyResolver(
     private val policy: PaymentMethodBillingAddressPolicy?,
     private val addressCollectionMode: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode,
+    private val requiresBillingAddressForAutomaticTax: Boolean,
     private val merchantAllowedCountryCodes: Set<String>,
 ) {
-    fun resolve(): ResolvedBillingAddress = resolvePaymentMethodPolicy()
+    fun resolve(): ResolvedBillingAddress = resolvePaymentMethodPolicy().resolveAutomaticTax()
 
     private fun resolvePaymentMethodPolicy(): ResolvedBillingAddress {
         return when (policy) {
@@ -68,6 +76,25 @@ internal class BillingAddressPolicyResolver(
                 }
             }
             PaymentMethodBillingAddressPolicy.Suppressed -> ResolvedBillingAddress.Suppressed
+        }
+    }
+
+    private fun ResolvedBillingAddress.resolveAutomaticTax(): ResolvedBillingAddress {
+        val requiresTaxMinimum =
+            addressCollectionMode ==
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic &&
+                requiresBillingAddressForAutomaticTax
+
+        if (!requiresTaxMinimum) {
+            return this
+        }
+
+        return when (this) {
+            ResolvedBillingAddress.Absent -> ResolvedBillingAddress.TaxMinimum(merchantAllowedCountryCodes)
+            is ResolvedBillingAddress.CountryOnly -> ResolvedBillingAddress.TaxMinimum(allowedCountryCodes)
+            is ResolvedBillingAddress.Full,
+            ResolvedBillingAddress.Suppressed,
+            is ResolvedBillingAddress.TaxMinimum -> this
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -168,6 +168,8 @@ internal sealed interface UiDefinitionFactory {
     }
 
     abstract class Simple : UiDefinitionFactory {
+        protected open val supportsAutomaticTaxBillingAddress: Boolean = true
+
         abstract fun createSupportedPaymentMethod(
             metadata: PaymentMethodMetadata,
         ): SupportedPaymentMethod
@@ -181,7 +183,10 @@ internal sealed interface UiDefinitionFactory {
         }
 
         fun createFormElements(metadata: PaymentMethodMetadata, arguments: Arguments): List<FormElement> {
-            val builder = FormElementsBuilder(arguments)
+            val builder = FormElementsBuilder(
+                arguments = arguments,
+                supportsAutomaticTaxBillingAddress = supportsAutomaticTaxBillingAddress,
+            )
 
             buildFormElements(metadata, arguments, builder)
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
@@ -13,6 +13,8 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal class CustomPaymentMethodUiDefinitionFactory(
     private val displayableCustomPaymentMethod: DisplayableCustomPaymentMethod
 ) : UiDefinitionFactory.Simple() {
+    override val supportsAutomaticTaxBillingAddress: Boolean = false
+
     override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = displayableCustomPaymentMethod.id,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
@@ -9,6 +9,8 @@ import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 internal class ExternalPaymentMethodUiDefinitionFactory(
     private val externalPaymentMethodSpec: ExternalPaymentMethodSpec
 ) : UiDefinitionFactory.Simple() {
+    override val supportsAutomaticTaxBillingAddress: Boolean = false
+
     override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = externalPaymentMethodSpec.type,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressPolicyResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressPolicyResolverTest.kt
@@ -77,6 +77,34 @@ class BillingAddressPolicyResolverTest {
             .isEqualTo(ResolvedBillingAddress.Suppressed)
     }
 
+    @Test
+    fun `automatic tax promotes absent to tax minimum using merchant countries`() {
+        assertThat(resolveWithAutomaticTax(policy = null, mode = Mode.Automatic))
+            .isEqualTo(ResolvedBillingAddress.TaxMinimum(MERCHANT_COUNTRIES))
+    }
+
+    @Test
+    fun `automatic tax promotes country-only to tax minimum using policy countries`() {
+        assertThat(resolveWithAutomaticTax(policy = countryOnly(), mode = Mode.Automatic))
+            .isEqualTo(ResolvedBillingAddress.TaxMinimum(POLICY_COUNTRIES))
+    }
+
+    @Test
+    fun `automatic tax preserves full address`() {
+        assertThat(resolveWithAutomaticTax(policy = fullAddressIfAllowed(), mode = Mode.Automatic))
+            .isEqualTo(ResolvedBillingAddress.Full(POLICY_COUNTRIES))
+    }
+
+    @Test
+    fun `automatic tax preserves suppressed`() {
+        assertThat(
+            resolveWithAutomaticTax(
+                policy = PaymentMethodBillingAddressPolicy.Suppressed,
+                mode = Mode.Automatic,
+            )
+        ).isEqualTo(ResolvedBillingAddress.Suppressed)
+    }
+
     private fun resolve(
         policy: PaymentMethodBillingAddressPolicy?,
         mode: Mode,
@@ -84,6 +112,19 @@ class BillingAddressPolicyResolverTest {
         return BillingAddressPolicyResolver(
             policy = policy,
             addressCollectionMode = mode,
+            requiresBillingAddressForAutomaticTax = false,
+            merchantAllowedCountryCodes = MERCHANT_COUNTRIES,
+        ).resolve()
+    }
+
+    private fun resolveWithAutomaticTax(
+        policy: PaymentMethodBillingAddressPolicy?,
+        mode: Mode,
+    ): ResolvedBillingAddress {
+        return BillingAddressPolicyResolver(
+            policy = policy,
+            addressCollectionMode = mode,
+            requiresBillingAddressForAutomaticTax = true,
             merchantAllowedCountryCodes = MERCHANT_COUNTRIES,
         ).resolve()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -34,7 +34,7 @@ import org.robolectric.RobolectricTestRunner
 class FormElementsBuilderTest {
     @Test
     fun `build returns an emptyList`() {
-        assertThat(FormElementsBuilder(arguments()).build()).isEmpty()
+        assertThat(formElementsBuilder(arguments()).build()).isEmpty()
     }
 
     @Test
@@ -47,7 +47,7 @@ class FormElementsBuilderTest {
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
         )
-        val formElements = FormElementsBuilder(arguments).build()
+        val formElements = formElementsBuilder(arguments).build()
         assertThat(formElements).hasSize(4)
         assertThat(formElements[0].identifier.v1).isEqualTo("billing_details[name]_section")
         assertThat(formElements[1].identifier.v1).isEqualTo("billing_details[phone]_section")
@@ -57,7 +57,7 @@ class FormElementsBuilderTest {
 
     @Test
     fun `build orders fields correctly`() {
-        val formElements = FormElementsBuilder(arguments())
+        val formElements = formElementsBuilder(arguments())
             .element(EmptyFormElement(identifier = IdentifierSpec(v1 = "element")))
             .header(EmptyFormElement(identifier = IdentifierSpec(v1 = "header")))
             .footer(EmptyFormElement(identifier = IdentifierSpec(v1 = "footer")))
@@ -86,7 +86,7 @@ class FormElementsBuilderTest {
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
             )
         )
-        val formElements = FormElementsBuilder(arguments)
+        val formElements = formElementsBuilder(arguments)
             .billingAddressPolicy(
                 PaymentMethodBillingAddressPolicy.FullAddressIfAllowed(
                     allowedCountryCodes = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
@@ -101,7 +101,7 @@ class FormElementsBuilderTest {
 
     @Test
     fun `build returns fields in the order they were added`() {
-        val formElements = FormElementsBuilder(arguments())
+        val formElements = formElementsBuilder(arguments())
             .element(EmptyFormElement(identifier = IdentifierSpec(v1 = "element1")))
             .element(EmptyFormElement(identifier = IdentifierSpec(v1 = "element2")))
             .footer(EmptyFormElement(identifier = IdentifierSpec(v1 = "footer1")))
@@ -120,7 +120,7 @@ class FormElementsBuilderTest {
 
     @Test
     fun `build uses the latest payment method billing address policy`() {
-        val formElements = FormElementsBuilder(arguments())
+        val formElements = formElementsBuilder(arguments())
             .billingAddressPolicy(PaymentMethodBillingAddressPolicy.CountryOnly(allowedCountryCodes = setOf("US")))
             .billingAddressPolicy(PaymentMethodBillingAddressPolicy.CountryOnly(allowedCountryCodes = setOf("CA")))
             .build()
@@ -137,7 +137,7 @@ class FormElementsBuilderTest {
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
         )
-        val formElements = FormElementsBuilder(arguments)
+        val formElements = formElementsBuilder(arguments)
             .element(EmptyFormElement(identifier = IdentifierSpec(v1 = "element")))
             .billingAddressPolicy(PaymentMethodBillingAddressPolicy.Suppressed)
             .build()
@@ -154,7 +154,7 @@ class FormElementsBuilderTest {
                 phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             )
         )
-        val formElements = FormElementsBuilder(arguments)
+        val formElements = formElementsBuilder(arguments)
             .element(EmptyFormElement(identifier = IdentifierSpec(v1 = "element")))
             .ignoreContactInformationRequirements()
             .build()
@@ -173,7 +173,7 @@ class FormElementsBuilderTest {
             }
         )
 
-        val formElements = FormElementsBuilder(arguments).build()
+        val formElements = formElementsBuilder(arguments).build()
 
         assertThat(formElements).hasSize(1)
         assertThat(formElements.firstOrNull()).isInstanceOf<SectionElement>()
@@ -195,7 +195,7 @@ class FormElementsBuilderTest {
                 allowedCountries = emptySet()
             )
         )
-        val formElements = FormElementsBuilder(arguments).build()
+        val formElements = formElementsBuilder(arguments).build()
 
         assertThat(formElements).hasSize(1)
         assertThat(formElements.firstOrNull()).isInstanceOf<SectionElement>()
@@ -223,7 +223,7 @@ class FormElementsBuilderTest {
                 allowedCountries = setOf("US", "CA")
             )
         )
-        val formElements = FormElementsBuilder(arguments).build()
+        val formElements = formElementsBuilder(arguments).build()
 
         assertThat(formElements).hasSize(1)
         assertThat(formElements.firstOrNull()).isInstanceOf<SectionElement>()
@@ -253,7 +253,7 @@ class FormElementsBuilderTest {
                 allowedCountries = setOf("US", "CA")
             )
         )
-        val formElements = FormElementsBuilder(arguments)
+        val formElements = formElementsBuilder(arguments)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Phone)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Name)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Email)
@@ -282,7 +282,7 @@ class FormElementsBuilderTest {
                 allowedCountries = setOf("US", "CA")
             )
         )
-        val formElements = FormElementsBuilder(arguments)
+        val formElements = formElementsBuilder(arguments)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Phone)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Name)
             .build()
@@ -301,7 +301,7 @@ class FormElementsBuilderTest {
 
     @Test
     fun `build keeps country-only source for automatic address collection`() {
-        val formElements = FormElementsBuilder(
+        val formElements = formElementsBuilder(
             arguments(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
@@ -322,7 +322,7 @@ class FormElementsBuilderTest {
 
     @Test
     fun `build propagates initial shipping and autocomplete values to resolved full address`() = runTest {
-        val formElements = FormElementsBuilder(
+        val formElements = formElementsBuilder(
             arguments(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
@@ -355,15 +355,41 @@ class FormElementsBuilderTest {
     }
 
     @Test
+    fun `build initializes automatic tax same as shipping to false`() {
+        val formElements = automaticTaxFormElements(
+            shippingValues = mapOf(IdentifierSpec.SameAsShipping to "false"),
+        )
+
+        val sameAsShippingElement = formElements.filterIsInstance<SameAsShippingElement>().single()
+        assertThat(sameAsShippingElement.controller.value.value).isFalse()
+    }
+
+    @Test
+    fun `build omits automatic tax same as shipping without a value`() {
+        val formElements = automaticTaxFormElements(shippingValues = emptyMap())
+
+        assertThat(formElements.filterIsInstance<SameAsShippingElement>()).isEmpty()
+    }
+
+    @Test
+    fun `build omits automatic tax same as shipping for malformed value`() {
+        val formElements = automaticTaxFormElements(
+            shippingValues = mapOf(IdentifierSpec.SameAsShipping to "yes"),
+        )
+
+        assertThat(formElements.filterIsInstance<SameAsShippingElement>()).isEmpty()
+    }
+
+    @Test
     fun `build renders billing address after UI elements regardless of policy order`() {
         val policy = PaymentMethodBillingAddressPolicy.CountryOnly(allowedCountryCodes = setOf("US"))
         val builderArguments = arguments()
 
-        val policyFirst = FormElementsBuilder(builderArguments)
+        val policyFirst = formElementsBuilder(builderArguments)
             .billingAddressPolicy(policy)
             .element(EmptyFormElement(identifier = IdentifierSpec.Generic("element")))
             .build()
-        val policyLast = FormElementsBuilder(builderArguments)
+        val policyLast = formElementsBuilder(builderArguments)
             .element(EmptyFormElement(identifier = IdentifierSpec.Generic("element")))
             .billingAddressPolicy(policy)
             .build()
@@ -375,6 +401,50 @@ class FormElementsBuilderTest {
         assertThat(policyLast.map { it.identifier.v1 }).isEqualTo(
             policyFirst.map { it.identifier.v1 },
         )
+    }
+
+    @Test
+    fun `build promotes country-only source to address-last automatic tax fields`() {
+        val formElements = formElementsBuilder(
+            arguments = arguments(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                ),
+                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                requiresBillingAddressForAutomaticTax = true,
+            ),
+        ).billingAddressPolicy(
+            PaymentMethodBillingAddressPolicy.CountryOnly(allowedCountryCodes = setOf("US", "CA")),
+        ).element(
+            EmptyFormElement(identifier = IdentifierSpec.Generic("element")),
+        ).build()
+
+        assertThat(formElements.map { it.identifier.v1 }).containsExactly(
+            "element",
+            "billing_details[address]_section",
+        ).inOrder()
+    }
+
+    @Test
+    fun `build adds absent automatic tax source before footer`() {
+        val formElements = formElementsBuilder(
+            arguments = arguments(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                ),
+                requiresBillingAddressForAutomaticTax = true,
+            ),
+        ).element(
+            EmptyFormElement(identifier = IdentifierSpec.Generic("element")),
+        ).footer(
+            EmptyFormElement(identifier = IdentifierSpec.Generic("footer")),
+        ).build()
+
+        assertThat(formElements.map { it.identifier.v1 }).containsExactly(
+            "element",
+            "billing_details[address]_section",
+            "footer",
+        ).inOrder()
     }
 
     private inline fun <reified T : SectionFieldElement> SectionElement.assertSingleElementInSection() {
@@ -399,6 +469,7 @@ class FormElementsBuilderTest {
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
         initialValues: Map<IdentifierSpec, String?> = emptyMap(),
         shippingValues: Map<IdentifierSpec, String?>? = emptyMap(),
+        requiresBillingAddressForAutomaticTax: Boolean = false,
     ): UiDefinitionFactory.Arguments {
         val context = ApplicationProvider.getApplicationContext<Application>()
         return UiDefinitionFactory.Arguments(
@@ -410,7 +481,7 @@ class FormElementsBuilderTest {
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
-            requiresBillingAddressForAutomaticTax = false,
+            requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
             requiresMandate = false,
             linkConfigurationCoordinator = null,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
@@ -420,5 +491,30 @@ class FormElementsBuilderTest {
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             linkInlineHandler = null,
         )
+    }
+
+    private fun formElementsBuilder(
+        arguments: UiDefinitionFactory.Arguments,
+    ): FormElementsBuilder {
+        return FormElementsBuilder(
+            arguments = arguments,
+            supportsAutomaticTaxBillingAddress = true,
+        )
+    }
+
+    private fun automaticTaxFormElements(
+        shippingValues: Map<IdentifierSpec, String?>,
+    ): List<FormElement> {
+        return formElementsBuilder(
+            arguments(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                ),
+                shippingValues = shippingValues,
+                requiresBillingAddressForAutomaticTax = true,
+            ),
+        ).billingAddressPolicy(
+            PaymentMethodBillingAddressPolicy.CountryOnly(allowedCountryCodes = setOf("US")),
+        ).build()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AutomaticTaxPaymentMethodRegistryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AutomaticTaxPaymentMethodRegistryTest.kt
@@ -1,0 +1,70 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import com.google.common.truth.Truth.assertWithMessage
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.uicore.elements.AddressFieldsElement
+import com.stripe.android.uicore.elements.CountryElement
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.SectionElement
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutomaticTaxPaymentMethodRegistryTest {
+    @Test
+    fun `direct registry definitions have one billing country controller for automatic tax`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = PaymentMethodRegistry.all.map { it.type.code },
+            ),
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
+        val argumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create()
+
+        PaymentMethodRegistry.all.forEach { definition ->
+            val uiDefinitionFactory = definition.uiDefinitionFactory(metadata)
+            if (uiDefinitionFactory !is UiDefinitionFactory.Simple) {
+                return@forEach
+            }
+            val formElements = requireNotNull(
+                uiDefinitionFactory.formElements(
+                    definition = definition,
+                    metadata = metadata,
+                    sharedDataSpecs = metadata.sharedDataSpecs,
+                    arguments = argumentsFactory.create(
+                        metadata = metadata,
+                        requiresMandate = definition.requiresMandate(metadata),
+                    ),
+                ),
+            ) { "No form elements for ${definition.type.code}" }
+            val addressControllerCount = formElements.addressFields().size +
+                formElements.standaloneCountries().size
+
+            assertWithMessage(definition.type.code)
+                .that(addressControllerCount)
+                .isEqualTo(1)
+        }
+    }
+
+    private fun List<FormElement>.addressFields(): List<AddressFieldsElement> {
+        return filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<AddressFieldsElement>()
+    }
+
+    private fun List<FormElement>.standaloneCountries(): List<CountryElement> {
+        return filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<CountryElement>()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -627,6 +627,57 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
+    fun `formElementsForCode does not add automatic tax address to external payment method`() = runTest {
+        val metadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            ),
+            externalPaymentMethodSpecs = listOf(PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
+
+        val formElements = metadata.formElementsForCode(
+            code = PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC.type,
+            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
+        )!!
+
+        val addressElements = formElements.filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<AddressElement>()
+        assertThat(addressElements).isEmpty()
+    }
+
+    @Test
+    fun `formElementsForCode does not add automatic tax address to custom payment method`() = runTest {
+        val customPaymentMethod = PaymentMethodFixtures.PAYPAL_CUSTOM_PAYMENT_METHOD.copy(
+            doesNotCollectBillingDetails = false,
+        )
+        val metadata = PaymentMethodMetadataFactory.create(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+            ),
+            displayableCustomPaymentMethods = listOf(customPaymentMethod),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
+
+        val formElements = metadata.formElementsForCode(
+            code = customPaymentMethod.id,
+            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
+        )!!
+
+        val addressElements = formElements.filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<AddressElement>()
+        assertThat(addressElements).isEmpty()
+    }
+
+    @Test
     fun `formElementsForCode uses one address owner for Full address collection`() = runTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -646,11 +697,11 @@ internal class PaymentMethodMetadataTest {
         )!!
 
         assertThat(formElement).hasSize(5)
-
         val addressSection = formElement[4] as SectionElement
         val addressElement = addressSection.fields[0] as AddressElement
         val addressIdentifiers = addressElement.fields.first().map { it.identifier }
         assertThat(addressIdentifiers).contains(IdentifierSpec.Country)
+        assertThat(addressIdentifiers.count { it == IdentifierSpec.Country }).isEqualTo(1)
         assertThat(
             formElement.filterIsInstance<SectionElement>()
                 .flatMap { it.fields }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinitionTest.kt
@@ -4,7 +4,11 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.elements.SectionElement
 import org.junit.Test
 
@@ -42,5 +46,28 @@ class BlikDefinitionTest {
         assertThat(formElements[2].identifier.v1).isEqualTo("billing_details[email]_section")
         assertThat(formElements[3].identifier.v1).isEqualTo("blik[code]_section")
         assertThat(formElements[4].identifier.v1).isEqualTo("billing_details[address]_section")
+    }
+
+    @Test
+    fun `createFormElements adds automatic tax billing address after payment fields`() {
+        val formElements = BlikDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf(PaymentMethod.Type.Blik.code),
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                ),
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    automaticTaxEnabled = true,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                ),
+            ),
+        )
+
+        assertThat(formElements).hasSize(2)
+        assertThat(formElements[0].identifier.v1).isEqualTo("blik[code]_section")
+        assertThat((formElements[1] as SectionElement).fields.single())
+            .isInstanceOf(BillingAddressElement::class.java)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionTest.kt
@@ -10,17 +10,29 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.RowElement
+import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.filterOutHiddenIdentifiers
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -89,6 +101,127 @@ class KlarnaDefinitionTest {
                 .filterIsInstance<CountryElement>(),
         ).hasSize(1)
         assertThat(countrySection.fields.map { it.identifier }).containsExactly(IdentifierSpec.Country)
+    }
+
+    @Test
+    fun `createFormElements promotes country to automatic tax billing address`() {
+        val formElements = KlarnaDefinition.formElements(
+            metadata = automaticTaxMetadata(),
+        )
+
+        val billingAddressElements = formElements.filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<BillingAddressElement>()
+        val standaloneCountryElements = formElements.filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<CountryElement>()
+
+        assertThat(billingAddressElements).hasSize(1)
+        assertThat(standaloneCountryElements).isEmpty()
+        assertThat(billingAddressElements.single().countryElement.controller.rawFieldValue.value).isEqualTo("US")
+        assertThat(billingAddressElements.single().shownIdentifierParamPaths()).containsExactly(
+            IdentifierSpec.Country.v1,
+            IdentifierSpec.Line1.v1,
+            IdentifierSpec.City.v1,
+            IdentifierSpec.PostalCode.v1,
+            IdentifierSpec.State.v1,
+        )
+    }
+
+    @Test
+    fun `createFormElements preserves same as shipping through Klarna production path`() {
+        val metadata = automaticTaxMetadata().copy(
+            defaultBillingDetails = null,
+            shippingDetails = AddressDetails(
+                address = PaymentSheet.Address(country = "US"),
+                isCheckboxSelected = true,
+            ),
+        )
+
+        val sameAsShippingElement = KlarnaDefinition.formElements(metadata)
+            .filterIsInstance<SameAsShippingElement>()
+            .single()
+
+        assertThat(sameAsShippingElement.controller.value.value).isTrue()
+    }
+
+    @Test
+    fun `createFormElements omits same as shipping when default billing takes precedence`() {
+        val metadata = automaticTaxMetadata().copy(
+            shippingDetails = AddressDetails(
+                address = PaymentSheet.Address(country = "CA"),
+                isCheckboxSelected = true,
+            ),
+        )
+
+        val sameAsShippingElements = KlarnaDefinition.formElements(metadata)
+            .filterIsInstance<SameAsShippingElement>()
+
+        assertThat(sameAsShippingElements).isEmpty()
+    }
+
+    @Test
+    fun `createFormElements orders automatic tax address before conditional mandate`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFactory.create(
+                paymentMethodTypes = listOf(PaymentMethod.Type.Klarna.code),
+            ),
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                allowedCountries = setOf("US", "CA"),
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
+
+        val formElements = KlarnaDefinition.formElements(metadata)
+
+        assertThat(formElements).hasSize(4)
+        checkKlarnaHeaderText(formElements, 0)
+        checkEmailField(formElements, 1)
+        val addressSection = formElements[2] as SectionElement
+        assertThat(addressSection.fields.single()).isInstanceOf<BillingAddressElement>()
+        checkMandateField(formElements, metadata, 3)
+    }
+
+    @Test
+    fun `completed automatic tax billing address serializes to billing details`() = runTest {
+        val metadata = automaticTaxMetadata()
+        val billingAddressElement = KlarnaDefinition.formElements(metadata)
+            .filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<BillingAddressElement>()
+            .single()
+
+        billingAddressElement.setRawValue(
+            mapOf(
+                IdentifierSpec.Country to "US",
+                IdentifierSpec.Line1 to "510 Townsend St",
+                IdentifierSpec.City to "San Francisco",
+                IdentifierSpec.State to "CA",
+                IdentifierSpec.PostalCode to "94103",
+            ),
+        )
+        advanceUntilIdle()
+        val visibleValues = billingAddressElement.getFormFieldValueFlow().value
+            .toMap()
+            .filterKeys { it !in billingAddressElement.hiddenIdentifiers.value }
+        val params = FormFieldValues(
+            fieldValuePairs = visibleValues,
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
+        ).transformToPaymentMethodCreateParams(
+            paymentMethodCode = PaymentMethod.Type.Klarna.code,
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(visibleValues.values.all { it.isComplete }).isTrue()
+        assertThat(params.billingDetails?.address?.country).isEqualTo("US")
+        assertThat(params.billingDetails?.address?.line1).isEqualTo("510 Townsend St")
+        assertThat(params.billingDetails?.address?.city).isEqualTo("San Francisco")
+        assertThat(params.billingDetails?.address?.state).isEqualTo("CA")
+        assertThat(params.billingDetails?.address?.postalCode).isEqualTo("94103")
     }
 
     @Test
@@ -310,5 +443,35 @@ class KlarnaDefinitionTest {
 
         assertThat(mandateElement.stringResId).isEqualTo(R.string.stripe_klarna_mandate)
         assertThat(mandateElement.args).isEqualTo(listOf(metadata.merchantName, metadata.merchantName))
+    }
+
+    private fun automaticTaxMetadata(): PaymentMethodMetadata {
+        return PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFactory.create(
+                paymentMethodTypes = listOf(PaymentMethod.Type.Klarna.code),
+            ),
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                allowedCountries = setOf("US", "CA"),
+            ),
+            defaultBillingDetails = PaymentSheet.BillingDetails(
+                address = PaymentSheet.Address(country = "US"),
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
+    }
+
+    private fun BillingAddressElement.shownIdentifierParamPaths(): List<String> {
+        return addressController.value.fieldsFlowable.value
+            .filterOutHiddenIdentifiers(hiddenIdentifiers.value)
+            .flatMap { field ->
+                when (field) {
+                    is RowElement -> field.fields.map { it.identifier.v1 }
+                    else -> listOf(field.identifier.v1)
+                }
+            }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinitionTest.kt
@@ -3,11 +3,16 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,10 +26,7 @@ class WeroDefinitionTest {
             metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFactory.create(
                     paymentMethodTypes = listOf("wero")
-                ),
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
-                ),
+                )
             )
         )
 
@@ -55,6 +57,37 @@ class WeroDefinitionTest {
         checkEmailField(formElements, 1)
         checkPhoneField(formElements, 2)
         checkCountryField(formElements, 3)
+    }
+
+    @Test
+    fun `createFormElements promotes country and preserves Wero countries for automatic tax`() {
+        val formElements = WeroDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf(PaymentMethod.Type.Wero.code),
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                ),
+                defaultBillingDetails = PaymentSheet.BillingDetails(
+                    address = PaymentSheet.Address(country = "DE"),
+                ),
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    automaticTaxEnabled = true,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                ),
+            ),
+        )
+
+        val billingAddressElement = (formElements.single() as SectionElement)
+            .fields.single() as BillingAddressElement
+        assertThat(billingAddressElement.countryElement.controller.rawFieldValue.value).isEqualTo("DE")
+        assertThat(billingAddressElement.countryElement.controller.displayItems).containsExactly(
+            "🇧🇪 Belgium",
+            "🇫🇷 France",
+            "🇩🇪 Germany",
+        ).inOrder()
+        assertThat(billingAddressElement.hiddenIdentifiers.value).contains(IdentifierSpec.PostalCode)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -6,11 +6,16 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.TestUiDefinitionFactoryArgumentsFactory
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
@@ -27,10 +32,12 @@ import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.RowElement
+import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -38,6 +45,7 @@ import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -856,6 +864,81 @@ internal class FormViewModelTest {
         formViewModel.updateFormElements(newElementsWithSameIdentifiers)
 
         assertThat(formViewModel.elements).isSameInstanceAs(originalElements)
+    }
+
+    @Suppress("LongMethod")
+    @Test
+    fun `same as shipping serializes Klarna tax fields`() = runTest {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf(PaymentMethod.Type.Klarna.code),
+            ),
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                allowedCountries = setOf("US"),
+            ),
+            shippingDetails = AddressDetails(
+                address = PaymentSheet.Address(
+                    line1 = "510 Townsend St",
+                    line2 = "Suite 42",
+                    city = "San Francisco",
+                    state = "CA",
+                    postalCode = "94103",
+                    country = "US",
+                ),
+                isCheckboxSelected = false,
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            ),
+        )
+        val formElements = requireNotNull(
+            metadata.formElementsForCode(
+                code = PaymentMethod.Type.Klarna.code,
+                uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
+            ),
+        )
+        val sameAsShippingElement = formElements.filterIsInstance<SameAsShippingElement>().single()
+        val emailElement = formElements
+            .filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<EmailElement>()
+            .single()
+        val formViewModel = createViewModel(
+            arguments = COMPOSE_FRAGMENT_ARGS.copy(
+                paymentMethodCode = PaymentMethod.Type.Klarna.code,
+                billingDetails = null,
+            ),
+            formElements = formElements,
+        )
+
+        sameAsShippingElement.setRawValue(mapOf(IdentifierSpec.SameAsShipping to "true"))
+        emailElement.controller.onValueChange("jane@example.com")
+        advanceUntilIdle()
+        val formValues = requireNotNull(formViewModel.completeFormValues.first())
+        val params = formValues.transformToPaymentMethodCreateParams(
+            paymentMethodCode = PaymentMethod.Type.Klarna.code,
+            paymentMethodMetadata = metadata,
+        )
+
+        assertThat(formValues.fieldValuePairs).containsAtLeastEntriesIn(
+            mapOf(
+                IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
+                IdentifierSpec.Line1 to FormFieldEntry(value = "510 Townsend St", isComplete = true),
+                IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
+                IdentifierSpec.PostalCode to FormFieldEntry(value = "94103", isComplete = true),
+            ),
+        )
+        assertThat(formViewModel.hiddenIdentifiers.value).contains(IdentifierSpec.Line2)
+        assertThat(formValues.fieldValuePairs).doesNotContainKey(IdentifierSpec.Line2)
+        assertThat(params.billingDetails?.address?.country).isEqualTo("US")
+        assertThat(params.billingDetails?.address?.line1).isEqualTo("510 Townsend St")
+        assertThat(params.billingDetails?.address?.city).isEqualTo("San Francisco")
+        assertThat(params.billingDetails?.address?.state).isEqualTo("CA")
+        assertThat(params.billingDetails?.address?.postalCode).isEqualTo("94103")
+        assertThat(params.billingDetails?.address?.line2).isNull()
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary

With Automatic collection and billing-sourced Checkout automatic tax, eligible direct forms whose policy resolves to `Absent` or `CountryOnly` collect the country-specific tax minimum. `Full` and `Suppressed` remain unchanged.

This PR applies that behavior as the second stage of billing-address resolution:

```text
PaymentMethodBillingAddressPolicy
        + merchant configuration
        + automatic-tax requirement
        -> ResolvedBillingAddress
```

## What changed

- `ResolvedBillingAddress.TaxMinimum` represents the tax-specific rendered shape.
- `BillingAddressPolicyResolver.resolveAutomaticTax()` promotes only `Absent` and `CountryOnly`.
- Tax-created addresses keep the resolved country payload and render through the automatic-tax factory.
- Custom and external payment methods explicitly opt out. Tax-minimum addresses render a same-as-shipping control only when shipping supplies a parseable boolean value.

## What stays the same

- `Full` and `Suppressed` are preserved by automatic tax.
- Tax-disabled Automatic preserves country-only forms.
- Full resolution and generic billing-address construction remain owned by #13862.
- Server-defined forms, card AVS, Link, U.S. Bank Account, saved-payment-method behavior, public APIs, and changelog are unchanged.

## Coverage

`BillingAddressPolicyResolverTest` proves promotion of `Absent` and `CountryOnly`, preservation of `Full` and `Suppressed`, and merchant-versus-policy country selection. The registry test covers registered direct `Simple` definitions, including Boleto and SEPA Debit. Focused tests cover Blik, Klarna, and Wero positive paths; metadata tests cover custom and external opt-outs.

# Testing

- At the final stack tip, the uncached focused 85-test billing-address suite passed.
- At the final stack tip, `:paymentsheet:detekt`, `:paymentsheet:apiCheck`, `:payments-ui-core:detekt`, and `:payments-ui-core:apiCheck` passed.

# Screenshots

At the final stack tip, the selected Klarna and Cash App automatic-tax snapshots passed verification without recording.

# Changelog

Not applicable. This behavior is not public yet.
