### PR TITLE
Add shown event for all card element types

### DIFF
--- a/payments-core/res/layout/stripe_card_form_view.xml
+++ b/payments-core/res/layout/stripe_card_form_view.xml
@@ -16,6 +16,7 @@
                 android:id="@+id/card_multiline_widget"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                app:isIntegratedInStripeView="true"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:shouldShowPostalCode="false" />

--- a/payments-core/res/values/attrs.xml
+++ b/payments-core/res/values/attrs.xml
@@ -11,6 +11,7 @@
         <attr name="shouldShowPostalCode" format="boolean" />
         <attr name="shouldRequirePostalCode" format="boolean" />
         <attr name="shouldRequireUsZipCode" format="boolean" />
+        <attr name="isIntegratedInStripeView" format="boolean" />
     </declare-styleable>
 
     <declare-styleable name="BecsDebitWidget" tools:ignore="ResourceName">

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -113,7 +113,10 @@ enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
     CardMetadataMissingRange("card_metadata_missing_range"),
     CardMetadataExpectedExtraDigitsButUserEntered16ThenSwitchedFields(
         "card_metadata.expected_extra_digits_but_user_entered_16_then_switched_fields"
-    );
+    ),
+
+    // Card Element
+    MobileCardElementShown("mobile_card_element_shown");
 
     @Keep
     override fun toString(): String {

--- a/payments-core/src/main/java/com/stripe/android/view/CardElementAnalytics.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardElementAnalytics.kt
@@ -1,0 +1,153 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import com.stripe.android.BuildConfig
+import com.stripe.android.core.Logger
+import com.stripe.android.core.networking.AnalyticsRequestV2Executor
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory
+import com.stripe.android.core.networking.DefaultAnalyticsRequestV2Executor
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.networking.RealAnalyticsRequestV2Storage
+import com.stripe.android.networking.PaymentAnalyticsEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+internal interface CardElementAnalytics {
+    fun reportShown(context: Context)
+
+    fun saveState(outState: Bundle)
+
+    fun restoreState(savedState: Bundle)
+}
+
+internal class DefaultCardElementAnalytics internal constructor(
+    private val widgetType: CardElementWidgetType,
+    private val cardElementAnalyticsRequestExecutorFactory: CardElementAnalyticsRequestExecutor.Factory,
+) : CardElementAnalytics {
+    internal constructor(
+        widgetType: CardElementWidgetType,
+    ) : this(
+        widgetType = widgetType,
+        cardElementAnalyticsRequestExecutorFactory = DefaultCardElementAnalyticsRequestExecutor.Factory,
+    )
+
+    private var hasReportedShown: Boolean = false
+
+    override fun reportShown(context: Context) {
+        if (hasReportedShown) {
+            return
+        }
+        hasReportedShown = true
+        fire(
+            context = context,
+            event = PaymentAnalyticsEvent.MobileCardElementShown,
+            params = mapOf(PARAM_WIDGET_TYPE to widgetType.analyticsValue),
+        )
+    }
+
+    override fun saveState(outState: Bundle) {
+        outState.putBundle(
+            STATE_CARD_ELEMENT_ANALYTICS,
+            bundleOf(
+                KEY_HAS_REPORTED_SHOWN to hasReportedShown,
+            )
+        )
+    }
+
+    override fun restoreState(savedState: Bundle) {
+        val state = savedState.getBundle(STATE_CARD_ELEMENT_ANALYTICS)
+
+        hasReportedShown = state?.getBoolean(KEY_HAS_REPORTED_SHOWN) ?: false
+    }
+
+    private fun fire(
+        context: Context,
+        event: PaymentAnalyticsEvent,
+        params: Map<String, String>,
+    ) {
+        cardElementAnalyticsRequestExecutorFactory
+            .create(context)
+            .report(event, params)
+    }
+
+    internal companion object {
+        const val PARAM_WIDGET_TYPE = "widget_type"
+
+        const val STATE_CARD_ELEMENT_ANALYTICS = "stripe_card_element_analytics_state"
+
+        const val KEY_HAS_REPORTED_SHOWN = "stripe_card_element_has_reported_shown"
+    }
+}
+
+internal object NoOpCardElementCardElementAnalytics : CardElementAnalytics {
+    override fun reportShown(context: Context) {
+        // No-op
+    }
+
+    override fun saveState(outState: Bundle) {
+        // No-op
+    }
+
+    override fun restoreState(savedState: Bundle) {
+        // No-op
+    }
+}
+
+internal interface CardElementAnalyticsRequestExecutor {
+    fun report(
+        event: PaymentAnalyticsEvent,
+        params: Map<String, String>,
+    )
+
+    interface Factory {
+        fun create(context: Context): CardElementAnalyticsRequestExecutor
+    }
+}
+
+internal class DefaultCardElementAnalyticsRequestExecutor internal constructor(
+    private val analyticsFactory: AnalyticsRequestV2Factory,
+    private val analyticsExecutor: AnalyticsRequestV2Executor,
+    private val coroutineScope: CoroutineScope,
+) : CardElementAnalyticsRequestExecutor {
+    override fun report(
+        event: PaymentAnalyticsEvent,
+        params: Map<String, String>,
+    ) {
+        coroutineScope.launch {
+            analyticsExecutor.enqueue(
+                analyticsFactory.createRequest(event.eventName, params),
+            )
+        }
+    }
+
+    object Factory : CardElementAnalyticsRequestExecutor.Factory {
+        override fun create(context: Context): CardElementAnalyticsRequestExecutor {
+            val applicationContext = context.applicationContext
+            val logger = Logger.getInstance(BuildConfig.DEBUG)
+
+            return DefaultCardElementAnalyticsRequestExecutor(
+                analyticsFactory = AnalyticsRequestV2Factory(
+                    clientId = CLIENT_ID,
+                    origin = ORIGIN,
+                    context = applicationContext,
+                ),
+                analyticsExecutor = DefaultAnalyticsRequestV2Executor(
+                    context = applicationContext,
+                    logger = logger,
+                    networkClient = DefaultStripeNetworkClient(
+                        logger = logger,
+                    ),
+                    storage = RealAnalyticsRequestV2Storage(applicationContext),
+                    isWorkManagerAvailable = { false },
+                ),
+                coroutineScope = CoroutineScope(Dispatchers.IO),
+            )
+        }
+
+        private const val CLIENT_ID = "stripe-mobile-sdk"
+        private const val ORIGIN = "stripe-mobile-sdk-android"
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardElementWidgetType.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardElementWidgetType.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.view
+
+internal enum class CardElementWidgetType(val analyticsValue: String) {
+    CardInputWidget("card_input_widget"),
+    CardFormView("card_form_view"),
+    CardMultilineWidget("card_multiline_widget"),
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -43,10 +43,11 @@ import com.stripe.payments.model.R as PaymentsModelR
  * To access the [CardParams], see details in [cardParams] property.
  * To get notified if the current card params are valid, set a [CardValidCallback] object with [setCardValidCallback].
  */
-class CardFormView @JvmOverloads constructor(
+class CardFormView internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    defStyleAttr: Int = 0,
+    private val cardElementAnalytics: CardElementAnalytics,
 ) : LinearLayout(context, attrs, defStyleAttr) {
     private val layoutInflater = LayoutInflater.from(context)
     private val viewBinding = StripeCardFormViewBinding.inflate(layoutInflater, this)
@@ -251,6 +252,19 @@ class CardFormView @JvmOverloads constructor(
         }
     }
 
+    @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : this(
+        context = context,
+        attrs = attrs,
+        defStyleAttr = defStyleAttr,
+        cardElementAnalytics = DefaultCardElementAnalytics(
+            widgetType = CardElementWidgetType.CardFormView,
+        ),
+    )
+
     fun setCardValidCallback(callback: CardValidCallback?) {
         this.cardValidCallback = callback
         allEditTextFields.forEach { it.removeTextChangedListener(cardValidTextWatcher) }
@@ -438,11 +452,14 @@ class CardFormView @JvmOverloads constructor(
             STATE_SUPER_STATE to super.onSaveInstanceState(),
             STATE_ENABLED to isEnabled,
             STATE_ON_BEHALF_OF to onBehalfOf,
-        )
+        ).apply {
+            cardElementAnalytics.saveState(this)
+        }
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
         if (state is Bundle) {
+            cardElementAnalytics.restoreState(state)
             super.onRestoreInstanceState(state.getParcelable(STATE_SUPER_STATE))
             isEnabled = state.getBoolean(STATE_ENABLED)
             onBehalfOf = state.getString(STATE_ON_BEHALF_OF)
@@ -453,6 +470,7 @@ class CardFormView @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        cardElementAnalytics.reportShown(context = context)
         lifecycleOwnerDelegate.initLifecycle(this)
         // Merchant could set onBehalfOf before view is attached to window.
         // Check and set if needed.

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -54,10 +54,11 @@ import kotlin.properties.Delegates
  * The card number, cvc, and expiry date will always be left to right regardless of locale.  Postal
  * code layout direction will be set according to the locale.
  */
-class CardInputWidget @JvmOverloads constructor(
+class CardInputWidget internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    defStyleAttr: Int = 0,
+    private val cardElementAnalytics: CardElementAnalytics,
 ) : LinearLayout(context, attrs, defStyleAttr), CardWidget {
     private var customCvcLabel: String? = null
     private val viewBinding = StripeCardInputWidgetBinding.inflate(
@@ -426,6 +427,19 @@ class CardInputWidget @JvmOverloads constructor(
             }
         }
 
+    @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
+    ) : this(
+        context = context,
+        attrs = attrs,
+        defStyleAttr = defStyleAttr,
+        cardElementAnalytics = DefaultCardElementAnalytics(
+            widgetType = CardElementWidgetType.CardInputWidget,
+        ),
+    )
+
     init {
         // This ensures that onRestoreInstanceState is called
         // during rotations.
@@ -450,6 +464,7 @@ class CardInputWidget @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        cardElementAnalytics.reportShown(context = context)
         lifecycleDelegate.initLifecycle(this)
 
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
@@ -641,11 +656,14 @@ class CardInputWidget @JvmOverloads constructor(
             STATE_CARD_VIEWED to isShowingFullCard,
             STATE_POSTAL_CODE_ENABLED to postalCodeEnabled,
             STATE_ON_BEHALF_OF to onBehalfOf
-        )
+        ).apply {
+            cardElementAnalytics.saveState(this)
+        }
     }
 
     override fun onRestoreInstanceState(state: Parcelable) {
         if (state is Bundle) {
+            cardElementAnalytics.restoreState(state)
             postalCodeEnabled = state.getBoolean(STATE_POSTAL_CODE_ENABLED, true)
             isShowingFullCard = state.getBoolean(STATE_CARD_VIEWED, true)
             onBehalfOf = state.getString(STATE_ON_BEHALF_OF)

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -32,6 +32,7 @@ import com.stripe.android.model.CardParams
 import com.stripe.android.model.ExpirationDate
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import kotlin.jvm.JvmOverloads
 import kotlin.properties.Delegates
 
 /**
@@ -43,11 +44,12 @@ import kotlin.properties.Delegates
  * The card number, cvc, and expiry date will always be left to right regardless of locale.  Postal
  * code layout direction will be set according to the locale.
  */
-class CardMultilineWidget @JvmOverloads constructor(
+class CardMultilineWidget internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-    private var shouldShowPostalCode: Boolean = CardWidget.DEFAULT_POSTAL_CODE_ENABLED
+    private var shouldShowPostalCode: Boolean = CardWidget.DEFAULT_POSTAL_CODE_ENABLED,
+    private val cardElementAnalytics: CardElementAnalytics,
 ) : LinearLayout(context, attrs, defStyleAttr), CardWidget {
     private val viewBinding = StripeCardMultilineWidgetBinding.inflate(
         LayoutInflater.from(context),
@@ -371,6 +373,24 @@ class CardMultilineWidget @JvmOverloads constructor(
         cardBrandView.merchantPreferredNetworks = preferredNetworks
     }
 
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+        shouldShowPostalCode: Boolean = CardWidget.DEFAULT_POSTAL_CODE_ENABLED,
+    ) : this(
+        context = context,
+        attrs = attrs,
+        defStyleAttr = defStyleAttr,
+        shouldShowPostalCode = shouldShowPostalCode,
+        cardElementAnalytics = if (isIntegratedWithinStripeView(context, attrs)) {
+            NoOpCardElementCardElementAnalytics
+        } else {
+            DefaultCardElementAnalytics(CardElementWidgetType.CardMultilineWidget)
+        },
+    )
+
     init {
         orientation = VERTICAL
 
@@ -483,6 +503,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        cardElementAnalytics.reportShown(context)
         // see https://github.com/stripe/stripe-android/pull/3154
         cvcEditText.hint = null
 
@@ -583,13 +604,15 @@ class CardMultilineWidget @JvmOverloads constructor(
         return bundleOf(
             STATE_REMAINING_STATE to super.onSaveInstanceState(),
             STATE_ON_BEHALF_OF to onBehalfOf
-        )
+        ).apply {
+            cardElementAnalytics.saveState(this)
+        }
     }
 
     override fun onRestoreInstanceState(state: Parcelable) {
         if (state is Bundle) {
             onBehalfOf = state.getString(STATE_ON_BEHALF_OF)
-
+            cardElementAnalytics.restoreState(state)
             super.onRestoreInstanceState(state.getParcelable(STATE_REMAINING_STATE))
         } else {
             super.onRestoreInstanceState(state)
@@ -857,5 +880,25 @@ class CardMultilineWidget @JvmOverloads constructor(
         private const val CARD_MULTILINE_TOKEN = "CardMultilineView"
         private const val STATE_REMAINING_STATE = "state_remaining_state"
         private const val STATE_ON_BEHALF_OF = "state_on_behalf_of"
+    }
+}
+
+private fun isIntegratedWithinStripeView(
+    context: Context,
+    attrs: AttributeSet?,
+): Boolean {
+    if (attrs == null) {
+        return false
+    }
+
+    val typedArray = context.obtainStyledAttributes(attrs, R.styleable.CardElement)
+
+    return try {
+        typedArray.getBoolean(
+            R.styleable.CardElement_isIntegratedInStripeView,
+            false,
+        )
+    } finally {
+        typedArray.recycle()
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.utils.CardElementTestHelper
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
 import com.stripe.android.view.CardFormViewTestActivity.Companion.VIEW_ID
+import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
 import org.junit.Before
 import org.junit.Rule
@@ -510,6 +511,60 @@ internal class CardFormViewTest {
         }
     }
 
+    @Test
+    fun `reportShown is called when card form attaches`() = runCardFormViewAnalyticsTest {
+        assertThat(analytics.awaitShown()).isNotNull()
+    }
+
+    private data class AnalyticsScenario(
+        val analytics: RecordingCardElementAnalytics,
+        val cardFormView: CardFormView,
+        val binding: StripeCardFormViewBinding,
+    )
+
+    private fun runCardFormViewAnalyticsTest(
+        locale: Locale = Locale.US,
+        block: suspend AnalyticsScenario.() -> Unit,
+    ) {
+        val originalLocale = Locale.getDefault()
+        Locale.setDefault(locale)
+
+        ActivityScenario.launch<CardFormViewTestActivity>(
+            Intent(context, CardFormViewTestActivity::class.java).apply {
+                putExtra(
+                    "args",
+                    CardFormViewTestActivity.Args(
+                        isCbcEligible = false,
+                        borderless = false,
+                        useRecordingCardElementAnalytics = true,
+                    ),
+                )
+            }
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                runBlocking {
+                    val cardFormView = activity.findViewById<CardFormView>(VIEW_ID)
+                    val binding = StripeCardFormViewBinding.bind(cardFormView)
+                    val analytics = activity.recordingCardElementAnalytics
+
+                    idleLooper()
+
+                    block(
+                        AnalyticsScenario(
+                            analytics = analytics,
+                            cardFormView = cardFormView,
+                            binding = binding,
+                        )
+                    )
+
+                    analytics.ensureAllEventsConsumed()
+                }
+            }
+        }
+
+        Locale.setDefault(originalLocale)
+    }
+
     private fun StripeCardFormViewBinding.populate(
         visa: String,
         month: String,
@@ -576,6 +631,7 @@ internal class CardFormViewTestActivity : AppCompatActivity() {
     data class Args(
         val isCbcEligible: Boolean,
         val borderless: Boolean,
+        val useRecordingCardElementAnalytics: Boolean = false,
     ) : Parcelable
 
     private val args: Args by lazy {
@@ -583,13 +639,26 @@ internal class CardFormViewTestActivity : AppCompatActivity() {
         intent.getParcelableExtra("args")!!
     }
 
+    val recordingCardElementAnalytics = RecordingCardElementAnalytics()
+
     private val cardFormView: CardFormView by lazy {
         val style = if (args.borderless) "1" else "0"
         val attributes = Robolectric.buildAttributeSet()
             .addAttribute(R.attr.cardFormStyle, style)
             .build()
 
-        CardFormView(this, attributes).apply {
+        val view = if (args.useRecordingCardElementAnalytics) {
+            CardFormView(
+                context = this,
+                attrs = attributes,
+                defStyleAttr = 0,
+                cardElementAnalytics = recordingCardElementAnalytics,
+            )
+        } else {
+            CardFormView(this, attributes)
+        }
+
+        view.apply {
             id = VIEW_ID
 
             val storeOwner = CardElementTestHelper.createViewModelStoreOwner(

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -46,6 +46,7 @@ import com.stripe.android.utils.createTestActivityRule
 import com.stripe.android.view.CardInputWidget.Companion.LOGGING_TOKEN
 import com.stripe.android.view.CardInputWidget.Companion.shouldIconShowBrand
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.hamcrest.CoreMatchers.anything
 import org.junit.Rule
@@ -1822,6 +1823,49 @@ internal class CardInputWidgetTest {
         assertThat(cardBrandView.possibleBrands.size).isEqualTo(2)
     }
 
+    @Test
+    fun `card element analytics reportShown when widget attaches`() = runCardInputWidgetAnalyticsTest {
+        assertThat(cardElementAnalytics.awaitShown()).isNotNull()
+    }
+
+    private fun runCardInputWidgetAnalyticsTest(
+        block: suspend AnalyticsScenario.() -> Unit,
+    ) {
+        ActivityScenario.launch<CardInputWidgetTestActivity>(
+            Intent(context, CardInputWidgetTestActivity::class.java).apply {
+                putExtra(
+                    "args",
+                    CardInputWidgetTestActivity.Args(
+                        isCbcEligible = false,
+                    ),
+                )
+            }
+        ).use { scenario ->
+            scenario.onActivity { activity ->
+                runTest {
+                    val widget = activity.findViewById<CardInputWidget>(CardInputWidgetTestActivity.VIEW_ID)
+                    val cardElementAnalytics = activity.recordingCardElementAnalytics
+
+                    idleLooper()
+
+                    block(
+                        AnalyticsScenario(
+                            cardInputWidget = widget,
+                            cardElementAnalytics = cardElementAnalytics,
+                        )
+                    )
+
+                    cardElementAnalytics.ensureAllEventsConsumed()
+                }
+            }
+        }
+    }
+
+    private class AnalyticsScenario(
+        val cardInputWidget: CardInputWidget,
+        val cardElementAnalytics: RecordingCardElementAnalytics,
+    )
+
     private fun runCardInputWidgetTest(
         isCbcEligible: Boolean = false,
         afterRecreation: (CardInputWidget.() -> Unit)? = null,
@@ -1924,8 +1968,15 @@ internal class CardInputWidgetTestActivity : AppCompatActivity() {
         intent.getParcelableExtra("args")!!
     }
 
+    val recordingCardElementAnalytics = RecordingCardElementAnalytics()
+
     private val cardInputWidget: CardInputWidget by lazy {
-        CardInputWidget(this).apply {
+        CardInputWidget(
+            context = this,
+            attrs = null,
+            defStyleAttr = 0,
+            cardElementAnalytics = recordingCardElementAnalytics,
+        ).apply {
             id = VIEW_ID
 
             layoutWidthCalculator = CardInputWidget.LayoutWidthCalculator { text, _ -> text.length * 10 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -45,6 +45,7 @@ import com.stripe.android.utils.CardElementTestHelper
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.hamcrest.CoreMatchers.anything
 import org.hamcrest.Matchers
@@ -1340,6 +1341,54 @@ internal class CardMultilineWidgetTest {
         }
     }
 
+    @Test
+    fun `reportShown is called on attach`() =
+        runCardMultilineWidgetAnalyticsTest {
+            assertThat(cardAnalytics.awaitShown()).isNotNull()
+        }
+
+    private data class AnalyticsScenario(
+        val activity: CardMultilineWidgetTestActivity,
+        val cardAnalytics: RecordingCardElementAnalytics,
+        val widgetGroup: WidgetControlGroup,
+    )
+
+    private fun runCardMultilineWidgetAnalyticsTest(
+        block: suspend AnalyticsScenario.() -> Unit,
+    ) {
+        ActivityScenario.launch<CardMultilineWidgetTestActivity>(
+            Intent(context, CardMultilineWidgetTestActivity::class.java).apply {
+                putExtra(
+                    "args",
+                    CardMultilineWidgetTestActivity.Args(
+                        isCbcEligible = false,
+                        useRecordingCardElementAnalytics = true,
+                    ),
+                )
+            }
+        ).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                runTest {
+                    activity.setWorkContext(coroutineContext)
+
+                    val cardElementAnalytics = activity.recordingFullCardElementAnalytics
+
+                    idleLooper()
+
+                    block(
+                        AnalyticsScenario(
+                            activity = activity,
+                            cardAnalytics = cardElementAnalytics,
+                            widgetGroup = activity.fullGroup,
+                        )
+                    )
+
+                    cardElementAnalytics.ensureAllEventsConsumed()
+                }
+            }
+        }
+    }
+
     private fun runCardMultilineWidgetTest(
         isCbcEligible: Boolean = false,
         block: TestContext.() -> Unit,
@@ -1406,6 +1455,7 @@ internal class CardMultilineWidgetTestActivity : AppCompatActivity() {
     @Parcelize
     data class Args(
         val isCbcEligible: Boolean,
+        val useRecordingCardElementAnalytics: Boolean = false,
     ) : Parcelable
 
     private val args: Args by lazy {
@@ -1413,8 +1463,24 @@ internal class CardMultilineWidgetTestActivity : AppCompatActivity() {
         intent.getParcelableExtra("args")!!
     }
 
+    val recordingFullCardElementAnalytics = RecordingCardElementAnalytics()
+
+    val recordingNoZipCardElementAnalytics = RecordingCardElementAnalytics()
+
     private val cardMultilineWidget: CardMultilineWidget by lazy {
-        CardMultilineWidget(this, shouldShowPostalCode = true).apply {
+        val widget = if (args.useRecordingCardElementAnalytics) {
+            CardMultilineWidget(
+                context = this,
+                attrs = null,
+                defStyleAttr = 0,
+                shouldShowPostalCode = true,
+                cardElementAnalytics = recordingFullCardElementAnalytics,
+            )
+        } else {
+            CardMultilineWidget(this, shouldShowPostalCode = true)
+        }
+
+        widget.apply {
             id = VIEW_ID
 
             val storeOwner = CardElementTestHelper.createViewModelStoreOwner(
@@ -1427,7 +1493,19 @@ internal class CardMultilineWidgetTestActivity : AppCompatActivity() {
     }
 
     private val noZipCardMultilineWidget: CardMultilineWidget by lazy {
-        CardMultilineWidget(this, shouldShowPostalCode = false).apply {
+        val widget = if (args.useRecordingCardElementAnalytics) {
+            CardMultilineWidget(
+                context = this,
+                attrs = null,
+                defStyleAttr = 0,
+                shouldShowPostalCode = false,
+                cardElementAnalytics = recordingNoZipCardElementAnalytics,
+            )
+        } else {
+            CardMultilineWidget(this, shouldShowPostalCode = false)
+        }
+
+        widget.apply {
             id = NO_ZIP_VIEW_ID
 
             val storeOwner = CardElementTestHelper.createViewModelStoreOwner(

--- a/payments-core/src/test/java/com/stripe/android/view/DefaultCardElementAnalyticsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/DefaultCardElementAnalyticsTest.kt
@@ -1,0 +1,145 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networking.PaymentAnalyticsEvent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultCardElementAnalyticsTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `reportShown sends event once per session`() = test(
+        widgetType = CardElementWidgetType.CardInputWidget,
+    ) {
+        analytics.reportShown(context)
+        analytics.reportShown(context)
+
+        assertThat(executor.awaitReportCall()).isEqualTo(
+            FakeCardElementAnalyticsRequestExecutor.ReportCall(
+                event = PaymentAnalyticsEvent.MobileCardElementShown,
+                params = mapOf(
+                    DefaultCardElementAnalytics.PARAM_WIDGET_TYPE to
+                        CardElementWidgetType.CardInputWidget.analyticsValue,
+                ),
+            ),
+        )
+        executor.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `reportShown uses multiline widget type`() = test(
+        widgetType = CardElementWidgetType.CardMultilineWidget,
+    ) {
+        analytics.reportShown(context)
+
+        assertThat(executor.awaitReportCall()).isEqualTo(
+            FakeCardElementAnalyticsRequestExecutor.ReportCall(
+                event = PaymentAnalyticsEvent.MobileCardElementShown,
+                params = mapOf(
+                    DefaultCardElementAnalytics.PARAM_WIDGET_TYPE to
+                        CardElementWidgetType.CardMultilineWidget.analyticsValue,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `saveState and restoreState preserve dedupe across instances`() = runTest {
+        val executor = FakeCardElementAnalyticsRequestExecutor()
+        val factory = FakeCardElementAnalyticsRequestExecutorFactory(executor = executor)
+
+        val first = DefaultCardElementAnalytics(
+            widgetType = CardElementWidgetType.CardFormView,
+            cardElementAnalyticsRequestExecutorFactory = factory,
+        )
+
+        first.reportShown(context)
+
+        assertThat(executor.awaitReportCall().event)
+            .isEqualTo(PaymentAnalyticsEvent.MobileCardElementShown)
+
+        val bundle = Bundle()
+        first.saveState(bundle)
+
+        val second = DefaultCardElementAnalytics(
+            widgetType = CardElementWidgetType.CardFormView,
+            cardElementAnalyticsRequestExecutorFactory = factory,
+        )
+
+        second.restoreState(bundle)
+
+        second.reportShown(context)
+
+        executor.expectNoEvents()
+    }
+
+    private fun test(
+        widgetType: CardElementWidgetType = CardElementWidgetType.CardFormView,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val executor = FakeCardElementAnalyticsRequestExecutor()
+        val analytics = DefaultCardElementAnalytics(
+            widgetType = widgetType,
+            cardElementAnalyticsRequestExecutorFactory = FakeCardElementAnalyticsRequestExecutorFactory(
+                executor = executor,
+            ),
+        )
+
+        Scenario(
+            context = context,
+            executor = executor,
+            analytics = analytics,
+        ).block()
+
+        executor.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val context: Context,
+        val executor: FakeCardElementAnalyticsRequestExecutor,
+        val analytics: CardElementAnalytics,
+    )
+
+    private class FakeCardElementAnalyticsRequestExecutor : CardElementAnalyticsRequestExecutor {
+        private val reportCalls = Turbine<ReportCall>()
+
+        suspend fun awaitReportCall(): ReportCall = reportCalls.awaitItem()
+
+        fun ensureAllEventsConsumed() {
+            reportCalls.ensureAllEventsConsumed()
+        }
+
+        fun expectNoEvents() {
+            reportCalls.expectNoEvents()
+        }
+
+        override fun report(
+            event: PaymentAnalyticsEvent,
+            params: Map<String, String>,
+        ) {
+            reportCalls.add(ReportCall(event = event, params = params))
+        }
+
+        data class ReportCall(
+            val event: PaymentAnalyticsEvent,
+            val params: Map<String, String>,
+        )
+    }
+
+    private class FakeCardElementAnalyticsRequestExecutorFactory(
+        private val executor: FakeCardElementAnalyticsRequestExecutor,
+    ) : CardElementAnalyticsRequestExecutor.Factory {
+        override fun create(context: Context): CardElementAnalyticsRequestExecutor {
+            return executor
+        }
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/view/RecordingCardElementAnalytics.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/RecordingCardElementAnalytics.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.os.Bundle
+import app.cash.turbine.Turbine
+
+internal class RecordingCardElementAnalytics : CardElementAnalytics {
+    private val shownCalls = Turbine<Unit>()
+
+    override fun reportShown(context: Context) {
+        shownCalls.add(Unit)
+    }
+
+    override fun saveState(outState: Bundle) {
+        // No-op
+    }
+
+    override fun restoreState(savedState: Bundle) {
+        // No-op
+    }
+
+    suspend fun awaitShown() {
+        shownCalls.awaitItem()
+    }
+
+    fun ensureAllEventsConsumed() {
+        shownCalls.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
## Summary
Add a shown event for all card element types:
- Introduces `CardElementAnalytics` and wires it into `CardInputWidget`, `CardFormView`, and `CardMultilineWidget`
- Persists analytics dedupe state across configuration changes via save/restore instance state
- Reports `mobile_card_element_shown` on attach, with analytics omitted for `CardMultilineWidget` when embedded in `CardFormView` & `CardInputWidget`.

# Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5438 

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified