### PR TITLE
Add CheckoutController.Configuration.defaults API

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -768,9 +768,9 @@ class CheckoutController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
         private var adaptivePricingAllowed: Boolean = false
-        private var defaultBillingAddress: Address? = null
         private var merchantDisplayName: String? = null
         private var googlePayConfiguration: GooglePayConfiguration? = null
+        private var defaults: Defaults = Defaults()
         private var paymentElementConfiguration: PaymentElement.Configuration = PaymentElement.Configuration()
         private var currencySelectorElementConfiguration: CurrencySelectorElement.Configuration =
             CurrencySelectorElement.Configuration()
@@ -786,18 +786,6 @@ class CheckoutController @Inject internal constructor(
             adaptivePricingAllowed: Boolean
         ): Configuration = apply {
             this.adaptivePricingAllowed = adaptivePricingAllowed
-        }
-
-        /**
-         * Sets the customer's known billing address.
-         *
-         * The address is used to prefill payment method forms. When automatic tax uses the billing
-         * address, Checkout can also use it to calculate an initial tax estimate.
-         */
-        fun defaultBillingAddress(
-            defaultBillingAddress: Address,
-        ): Configuration = apply {
-            this.defaultBillingAddress = defaultBillingAddress
         }
 
         /**
@@ -857,28 +845,122 @@ class CheckoutController @Inject internal constructor(
             this.googlePayConfiguration = configuration
         }
 
+        /**
+         * Prefill values for the customer's details. If known up front, these prepopulate the
+         * elements (and the Checkout Session) so the customer doesn't re-enter them.
+         */
+        fun defaults(
+            defaults: Defaults
+        ): Configuration = apply {
+            this.defaults = defaults
+        }
+
         @Parcelize
         internal data class State(
             val adaptivePricingAllowed: Boolean,
+            // Compatibility field for the existing billing-address consumers. The implementation
+            // layer removes this after migrating them to [defaults].
             val defaultBillingAddress: Address.State?,
             val merchantDisplayName: String?,
             val googlePayConfiguration: GooglePayConfiguration.State?,
+            val defaults: Defaults.State,
             val paymentElementConfiguration: PaymentElement.Configuration.State,
             val currencySelectorElementConfiguration: CurrencySelectorElement.Configuration.State,
             val shippingAddressElementConfiguration: ShippingAddressElement.Configuration.State,
             val expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State,
         ) : Parcelable
 
