### PR TITLE
Simplify CheckoutController terminal result handling

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -41,6 +41,9 @@ internal class CheckoutControllerExampleViewModel(
         savedStateHandle = savedStateHandle,
     ).resultCallback { result ->
         Log.d(TAG, "Result: $result")
+        if (result is CheckoutController.Result.Completed) {
+            _sessionComplete.tryEmit(Unit)
+        }
     }.build()
 
     init {
@@ -50,9 +53,6 @@ internal class CheckoutControllerExampleViewModel(
         viewModelScope.launch {
             controller.session.collect { session ->
                 updateConfiguredState { it.copy(session = session) }
-                if (session?.status == Session.Status.Complete) {
-                    _sessionComplete.tryEmit(Unit)
-                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultProcessor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationResultProcessor.kt
@@ -1,0 +1,89 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.core.Logger
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutConfirmationResultProcessor internal constructor(
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val fetchResponse: suspend (sessionId: String, adaptivePricingAllowed: Boolean) ->
+        Result<CheckoutSessionResponse>,
+    private val reloadState: suspend (CheckoutControllerState) -> Unit,
+    private val clearState: () -> Unit,
+    private val logger: Logger,
+) {
+    @Inject
+    constructor(
+        stateHolder: CheckoutControllerStateHolder,
+        checkoutSessionRepository: CheckoutSessionRepository,
+        checkoutStateLoader: CheckoutStateLoader,
+        logger: Logger,
+    ) : this(
+        stateHolder = stateHolder,
+        fetchResponse = checkoutSessionRepository::init,
+        reloadState = checkoutStateLoader::reload,
+        clearState = checkoutStateLoader::clear,
+        logger = logger,
+    )
+
+    suspend fun process(
+        result: ConfirmationHandler.Result,
+        confirmationWasRestored: Boolean,
+    ): CheckoutController.Result? {
+        return when (result) {
+            is ConfirmationHandler.Result.Succeeded -> {
+                clearState()
+                CheckoutController.Result.Completed()
+            }
+            is ConfirmationHandler.Result.Failed -> {
+                refresh()
+                CheckoutController.Result.Failed(result.cause)
+            }
+            is ConfirmationHandler.Result.Canceled -> {
+                refresh()
+                result.asCheckoutResult(confirmationWasRestored)
+            }
+        }
+    }
+
+    suspend fun processFailure(error: Throwable): CheckoutController.Result.Failed {
+        refresh()
+        return CheckoutController.Result.Failed(error)
+    }
+
+    private suspend fun refresh() {
+        val state = stateHolder.state ?: return
+
+        try {
+            val response = fetchResponse(
+                state.checkoutSessionResponse.id,
+                state.configuration.adaptivePricingAllowed,
+            ).getOrThrow()
+            reloadState(state.copy(checkoutSessionResponse = response))
+        } catch (error: CancellationException) {
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            logger.error("Failed to refresh CheckoutController state after confirmation.", error)
+        }
+    }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun ConfirmationHandler.Result.Canceled.asCheckoutResult(
+    confirmationWasRestored: Boolean,
+): CheckoutController.Result? {
+    return when (action) {
+        ConfirmationHandler.Result.Canceled.Action.InformCancellation -> CheckoutController.Result.Canceled()
+        ConfirmationHandler.Result.Canceled.Action.None -> if (confirmationWasRestored) {
+            CheckoutController.Result.Canceled()
+        } else {
+            null
+        }
+        ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails -> null
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -64,7 +64,8 @@ class CheckoutController @Inject internal constructor(
     private val savedState: CheckoutControllerSavedState,
 ) {
     /**
-     * The latest [Session] data, or `null` until [configure] has completed successfully.
+     * The latest [Session] data, or `null` until [configure] completes successfully and once a
+     * payment flow completes successfully.
      */
     val session: StateFlow<Session?>
         get() = stateHolder.session
@@ -333,7 +334,7 @@ class CheckoutController @Inject internal constructor(
      */
     fun destroy() {
         viewModelScope.cancel()
-        stateHolder.state = null
+        checkoutStateLoader.clear()
         savedState.clear()
     }
 
@@ -1081,7 +1082,8 @@ class CheckoutController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Result {
         /**
-         * The customer completed the payment flow.
+         * The customer completed the payment flow. The controller's loaded [session] is cleared
+         * before this result is delivered.
          */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -16,12 +16,14 @@ import javax.inject.Singleton
 internal class CheckoutOperationCoordinator @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val sheetStateHolder: SheetStateHolder,
+    private val confirmationResultProcessor: CheckoutConfirmationResultProcessor,
     private val resultCallback: CheckoutController.ResultCallback,
 ) {
     private val admissionLock = Any()
     private var pendingMutations = 0
     private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
         confirmationHandler.state.value is ConfirmationHandler.State.Confirming
+    private var confirmationWasRestored = confirmationHandler.hasReloadedFromProcessDeath
     private var confirmationCompletionClaimed = false
     private val mutex = Mutex(locked = confirmationInFlight)
 
@@ -91,6 +93,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
                         "Checkout operation gate should be available after confirmation admission."
                     }
                     confirmationInFlight = true
+                    confirmationWasRestored = false
                     updateIsUpdating()
                     ConfirmationAdmission.Accepted(confirmationArguments)
                 }
@@ -110,31 +113,36 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation(state.result.asCheckoutResult())
+                completeConfirmation { confirmationWasRestored ->
+                    confirmationResultProcessor.process(state.result, confirmationWasRestored)
+                }
             }
         }
     }
 
-    fun failConfirmation(error: Throwable) {
-        completeConfirmation(CheckoutController.Result.Failed(error))
+    suspend fun failConfirmation(error: Throwable) {
+        completeConfirmation {
+            confirmationResultProcessor.processFailure(error)
+        }
     }
 
-    private fun completeConfirmation(result: CheckoutController.Result) {
-        val shouldComplete = synchronized(admissionLock) {
+    private suspend fun completeConfirmation(
+        processResult: suspend (confirmationWasRestored: Boolean) -> CheckoutController.Result?,
+    ) {
+        val wasRestored = synchronized(admissionLock) {
             if (!confirmationInFlight || confirmationCompletionClaimed) {
-                false
-            } else {
-                confirmationCompletionClaimed = true
-                true
+                return
             }
+            confirmationCompletionClaimed = true
+            confirmationWasRestored
         }
-        if (!shouldComplete) return
 
         try {
-            resultCallback.onResult(result)
+            processResult(wasRestored)?.let(resultCallback::onResult)
         } finally {
             synchronized(admissionLock) {
                 confirmationInFlight = false
+                confirmationWasRestored = false
                 confirmationCompletionClaimed = false
                 mutex.unlock()
                 updateIsUpdating()
@@ -150,13 +158,5 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         data class Accepted(val arguments: ConfirmationHandler.Args) : ConfirmationAdmission
         data class Rejected(val error: Throwable) : ConfirmationAdmission
         data object NoArguments : ConfirmationAdmission
-    }
-}
-
-private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result {
-    return when (this) {
-        is ConfirmationHandler.Result.Succeeded -> CheckoutController.Result.Completed()
-        is ConfirmationHandler.Result.Canceled -> CheckoutController.Result.Canceled()
-        is ConfirmationHandler.Result.Failed -> CheckoutController.Result.Failed(cause)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -41,6 +41,11 @@ internal class CheckoutStateLoader @Inject constructor(
         )
     }
 
+    fun clear() {
+        stateHolder.state = null
+        customerStateHolder.setCustomerState(null)
+    }
+
     private suspend fun commit(
         configuration: CheckoutController.Configuration.State,
         response: CheckoutSessionResponse,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -157,7 +157,6 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     intent = intent,
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
-                        set(CheckoutSessionResponseKey, response)
                     },
                     completedFullPaymentFlow = true,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionResponseKey.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionResponseKey.kt
@@ -1,6 +1,0 @@
-package com.stripe.android.paymentelement.confirmation.intent
-
-import com.stripe.android.paymentelement.confirmation.ConfirmationMetadata
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
-
-internal object CheckoutSessionResponseKey : ConfirmationMetadata.Key<CheckoutSessionResponse>

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -102,6 +102,7 @@ internal class CheckoutConfirmationPerformerTest {
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
+            confirmationResultProcessor = CheckoutControllerStateFactory.createConfirmationResultProcessor(stateHolder),
             resultCallback = {},
         )
         val performer = CheckoutConfirmationPerformer(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultProcessorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationResultProcessorTest.kt
@@ -1,0 +1,307 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutConfirmationResultProcessorTest {
+
+    @Test
+    fun `success clears state and returns completed`() = runScenario {
+        val result = processor.process(
+            result = ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED),
+            confirmationWasRestored = false,
+        )
+
+        assertThat(result).isInstanceOf(CheckoutController.Result.Completed::class.java)
+        clearCalls.awaitItem()
+        assertThat(stateHolder.state).isNull()
+        fetchCalls.expectNoEvents()
+        reloadCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `failure refreshes state and preserves its cause`() {
+        val error = IllegalStateException("Confirmation failed")
+        val refreshedResponse = response(id = "cs_refreshed")
+
+        runScenario(fetchResult = Result.success(refreshedResponse)) {
+            val result = processor.process(
+                result = failedResult(error),
+                confirmationWasRestored = false,
+            )
+
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(error)
+            assertThat(fetchCalls.awaitItem()).isEqualTo(expectedFetchCall())
+            assertThat(reloadCalls.awaitItem().checkoutSessionResponse).isEqualTo(refreshedResponse)
+            clearCalls.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `informed cancellation refreshes state and returns canceled`() = runScenario(
+        fetchResult = Result.success(response()),
+    ) {
+        val result = processor.process(
+            result = canceledResult(ConfirmationHandler.Result.Canceled.Action.InformCancellation),
+            confirmationWasRestored = false,
+        )
+
+        assertThat(result).isInstanceOf(CheckoutController.Result.Canceled::class.java)
+        fetchCalls.awaitItem()
+        reloadCalls.awaitItem()
+    }
+
+    @Test
+    fun `none cancellation refreshes state without returning a result`() = runScenario(
+        fetchResult = Result.success(response()),
+    ) {
+        val result = processor.process(
+            result = canceledResult(ConfirmationHandler.Result.Canceled.Action.None),
+            confirmationWasRestored = false,
+        )
+
+        assertThat(result).isNull()
+        fetchCalls.awaitItem()
+        reloadCalls.awaitItem()
+    }
+
+    @Test
+    fun `restored none cancellation returns canceled`() = runScenario(
+        fetchResult = Result.success(response()),
+    ) {
+        val result = processor.process(
+            result = canceledResult(ConfirmationHandler.Result.Canceled.Action.None),
+            confirmationWasRestored = true,
+        )
+
+        assertThat(result).isInstanceOf(CheckoutController.Result.Canceled::class.java)
+        fetchCalls.awaitItem()
+        reloadCalls.awaitItem()
+    }
+
+    @Test
+    fun `modify payment details refreshes state without returning a result`() = runScenario(
+        fetchResult = Result.success(response()),
+    ) {
+        val result = processor.process(
+            result = canceledResult(ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails),
+            confirmationWasRestored = false,
+        )
+
+        assertThat(result).isNull()
+        fetchCalls.awaitItem()
+        reloadCalls.awaitItem()
+    }
+
+    @Test
+    fun `start failure refreshes state and preserves its cause`() {
+        val error = IllegalStateException("Start failed")
+
+        runScenario(fetchResult = Result.success(response())) {
+            val result = processor.processFailure(error)
+
+            assertThat(result.error).isSameInstanceAs(error)
+            fetchCalls.awaitItem()
+            reloadCalls.awaitItem()
+        }
+    }
+
+    @Test
+    fun `failed refresh leaves state unchanged and preserves confirmation result`() {
+        val error = IllegalStateException("Confirmation failed")
+
+        runScenario(fetchResult = Result.failure(IllegalStateException("Refresh failed"))) {
+            val result = processor.process(
+                result = failedResult(error),
+                confirmationWasRestored = false,
+            )
+
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(error)
+            fetchCalls.awaitItem()
+            reloadCalls.expectNoEvents()
+            assertThat(stateHolder.state).isEqualTo(initialState)
+        }
+    }
+
+    @Test
+    fun `thrown refresh failure leaves state unchanged and preserves confirmation result`() {
+        val error = IllegalStateException("Confirmation failed")
+
+        runScenario(fetchError = IllegalStateException("Refresh failed")) {
+            val result = processor.process(
+                result = failedResult(error),
+                confirmationWasRestored = false,
+            )
+
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(error)
+            fetchCalls.awaitItem()
+            reloadCalls.expectNoEvents()
+            assertThat(stateHolder.state).isEqualTo(initialState)
+        }
+    }
+
+    @Test
+    fun `fetch result cancellation is propagated`() {
+        val cancellation = CancellationException("Canceled")
+
+        runScenario(fetchResult = Result.failure(cancellation)) {
+            val thrown = assertFailsWith<CancellationException> {
+                processor.processFailure(IllegalStateException("Start failed"))
+            }
+
+            assertThat(thrown).isSameInstanceAs(cancellation)
+            fetchCalls.awaitItem()
+            reloadCalls.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `thrown fetch cancellation is propagated`() {
+        val cancellation = CancellationException("Canceled")
+
+        runScenario(fetchError = cancellation) {
+            val thrown = assertFailsWith<CancellationException> {
+                processor.processFailure(IllegalStateException("Start failed"))
+            }
+
+            assertThat(thrown).isSameInstanceAs(cancellation)
+            fetchCalls.awaitItem()
+            reloadCalls.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `reload failure leaves state unchanged and preserves confirmation result`() {
+        val error = IllegalStateException("Confirmation failed")
+
+        runScenario(
+            fetchResult = Result.success(response(id = "cs_refreshed")),
+            reloadError = IllegalStateException("Reload failed"),
+        ) {
+            val result = processor.process(
+                result = failedResult(error),
+                confirmationWasRestored = false,
+            )
+
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(error)
+            fetchCalls.awaitItem()
+            reloadCalls.awaitItem()
+            assertThat(stateHolder.state).isEqualTo(initialState)
+        }
+    }
+
+    @Test
+    fun `missing state skips refresh and preserves confirmation result`() = runScenario(state = null) {
+        val error = IllegalStateException("Confirmation failed")
+
+        val result = processor.process(
+            result = failedResult(error),
+            confirmationWasRestored = false,
+        )
+
+        assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(error)
+        fetchCalls.expectNoEvents()
+        reloadCalls.expectNoEvents()
+    }
+
+    private fun runScenario(
+        state: CheckoutControllerState? = CheckoutControllerStateFactory.create(),
+        fetchResult: Result<CheckoutSessionResponse> = Result.failure(
+            IllegalStateException("Unexpected fetch")
+        ),
+        fetchError: Exception? = null,
+        reloadError: Exception? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val fetchCalls = Turbine<FetchCall>()
+        val reloadCalls = Turbine<CheckoutControllerState>()
+        val clearCalls = Turbine<Unit>()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle()).apply {
+            this.state = state
+        }
+        val processor = CheckoutConfirmationResultProcessor(
+            stateHolder = stateHolder,
+            fetchResponse = { sessionId, adaptivePricingAllowed ->
+                fetchCalls.add(FetchCall(sessionId, adaptivePricingAllowed))
+                fetchError?.let { throw it }
+                fetchResult
+            },
+            reloadState = { updatedState ->
+                reloadCalls.add(updatedState)
+                reloadError?.let { throw it }
+                stateHolder.state = updatedState
+            },
+            clearState = {
+                clearCalls.add(Unit)
+                stateHolder.state = null
+            },
+            logger = Logger.noop(),
+        )
+
+        Scenario(
+            processor = processor,
+            initialState = state,
+            stateHolder = stateHolder,
+            fetchCalls = fetchCalls,
+            reloadCalls = reloadCalls,
+            clearCalls = clearCalls,
+        ).block()
+
+        fetchCalls.ensureAllEventsConsumed()
+        reloadCalls.ensureAllEventsConsumed()
+        clearCalls.ensureAllEventsConsumed()
+    }
+
+    private fun failedResult(error: Throwable): ConfirmationHandler.Result.Failed {
+        return ConfirmationHandler.Result.Failed(
+            cause = error,
+            message = "Confirmation failed".resolvableString,
+            type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+        )
+    }
+
+    private fun canceledResult(
+        action: ConfirmationHandler.Result.Canceled.Action,
+    ): ConfirmationHandler.Result.Canceled {
+        return ConfirmationHandler.Result.Canceled(action)
+    }
+
+    private fun response(id: String = "cs_test"): CheckoutSessionResponse {
+        return CheckoutSessionResponseFactory.create(id = id)
+    }
+
+    private class Scenario(
+        val processor: CheckoutConfirmationResultProcessor,
+        val initialState: CheckoutControllerState?,
+        val stateHolder: CheckoutControllerStateHolder,
+        val fetchCalls: Turbine<FetchCall>,
+        val reloadCalls: Turbine<CheckoutControllerState>,
+        val clearCalls: Turbine<Unit>,
+    ) {
+        fun expectedFetchCall(): FetchCall {
+            val state = requireNotNull(initialState)
+            return FetchCall(
+                sessionId = state.checkoutSessionResponse.id,
+                adaptivePricingAllowed = state.configuration.adaptivePricingAllowed,
+            )
+        }
+    }
+
+    private data class FetchCall(
+        val sessionId: String,
+        val adaptivePricingAllowed: Boolean,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.checkout.ece.FakeAvailableExpressButtonTypesFactory
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.Logger
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -62,6 +63,18 @@ internal object CheckoutControllerStateFactory {
             errorReporter = errorReporter,
             paymentOptionFactory = paymentOptionFactory,
             availableExpressButtonTypesFactory = availableExpressButtonTypesFactory,
+        )
+    }
+
+    fun createConfirmationResultProcessor(
+        stateHolder: CheckoutControllerStateHolder,
+    ): CheckoutConfirmationResultProcessor {
+        return CheckoutConfirmationResultProcessor(
+            stateHolder = stateHolder,
+            fetchResponse = { _, _ -> Result.failure(AssertionError("Unexpected fetch")) },
+            reloadState = { _ -> },
+            clearState = { stateHolder.state = null },
+            logger = Logger.noop(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
@@ -271,7 +270,7 @@ internal class CheckoutOperationCoordinatorTest {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
-                ConfirmationHandler.Result.Canceled.Action.None
+                ConfirmationHandler.Result.Canceled.Action.InformCancellation
             )
         )
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
@@ -307,7 +306,7 @@ internal class CheckoutOperationCoordinatorTest {
 
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
-                    ConfirmationHandler.Result.Canceled.Action.None
+                    ConfirmationHandler.Result.Canceled.Action.InformCancellation
                 )
             )
             assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
@@ -319,19 +318,7 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `successful confirmation is delivered as completed`() = runScenario {
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
-
-        confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
-        )
-
-        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
-        assertThat(coordinator.isUpdating.value).isFalse()
-    }
-
-    @Test
-    fun `canceled confirmation is delivered as canceled`() = runScenario {
+    fun `canceled with ModifyPaymentDetails does not invoke callback and releases gate`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         confirmationState.value = ConfirmationHandler.State.Complete(
@@ -339,27 +326,34 @@ internal class CheckoutOperationCoordinatorTest {
                 ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
             )
         )
+        runCurrent()
 
-        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        resultTurbine.expectNoEvents()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
-    fun `failed confirmation preserves its cause`() = runScenario {
-        val expected = IllegalStateException("Confirmation failed")
+    fun `canceled with None does not invoke callback and releases gate`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val mutationStarted = CompletableDeferred<Unit>()
+        val mutation = async {
+            coordinator.runMutation {
+                mutationStarted.complete(Unit)
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+        assertThat(mutationStarted.isCompleted).isFalse()
 
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Failed(
-                cause = expected,
-                message = "Confirmation failed".resolvableString,
-                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            ConfirmationHandler.Result.Canceled(
+                ConfirmationHandler.Result.Canceled.Action.None
             )
         )
+        mutation.await()
 
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        resultTurbine.expectNoEvents()
+        assertThat(mutationStarted.isCompleted).isTrue()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
@@ -532,14 +526,20 @@ internal class CheckoutOperationCoordinatorTest {
             hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
             state = confirmationState,
         )
-        val sheetStateHolder = SheetStateHolder(SavedStateHandle()).apply {
+        val savedStateHandle = SavedStateHandle()
+        val sheetStateHolder = SheetStateHolder(savedStateHandle).apply {
             this.sheetIsOpen = sheetIsOpen
         }
+        val checkoutStateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         val resultTurbine = Turbine<CheckoutController.Result>()
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
-            resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+            confirmationResultProcessor =
+                CheckoutControllerStateFactory.createConfirmationResultProcessor(checkoutStateHolder),
+            resultCallback = resultCallback ?: CheckoutController.ResultCallback { result ->
+                resultTurbine.add(result)
+            },
         )
         backgroundScope.launch {
             coordinator.observeConfirmationResults()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -138,6 +138,19 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `clear removes controller and customer state`() = runScenario(
+        customer = savedCustomer(),
+    ) {
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        loader.clear()
+
+        assertThat(stateHolder.state).isNull()
+        assertThat(customerStateHolder.customer.value).isNull()
+        assertThat(customerStateHolder.paymentMethods.value).isEmpty()
+    }
+
+    @Test
     fun `loadInitial leaves the customer state holder empty when the session has no customer`() = runScenario {
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -219,6 +219,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
+            confirmationResultProcessor = CheckoutControllerStateFactory.createConfirmationResultProcessor(stateHolder),
             resultCallback = {},
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -35,7 +35,6 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
@@ -78,8 +77,6 @@ class CheckoutSessionConfirmationInterceptorTest {
         assertThat((completeAction.intent as PaymentIntent).status).isEqualTo(StripeIntent.Status.Succeeded)
         assertThat(completeAction.metadata[DeferredIntentConfirmationTypeKey])
             .isEqualTo(DeferredIntentConfirmationType.Server)
-        assertThat(completeAction.metadata[CheckoutSessionResponseKey]?.status)
-            .isEqualTo(CheckoutSessionResponse.Status.COMPLETE)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 
@@ -215,8 +212,6 @@ class CheckoutSessionConfirmationInterceptorTest {
         assertThat((completeAction.intent as PaymentIntent).status).isEqualTo(StripeIntent.Status.Succeeded)
         assertThat(completeAction.metadata[DeferredIntentConfirmationTypeKey])
             .isEqualTo(DeferredIntentConfirmationType.Server)
-        assertThat(completeAction.metadata[CheckoutSessionResponseKey]?.status)
-            .isEqualTo(CheckoutSessionResponse.Status.COMPLETE)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 


### PR DESCRIPTION
# Summary

- Keeps `CheckoutOperationCoordinator` as the single owner of confirmation result delivery and its exactly-once gate.
- Moves result-to-state policy into `CheckoutConfirmationResultProcessor`, which clears completed checkout state and best-effort refreshes non-success outcomes before returning the merchant-facing result.
- Clears both controller and saved customer state after successful completion or controller destruction.
- Delivers merchant-visible cancellations while silently returning customers to payment details for internal cancellations.
- Removes unused Checkout Session response confirmation metadata.

# Motivation

Confirmation result delivery, state refresh policy, and public result mapping had become split across freely combinable action and outcome types. Processing the `ConfirmationHandler.Result` exhaustively in one component makes invalid result/state combinations unrepresentable while leaving concurrency and callback delivery in the coordinator.

Completed checkout flows no longer retain saved customer state after the public session is cleared. Refresh failures remain best effort, preserve the original confirmation result, propagate coroutine cancellation, and are logged for diagnosis.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutConfirmationResultProcessorTest --tests com.stripe.android.checkout.CheckoutOperationCoordinatorTest --tests com.stripe.android.checkout.CheckoutStateLoaderTest --tests com.stripe.android.checkout.CheckoutConfirmationPerformerTest --tests com.stripe.android.checkout.ece.DefaultExpressCheckoutElementConfirmationPerformerTest --tests com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionConfirmationInterceptorTest`
- `./gradlew :paymentsheet:testDebugUnitTest :paymentsheet-example:compileBaseDebugKotlin :paymentsheet:detekt :paymentsheet-example:detekt`

No tests were ignored.

# Screenshots

Not applicable — there are no visual changes.

# Changelog

Not applicable — `CheckoutController` remains a preview API.
