### PR TITLE
Clear CheckoutController saved state on destroy

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -2,7 +2,6 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.graphics.drawable.Drawable
-import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
@@ -33,7 +32,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
-import java.util.WeakHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
@@ -60,6 +58,7 @@ class CheckoutController @Inject internal constructor(
     private val operationCoordinator: CheckoutOperationCoordinator,
     private val checkoutPresenterSubcomponentFactory: CheckoutPresenterSubcomponent.Factory,
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
+    private val savedState: CheckoutControllerSavedState,
 ) {
     /**
      * The latest [Session] data, or `null` until [configure] has completed successfully.
@@ -324,6 +323,7 @@ class CheckoutController @Inject internal constructor(
     fun destroy() {
         viewModelScope.cancel()
         stateHolder.state = null
+        savedState.clear()
     }
 
     /**
@@ -750,11 +750,15 @@ class CheckoutController @Inject internal constructor(
          * Builds a [CheckoutController] from the current configuration.
          */
         fun build(): CheckoutController {
+            val checkoutControllerSavedState = CheckoutControllerSavedState(
+                parentHandle = savedStateHandle,
+                integrationName = integrationName,
+            )
             val component = DaggerCheckoutControllerComponent.factory().create(
                 application = application,
-                savedStateHandle = savedStateHandle.checkoutSubHandle(integrationName),
                 paymentElementCallbackIdentifier = integrationName,
                 resultCallback = resultCallback,
+                checkoutControllerSavedState = checkoutControllerSavedState,
             )
 
             return component.checkoutController
@@ -1004,31 +1008,3 @@ class CheckoutController @Inject internal constructor(
         fun onResult(result: Result)
     }
 }
-
-/**
- * Caches the child handle derived for each (parent, integrationName) pair so repeated derivations
- * return the same instance. Every [CheckoutController] key lives inside its own child, so multiple
- * controllers sharing one parent handle never clobber one another, and the shared instance means
- * writes are observable across every reference within a process. Weak keys let a parent — and the
- * children scoped to it — be collected once the parent goes away.
- */
-private val checkoutChildHandles = WeakHashMap<SavedStateHandle, MutableMap<String, SavedStateHandle>>()
-
-/**
- * Derives a child [SavedStateHandle] namespaced under [integrationName] within this parent handle.
- * The child folds its contents back into the parent through [SavedStateHandle.setSavedStateProvider],
- * so they persist with the parent and are restored from the parent's bundle after process death.
- *
- * [SavedStateHandle.savedStateProvider] is the only way to snapshot a whole handle — there is no
- * public equivalent — so the RestrictedApi suppression is intentional.
- */
-@Suppress("RestrictedApi")
-internal fun SavedStateHandle.checkoutSubHandle(integrationName: String): SavedStateHandle =
-    synchronized(checkoutChildHandles) {
-        val children = checkoutChildHandles.getOrPut(this) { mutableMapOf() }
-        children.getOrPut(integrationName) {
-            val subHandle = SavedStateHandle.createHandle(get<Bundle>(integrationName), null)
-            setSavedStateProvider(integrationName) { subHandle.savedStateProvider().saveState() }
-            subHandle
-        }
-    }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerSavedState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerSavedState.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.checkout
+
+import android.os.Bundle
+import androidx.lifecycle.SavedStateHandle
+
+@Suppress("RestrictedApi")
+internal class CheckoutControllerSavedState(
+    private val parentHandle: SavedStateHandle,
+    private val integrationName: String,
+) {
+    val handle: SavedStateHandle = SavedStateHandle.createHandle(
+        restoredState = parentHandle.remove<Bundle>(integrationName),
+        defaultState = null,
+    ).also { childHandle ->
+        parentHandle.setSavedStateProvider(integrationName) {
+            childHandle.savedStateProvider().saveState()
+        }
+    }
+
+    fun clear() {
+        parentHandle.clearSavedStateProvider(integrationName)
+        parentHandle.remove<Bundle>(integrationName)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.checkout.CheckoutControllerSavedState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutPaymentOptionDisplayDataFactory
 import com.stripe.android.checkout.DefaultCheckoutPaymentOptionDisplayDataFactory
@@ -121,9 +122,9 @@ internal interface CheckoutControllerComponent {
     interface Factory {
         fun create(
             @BindsInstance application: Application,
-            @BindsInstance savedStateHandle: SavedStateHandle,
             @BindsInstance @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
             @BindsInstance resultCallback: CheckoutController.ResultCallback,
+            @BindsInstance checkoutControllerSavedState: CheckoutControllerSavedState,
         ): CheckoutControllerComponent
     }
 }
@@ -209,6 +210,13 @@ internal interface CheckoutControllerModule {
     ): AvailableExpressButtonTypesFactory
 
     companion object {
+        @Provides
+        fun provideSavedStateHandle(
+            checkoutControllerSavedState: CheckoutControllerSavedState,
+        ): SavedStateHandle {
+            return checkoutControllerSavedState.handle
+        }
+
         @Provides
         @Singleton
         fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerSavedStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerSavedStateTest.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@Suppress("RestrictedApi")
+internal class CheckoutControllerSavedStateTest {
+    @Test
+    fun `handle restores state from the parent namespace`() {
+        val savedState = CheckoutControllerSavedState(
+            parentHandle = parentHandleWithValue("restored"),
+            integrationName = INTEGRATION_NAME,
+        )
+
+        assertThat(savedState.handle.get<String>(VALUE_KEY)).isEqualTo("restored")
+    }
+
+    @Test
+    fun `handle state is persisted through the parent`() {
+        val parentHandle = SavedStateHandle()
+        val savedState = CheckoutControllerSavedState(
+            parentHandle = parentHandle,
+            integrationName = INTEGRATION_NAME,
+        )
+        savedState.handle[VALUE_KEY] = "persisted"
+
+        val restored = CheckoutControllerSavedState(
+            parentHandle = parentHandle.simulateProcessDeath(),
+            integrationName = INTEGRATION_NAME,
+        )
+
+        assertThat(restored.handle.get<String>(VALUE_KEY)).isEqualTo("persisted")
+    }
+
+    @Test
+    fun `instances do not share a child handle`() {
+        val parentHandle = SavedStateHandle()
+
+        val first = CheckoutControllerSavedState(parentHandle, INTEGRATION_NAME)
+        val second = CheckoutControllerSavedState(parentHandle, INTEGRATION_NAME)
+
+        assertThat(first.handle).isNotSameInstanceAs(second.handle)
+    }
+
+    @Test
+    fun `clear removes the namespace from the parent`() {
+        val parentHandle = SavedStateHandle()
+        val savedState = CheckoutControllerSavedState(parentHandle, INTEGRATION_NAME)
+        savedState.handle[VALUE_KEY] = "value"
+        parentHandle.savedStateProvider().saveState()
+
+        savedState.clear()
+
+        assertThat(parentHandle.keys()).doesNotContain(INTEGRATION_NAME)
+    }
+
+    @Test
+    fun `clear prevents state restoration`() {
+        val parentHandle = SavedStateHandle()
+        val savedState = CheckoutControllerSavedState(parentHandle, INTEGRATION_NAME)
+        savedState.handle[VALUE_KEY] = "value"
+
+        savedState.clear()
+        val restored = CheckoutControllerSavedState(
+            parentHandle = parentHandle.simulateProcessDeath(),
+            integrationName = INTEGRATION_NAME,
+        )
+
+        assertThat(restored.handle.get<String>(VALUE_KEY)).isNull()
+    }
+
+    private fun parentHandleWithValue(value: String): SavedStateHandle {
+        val childHandle = SavedStateHandle(mapOf(VALUE_KEY to value))
+        return SavedStateHandle(
+            mapOf(INTEGRATION_NAME to childHandle.savedStateProvider().saveState())
+        )
+    }
+
+    private fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle {
+        return SavedStateHandle.createHandle(savedStateProvider().saveState(), null)
+    }
+
+    private companion object {
+        const val INTEGRATION_NAME = "integration_name"
+        const val VALUE_KEY = "value"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -9,6 +9,7 @@ import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
@@ -291,10 +292,9 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `session is null before configure`() = runTest {
-        val savedStateHandle = SavedStateHandle()
-        val controller = createController(savedStateHandle)
-        assertThat(controller.session.value).isNull()
-        assertThat(committedStateFor(savedStateHandle)).isNull()
+        val setup = createControllerSetup(SavedStateHandle(), DEFAULT_INTEGRATION_NAME)
+        assertThat(setup.controller.session.value).isNull()
+        assertThat(setup.stateHolder.state).isNull()
     }
 
     @Test
@@ -319,14 +319,18 @@ internal class CheckoutControllerTest {
 
         // Persisting and restoring the handle simulates the controller being rebuilt after process
         // death: the committed state is read back from the restored namespaced child.
-        val state = committedStateFor(savedStateHandle.simulateProcessDeath())
+        val recreated = createControllerSetup(
+            savedStateHandle.simulateProcessDeath(),
+            DEFAULT_INTEGRATION_NAME,
+        )
+        val state = recreated.stateHolder.state
         assertThat(state).isNotNull()
         assertThat(state!!.embeddedConfiguration.merchantDisplayName)
             .isEqualTo(expectedMerchantDisplayName)
     }
 
     @Test
-    fun `destroy clears the committed state`() = runConfigureScenario {
+    fun `destroy clears persisted state`() = runConfigureScenario {
         result.getOrThrow()
         // Pre-condition: configure committed a non-null state so the clear is observable.
         assertThat(committedState).isNotNull()
@@ -335,13 +339,13 @@ internal class CheckoutControllerTest {
 
         assertThat(committedState).isNull()
         assertThat(controller.session.value).isNull()
+        assertThat(savedStateHandle.keys()).doesNotContain(DEFAULT_INTEGRATION_NAME)
+        assertThat(createController(savedStateHandle.simulateProcessDeath()).session.value).isNull()
     }
 
     @Test
     fun `clearPaymentOption clears paymentOptionDisplayData`() = runTest {
-        val savedStateHandle = SavedStateHandle()
-        // Seed the controller's namespaced child before building; the controller reuses that child.
-        savedStateHandle.checkoutSubHandle(DEFAULT_INTEGRATION_NAME)[CheckoutControllerStateHolder.STATE_KEY] =
+        val savedStateHandle = parentHandleWithState(
             CheckoutControllerStateFactory.create(
                 paymentSelection = PaymentSelection.GooglePay,
                 temporarySelection = "card",
@@ -349,6 +353,7 @@ internal class CheckoutControllerTest {
                     putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
                 },
             )
+        )
 
         val controller = createController(savedStateHandle)
         controller.session.test {
@@ -374,10 +379,7 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `clearPaymentOption returns failure and preserves selection when a payment flow is presented`() =
-        runMutationScenario {
-            selectPaymentMethod(PaymentSelection.GooglePay)
-            markIntegrationLaunched()
-
+        runMutationScenario(paymentSelection = PaymentSelection.GooglePay, sheetIsOpen = true) {
             val result = controller.clearPaymentOption()
 
             assertThat(result.isFailure).isTrue()
@@ -799,9 +801,9 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `mutation returns failure when a payment flow is presented`() = runMutationScenario {
-        markIntegrationLaunched()
-
+    fun `mutation returns failure when a payment flow is presented`() = runMutationScenario(
+        sheetIsOpen = true
+    ) {
         val result = controller.applyPromotionCode("10OFF")
 
         assertThat(result.isFailure).isTrue()
@@ -811,9 +813,9 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `runServerUpdate returns failure when a payment flow is presented`() = runMutationScenario {
-        markIntegrationLaunched()
-
+    fun `runServerUpdate returns failure when a payment flow is presented`() = runMutationScenario(
+        sheetIsOpen = true
+    ) {
         val result = controller.runServerUpdate { Result.success(Unit) }
 
         assertThat(result.isFailure).isTrue()
@@ -822,9 +824,9 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `configure returns failure when a payment flow is presented`() = runMutationScenario {
-        markIntegrationLaunched()
-
+    fun `configure returns failure when a payment flow is presented`() = runMutationScenario(
+        sheetIsOpen = true
+    ) {
         val result = controller.configure(DEFAULT_CLIENT_SECRET)
 
         assertThat(result.isFailure).isTrue()
@@ -835,9 +837,7 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `configure does not open a loading window when a payment flow is presented`() =
-        runMutationScenario(assertLoadingConsumed = true) {
-            markIntegrationLaunched()
-
+        runMutationScenario(sheetIsOpen = true, assertLoadingConsumed = true) {
             // The guard fast-fails before entering the coordinator, so isUpdating never flips true.
             assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
@@ -1081,12 +1081,15 @@ internal class CheckoutControllerTest {
     private fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle =
         SavedStateHandle.createHandle(savedStateProvider().saveState(), null)
 
-    // Reads the CheckoutControllerState the controller committed into its namespaced child of [parent].
-    private fun committedStateFor(
-        parent: SavedStateHandle,
-        integrationName: String = DEFAULT_INTEGRATION_NAME,
-    ): CheckoutControllerState? =
-        CheckoutControllerStateFactory.createStateHolder(parent.checkoutSubHandle(integrationName)).state
+    @Suppress("RestrictedApi")
+    private fun parentHandleWithState(state: CheckoutControllerState): SavedStateHandle {
+        val childHandle = SavedStateHandle(
+            mapOf(CheckoutControllerStateHolder.STATE_KEY to state)
+        )
+        return SavedStateHandle(
+            mapOf(DEFAULT_INTEGRATION_NAME to childHandle.savedStateProvider().saveState())
+        )
+    }
 
     private fun createController(
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
@@ -1100,6 +1103,35 @@ internal class CheckoutControllerTest {
         )
     }
 
+    private fun createControllerSetup(
+        savedStateHandle: SavedStateHandle,
+        integrationName: String,
+    ): ControllerSetup {
+        val controllerSavedState = CheckoutControllerSavedState(
+            parentHandle = savedStateHandle,
+            integrationName = integrationName,
+        )
+        val controller = destroyControllerRule.track(
+            DaggerCheckoutControllerComponent.factory().create(
+                application = applicationContext,
+                paymentElementCallbackIdentifier = integrationName,
+                resultCallback = CheckoutController.ResultCallback {},
+                checkoutControllerSavedState = controllerSavedState,
+            ).checkoutController
+        )
+        return ControllerSetup(
+            controller = controller,
+            stateHolder = CheckoutControllerStateFactory.createStateHolder(controllerSavedState.handle),
+            sheetStateHolder = SheetStateHolder(controllerSavedState.handle),
+        )
+    }
+
+    private class ControllerSetup(
+        val controller: CheckoutController,
+        val stateHolder: CheckoutControllerStateHolder,
+        val sheetStateHolder: SheetStateHolder,
+    )
+
     private fun runConfigureScenario(
         clientSecret: String = DEFAULT_CLIENT_SECRET,
         configuration: CheckoutController.Configuration = CheckoutController.Configuration(),
@@ -1108,50 +1140,48 @@ internal class CheckoutControllerTest {
     ) = runTest {
         networkSetup()
         val savedStateHandle = SavedStateHandle()
-        val controller = createController(savedStateHandle)
-        val result = controller.configure(clientSecret, configuration)
-        block(Scenario(controller, result, savedStateHandle))
+        val setup = createControllerSetup(savedStateHandle, DEFAULT_INTEGRATION_NAME)
+        val result = setup.controller.configure(clientSecret, configuration)
+        block(Scenario(setup.controller, result, savedStateHandle, setup.stateHolder))
     }
 
     private class Scenario(
         val controller: CheckoutController,
         val result: Result<Unit>,
-        private val savedStateHandle: SavedStateHandle,
+        val savedStateHandle: SavedStateHandle,
+        private val stateHolder: CheckoutControllerStateHolder,
     ) {
-        // Reads the state the controller committed by re-deriving its namespaced child of the handle.
         val committedState: CheckoutControllerState?
-            get() = CheckoutControllerStateFactory
-                .createStateHolder(savedStateHandle.checkoutSubHandle(DEFAULT_INTEGRATION_NAME))
-                .state
+            get() = stateHolder.state
     }
 
-    // Configures a controller from a fresh init, then hands it to [block] alongside the shared
-    // SavedStateHandle (used to read committed state and simulate a presented payment flow) and an
-    // isUpdating Turbine.
+    // Configures a controller from a fresh init, seeds the requested scenario state, then hands it
+    // to [block] alongside an isUpdating Turbine.
     //
     // Set [assertLoadingConsumed] for tests that verify loading behavior: the block must consume
     // every isUpdating emission and this asserts none are left over. Tests that don't care about
     // loading leave it false, and any unconsumed emissions are ignored.
     private fun runMutationScenario(
         initModifier: (JSONObject) -> Unit = {},
+        paymentSelection: PaymentSelection? = null,
+        sheetIsOpen: Boolean = false,
         assertLoadingConsumed: Boolean = false,
         block: suspend MutationScenario.() -> Unit,
     ) = runTest {
         networkRule.checkoutInit(responseFactory = successResponseFactory(initModifier))
         val savedStateHandle = SavedStateHandle()
-        val controller = createController(savedStateHandle)
+        val setup = createControllerSetup(savedStateHandle, DEFAULT_INTEGRATION_NAME)
+        val controller = setup.controller
         controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+        paymentSelection?.let(setup.stateHolder::setSelection)
+        setup.sheetStateHolder.sheetIsOpen = sheetIsOpen
 
         turbineScope {
             val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
-            // Re-derive the controller's own child handle so writes made here (selection, sheet-open)
-            // are observed by the controller and vice versa.
-            val childHandle = savedStateHandle.checkoutSubHandle(DEFAULT_INTEGRATION_NAME)
             block(
                 MutationScenario(
                     controller = controller,
-                    stateHolder = CheckoutControllerStateFactory.createStateHolder(childHandle),
-                    sheetStateHolder = SheetStateHolder(childHandle),
+                    stateHolder = setup.stateHolder,
                     testScope = this@runTest,
                     isUpdatingTurbine = isUpdatingTurbine,
                 )
@@ -1167,7 +1197,6 @@ internal class CheckoutControllerTest {
     private class MutationScenario(
         val controller: CheckoutController,
         private val stateHolder: CheckoutControllerStateHolder,
-        private val sheetStateHolder: SheetStateHolder,
         private val testScope: TestScope,
         val isUpdatingTurbine: ReceiveTurbine<Boolean>,
     ) : CoroutineScope by testScope {
@@ -1184,18 +1213,6 @@ internal class CheckoutControllerTest {
         // Reads the state the controller committed via its state holder, which shares this
         // SavedStateHandle in the production graph.
         fun committedState(): CheckoutControllerState = requireNotNull(stateHolder.state)
-
-        // Simulates a presented payment flow by opening the sheet through the SheetStateHolder backed
-        // by the shared SavedStateHandle, which the mutation guard reads back through the same holder.
-        fun markIntegrationLaunched() {
-            sheetStateHolder.sheetIsOpen = true
-        }
-
-        // Simulates a payment method already being selected via the same setSelection path the
-        // production embedded selection flow uses.
-        fun selectPaymentMethod(selection: PaymentSelection) {
-            stateHolder.setSelection(selection)
-        }
     }
 
     private companion object {


### PR DESCRIPTION
# Summary

- Remove the process-global cache of namespaced `CheckoutController` child handles.
- Give each controller ownership of its child saved state and clear its provider and persisted namespace during `destroy()`.
- Provide the child `SavedStateHandle` transitively through `CheckoutControllerModule` and cover its lifecycle in focused unit tests.

# Motivation

`CheckoutController.destroy()` cleared loaded session state but left the namespaced child handle cached and its saved-state provider registered for as long as the parent handle remained alive. The child saved state should instead have the same lifecycle as its controller so destroyed controllers do not retain or restore stale state.

# Testing

- [x] Added tests — `CheckoutControllerSavedStateTest` covers restoration, persistence, handle isolation, and cleanup.
- [x] Modified tests — `CheckoutControllerTest` verifies destroyed state is removed and cannot be restored.
- [ ] Manually verified

Ignored tests: No newly ignored tests.

# Screenshots

Not applicable — this is saved-state lifecycle behavior with no UI changes.

# Changelog

Not applicable — this changes an internal preview implementation detail without changing the customer-facing API.
