### PR TITLE
Disable Google Pay tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -33,7 +33,7 @@ pipelines:
         parallel: $PAYMENTSHEET_E2E_SHARD_COUNT
         depends_on:
           - build-paymentsheet-e2e
-      run-paymentsheet-google-pay-e2e: { }
+#      run-paymentsheet-google-pay-e2e: { }
       check-dependencies: { }
       verify-publish-pom: { }
   pipeline-connect-e2e-debug-tests:


### PR DESCRIPTION
# Summary
Disable Google Pay tests due to infrastructure failures

# Motivation
Firebase incident: https://status.firebase.google.com/incidents/UwSNSvaJafMh9mykWuq5 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified