### PR TITLE
Preserve vertical form selections by payment method

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -7,10 +7,10 @@ import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.previousNewSelection
-import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.previousNewSelection
+import com.stripe.android.paymentsheet.model.stashNewSelection
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.previousNewSelection
+import com.stripe.android.paymentsheet.model.stashNewSelection
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -65,8 +65,9 @@ internal class DefaultFormHelper(
                 linkInlineHandler = linkInlineHandler,
                 cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
                 paymentMethodMetadata = paymentMethodMetadata,
-                newPaymentSelectionProvider = {
-                    viewModel.newPaymentSelection
+                newPaymentSelectionProvider = { code ->
+                    viewModel.newPaymentSelection?.takeIf { it.getPaymentMethodCode() == code }
+                        ?: viewModel.getPreviousNewSelection(code)?.let { NewPaymentOptionSelection.New(it) }
                 },
                 linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
                 selectionUpdater = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PreviousNewSelections.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PreviousNewSelections.kt
@@ -1,9 +1,7 @@
-package com.stripe.android.paymentelement.embedded
+package com.stripe.android.paymentsheet.model
 
 import android.os.Bundle
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.paymentMethodType
 
 internal fun Bundle.stashNewSelection(selection: PaymentSelection?) {
     if (selection is PaymentSelection.New) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.viewmodels
 
+import android.os.Bundle
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
@@ -30,6 +31,8 @@ import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherE
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.previousNewSelection
+import com.stripe.android.paymentsheet.model.stashNewSelection
 import com.stripe.android.paymentsheet.navigation.NavigationHandler
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
@@ -118,6 +121,11 @@ internal abstract class BaseSheetViewModel(
 
     internal val selection: StateFlow<PaymentSelection?> = savedStateHandle
         .getStateFlow<PaymentSelection?>(SAVE_SELECTION, null)
+
+    private val previousNewSelections: Bundle = savedStateHandle[PREVIOUS_NEW_SELECTIONS]
+        ?: Bundle().also {
+            savedStateHandle[PREVIOUS_NEW_SELECTIONS] = it
+        }
 
     val processing: StateFlow<Boolean> = savedStateHandle
         .getStateFlow(SAVE_PROCESSING, false)
@@ -223,9 +231,15 @@ internal abstract class BaseSheetViewModel(
         }
 
         savedStateHandle[SAVE_SELECTION] = selection
+        previousNewSelections.stashNewSelection(selection)
+        savedStateHandle[PREVIOUS_NEW_SELECTIONS] = previousNewSelections
 
         updateCvcFlows(selection)
         clearErrorMessages()
+    }
+
+    fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
+        return previousNewSelections.previousNewSelection(code)
     }
 
     private fun updateCvcFlows(selection: PaymentSelection?) {
@@ -267,5 +281,6 @@ internal abstract class BaseSheetViewModel(
     companion object {
         internal const val SAVE_SELECTION = "selection"
         internal const val SAVE_PROCESSING = "processing"
+        internal const val PREVIOUS_NEW_SELECTIONS = "previous_new_selections"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -10,9 +10,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.previousNewSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -22,14 +22,14 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
-import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
-import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.previousNewSelection
+import com.stripe.android.paymentsheet.model.stashNewSelection
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
 import com.stripe.android.testing.FakeErrorReporter

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder.Companion.EMBEDDED_TEMPORARY_SELECTION_KEY
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.model.previousNewSelection
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -21,14 +21,14 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
-import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.previousNewSelection
+import com.stripe.android.paymentsheet.model.stashNewSelection
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -16,10 +16,10 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.stashNewSelection
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import org.junit.Rule
 import org.junit.Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddMode
 import com.stripe.android.common.taptoadd.TapToAddNextStep
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
@@ -70,6 +71,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -112,6 +114,12 @@ internal class PaymentOptionsViewModelTest {
 
     @get:Rule
     val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @get:Rule
+    val enableKlarnaFormRemovalRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.enableKlarnaFormRemoval,
+        isEnabled = true,
+    )
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val standardTestDispatcher = StandardTestDispatcher()
@@ -767,6 +775,68 @@ internal class PaymentOptionsViewModelTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `updateSelection retains each new selection by payment method code`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.updateSelection(NEW_CARD_PAYMENT_SELECTION)
+        viewModel.updateSelection(PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION)
+
+        assertThat(viewModel.getPreviousNewSelection("card")).isEqualTo(NEW_CARD_PAYMENT_SELECTION)
+        assertThat(viewModel.getPreviousNewSelection("us_bank_account"))
+            .isEqualTo(PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `previous new selections survive view model reconstruction`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val originalViewModel = createViewModel(savedStateHandle = savedStateHandle)
+
+        originalViewModel.updateSelection(NEW_CARD_PAYMENT_SELECTION)
+        originalViewModel.updateSelection(PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION)
+
+        val restoredViewModel = createViewModel(savedStateHandle = savedStateHandle)
+
+        assertThat(restoredViewModel.getPreviousNewSelection("card"))
+            .isEqualTo(NEW_CARD_PAYMENT_SELECTION)
+        assertThat(restoredViewModel.getPreviousNewSelection("us_bank_account"))
+            .isEqualTo(PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `form helper restores a previous new selection for a different payment method`() = runTest {
+        val viewModel = createViewModel(args = formHelperArgs())
+        val formHelper = DefaultFormHelper.create(
+            viewModel = viewModel,
+            coroutineScope = viewModel.viewModelScope,
+            paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
+        )
+
+        viewModel.updateSelection(klarnaSelection(email = "klarna@example.com"))
+        viewModel.updateSelection(NEW_CARD_PAYMENT_SELECTION)
+
+        assertThat(formHelper.formElementsForCode("klarna")[0].getFormFieldValueFlow().value[0].second.value)
+            .isEqualTo("klarna@example.com")
+    }
+
+    @Test
+    fun `form helper prefers a current matching new selection over a previous selection`() = runTest {
+        val viewModel = createViewModel(args = formHelperArgs())
+        val formHelper = DefaultFormHelper.create(
+            viewModel = viewModel,
+            coroutineScope = viewModel.viewModelScope,
+            paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
+        )
+        viewModel.updateSelection(klarnaSelection(email = "previous@example.com"))
+        viewModel.updateSelection(NEW_CARD_PAYMENT_SELECTION)
+        viewModel.newPaymentSelection = NewPaymentOptionSelection.New(
+            klarnaSelection(email = "current@example.com")
+        )
+
+        assertThat(formHelper.formElementsForCode("klarna")[0].getFormFieldValueFlow().value[0].second.value)
+            .isEqualTo("current@example.com")
     }
 
     @Test
@@ -1451,7 +1521,11 @@ internal class PaymentOptionsViewModelTest {
         tapToAddHelperFactory: TapToAddHelper.Factory = FakeTapToAddHelper.Factory.noOp(),
         errorReporter: ErrorReporter = FakeErrorReporter(),
         customerStateHolder: CustomerStateHolder? = null,
-    ) = TestViewModelFactory.create(linkConfigurationCoordinator) { linkHandler, savedStateHandle ->
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    ) = TestViewModelFactory.create(
+        linkConfigurationCoordinator = linkConfigurationCoordinator,
+        savedStateHandle = savedStateHandle,
+    ) { linkHandler, thisSavedStateHandle ->
         PaymentOptionsViewModel(
             args = args.copy(
                 state = args.state.copy(
@@ -1464,7 +1538,7 @@ internal class PaymentOptionsViewModelTest {
             eventReporter = eventReporter,
             savedPaymentMethodRepository = savedPaymentMethodRepository,
             workContext = workContext,
-            savedStateHandle = savedStateHandle,
+            savedStateHandle = thisSavedStateHandle,
             linkHandler = linkHandler,
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             linkGateFactory = FakeLinkGate.Factory(linkGate),
@@ -1515,6 +1589,39 @@ internal class PaymentOptionsViewModelTest {
             CardBrand.Discover,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         )
+
+        private fun formHelperArgs(): PaymentOptionContract.Args {
+            return PAYMENT_OPTION_CONTRACT_ARGS.copy(
+                state = PAYMENT_OPTION_CONTRACT_ARGS.state.copy(
+                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                        stripeIntent = PAYMENT_INTENT.copy(
+                            paymentMethodTypes = listOf("card", "klarna"),
+                        ),
+                        billingDetailsCollectionConfiguration =
+                        PaymentSheet.BillingDetailsCollectionConfiguration(
+                            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        private fun klarnaSelection(email: String): PaymentSelection.New.GenericPaymentMethod {
+            return PaymentSelection.New.GenericPaymentMethod(
+                label = "Klarna".resolvableString,
+                iconResource = 0,
+                iconResourceNight = null,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+                paymentMethodCreateParams = PaymentMethodCreateParams.createKlarna(
+                    billingDetails = PaymentMethod.BillingDetails(email = email),
+                ),
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+                paymentMethodOptionsParams = null,
+                paymentMethodExtraParams = null,
+            )
+        }
+
         private val PAYMENT_OPTION_CONTRACT_ARGS = PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
                 customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,


### PR DESCRIPTION
# Summary

Preserves the last valid new payment selection for each payment-method code in the shared PaymentSheet view model. Forms now restore their matching selection after the user switches methods.

# Motivation

The vertical picker previously retained only one new payment selection. Entering valid details for a method such as Klarna, switching to card, and switching back left the Klarna form blank.

Follow up to https://github.com/stripe/stripe-android/pull/13616#pullrequestreview-4789579850

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused `:paymentsheet:testDebugUnitTest` covering FormHelper, PaymentOptionsViewModel, PaymentSheetViewModel, and EmbeddedFormHelperFactory; full `:paymentsheet:testDebugUnitTest`; and `:paymentsheet:detekt`.

# Screenshots

Not applicable — this is state-restoration behavior with no visual design change.

# Changelog

Not applicable — no public API change.
