### PR TITLE
Fix NfcCoilAnimatedInteriorTest timing

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/ui/NfcCoilAnimatedInteriorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/ui/NfcCoilAnimatedInteriorTest.kt
@@ -378,7 +378,7 @@ internal class NfcCoilAnimatedInteriorTest {
         const val FRAME_BUFFER_MS = 32L
         val CoilSize = 200.dp
         const val PROGRESS_TOLERANCE = 0.02f
-        const val CHECKMARK_START_DELAY_MS = 100L
+        const val CHECKMARK_START_DELAY_MS = 150L
         const val SUCCESS_SHOWN_DELAY_MS = 900L
         const val ERROR_SHOWN_DELAY_MS = 1_700L
         val ERROR_MESSAGE = "Card expired. Try another card.".resolvableString


### PR DESCRIPTION
# Summary

Align `NfcCoilAnimatedInteriorTest`'s checkmark start delay with the 150 ms production delay.

# Motivation

The test advanced only 100 ms for a production delay of 150 ms. This consumed the test's 32 ms frame buffer and allowed completion assertions to run before the animation had actually completed, making the test timing-sensitive.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.common.nfcscan.ui.NfcCoilAnimatedInteriorTest'`
- 2 uncached focused iterations passed.
- 50 uncached focused iterations passed (600 test method executions).

No tests were ignored.

# Screenshots

Not applicable; this is a test-only timing correction with no UI changes.

# Changelog

Not applicable; this test-only change does not affect SDK behavior.
