### PR TITLE
Propagate parent CoroutineScope to card form controllers and elements.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -28,6 +28,7 @@ import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -49,7 +50,8 @@ internal class CardDetailsController(
     ),
     cvcTextFieldConfig: CvcTextFieldConfig = CvcConfig(),
     dateConfig: TextFieldConfig = DateConfig(),
-    private val validationMessageComparator: FieldValidationMessageComparator = DefaultFieldValidationMessageComparator
+    private val validationMessageComparator: FieldValidationMessageComparator = DefaultFieldValidationMessageComparator,
+    parentCoroutineScope: CoroutineScope,
 ) : SectionFieldValidationController, SectionFieldComposable {
     private val initialCardNumber = initialValues[IdentifierSpec.CardNumber]
 
@@ -103,7 +105,8 @@ internal class CardDetailsController(
                 is CardBrandChoiceEligibility.Ineligible -> CardBrandChoiceConfig.Ineligible
             },
             cardBrandFilter = cardBrandFilter,
-            cardFundingFilter = cardFundingFilter
+            cardFundingFilter = cardFundingFilter,
+            parentCoroutineScope = parentCoroutineScope,
         )
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -17,6 +17,7 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -31,14 +32,16 @@ internal class CardDetailsElement(
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
+    parentCoroutineScope: CoroutineScope,
     val controller: CardDetailsController = CardDetailsController(
         cardAccountRangeRepositoryFactory,
         initialValues,
         collectName,
         cbcEligibility,
         cardBrandFilter = cardBrandFilter,
-        cardFundingFilter = cardFundingFilter
-    )
+        cardFundingFilter = cardFundingFilter,
+        parentCoroutineScope = parentCoroutineScope,
+    ),
 ) : SectionMultiFieldElement(identifier) {
 
     override val allowsUserInteraction: Boolean = true

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -10,6 +10,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionFieldValidationController
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardDetailsSectionController(
@@ -20,6 +21,7 @@ class CardDetailsSectionController(
     cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
     val cardDetailsAction: CardDetailsAction? = null,
+    parentCoroutineScope: CoroutineScope,
 ) : SectionFieldValidationController {
     internal val cardDetailsElement = CardDetailsElement(
         IdentifierSpec.Generic("card_detail"),
@@ -29,6 +31,7 @@ class CardDetailsSectionController(
         cbcEligibility,
         cardBrandFilter,
         cardFundingFilter,
+        parentCoroutineScope,
     )
 
     internal val shouldHideHeader = cardDetailsElement.controller.cardPillElement.mapAsStateFlow { element ->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -10,6 +10,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -22,6 +23,7 @@ class CardDetailsSectionElement(
     private val cardFundingFilter: CardFundingFilter,
     override val identifier: IdentifierSpec,
     private val cardDetailsAction: CardDetailsAction? = null,
+    parentCoroutineScope: CoroutineScope,
     override val controller: CardDetailsSectionController = CardDetailsSectionController(
         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
         initialValues = initialValues,
@@ -30,7 +32,8 @@ class CardDetailsSectionElement(
         cardBrandFilter = cardBrandFilter,
         cardFundingFilter = cardFundingFilter,
         cardDetailsAction = cardDetailsAction,
-    )
+        parentCoroutineScope = parentCoroutineScope,
+    ),
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -43,6 +43,7 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -80,7 +81,10 @@ internal class DefaultCardNumberController(
     cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
-    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext + SupervisorJob()),
+    parentCoroutineScope: CoroutineScope,
+    private val coroutineScope: CoroutineScope = CoroutineScope(
+        uiContext + SupervisorJob(parentCoroutineScope.coroutineContext[Job])
+    ),
     private val accountRangeService: CardAccountRangeService = DefaultCardAccountRangeService(
         cardAccountRangeRepository,
         uiContext,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -21,6 +21,8 @@ import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.isInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -34,6 +36,8 @@ class CardDetailsControllerTest {
     val coroutineTestRule = CoroutineTestRule()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val parentCoroutineScope = CoroutineScope(SupervisorJob())
 
     @Test
     fun `Validation message uses comparator to determine which message to show`() = runTest {
@@ -395,6 +399,7 @@ class CardDetailsControllerTest {
                     }
                 }
             },
+            parentCoroutineScope = parentCoroutineScope,
         )
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -13,6 +13,8 @@ import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -27,6 +29,8 @@ class CardDetailsElementTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val parentCoroutineScope = CoroutineScope(SupervisorJob() + testDispatcher)
+
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @get:Rule
@@ -39,11 +43,13 @@ class CardDetailsElementTest {
             initialValues = emptyMap(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = emptyMap(),
+            parentCoroutineScope = parentCoroutineScope,
             controller = cardController
         )
 
@@ -74,7 +80,8 @@ class CardDetailsElementTest {
             initialValues = mapOf(
                 IdentifierSpec.CardNumber to "4242424242424242",
                 IdentifierSpec.CardBrand to CardBrand.Visa.code
-            )
+            ),
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         assertThat(cardDetailsElement.controller.nameElement).isNull()
@@ -103,12 +110,14 @@ class CardDetailsElementTest {
             collectName = true,
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = emptyMap(),
             collectName = true,
+            parentCoroutineScope = parentCoroutineScope,
             controller = cardController,
         )
 
@@ -143,6 +152,7 @@ class CardDetailsElementTest {
             cbcEligibility = cbcEligibility,
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         val cardDetailsElement = CardDetailsElement(
@@ -151,7 +161,8 @@ class CardDetailsElementTest {
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
-            cbcEligibility = cbcEligibility
+            cbcEligibility = cbcEligibility,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         assertThat(cardDetailsElement.controller.nameElement).isNotNull()
@@ -186,6 +197,7 @@ class CardDetailsElementTest {
             cbcEligibility = cbcEligibility,
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         val cardDetailsElement = CardDetailsElement(
@@ -194,7 +206,8 @@ class CardDetailsElementTest {
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
-            cbcEligibility = cbcEligibility
+            cbcEligibility = cbcEligibility,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         assertThat(cardDetailsElement.controller.nameElement).isNotNull()
@@ -236,6 +249,7 @@ class CardDetailsElementTest {
             cbcEligibility = cbcEligibility,
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         val cardDetailsElement = CardDetailsElement(
@@ -244,7 +258,8 @@ class CardDetailsElementTest {
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
-            cbcEligibility = cbcEligibility
+            cbcEligibility = cbcEligibility,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         assertThat(cardDetailsElement.controller.nameElement).isNotNull()
@@ -276,11 +291,13 @@ class CardDetailsElementTest {
             initialValues = emptyMap(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = emptyMap(),
+            parentCoroutineScope = parentCoroutineScope,
             controller = cardController
         )
 
@@ -317,6 +334,7 @@ class CardDetailsElementTest {
                 IdentifierSpec.CardExpMonth to "06",
                 IdentifierSpec.CardExpYear to "2030",
             ),
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         cardDetailsElement.getFormFieldValueFlow().test {
@@ -341,12 +359,14 @@ class CardDetailsElementTest {
             initialValues = emptyMap(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
 
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = repositoryFactory,
             initialValues = emptyMap(),
+            parentCoroutineScope = parentCoroutineScope,
             controller = cardController,
         )
 
@@ -386,11 +406,13 @@ class CardDetailsElementTest {
             initialValues = initialValues,
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            parentCoroutineScope = parentCoroutineScope,
         )
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = repositoryFactory,
             initialValues = initialValues,
+            parentCoroutineScope = parentCoroutineScope,
             controller = cardController,
         )
 
@@ -412,6 +434,7 @@ class CardDetailsElementTest {
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = emptyMap(),
             collectName = true,
+            parentCoroutineScope = parentCoroutineScope,
             controller = CardDetailsController(
                 cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
                 initialValues = emptyMap(),
@@ -419,8 +442,9 @@ class CardDetailsElementTest {
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,
                 uiContext = testDispatcher,
                 workContext = testDispatcher,
+                parentCoroutineScope = parentCoroutineScope,
             ),
-            cbcEligibility = CardBrandChoiceEligibility.Ineligible
+            cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         )
 
         assertThat(cardDetailsElement.controller.nameElement).isNotNull()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionControllerTest.kt
@@ -8,6 +8,8 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -21,6 +23,8 @@ class CardDetailsSectionControllerTest {
     val coroutineTestRule = CoroutineTestRule()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val parentCoroutineScope = CoroutineScope(SupervisorJob())
 
     @Test
     fun `shouldHideHeader is false when card pill is not shown`() = runTest {
@@ -76,5 +80,6 @@ class CardDetailsSectionControllerTest {
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         cardBrandFilter = DefaultCardBrandFilter,
         cardDetailsAction = null,
+        parentCoroutineScope = parentCoroutineScope,
     )
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
@@ -90,6 +90,7 @@ internal class CardDetailsSectionElementUITest {
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             cardBrandFilter = DefaultCardBrandFilter,
             cardDetailsAction = cardDetailsAction,
+            parentCoroutineScope = this,
         )
 
         composeTestRule.setContent {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -38,6 +38,9 @@ import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeCardBrandFilter
 import com.stripe.android.utils.TestUtils.idleLooper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -67,6 +70,8 @@ internal class CardNumberControllerTest {
     val composeCleanupRule = createComposeCleanupRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val parentCoroutineScope = CoroutineScope(SupervisorJob() + testDispatcher)
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(testDispatcher)
@@ -893,10 +898,26 @@ internal class CardNumberControllerTest {
         }
     }
 
+    @Test
+    fun `Cancelling parent coroutine scope cancels controller scope`() = runTest {
+        val parentJob = Job()
+        createController(
+            parentCoroutineScope = CoroutineScope(parentJob + testDispatcher),
+        )
+
+        val controllerJob = parentJob.children.single()
+        assertThat(controllerJob.isActive).isTrue()
+
+        parentJob.cancel()
+
+        assertThat(controllerJob.isActive).isFalse()
+    }
+
     private fun createController(
         initialValue: String? = null,
         cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
-        cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
+        cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
+        parentCoroutineScope: CoroutineScope = this.parentCoroutineScope,
     ): DefaultCardNumberController {
         return DefaultCardNumberController(
             cardTextFieldConfig = CardNumberConfig(
@@ -908,7 +929,8 @@ internal class CardNumberControllerTest {
             workContext = testDispatcher,
             initialValue = initialValue,
             cardBrandChoiceConfig = cardBrandChoiceConfig,
-            cardBrandFilter = cardBrandFilter
+            cardBrandFilter = cardBrandFilter,
+            parentCoroutineScope = parentCoroutineScope,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -485,6 +485,7 @@ internal class CustomerSheetViewModel(
                         automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
                         paymentMethodMessagingPromotionsHelper = null,
                         isNfcScanningAvailable = isNfcScanningAvailable,
+                        coroutineScope = viewModelScope,
                     ),
                 ) ?: listOf(),
                 primaryButtonLabel = if (
@@ -834,6 +835,7 @@ internal class CustomerSheetViewModel(
                 automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
                 paymentMethodMessagingPromotionsHelper = null,
                 isNfcScanningAvailable = isNfcScanningAvailable,
+                coroutineScope = viewModelScope,
             )
         ) ?: emptyList()
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -30,6 +30,7 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CoroutineScope
 
 internal sealed interface UiDefinitionFactory {
     class Arguments(
@@ -56,6 +57,7 @@ internal sealed interface UiDefinitionFactory {
         val tapToAddHelper: TapToAddHelper? = null,
         val paymentMethodMessagingPromotionsHelper: PaymentMethodMessagePromotionsHelper? = null,
         val isNfcScanningAvailable: IsNfcScanningAvailable? = null,
+        val coroutineScope: CoroutineScope,
     ) {
         interface Factory {
             fun create(
@@ -82,6 +84,7 @@ internal sealed interface UiDefinitionFactory {
                 private val tapToAddHelper: TapToAddHelper? = null,
                 private val paymentMethodMessagingPromotionsHelper: PaymentMethodMessagePromotionsHelper? = null,
                 private val isNfcScanningAvailable: IsNfcScanningAvailable? = null,
+                private val coroutineScope: CoroutineScope,
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
@@ -115,6 +118,7 @@ internal sealed interface UiDefinitionFactory {
                         tapToAddHelper = tapToAddHelper,
                         paymentMethodMessagingPromotionsHelper = paymentMethodMessagingPromotionsHelper,
                         isNfcScanningAvailable = isNfcScanningAvailable,
+                        coroutineScope = coroutineScope,
                     )
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -131,7 +131,8 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                     cbcEligibility = arguments.cbcEligibility,
                     cardBrandFilter = arguments.cardBrandFilter,
                     cardFundingFilter = arguments.cardFundingFilter,
-                    cardDetailsAction = createCardDetailsAction(metadata, arguments)
+                    cardDetailsAction = createCardDetailsAction(metadata, arguments),
+                    parentCoroutineScope = arguments.coroutineScope,
                 )
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/NullUiDefinitionFactoryHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/NullUiDefinitionFactoryHelper.kt
@@ -6,6 +6,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.AccountRange
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 
 internal object NullUiDefinitionFactoryHelper {
@@ -17,7 +19,10 @@ internal object NullUiDefinitionFactoryHelper {
         onLinkInlineSignupStateChanged = {
             throw IllegalStateException("Not possible.")
         },
-        paymentMethodMessagingPromotionsHelper = null
+        paymentMethodMessagingPromotionsHelper = null,
+        // These arguments are only used to read static form information, never to drive UI, so hand
+        // out an already cancelled scope. Anything launched in it is a no-op and nothing leaks.
+        coroutineScope = CoroutineScope(Job().apply { cancel() }),
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -253,6 +253,7 @@ internal class DefaultFormHelper(
             tapToAddHelper = tapToAddHelper,
             paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = isNfcScanningAvailable,
+            coroutineScope = coroutineScope,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
@@ -10,6 +10,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -110,5 +112,6 @@ internal class TapToAddCardDetailsActionTest {
     private fun fakeController() = CardDetailsSectionController(
         cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
         initialValues = emptyMap(),
+        parentCoroutineScope = CoroutineScope(SupervisorJob()),
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -37,6 +37,8 @@ import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -128,7 +130,8 @@ internal class CustomerSheetScreenshotTest {
                 linkConfigurationCoordinator = null,
                 onLinkInlineSignupStateChanged = {},
                 autocompleteAddressInteractorFactory = null,
-                linkInlineHandler = null
+                linkInlineHandler = null,
+                coroutineScope = CoroutineScope(SupervisorJob()),
             )
         ) ?: listOf(),
         formArguments = FormArguments(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
@@ -17,7 +17,9 @@ import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -130,6 +132,7 @@ internal class PaymentMethodScreenScreenshotTest {
             linkInlineHandler = null,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },
             autocompleteAddressInteractorFactory = null,
+            coroutineScope = CoroutineScope(SupervisorJob()),
         )
         val formElements = metadata.formElementsForCode(
             code = paymentMethodCode,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -23,6 +23,8 @@ import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SimpleTextElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -317,6 +319,7 @@ class FormElementsBuilderTest {
             setAsDefaultMatchesSaveForFutureUse = false,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             linkInlineHandler = null,
+            coroutineScope = CoroutineScope(SupervisorJob()),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -43,6 +43,8 @@ import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -456,6 +458,7 @@ private object TransformSpecToElementsFactory {
                 setAsDefaultMatchesSaveForFutureUse = false,
                 autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
                 linkInlineHandler = null,
+                coroutineScope = CoroutineScope(SupervisorJob()),
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -17,8 +17,12 @@ import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotio
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 
 internal object TestUiDefinitionFactoryArgumentsFactory {
+    private val coroutineScope = CoroutineScope(SupervisorJob())
+
     fun create(
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
@@ -53,6 +57,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             tapToAddHelper = tapToAddHelper,
             paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = isNfcScanningAvailable,
+            coroutineScope = coroutineScope,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -10,6 +10,8 @@ import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import org.mockito.kotlin.mock
 
@@ -50,6 +52,7 @@ internal class FakeAddPaymentMethodInteractor(
                 onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },
                 autocompleteAddressInteractorFactory = null,
                 linkInlineHandler = null,
+                coroutineScope = CoroutineScope(SupervisorJob()),
             )
 
             return AddPaymentMethodInteractor.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -6,6 +6,8 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import org.mockito.Mockito.mock
 
@@ -40,6 +42,7 @@ internal class FakeVerticalModeFormInteractor private constructor(
                 linkInlineHandler = null,
                 onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },
                 autocompleteAddressInteractorFactory = null,
+                coroutineScope = CoroutineScope(SupervisorJob()),
             )
 
             return FakeVerticalModeFormInteractor(


### PR DESCRIPTION
# Summary
This PR updates the card collection form and associated controllers to accept a parent CoroutineScope, ensuring proper coroutine hierarchy and lifecycle management throughout the form elements. This prevents scope leaks and allows for cancellation of child jobs when the parent is cancelled.

# Motivation
Previously, coroutines in card form controllers and elements used their own SupervisorJobs, leading to potential leaking and improper cancellation. By passing a parent CoroutineScope, we ensure coroutines within card form elements are children of a logical parent, such as a ViewModel scope, improving resource management and avoiding lifecycle issues.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
- [Fixed] Improved lifecycle management of coroutines in card collection form controllers by accepting a parent CoroutineScope.