### PR TITLE
Add currency selector availability to checkout session

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -415,6 +415,11 @@ class CheckoutController @Inject internal constructor(
         val isExpressCheckoutElementAvailable: Boolean = availableExpressButtonTypes.isNotEmpty()
 
         /**
+         * Whether Currency Selector Element has content to display for this checkout session.
+         */
+        val isCurrencySelectorAvailable: Boolean = currencySelectorOptions != null
+
+        /**
          * The status of a checkout session.
          */
         @CheckoutSessionPreview

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -279,6 +279,34 @@ class CheckoutSessionMappersTest {
         assertThat(session.shippingOptions).isEmpty()
     }
 
+    @Test
+    fun `currency selector is unavailable when adaptive pricing is absent`() {
+        val session = createSession()
+
+        assertThat(session.isCurrencySelectorAvailable).isFalse()
+    }
+
+    @Test
+    fun `currency selector is available when adaptive pricing has a local currency option`() {
+        val session = createSession(
+            adaptivePricingInfo = CheckoutSessionResponse.AdaptivePricingInfo(
+                activePresentmentCurrency = "usd",
+                integrationAmount = 5099L,
+                integrationCurrency = "eur",
+                localCurrencyOptions = listOf(
+                    CheckoutSessionResponse.LocalCurrencyOption(
+                        amount = 6106L,
+                        conversionMarkupBps = 150,
+                        currency = "usd",
+                        presentmentExchangeRate = "1.19749",
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(session.isCurrencySelectorAvailable).isTrue()
+    }
+
     private fun createSession(
         id: String = DEFAULT_CHECKOUT_SESSION_ID,
         status: CheckoutSessionResponse.Status = CheckoutSessionResponse.Status.OPEN,
@@ -289,6 +317,7 @@ class CheckoutSessionMappersTest {
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
         shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
+        adaptivePricingInfo: CheckoutSessionResponse.AdaptivePricingInfo? = null,
     ): Session {
         return CheckoutSessionResponseFactory.create(
             id = id,
@@ -300,6 +329,7 @@ class CheckoutSessionMappersTest {
             totalSummary = totalSummary,
             lineItems = lineItems,
             shippingOptions = shippingOptions,
+            adaptivePricingInfo = adaptivePricingInfo,
         ).asCheckoutSession(
             flagImages = null,
             paymentOptionDisplayData = null,


### PR DESCRIPTION
# Summary

Adds `CheckoutController.Session.isCurrencySelectorAvailable`, which reports whether the Currency Selector Element has options to display.

# Motivation

MOBILESDK-4801 needs integrations to determine Currency Selector Element availability from the Checkout Session, using the same condition as the element's render gate.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutSessionMappersTest`.

No tests were ignored.

# Screenshots

Not applicable: this adds a session availability property and does not change visual UI behavior.

# Changelog

Not applicable: this is a library-group Checkout Session preview API addition with no customer-facing behavior change.
