### PR TITLE
Add `LifecycleOwner` to all confirmation definitions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
@@ -82,10 +83,12 @@ internal interface ConfirmationDefinition<
      *
      * @param activityResultCaller caller used to create & register activity result launchers onto the Android
      *   lifecycle provider
+     * @param lifecycleOwner the owner of an observable lifecycle to attach the launcher to
      * @param onResult the launcher result callback to provide when registering the activity result launcher if needed
      */
     fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (TLauncherResult) -> Unit,
     ): TLauncher
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.strings.ResolvableString
@@ -42,10 +43,12 @@ internal class ConfirmationMediator<
 
     fun register(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (ConfirmationDefinition.Result) -> Unit,
     ) {
         launcher = definition.createLauncher(
-            activityResultCaller
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
         ) { result ->
             val confirmationResult = persistedParameters?.let { params ->
                 persistedParameters = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -81,7 +81,11 @@ internal class DefaultConfirmationHandler(
         lifecycleOwner: LifecycleOwner,
     ) {
         mediators.forEach { mediator ->
-            mediator.register(activityResultCaller, ::onResult)
+            mediator.register(
+                activityResultCaller = activityResultCaller,
+                lifecycleOwner = lifecycleOwner,
+                onResult = ::onResult,
+            )
         }
 
         lifecycleOwner.lifecycle.addObserver(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.attestation
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.attestation.AttestationActivityContract
 import com.stripe.android.attestation.AttestationActivityResult
 import com.stripe.android.attestation.analytics.AttestationAnalyticsEventsReporter
@@ -109,6 +110,7 @@ internal class AttestationConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (AttestationActivityResult) -> Unit
     ): ActivityResultLauncher<AttestationActivityContract.Args> {
         return activityResultCaller.registerForActivityResult(AttestationActivityContract(), onResult)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.bacs
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -48,6 +49,7 @@ internal class BacsConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (BacsMandateConfirmationResult) -> Unit
     ): BacsMandateConfirmationLauncher {
         return bacsMandateConfirmationLauncherFactory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.cardart
 
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -56,6 +57,7 @@ internal class PaymentOptionCardArtPrefetchConfirmationDefinition @Inject constr
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (Nothing) -> Unit,
     ): Unit = Unit
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.challenge
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.challenge.passive.PassiveChallengeActivityContract
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
@@ -81,6 +82,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (PassiveChallengeActivityResult) -> Unit
     ): ActivityResultLauncher<PassiveChallengeActivityContract.Args> {
         passiveChallengeWarmer.register(activityResultCaller)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.cpms
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -63,6 +64,7 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (InternalCustomPaymentMethodResult) -> Unit
     ): ActivityResultLauncher<CustomPaymentMethodInput> {
         return activityResultCaller.registerForActivityResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.cvc
 
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -51,6 +52,7 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (CvcRecollectionResult) -> Unit
     ): CvcRecollectionLauncher {
         return factory.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.epms
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -66,6 +67,7 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (PaymentResult) -> Unit
     ): ActivityResultLauncher<ExternalPaymentMethodInput> {
         return activityResultCaller.registerForActivityResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.gpay
 
 import android.content.Context
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
@@ -66,6 +67,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (GooglePayPaymentMethodLauncher.Result) -> Unit
     ): InternalGooglePayPaymentMethodLauncher {
         val activityResultLauncher = activityResultCaller.registerForActivityResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.intent
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -72,6 +73,7 @@ internal class IntentConfirmationDefinition(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (InternalPaymentResult) -> Unit
     ): ActivityResultLauncher<PaymentLauncherContract.Args> {
         return activityResultCaller.registerForActivityResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.link
 
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
@@ -31,6 +32,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (LinkActivityResult) -> Unit
     ): LinkPaymentLauncher {
         return linkPaymentLauncher.apply {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.link
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.model.PaymentMethod
@@ -51,6 +52,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (Result) -> Unit
     ): Launcher {
         return Launcher(onResult)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.linkinline
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkPaymentDetails
@@ -52,6 +53,7 @@ internal class LinkInlineSignupConfirmationDefinition(
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (Result) -> Unit
     ): Launcher {
         return Launcher(onResult)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -93,15 +93,18 @@ class ConfirmationMediatorTest {
         )
 
         val activityResultCaller = mock<ActivityResultCaller>()
+        val lifecycleOwner = fakeLifecycleOwner()
 
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
             onResult = {},
         )
 
         val createLauncherCall = createLauncherCalls.awaitItem()
 
         assertThat(createLauncherCall.activityResultCaller).isEqualTo(activityResultCaller)
+        assertThat(createLauncherCall.lifecycleOwner).isEqualTo(lifecycleOwner)
     }
 
     @Test
@@ -115,6 +118,7 @@ class ConfirmationMediatorTest {
 
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = {
                 throw NotImplementedError("'onResult' should not be called!")
             },
@@ -260,6 +264,7 @@ class ConfirmationMediatorTest {
         ).apply {
             register(
                 activityResultCaller = mock(),
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = {}
             )
         }
@@ -320,6 +325,7 @@ class ConfirmationMediatorTest {
             ).apply {
                 register(
                     activityResultCaller = mock(),
+                    lifecycleOwner = fakeLifecycleOwner(),
                     onResult = {}
                 )
             }
@@ -391,6 +397,7 @@ class ConfirmationMediatorTest {
 
         mediator.register(
             activityResultCaller = mock(),
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = {}
         )
         mediator.unregister()
@@ -443,6 +450,7 @@ class ConfirmationMediatorTest {
 
         mediator.register(
             activityResultCaller = mock(),
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = { result ->
                 receivedResult = result
 
@@ -511,6 +519,7 @@ class ConfirmationMediatorTest {
 
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = { result ->
                 assertThat(result).isInstanceOf<ConfirmationDefinition.Result.Failed>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCallback
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -10,6 +11,7 @@ import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentIntentFactory
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -30,6 +32,7 @@ internal fun <
     DummyActivityResultCaller.test {
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = {}
         )
 
@@ -90,6 +93,7 @@ internal fun <
 
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = {
                 result = it
 
@@ -108,6 +112,10 @@ internal fun <
         assertThat(result).isEqualTo(definitionResult)
     }
 }
+
+internal fun fakeLifecycleOwner() = TestLifecycleOwner(
+    coroutineDispatcher = UnconfinedTestDispatcher(),
+)
 
 @Suppress("UNCHECKED_CAST")
 internal fun <T : ConfirmationHandler.Option> ConfirmationHandler.Option.asOption(): T {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.testing.TestLifecycleOwner
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import app.cash.turbine.TurbineTestContext
@@ -17,7 +16,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.CleanupTestRule
-import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeLogger
@@ -27,7 +25,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
@@ -39,9 +36,6 @@ import kotlin.time.Duration.Companion.seconds
 
 class DefaultConfirmationHandlerTest {
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
-
-    @get:Rule
     val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
@@ -49,10 +43,11 @@ class DefaultConfirmationHandlerTest {
         assertThat(confirmationHandler.hasReloadedFromProcessDeath).isFalse()
 
         val activityResultCaller = mock<ActivityResultCaller>()
+        val lifecycleOwner = fakeLifecycleOwner()
 
         confirmationHandler.register(
             activityResultCaller = activityResultCaller,
-            lifecycleOwner = TestLifecycleOwner(),
+            lifecycleOwner = lifecycleOwner,
         )
 
         val someDefinitionCreateLauncherCall = someDefinitionScenario.createLauncherCalls.awaitItem()
@@ -60,6 +55,8 @@ class DefaultConfirmationHandlerTest {
 
         assertThat(someDefinitionCreateLauncherCall.activityResultCaller).isEqualTo(activityResultCaller)
         assertThat(someOtherDefinitionCreateLauncherCall.activityResultCaller).isEqualTo(activityResultCaller)
+        assertThat(someDefinitionCreateLauncherCall.lifecycleOwner).isEqualTo(lifecycleOwner)
+        assertThat(someOtherDefinitionCreateLauncherCall.lifecycleOwner).isEqualTo(lifecycleOwner)
     }
 
     @Test
@@ -75,17 +72,18 @@ class DefaultConfirmationHandlerTest {
         ),
     ) {
         val activityResultCaller = mock<ActivityResultCaller>()
-        val lifecycleOwner = TestLifecycleOwner(
-            coroutineDispatcher = UnconfinedTestDispatcher(),
-        )
+        val lifecycleOwner = fakeLifecycleOwner()
 
         confirmationHandler.register(
             activityResultCaller = activityResultCaller,
             lifecycleOwner = lifecycleOwner,
         )
 
-        assertThat(someDefinitionScenario.createLauncherCalls.awaitItem()).isNotNull()
-        assertThat(someOtherDefinitionScenario.createLauncherCalls.awaitItem()).isNotNull()
+        val someDefinitionCreateLauncherCall = someDefinitionScenario.createLauncherCalls.awaitItem()
+        val someOtherDefinitionCreateLauncherCall = someOtherDefinitionScenario.createLauncherCalls.awaitItem()
+
+        assertThat(someDefinitionCreateLauncherCall.lifecycleOwner).isEqualTo(lifecycleOwner)
+        assertThat(someOtherDefinitionCreateLauncherCall.lifecycleOwner).isEqualTo(lifecycleOwner)
 
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
@@ -797,10 +795,11 @@ class DefaultConfirmationHandlerTest {
                 ).apply {
                     if (shouldRegister) {
                         val activityResultCaller = DummyActivityResultCaller.noOp()
+                        val lifecycleOwner = fakeLifecycleOwner()
 
                         register(
                             activityResultCaller = activityResultCaller,
-                            lifecycleOwner = TestLifecycleOwner(),
+                            lifecycleOwner = lifecycleOwner,
                         )
 
                         val someDefinitionCreateLauncherCall = someDefinitionScenario
@@ -814,6 +813,10 @@ class DefaultConfirmationHandlerTest {
                             .isEqualTo(activityResultCaller)
                         assertThat(someOtherDefinitionCreateLauncherCall.activityResultCaller)
                             .isEqualTo(activityResultCaller)
+                        assertThat(someDefinitionCreateLauncherCall.lifecycleOwner)
+                            .isEqualTo(lifecycleOwner)
+                        assertThat(someOtherDefinitionCreateLauncherCall.lifecycleOwner)
+                            .isEqualTo(lifecycleOwner)
 
                         someDefinitionOnResult = someDefinitionCreateLauncherCall.onResult
                         someOtherDefinitionOnResult = someOtherDefinitionCreateLauncherCall.onResult

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 
@@ -44,6 +45,7 @@ internal abstract class FakeConfirmationDefinition<
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (TLauncherResult) -> Unit
     ): TLauncher {
         return launcher

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -41,6 +41,7 @@ class IntentConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             val createdLauncher = definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = {},
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -70,11 +71,12 @@ internal class RecordingConfirmationDefinition<
 
     override fun createLauncher(
         activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
         onResult: (TLauncherResult) -> Unit
     ): TLauncher {
-        createLauncherCalls.add(CreateLauncherCall(activityResultCaller, onResult))
+        createLauncherCalls.add(CreateLauncherCall(activityResultCaller, lifecycleOwner, onResult))
 
-        return definition.createLauncher(activityResultCaller, onResult)
+        return definition.createLauncher(activityResultCaller, lifecycleOwner, onResult)
     }
 
     override fun unregister(launcher: TLauncher) {
@@ -125,6 +127,7 @@ internal class RecordingConfirmationDefinition<
 
     class CreateLauncherCall<TLauncherResult>(
         val activityResultCaller: ActivityResultCaller,
+        val lifecycleOwner: LifecycleOwner,
         val onResult: (TLauncherResult) -> Unit
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -121,6 +122,7 @@ internal class AttestationConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = onResult,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.confirmation.asCanceled
 import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
@@ -64,6 +65,7 @@ class BacsConfirmationDefinitionTest {
 
                 definition.createLauncher(
                     activityResultCaller = activityResultCaller,
+                    lifecycleOwner = fakeLifecycleOwner(),
                     onResult = onResult,
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
@@ -134,6 +135,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = onResult,
             )
 
@@ -161,6 +163,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = {},
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asSucceeded
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -54,6 +55,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = onResult,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.confirmation.asCanceled
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.FakeCvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.RecordingCvcRecollectionLauncher
@@ -112,6 +113,7 @@ class CvcRecollectionConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = onResult,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asSucceeded
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
@@ -64,6 +65,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         DummyActivityResultCaller.test {
             val launcher = definition.createLauncher(
                 activityResultCaller = activityResultCaller,
+                lifecycleOwner = fakeLifecycleOwner(),
                 onResult = onResult,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
@@ -96,6 +97,7 @@ class GooglePayConfirmationDefinitionTest {
             DummyActivityResultCaller.test {
                 definition.createLauncher(
                     activityResultCaller = activityResultCaller,
+                    lifecycleOwner = fakeLifecycleOwner(),
                     onResult = onResult,
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Param
 import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.paymentelement.confirmation.runResultTest
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.utils.RecordingInternalGooglePayPaymentMethodLauncherFactory
@@ -50,6 +51,7 @@ class GooglePayConfirmationFlowTest {
 
                 mediator.register(
                     activityResultCaller = activityResultCaller,
+                    lifecycleOwner = fakeLifecycleOwner(),
                     onResult = {}
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -23,8 +23,8 @@ import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeLinkStore
@@ -32,7 +32,6 @@ import com.stripe.android.utils.RecordingLinkPaymentLauncher
 import com.stripe.android.utils.RecordingLinkStore
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
@@ -40,9 +39,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 internal class LinkConfirmationDefinitionTest {
-    @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
-
     @Test
     fun `'key' should be 'Link'`() {
         val definition = createLinkConfirmationDefinition()
@@ -73,6 +69,7 @@ internal class LinkConfirmationDefinitionTest {
 
         definition.createLauncher(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = onResult,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Param
 import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
@@ -40,6 +41,7 @@ class LinkConfirmationFlowTest {
 
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = {}
         )
 
@@ -104,6 +106,7 @@ class LinkConfirmationFlowTest {
 
         mediator.register(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = onResult
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -47,6 +47,7 @@ import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNew
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
+import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -94,6 +95,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
         val launcher = definition.createLauncher(
             activityResultCaller = activityResultCaller,
+            lifecycleOwner = fakeLifecycleOwner(),
             onResult = onResult,
         )
 


### PR DESCRIPTION
# Summary
Add `LifecycleOwner` to all confirmation definitions. Not used right now but will be by Google Pay to support dynamic callbacks

# Motivation
Support for dynamic callbacks for Google Pay.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified