### PR TITLE
Fix search button not triggering autocomplete when field is unfocused

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -111,6 +111,7 @@ internal class InlineAutocompleteController(
     }
 
     fun onSearchActivated() {
+        predictionsPaused = false
         activationState = ActivationState.ActiveBySearch
         val q = queryFlow?.value ?: return
         val c = countryFlow?.value ?: ""

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -807,6 +807,28 @@ class InlineAutocompleteControllerTest {
         }
 
     @Test
+    fun `onSearchActivated fetches even when field is unfocused`() =
+        runScenario {
+            fakePlacesClient.findPredictionsResult = Result.success(
+                FindAutocompletePredictionsResponse(emptyList())
+            )
+            delegate.observeQueryChanges(queryFlow, countryFlow)
+            delegate.onSearchActivated()
+            queryFlow.value = "123 Main St"
+            advanceTimeBy(500)
+            fakePlacesClient.findPredictionsCalls.awaitItem()
+
+            delegate.onFocusLost()
+            advanceTimeBy(100)
+
+            delegate.onSearchActivated()
+            advanceTimeBy(100)
+
+            val call = fakePlacesClient.findPredictionsCalls.awaitItem()
+            assertThat(call.query).isEqualTo("123 Main St")
+        }
+
+    @Test
     fun `onSearchActivated does not double-fetch when debounce catches up`() =
         runScenario {
             fakePlacesClient.findPredictionsResult = Result.success(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
@@ -8,7 +8,10 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -43,12 +46,13 @@ fun AddressTextFieldUI(
     val inlineQuery by controller.inlineQuery.collectAsState()
     val error by controller.validationMessage.collectAsState()
     val textFieldInsets = LocalTextFieldInsets.current
+    val focusRequester = remember { FocusRequester() }
 
     val isEditable = controller.isEditable
     val isError = error != null
 
     val fieldModifier = modifier.fillMaxWidth().then(
-        if (isEditable) Modifier else Modifier.clickable(enabled = enabled) { onClick() }
+        if (isEditable) Modifier.focusRequester(focusRequester) else Modifier.clickable(enabled = enabled) { onClick() }
     )
 
     CompatTextField(
@@ -64,7 +68,10 @@ fun AddressTextFieldUI(
         trailingIcon = if (onSearchActivated != null) {
             {
                 SearchIconButton(
-                    onClick = onSearchActivated,
+                    onClick = {
+                        focusRequester.requestFocus()
+                        onSearchActivated()
+                    },
                     enabled = enabled,
                 )
             }


### PR DESCRIPTION


# Summary
<!-- Simple summary of what was changed. -->
 Fix search button not triggering autocomplete when the address Line 1 field is unfocused.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When an address is already filled in and the user clicks the search button while focused on a
    different field (or no field), autocomplete doesn't trigger. This is because onFocusLost() sets
    predictionsPaused = true, and onSearchActivated() checks isQueryEligible() which returns false due to
    the paused state.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Added onSearchActivated fetches even when field is unfocused test to InlineAutocompleteControllerTest.

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A Behind inline autocomplete feature flag.