### PR TITLE
Add card element interaction and form completed analytics events

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -116,7 +116,9 @@ enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
     ),
 
     // Card Element
-    MobileCardElementShown("mobile_card_element_shown");
+    MobileCardElementShown("mobile_card_element_shown"),
+    MobileCardElementInteraction("mobile_card_element_interaction"),
+    MobileCardElementFormCompleted("mobile_card_element_form_completed");
 
     @Keep
     override fun toString(): String {

--- a/payments-core/src/main/java/com/stripe/android/view/CardElementAnalytics.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardElementAnalytics.kt
@@ -18,6 +18,10 @@ import kotlinx.coroutines.launch
 internal interface CardElementAnalytics {
     fun reportShown(context: Context)
 
+    fun reportInteraction(context: Context)
+
+    fun reportFormCompleted(context: Context)
+
     fun saveState(outState: Bundle)
 
     fun restoreState(savedState: Bundle)
@@ -35,6 +39,8 @@ internal class DefaultCardElementAnalytics internal constructor(
     )
 
     private var hasReportedShown: Boolean = false
+    private var hasReportedInteraction: Boolean = false
+    private var hasReportedFormCompleted: Boolean = false
 
     override fun reportShown(context: Context) {
         if (hasReportedShown) {
@@ -48,11 +54,37 @@ internal class DefaultCardElementAnalytics internal constructor(
         )
     }
 
+    override fun reportInteraction(context: Context) {
+        if (hasReportedInteraction) {
+            return
+        }
+        hasReportedInteraction = true
+        fire(
+            context = context,
+            event = PaymentAnalyticsEvent.MobileCardElementInteraction,
+            params = mapOf(PARAM_WIDGET_TYPE to widgetType.analyticsValue),
+        )
+    }
+
+    override fun reportFormCompleted(context: Context) {
+        if (hasReportedFormCompleted) {
+            return
+        }
+        hasReportedFormCompleted = true
+        fire(
+            context = context,
+            event = PaymentAnalyticsEvent.MobileCardElementFormCompleted,
+            params = mapOf(PARAM_WIDGET_TYPE to widgetType.analyticsValue),
+        )
+    }
+
     override fun saveState(outState: Bundle) {
         outState.putBundle(
             STATE_CARD_ELEMENT_ANALYTICS,
             bundleOf(
                 KEY_HAS_REPORTED_SHOWN to hasReportedShown,
+                    KEY_HAS_REPORTED_INTERACTION to hasReportedInteraction,
+                KEY_HAS_REPORTED_FORM_COMPLETED to hasReportedFormCompleted,
             )
         )
     }
@@ -61,6 +93,8 @@ internal class DefaultCardElementAnalytics internal constructor(
         val state = savedState.getBundle(STATE_CARD_ELEMENT_ANALYTICS)
 
         hasReportedShown = state?.getBoolean(KEY_HAS_REPORTED_SHOWN) ?: false
+        hasReportedInteraction = state?.getBoolean(KEY_HAS_REPORTED_INTERACTION) ?: false
+        hasReportedFormCompleted = state?.getBoolean(KEY_HAS_REPORTED_FORM_COMPLETED) ?: false
     }
 
     private fun fire(
@@ -79,11 +113,21 @@ internal class DefaultCardElementAnalytics internal constructor(
         const val STATE_CARD_ELEMENT_ANALYTICS = "stripe_card_element_analytics_state"
 
         const val KEY_HAS_REPORTED_SHOWN = "stripe_card_element_has_reported_shown"
+        const val KEY_HAS_REPORTED_INTERACTION = "stripe_card_element_has_reported_interaction"
+        const val KEY_HAS_REPORTED_FORM_COMPLETED = "stripe_card_element_has_reported_form_completed"
     }
 }
 
 internal object NoOpCardElementCardElementAnalytics : CardElementAnalytics {
     override fun reportShown(context: Context) {
+        // No-op
+    }
+
+    override fun reportInteraction(context: Context) {
+        // No-op
+    }
+
+    override fun reportFormCompleted(context: Context) {
         // No-op
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardElementAnalytics.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardElementAnalytics.kt
@@ -83,7 +83,7 @@ internal class DefaultCardElementAnalytics internal constructor(
             STATE_CARD_ELEMENT_ANALYTICS,
             bundleOf(
                 KEY_HAS_REPORTED_SHOWN to hasReportedShown,
-                    KEY_HAS_REPORTED_INTERACTION to hasReportedInteraction,
+                KEY_HAS_REPORTED_INTERACTION to hasReportedInteraction,
                 KEY_HAS_REPORTED_FORM_COMPLETED to hasReportedFormCompleted,
             )
         )

--- a/payments-core/src/main/java/com/stripe/android/view/CardElementWatchers.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardElementWatchers.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.view
+
+import android.content.Context
+import android.text.Editable
+import android.view.View
+
+internal class CardElementWatchers(
+    private val context: Context,
+    private val cardElementAnalytics: CardElementAnalytics,
+    private val invalidFieldProviders: () -> Set<CardValidCallback.Fields>,
+    private val cardValidCallbackProvider: () -> CardValidCallback?,
+) {
+    val textFocusWatcher = View.OnFocusChangeListener { _, hasFocus ->
+        if (hasFocus) {
+            cardElementAnalytics.reportInteraction(context)
+        }
+    }
+
+    val textInputWatcher = object : StripeTextWatcher() {
+        override fun afterTextChanged(s: Editable?) {
+            super.afterTextChanged(s)
+
+            cardElementAnalytics.reportInteraction(context)
+
+            val invalidFields = invalidFieldProviders()
+
+            val isComplete = invalidFields.isEmpty()
+
+            if (isComplete) {
+                cardElementAnalytics.reportFormCompleted(context)
+            }
+
+            cardValidCallbackProvider()?.onInputChanged(invalidFields.isEmpty(), invalidFields)
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -94,10 +94,25 @@ class CardFormView internal constructor(
                 ).toSet()
         }
 
-    private val cardValidTextWatcher = object : StripeTextWatcher() {
+    private val textFocusWatcher = OnFocusChangeListener { _, hasFocus ->
+        if (hasFocus) {
+            cardElementAnalytics.reportInteraction(context)
+        }
+    }
+
+    private val textInputWatcher = object : StripeTextWatcher() {
         override fun afterTextChanged(s: Editable?) {
             super.afterTextChanged(s)
-            cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
+
+            cardElementAnalytics.reportInteraction(context)
+
+            val isComplete = invalidFields.isEmpty()
+
+            if (isComplete) {
+                cardElementAnalytics.reportFormCompleted(context)
+            }
+
+            cardValidCallback?.onInputChanged(isComplete, invalidFields)
         }
     }
 
@@ -222,6 +237,19 @@ class CardFormView internal constructor(
             }
         }
 
+    @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : this(
+        context = context,
+        attrs = attrs,
+        defStyleAttr = defStyleAttr,
+        cardElementAnalytics = DefaultCardElementAnalytics(
+            widgetType = CardElementWidgetType.CardFormView,
+        ),
+    )
+
     init {
         orientation = VERTICAL
 
@@ -246,33 +274,21 @@ class CardFormView internal constructor(
             postalCodeContainer.setBackgroundColor(Color.TRANSPARENT)
         }
 
+        allEditTextFields.forEach {
+            it.internalFocusChangeListeners.remove(textFocusWatcher)
+            it.removeTextChangedListener(textInputWatcher)
+            it.addTextChangedListener(textInputWatcher)
+            it.internalFocusChangeListeners.add(textFocusWatcher)
+        }
+
         when (style) {
             Style.Standard -> applyStandardStyle()
             Style.Borderless -> applyBorderlessStyle()
         }
     }
 
-    @JvmOverloads constructor(
-        context: Context,
-        attrs: AttributeSet? = null,
-        defStyleAttr: Int = 0,
-    ) : this(
-        context = context,
-        attrs = attrs,
-        defStyleAttr = defStyleAttr,
-        cardElementAnalytics = DefaultCardElementAnalytics(
-            widgetType = CardElementWidgetType.CardFormView,
-        ),
-    )
-
     fun setCardValidCallback(callback: CardValidCallback?) {
         this.cardValidCallback = callback
-        allEditTextFields.forEach { it.removeTextChangedListener(cardValidTextWatcher) }
-
-        // only add the TextWatcher if it will be used
-        if (callback != null) {
-            allEditTextFields.forEach { it.addTextChangedListener(cardValidTextWatcher) }
-        }
         // call immediately after setting
         cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
     }

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -5,7 +5,6 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Editable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -94,27 +93,16 @@ class CardFormView internal constructor(
                 ).toSet()
         }
 
-    private val textFocusWatcher = OnFocusChangeListener { _, hasFocus ->
-        if (hasFocus) {
-            cardElementAnalytics.reportInteraction(context)
-        }
-    }
+    private val cardElementWatchers = CardElementWatchers(
+        context = context,
+        cardElementAnalytics = cardElementAnalytics,
+        invalidFieldProviders = { invalidFields },
+        cardValidCallbackProvider = { cardValidCallback },
+    )
 
-    private val textInputWatcher = object : StripeTextWatcher() {
-        override fun afterTextChanged(s: Editable?) {
-            super.afterTextChanged(s)
+    private val textFocusWatcher = cardElementWatchers.textFocusWatcher
 
-            cardElementAnalytics.reportInteraction(context)
-
-            val isComplete = invalidFields.isEmpty()
-
-            if (isComplete) {
-                cardElementAnalytics.reportFormCompleted(context)
-            }
-
-            cardValidCallback?.onInputChanged(isComplete, invalidFields)
-        }
-    }
+    private val textInputWatcher = cardElementWatchers.textInputWatcher
 
     internal var viewModelStoreOwner: ViewModelStoreOwner? = null
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -92,10 +92,26 @@ class CardInputWidget internal constructor(
 
     private var cardInputListener: CardInputListener? = null
     private var cardValidCallback: CardValidCallback? = null
-    private val cardValidTextWatcher = object : StripeTextWatcher() {
+
+    private val textFocusWatcher = OnFocusChangeListener { _, hasFocus ->
+        if (hasFocus) {
+            cardElementAnalytics.reportInteraction(context)
+        }
+    }
+
+    private val textInputWatcher = object : StripeTextWatcher() {
         override fun afterTextChanged(s: Editable?) {
             super.afterTextChanged(s)
-            cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
+
+            val isComplete = invalidFields.isEmpty()
+
+            cardElementAnalytics.reportInteraction(context)
+
+            if (isComplete) {
+                cardElementAnalytics.reportFormCompleted(context)
+            }
+
+            cardValidCallback?.onInputChanged(isComplete, invalidFields)
         }
     }
 
@@ -341,15 +357,18 @@ class CardInputWidget internal constructor(
             cvcEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
 
             // First remove if it's already added, to make sure it's not added multiple times.
-            postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
-            postalCodeEditText.addTextChangedListener(cardValidTextWatcher)
+            postalCodeEditText.internalFocusChangeListeners.remove(textFocusWatcher)
+            postalCodeEditText.removeTextChangedListener(textInputWatcher)
+            postalCodeEditText.addTextChangedListener(textInputWatcher)
+            postalCodeEditText.internalFocusChangeListeners.add(textFocusWatcher)
         } else {
             postalCodeEditText.isEnabled = false
             postalCodeTextInputLayout.visibility = View.GONE
 
             cvcEditText.imeOptions = EditorInfo.IME_ACTION_DONE
 
-            postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
+            postalCodeEditText.internalFocusChangeListeners.remove(textFocusWatcher)
+            postalCodeEditText.removeTextChangedListener(textInputWatcher)
         }
         updatePostalRequired()
     }
@@ -491,12 +510,6 @@ class CardInputWidget internal constructor(
 
     override fun setCardValidCallback(callback: CardValidCallback?) {
         this.cardValidCallback = callback
-        requiredFields.forEach { it.removeTextChangedListener(cardValidTextWatcher) }
-
-        // only add the TextWatcher if it will be used
-        if (callback != null) {
-            requiredFields.forEach { it.addTextChangedListener(cardValidTextWatcher) }
-        }
 
         // call immediately after setting
         cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
@@ -814,6 +827,13 @@ class CardInputWidget internal constructor(
         expiryDateEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(cardNumberEditText))
         cvcEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(expiryDateEditText))
         postalCodeEditText.setDeleteEmptyListener(BackUpFieldDeleteListener(cvcEditText))
+
+        requiredFields.forEach {
+            it.internalFocusChangeListeners.remove(textFocusWatcher)
+            it.removeTextChangedListener(textInputWatcher)
+            it.addTextChangedListener(textInputWatcher)
+            it.internalFocusChangeListeners.add(textFocusWatcher)
+        }
 
         cvcEditText.internalFocusChangeListeners.add { _, hasFocus ->
             cardBrandView.shouldShowCvc = hasFocus

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -3,7 +3,6 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Editable
 import android.text.Layout
 import android.text.TextPaint
 import android.text.TextWatcher
@@ -93,27 +92,16 @@ class CardInputWidget internal constructor(
     private var cardInputListener: CardInputListener? = null
     private var cardValidCallback: CardValidCallback? = null
 
-    private val textFocusWatcher = OnFocusChangeListener { _, hasFocus ->
-        if (hasFocus) {
-            cardElementAnalytics.reportInteraction(context)
-        }
-    }
+    private val cardElementWatchers = CardElementWatchers(
+        context = context,
+        cardElementAnalytics = cardElementAnalytics,
+        invalidFieldProviders = { invalidFields },
+        cardValidCallbackProvider = { cardValidCallback },
+    )
 
-    private val textInputWatcher = object : StripeTextWatcher() {
-        override fun afterTextChanged(s: Editable?) {
-            super.afterTextChanged(s)
+    private val textFocusWatcher = cardElementWatchers.textFocusWatcher
 
-            val isComplete = invalidFields.isEmpty()
-
-            cardElementAnalytics.reportInteraction(context)
-
-            if (isComplete) {
-                cardElementAnalytics.reportFormCompleted(context)
-            }
-
-            cardValidCallback?.onInputChanged(isComplete, invalidFields)
-        }
-    }
+    private val textInputWatcher = cardElementWatchers.textInputWatcher
 
     private val invalidFields: Set<CardValidCallback.Fields>
         get() {

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -94,12 +94,29 @@ class CardMultilineWidget internal constructor(
 
     private var cardInputListener: CardInputListener? = null
     private var cardValidCallback: CardValidCallback? = null
-    private val cardValidTextWatcher = object : StripeTextWatcher() {
+
+    private val textFocusWatcher = OnFocusChangeListener { _, hasFocus ->
+        if (hasFocus) {
+            cardElementAnalytics.reportInteraction(context)
+        }
+    }
+
+    private val textInputWatcher = object : StripeTextWatcher() {
         override fun afterTextChanged(s: Editable?) {
             super.afterTextChanged(s)
+
+            cardElementAnalytics.reportInteraction(context)
+
+            val isComplete = invalidFields.isEmpty()
+
+            if (isComplete) {
+                cardElementAnalytics.reportFormCompleted(context)
+            }
+
             cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
         }
     }
+
     internal val invalidFields: Set<CardValidCallback.Fields>
         get() {
             return listOfNotNull(
@@ -479,6 +496,11 @@ class CardMultilineWidget internal constructor(
         updateBrandUi()
 
         allFields.forEach { field ->
+            field.internalFocusChangeListeners.remove(textFocusWatcher)
+            field.removeTextChangedListener(textInputWatcher)
+            field.addTextChangedListener(textInputWatcher)
+            field.internalFocusChangeListeners.add(textFocusWatcher)
+
             field.doAfterTextChanged {
                 shouldShowErrorIcon = false
             }
@@ -550,12 +572,6 @@ class CardMultilineWidget internal constructor(
 
     override fun setCardValidCallback(callback: CardValidCallback?) {
         this.cardValidCallback = callback
-        allFields.forEach { it.removeTextChangedListener(cardValidTextWatcher) }
-
-        // only add the TextWatcher if it will be used
-        if (callback != null) {
-            allFields.forEach { it.addTextChangedListener(cardValidTextWatcher) }
-        }
 
         // call immediately after setting
         cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -3,7 +3,6 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Bundle
 import android.os.Parcelable
-import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -95,27 +94,16 @@ class CardMultilineWidget internal constructor(
     private var cardInputListener: CardInputListener? = null
     private var cardValidCallback: CardValidCallback? = null
 
-    private val textFocusWatcher = OnFocusChangeListener { _, hasFocus ->
-        if (hasFocus) {
-            cardElementAnalytics.reportInteraction(context)
-        }
-    }
+    private val cardElementWatchers = CardElementWatchers(
+        context = context,
+        cardElementAnalytics = cardElementAnalytics,
+        invalidFieldProviders = { invalidFields },
+        cardValidCallbackProvider = { cardValidCallback },
+    )
 
-    private val textInputWatcher = object : StripeTextWatcher() {
-        override fun afterTextChanged(s: Editable?) {
-            super.afterTextChanged(s)
+    private val textFocusWatcher = cardElementWatchers.textFocusWatcher
 
-            cardElementAnalytics.reportInteraction(context)
-
-            val isComplete = invalidFields.isEmpty()
-
-            if (isComplete) {
-                cardElementAnalytics.reportFormCompleted(context)
-            }
-
-            cardValidCallback?.onInputChanged(invalidFields.isEmpty(), invalidFields)
-        }
-    }
+    private val textInputWatcher = cardElementWatchers.textInputWatcher
 
     internal val invalidFields: Set<CardValidCallback.Fields>
         get() {

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -514,6 +514,37 @@ internal class CardFormViewTest {
     @Test
     fun `reportShown is called when card form attaches`() = runCardFormViewAnalyticsTest {
         assertThat(analytics.awaitShown()).isNotNull()
+        assertThat(analytics.awaitInteraction()).isNotNull()
+    }
+
+    @Test
+    fun `reportInteraction called when postal focus`() = runCardFormViewAnalyticsTest {
+        assertThat(analytics.awaitShown()).isNotNull()
+
+        binding.postalCode.getParentOnFocusChangeListener()
+            .onFocusChange(binding.postalCode, true)
+
+        idleLooper()
+
+        repeat(2) { assertThat(analytics.awaitInteraction()).isNotNull() }
+    }
+
+    @Test
+    fun `reports form completed when form valid`() = runCardFormViewAnalyticsTest {
+        assertThat(analytics.awaitShown()).isNotNull()
+
+        binding.populate(
+            VISA_WITH_SPACES,
+            VALID_MONTH,
+            VALID_YEAR,
+            VALID_CVC,
+            VALID_US_ZIP,
+        )
+
+        idleLooper()
+
+        repeat(9) { assertThat(analytics.awaitInteraction()).isNotNull() }
+        assertThat(analytics.awaitFormCompleted()).isNotNull()
     }
 
     private data class AnalyticsScenario(

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1826,7 +1826,49 @@ internal class CardInputWidgetTest {
     @Test
     fun `card element analytics reportShown when widget attaches`() = runCardInputWidgetAnalyticsTest {
         assertThat(cardElementAnalytics.awaitShown()).isNotNull()
+        assertThat(cardElementAnalytics.awaitInteraction()).isNotNull()
     }
+
+    @Test
+    fun `card element analytics records focus events as interactions`() =
+        runCardInputWidgetAnalyticsTest {
+            with(cardInputWidget) {
+                cardNumberEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(cardNumberEditText, true)
+                expiryDateEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(expiryDateEditText, true)
+                cvcEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(cvcEditText, true)
+                postalCodeEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(postalCodeEditText, true)
+            }
+
+            idleLooper()
+
+            assertThat(cardElementAnalytics.awaitShown()).isNotNull()
+            repeat(6) {
+                assertThat(cardElementAnalytics.awaitInteraction()).isNotNull()
+            }
+        }
+
+    @Test
+    fun `card element analytics reports form completed when all inputs valid`() =
+        runCardInputWidgetAnalyticsTest {
+            with(cardInputWidget) {
+                postalCodeEnabled = true
+                updateCardNumberAndIdle(VISA_WITH_SPACES)
+                expiryDateEditText.append("12")
+                expiryDateEditText.append("50")
+                cvcEditText.append("123")
+                postalCodeEditText.append("94103")
+            }
+
+            idleLooper()
+
+            assertThat(cardElementAnalytics.awaitShown()).isNotNull()
+            repeat(9) { assertThat(cardElementAnalytics.awaitInteraction()).isNotNull() }
+            repeat(2) { assertThat(cardElementAnalytics.awaitFormCompleted()).isNotNull() }
+        }
 
     private fun runCardInputWidgetAnalyticsTest(
         block: suspend AnalyticsScenario.() -> Unit,
@@ -1861,11 +1903,6 @@ internal class CardInputWidgetTest {
         }
     }
 
-    private class AnalyticsScenario(
-        val cardInputWidget: CardInputWidget,
-        val cardElementAnalytics: RecordingCardElementAnalytics,
-    )
-
     private fun runCardInputWidgetTest(
         isCbcEligible: Boolean = false,
         afterRecreation: (CardInputWidget.() -> Unit)? = null,
@@ -1899,6 +1936,11 @@ internal class CardInputWidgetTest {
 
         activityScenario.close()
     }
+
+    private class AnalyticsScenario(
+        val cardInputWidget: CardInputWidget,
+        val cardElementAnalytics: RecordingCardElementAnalytics,
+    )
 
     private fun CardInputWidget.updateCardNumberAndIdle(cardNumber: String) {
         cardNumberEditText.setText(cardNumber)

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -1345,6 +1345,47 @@ internal class CardMultilineWidgetTest {
     fun `reportShown is called on attach`() =
         runCardMultilineWidgetAnalyticsTest {
             assertThat(cardAnalytics.awaitShown()).isNotNull()
+            assertThat(cardAnalytics.awaitInteraction()).isNotNull()
+        }
+
+    @Test
+    fun `reportInteraction called on text focus`() =
+        runCardMultilineWidgetAnalyticsTest {
+            assertThat(cardAnalytics.awaitShown()).isNotNull()
+
+            with(widgetGroup) {
+                cardNumberEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(cardNumberEditText, true)
+                expiryDateEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(expiryDateEditText, true)
+                cvcEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(cvcEditText, true)
+                postalCodeEditText.getParentOnFocusChangeListener()
+                    .onFocusChange(postalCodeEditText, true)
+            }
+
+            idleLooper()
+
+            repeat(5) { assertThat(cardAnalytics.awaitInteraction()).isNotNull() }
+        }
+
+    @Test
+    fun `reports form completed when multiline inputs valid`() =
+        runCardMultilineWidgetAnalyticsTest {
+            assertThat(cardAnalytics.awaitShown()).isNotNull()
+
+            with(widgetGroup) {
+                cardNumberEditText.setText(VISA_WITH_SPACES)
+                expiryDateEditText.append("12")
+                expiryDateEditText.append("50")
+                cvcEditText.append("123")
+                postalCodeEditText.append("94103")
+            }
+
+            idleLooper()
+
+            repeat(9) { assertThat(cardAnalytics.awaitInteraction()).isNotNull() }
+            repeat(2) { assertThat(cardAnalytics.awaitFormCompleted()).isNotNull() }
         }
 
     private data class AnalyticsScenario(

--- a/payments-core/src/test/java/com/stripe/android/view/DefaultCardElementAnalyticsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/DefaultCardElementAnalyticsTest.kt
@@ -36,6 +36,40 @@ internal class DefaultCardElementAnalyticsTest {
     }
 
     @Test
+    fun `reportInteraction sends event once per session`() = test {
+        analytics.reportInteraction(context)
+        analytics.reportInteraction(context)
+
+        assertThat(executor.awaitReportCall()).isEqualTo(
+            FakeCardElementAnalyticsRequestExecutor.ReportCall(
+                event = PaymentAnalyticsEvent.MobileCardElementInteraction,
+                params = mapOf(
+                    DefaultCardElementAnalytics.PARAM_WIDGET_TYPE to
+                        CardElementWidgetType.CardFormView.analyticsValue,
+                ),
+            ),
+        )
+        executor.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `reportFormCompleted sends event once per session`() = test {
+        analytics.reportFormCompleted(context)
+        analytics.reportFormCompleted(context)
+
+        assertThat(executor.awaitReportCall()).isEqualTo(
+            FakeCardElementAnalyticsRequestExecutor.ReportCall(
+                event = PaymentAnalyticsEvent.MobileCardElementFormCompleted,
+                params = mapOf(
+                    DefaultCardElementAnalytics.PARAM_WIDGET_TYPE to
+                        CardElementWidgetType.CardFormView.analyticsValue,
+                ),
+            ),
+        )
+        executor.ensureAllEventsConsumed()
+    }
+
+    @Test
     fun `reportShown uses multiline widget type`() = test(
         widgetType = CardElementWidgetType.CardMultilineWidget,
     ) {
@@ -63,9 +97,15 @@ internal class DefaultCardElementAnalyticsTest {
         )
 
         first.reportShown(context)
+        first.reportInteraction(context)
+        first.reportFormCompleted(context)
 
         assertThat(executor.awaitReportCall().event)
             .isEqualTo(PaymentAnalyticsEvent.MobileCardElementShown)
+        assertThat(executor.awaitReportCall().event)
+            .isEqualTo(PaymentAnalyticsEvent.MobileCardElementInteraction)
+        assertThat(executor.awaitReportCall().event)
+            .isEqualTo(PaymentAnalyticsEvent.MobileCardElementFormCompleted)
 
         val bundle = Bundle()
         first.saveState(bundle)
@@ -78,6 +118,8 @@ internal class DefaultCardElementAnalyticsTest {
         second.restoreState(bundle)
 
         second.reportShown(context)
+        second.reportInteraction(context)
+        second.reportFormCompleted(context)
 
         executor.expectNoEvents()
     }

--- a/payments-core/src/test/java/com/stripe/android/view/RecordingCardElementAnalytics.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/RecordingCardElementAnalytics.kt
@@ -6,9 +6,19 @@ import app.cash.turbine.Turbine
 
 internal class RecordingCardElementAnalytics : CardElementAnalytics {
     private val shownCalls = Turbine<Unit>()
+    private val interactionCalls = Turbine<Unit>()
+    private val formCompletedCalls = Turbine<Unit>()
 
     override fun reportShown(context: Context) {
         shownCalls.add(Unit)
+    }
+
+    override fun reportInteraction(context: Context) {
+        interactionCalls.add(Unit)
+    }
+
+    override fun reportFormCompleted(context: Context) {
+        formCompletedCalls.add(Unit)
     }
 
     override fun saveState(outState: Bundle) {
@@ -19,11 +29,21 @@ internal class RecordingCardElementAnalytics : CardElementAnalytics {
         // No-op
     }
 
+    suspend fun awaitInteraction() {
+        interactionCalls.awaitItem()
+    }
+
+    suspend fun awaitFormCompleted() {
+        formCompletedCalls.awaitItem()
+    }
+
     suspend fun awaitShown() {
         shownCalls.awaitItem()
     }
 
     fun ensureAllEventsConsumed() {
         shownCalls.ensureAllEventsConsumed()
+        interactionCalls.ensureAllEventsConsumed()
+        formCompletedCalls.ensureAllEventsConsumed()
     }
 }


### PR DESCRIPTION
# Summary
- Adds `mobile_card_element_interaction` and `mobile_card_element_form_completed` analytics events
- Reports interaction on field focus and text changes, and form completed when all required fields are valid
- Extends analytics state save/restore and test coverage for the new events

# Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5438 

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified