### PR TITLE
Cancel embedded configuration with ViewModel lifecycle

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
@@ -5,11 +5,13 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.parcelize.Parcelize
@@ -28,6 +30,7 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val sheetStateHolder: SheetStateHolder,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
+    @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : EmbeddedConfigurationHandler {
 
     private var cache: ConfigurationCache?
@@ -73,7 +76,7 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
             return Result.failure(IllegalStateException("Configuring while a sheet is open is not supported."))
         }
 
-        val supervisorJob = SupervisorJob()
+        val supervisorJob = SupervisorJob(viewModelScope.coroutineContext[Job])
         val coroutineScope = CoroutineScope(supervisorJob)
 
         val coalescingOrchestrator = CoalescingOrchestrator<Result<PaymentElementLoader.State>>(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -14,18 +14,28 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedConfigurationHandler.ConfigurationCache
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 
 internal class DefaultEmbeddedConfigurationHandlerTest {
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @Test
     fun `configuration fails when sheetIsOpen`() = runScenario {
         sheetStateHolder.sheetIsOpen = true
@@ -279,32 +289,35 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
     @Test
     fun `parallel calls to configure with different arguments results in different results`() = runScenario {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+        val firstInitializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Payment(amount = 5000, currency = "USD"),
+            )
+        )
+        val secondInitializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
+        )
 
         val first = testScope.backgroundScope.async(Dispatchers.IO) {
             handler.configure(
                 configuration = configuration,
-                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                    PaymentSheet.IntentConfiguration(
-                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(amount = 5000, currency = "USD"),
-                    )
-                ),
+                initializationMode = firstInitializationMode,
             ).getOrThrow()
         }
 
-        loader.loadCalledTurbine.awaitItem()
+        assertThat(loader.loadCalledTurbine.awaitItem()).isEqualTo(firstInitializationMode)
 
         val second = testScope.backgroundScope.async(Dispatchers.IO) {
             handler.configure(
                 configuration = configuration,
-                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                    PaymentSheet.IntentConfiguration(
-                        mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-                    )
-                ),
+                initializationMode = secondInitializationMode,
             ).getOrThrow()
         }
 
-        loader.loadCalledTurbine.awaitItem()
+        assertThat(loader.loadCancelledTurbine.awaitItem()).isEqualTo(firstInitializationMode)
+        assertThat(loader.loadCalledTurbine.awaitItem()).isEqualTo(secondInitializationMode)
         val expectedResult = loader.createSuccess(
             configuration.asCommonConfiguration(),
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
@@ -313,6 +326,30 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
         assertThat(first.isCompleted).isFalse()
         assertThat(second.await()).isEqualTo(expectedResult.getOrThrow())
+        assertThat(viewModelScope.coroutineContext[Job]?.isActive).isTrue()
+    }
+
+    @Test
+    fun `cancelling view model scope cancels in-flight request`() = runScenario {
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
+        )
+        val request = viewModelScope.async {
+            handler.configure(
+                configuration = configuration,
+                initializationMode = initializationMode,
+            ).getOrThrow()
+        }
+
+        assertThat(loader.loadCalledTurbine.awaitItem()).isEqualTo(initializationMode)
+
+        viewModelScope.cancel()
+
+        assertThat(loader.loadCancelledTurbine.awaitItem()).isEqualTo(initializationMode)
+        assertThat(request.isCancelled).isTrue()
     }
 
     private fun runScenario(
@@ -322,11 +359,15 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
             val loader = FakePaymentElementLoader()
             val savedStateHandle = SavedStateHandle()
             val sheetStateHolder = SheetStateHolder(savedStateHandle)
+            val viewModelScope = coroutineScopeCleanupRule.track(
+                CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+            )
             val handler = DefaultEmbeddedConfigurationHandler(
                 loader,
                 savedStateHandle,
                 sheetStateHolder,
                 internalRowSelectionCallback = { null },
+                viewModelScope = viewModelScope,
             )
             Scenario(
                 loader = loader,
@@ -334,6 +375,7 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
                 handler = handler,
                 testScope = this,
                 sheetStateHolder = sheetStateHolder,
+                viewModelScope = viewModelScope,
             ).apply {
                 block()
             }
@@ -347,11 +389,13 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val handler: DefaultEmbeddedConfigurationHandler,
         val testScope: TestScope,
         val sheetStateHolder: SheetStateHolder,
+        val viewModelScope: CoroutineScope,
     )
 
     private class FakePaymentElementLoader : PaymentElementLoader {
         private val resultTurbine: Turbine<Result<PaymentElementLoader.State>> = Turbine()
         val loadCalledTurbine: Turbine<PaymentElementLoader.InitializationMode> = Turbine()
+        val loadCancelledTurbine: Turbine<PaymentElementLoader.InitializationMode> = Turbine()
 
         fun emit(result: Result<PaymentElementLoader.State>) {
             resultTurbine.add(result)
@@ -359,6 +403,7 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
         fun assertConsumed() {
             resultTurbine.ensureAllEventsConsumed()
+            loadCancelledTurbine.ensureAllEventsConsumed()
         }
 
         fun createSuccess(
@@ -391,7 +436,12 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
             metadata: PaymentElementLoader.Metadata,
         ): Result<PaymentElementLoader.State> {
             loadCalledTurbine.add(initializationMode)
-            return resultTurbine.awaitItem()
+            return try {
+                resultTurbine.awaitItem()
+            } catch (e: CancellationException) {
+                loadCancelledTurbine.add(initializationMode)
+                throw e
+            }
         }
     }
 }


### PR DESCRIPTION
# Summary

Parents each Embedded Payment Element configuration request's supervisor job to the owning view-model scope. In-flight configuration loading is now cancelled when the Embedded Payment Element view model is cleared, while same-argument request coalescing and replacement-request cancellation remain intact.

# Motivation

`DefaultEmbeddedConfigurationHandler` previously created an independent `SupervisorJob` for each request. Clearing `EmbeddedPaymentElementViewModel` cancelled its injected scope but did not cancel an in-flight `PaymentElementLoader.load`, allowing configuration work to outlive its lifecycle owner.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

`./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedConfigurationHandlerTest'`

The focused test class passed. No tests were ignored.

# Screenshots

Not applicable — this changes coroutine ownership only and has no UI impact.

# Changelog

Not applicable — this is an internal lifecycle/resource-management fix with no public API or user-facing behavior change.