-        internal fun build(): State = State(
-            adaptivePricingAllowed = adaptivePricingAllowed,
-            defaultBillingAddress = defaultBillingAddress?.build(),
-            merchantDisplayName = merchantDisplayName,
-            paymentElementConfiguration = paymentElementConfiguration.build(),
-            currencySelectorElementConfiguration = currencySelectorElementConfiguration.build(),
-            shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),
-            expressCheckoutElementConfiguration = expressCheckoutElementConfiguration.build(),
-            googlePayConfiguration = googlePayConfiguration?.build(),
-        )
+        internal fun build(): State {
+            val defaultsState = defaults.build()
+            return State(
+                adaptivePricingAllowed = adaptivePricingAllowed,
+                defaultBillingAddress = defaultsState.billingDetails?.address,
+                merchantDisplayName = merchantDisplayName,
+                paymentElementConfiguration = paymentElementConfiguration.build(),
+                currencySelectorElementConfiguration = currencySelectorElementConfiguration.build(),
+                shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),
+                expressCheckoutElementConfiguration = expressCheckoutElementConfiguration.build(),
+                googlePayConfiguration = googlePayConfiguration?.build(),
+                defaults = defaultsState,
+            )
+        }
+
+        /**
+         * Prefill values for the customer's billing/shipping details and email.
+         */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Defaults {
+            private var billingDetails: ContactDetails? = null
+            private var shippingDetails: ContactDetails? = null
+            private var email: String? = null
+
+            /**
+             * The customer's known billing contact details.
+             */
+            fun billingDetails(billingDetails: ContactDetails): Defaults = apply {
+                this.billingDetails = billingDetails
+            }
+
+            /**
+             * The customer's known shipping contact details.
+             */
+            fun shippingDetails(shippingDetails: ContactDetails): Defaults = apply {
+                this.shippingDetails = shippingDetails
+            }
+
+            /**
+             * The customer's known email address.
+             */
+            fun email(email: String?): Defaults = apply {
+                this.email = email
+            }
+
+            @Parcelize
+            internal data class State(
+                val billingDetails: ContactDetails.State?,
+                val shippingDetails: ContactDetails.State?,
+                val email: String?,
+            ) : Parcelable
+
+            internal fun build(): State = State(
+                billingDetails = billingDetails?.build(),
+                shippingDetails = shippingDetails?.build(),
+                email = email?.trim()?.takeIf { it.isNotEmpty() },
+            )
+
+            /**
+             * A name, phone number, and postal address for a customer.
+             */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class ContactDetails {
+                private var name: String? = null
+                private var phoneNumber: String? = null
+                private var address: Address? = null
+
+                fun name(name: String?): ContactDetails = apply { this.name = name }
+
+                fun phoneNumber(phoneNumber: String?): ContactDetails = apply {
+                    this.phoneNumber = phoneNumber
+                }
+
+                fun address(address: Address): ContactDetails = apply { this.address = address }
+
+                @Parcelize
+                internal data class State(
+                    val name: String?,
+                    val phoneNumber: String?,
+                    val address: Address.State?,
+                ) : Parcelable
+
+                internal fun build(): State = State(
+                    name = name,
+                    phoneNumber = phoneNumber,
+                    address = address?.build(),
+                )
+            }
+        }
     }
 
     /**

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -144,13 +144,17 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `configure prefills the default billing address`() = runConfigureScenario(
-        configuration = CheckoutController.Configuration().defaultBillingAddress(
-            CheckoutController.Address()
-                .city(" San Francisco ")
-                .country(" US ")
-                .line1(" 510 Townsend St ")
-                .postalCode(" 94103 ")
-                .state(" CA ")
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().billingDetails(
+                CheckoutController.Configuration.Defaults.ContactDetails().address(
+                    CheckoutController.Address()
+                        .city(" San Francisco ")
+                        .country(" US ")
+                        .line1(" 510 Townsend St ")
+                        .postalCode(" 94103 ")
+                        .state(" CA ")
+                )
+            )
         ),
     ) {
         result.getOrThrow()
@@ -165,14 +169,18 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `configure sends default billing address when automatic tax targets billing`() = runConfigureScenario(
-        configuration = CheckoutController.Configuration().defaultBillingAddress(
-            CheckoutController.Address()
-                .city("San Francisco")
-                .country("US")
-                .line1("510 Townsend St")
-                .line2("Suite 100")
-                .postalCode("94103")
-                .state("CA")
+        configuration = CheckoutController.Configuration().defaults(
+            CheckoutController.Configuration.Defaults().billingDetails(
+                CheckoutController.Configuration.Defaults.ContactDetails().address(
+                    CheckoutController.Address()
+                        .city("San Francisco")
+                        .country("US")
+                        .line1("510 Townsend St")
+                        .line2("Suite 100")
+                        .postalCode("94103")
+                        .state("CA")
+                )
+            )
         ),
         networkSetup = {
             networkRule.checkoutInit(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -80,7 +80,12 @@ internal class CheckoutStateLoaderTest {
 
         loader.loadInitial(
             configuration = CheckoutController.Configuration()
-                .defaultBillingAddress(address)
+                .defaults(
+                    CheckoutController.Configuration.Defaults()
+                        .billingDetails(
+                            CheckoutController.Configuration.Defaults.ContactDetails().address(address),
+                        ),
+                )
                 .build(),
             checkoutSessionResponse = response(),
         )


### PR DESCRIPTION
# Summary

First PR in a two-PR stack. Adds the `CheckoutController.Configuration.defaults` API and its billing, shipping, email, and contact-detail builders. It replaces `defaultBillingAddress` with `defaults.billingDetails.address`.

This layer is limited to the API model, the internal compatibility state needed to preserve the existing billing-address behavior, and migration of the existing billing-address test call sites. The remaining prefill behavior is implemented by the dependent PR on `checkout-parity/configuration-defaults`.

# Motivation

Checkout Elements on iOS exposes configuration defaults for known customer details. Defining the Android API separately keeps the API shape reviewable independently from its runtime wiring while retaining the existing default-billing-address behavior between stack layers.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

No tests were ignored.

- `./gradlew :paymentsheet:testDebugUnitTest --tests "*CheckoutControllerTest" --tests "*CheckoutStateLoaderTest"`
- `./gradlew :paymentsheet:apiCheck :paymentsheet:detekt`

# Screenshots

Not applicable: this layer changes configuration APIs and has no visual UI changes.

# Changelog

Not applicable: `CheckoutController` is a preview, `LIBRARY_GROUP`-restricted API and is not part of the published API surface.
