### PR TITLE
Fix 3DS2 WebView source cancellation 🪿✨

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -76,33 +76,6 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
                         )
                     )
                 }
-                shouldRefreshOrPollIntent(stripeIntent, result.flowOutcome) -> {
-                    val intent = if (shouldCallRefreshIntent(stripeIntent)) {
-                        refreshStripeIntent(
-                            clientSecret = result.clientSecret,
-                            requestOptions = requestOptions,
-                            expandFields = EXPAND_PAYMENT_METHOD
-                        ).getOrThrow()
-                    } else {
-                        pollStripeIntentUntilTerminalState(
-                            originalIntent = stripeIntent,
-                            clientSecret = result.clientSecret,
-                            requestOptions = requestOptions,
-                            initialRetrieveIntentStartTime = initialRetrieveIntentStartTime
-                        ).getOrThrow()
-                    }
-
-                    val flowOutcome = determineFlowOutcome(intent, result.flowOutcome)
-                    createStripeIntentResult(
-                        intent,
-                        flowOutcome,
-                        failureMessageFactory.create(
-                            intent = intent,
-                            requestId = requestId,
-                            outcome = result.flowOutcome
-                        )
-                    )
-                }
                 shouldCancelIntentSource(stripeIntent, result.canCancelSource) -> {
                     val sourceId = result.sourceId.orEmpty()
                     logger.debug(
@@ -125,6 +98,33 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
                     createStripeIntentResult(
                         intent,
                         result.flowOutcome,
+                        failureMessageFactory.create(
+                            intent = intent,
+                            requestId = requestId,
+                            outcome = result.flowOutcome
+                        )
+                    )
+                }
+                shouldRefreshOrPollIntent(stripeIntent, result.flowOutcome) -> {
+                    val intent = if (shouldCallRefreshIntent(stripeIntent)) {
+                        refreshStripeIntent(
+                            clientSecret = result.clientSecret,
+                            requestOptions = requestOptions,
+                            expandFields = EXPAND_PAYMENT_METHOD
+                        ).getOrThrow()
+                    } else {
+                        pollStripeIntentUntilTerminalState(
+                            originalIntent = stripeIntent,
+                            clientSecret = result.clientSecret,
+                            requestOptions = requestOptions,
+                            initialRetrieveIntentStartTime = initialRetrieveIntentStartTime
+                        ).getOrThrow()
+                    }
+
+                    val flowOutcome = determineFlowOutcome(intent, result.flowOutcome)
+                    createStripeIntentResult(
+                        intent,
+                        flowOutcome,
                         failureMessageFactory.create(
                             intent = intent,
                             requestId = requestId,

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -146,6 +146,32 @@ internal class PaymentIntentFlowResultProcessorTest {
         }
 
     @Test
+    fun `3ds2 web view cancellation cancels source instead of polling`() =
+        runTest(testDispatcher) {
+            val intent = PaymentIntentFixtures.PI_VISA_3DS2.copy(
+                status = StripeIntent.Status.RequiresAction
+            )
+            whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
+                Result.success(intent)
+            )
+            whenever(mockStripeRepository.cancelPaymentIntentSource(any(), any(), any())).thenReturn(
+                Result.success(PaymentIntentFixtures.PAYMENT_INTENT_WITH_CANCELED_3DS2_SOURCE)
+            )
+
+            createProcessor().processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = requireNotNull(intent.clientSecret),
+                    sourceId = "source_id",
+                    flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                    canCancelSource = true
+                )
+            ).getOrThrow()
+
+            verify(mockStripeRepository).cancelPaymentIntentSource(any(), eq("source_id"), any())
+            verify(mockStripeRepository).retrievePaymentIntent(any(), any(), any())
+        }
+
+    @Test
     fun `no refresh when user cancels the payment`() = runTest(testDispatcher) {
         whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
             Result.success(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -74,6 +74,32 @@ internal class SetupIntentFlowResultProcessorTest {
         }
 
     @Test
+    fun `3ds2 web view cancellation cancels source instead of polling`() =
+        runTest(testDispatcher) {
+            val intent = SetupIntentFixtures.SI_3DS2_PROCESSING.copy(
+                status = StripeIntent.Status.RequiresAction
+            )
+            whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
+                Result.success(intent)
+            )
+            whenever(mockStripeRepository.cancelSetupIntentSource(any(), any(), any())).thenReturn(
+                Result.success(SetupIntentFixtures.CANCELLED)
+            )
+
+            processor.processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = requireNotNull(intent.clientSecret),
+                    sourceId = "source_id",
+                    flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                    canCancelSource = true
+                )
+            ).getOrThrow()
+
+            verify(mockStripeRepository).cancelSetupIntentSource(any(), eq("source_id"), any())
+            verify(mockStripeRepository).retrieveSetupIntent(any(), any(), any())
+        }
+
+    @Test
     fun `3ds2 canceled with processing intent should succeed`() =
         runTest(testDispatcher) {
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/5392ae2c-d2ab-47bb-8a1b-c48077c2acf9)

#### 🧑‍💻 Human Summary
<!-- To be filled out by humans -->

#### 🤖 LLM Summary

# Summary
Prioritize source cancellation over refresh or polling when a cancelable 3DS2 WebView flow returns an intent that still requires action. Adds PaymentIntent and SetupIntent regression coverage.

# Motivation
The result processor matched the 3DS2 polling branch before its existing source-cancellation branch, so dismissing the WebView could leave the intent requiring action instead of canceling its source. This replaces the direct Activity networking approach proposed in [#13502](https://github.com/stripe/stripe-android/pull/13502) by keeping cancellation in the existing result processor.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| Not applicable | Not applicable |

# Changelog
No changelog entry included.