### PR TITLE
Add ApiConfiguration to CheckoutController configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -14,6 +14,7 @@ import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.common.ui.PaymentElementActivityResultCaller
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.elements.CurrencySelectorElement
@@ -774,6 +775,7 @@ class CheckoutController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
         private var adaptivePricingAllowed: Boolean = false
+        private var apiConfiguration: ApiConfiguration? = null
         private var merchantDisplayName: String? = null
         private var googlePayConfiguration: GooglePayConfiguration? = null
         private var defaults: Defaults = Defaults()
@@ -792,6 +794,15 @@ class CheckoutController @Inject internal constructor(
             adaptivePricingAllowed: Boolean
         ): Configuration = apply {
             this.adaptivePricingAllowed = adaptivePricingAllowed
+        }
+
+        /**
+         * Sets the API configuration for this checkout session.
+         */
+        fun apiConfiguration(
+            apiConfiguration: ApiConfiguration,
+        ): Configuration = apply {
+            this.apiConfiguration = apiConfiguration
         }
 
         /**
@@ -864,6 +875,7 @@ class CheckoutController @Inject internal constructor(
         @Parcelize
         internal data class State(
             val adaptivePricingAllowed: Boolean,
+            val apiConfiguration: ApiConfiguration.State?,
             // Compatibility field for the existing billing-address consumers. The implementation
             // layer removes this after migrating them to [defaults].
             val defaultBillingAddress: Address.State?,
@@ -880,6 +892,7 @@ class CheckoutController @Inject internal constructor(
             val defaultsState = defaults.build()
             return State(
                 adaptivePricingAllowed = adaptivePricingAllowed,
+                apiConfiguration = apiConfiguration?.build(),
                 defaultBillingAddress = defaultsState.billingDetails?.address,
                 merchantDisplayName = merchantDisplayName,
                 paymentElementConfiguration = paymentElementConfiguration.build(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerConfigurationTest.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutControllerConfigurationTest {
+    @Test
+    fun `api configuration is null by default`() {
+        val state = CheckoutController.Configuration().build()
+
+        assertThat(state.apiConfiguration).isNull()
+    }
+
+    @Test
+    fun `api configuration builds requested credentials`() {
+        val state = CheckoutController.Configuration()
+            .apiConfiguration(
+                ApiConfiguration("pk_test_123")
+                    .stripeAccountId("acct_123")
+            )
+            .build()
+
+        assertThat(state.apiConfiguration?.publishableKey).isEqualTo("pk_test_123")
+        assertThat(state.apiConfiguration?.stripeAccountId).isEqualTo("acct_123")
+    }
+}


### PR DESCRIPTION
# Summary
- Adds optional `ApiConfiguration` storage to `CheckoutController.Configuration` and its parcelable state.
- Preserves the configured publishable key and Stripe account ID for later Checkout credential threading.

# Motivation
Checkout configuration needs to carry per-instance API credentials as part of the ongoing migration away from relying exclusively on global `PaymentConfiguration`. This change adds the configuration surface and state mapping without changing current credential resolution behavior.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutControllerConfigurationTest`

No tests were ignored.

# Screenshots
Not applicable — this change has no UI impact.

# Changelog
Not applicable — this API remains restricted to the library group and does not change user-facing behavior.
