### PR TITLE
 Fix address autocomplete analytics field naming and payload structure

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -19,6 +19,7 @@ internal class StripeHostedPlacesClientProxy(
     private var lastQueryLength: Int = 0
     private var sessionStartReported: Boolean = false
     private var lastSource: String? = null
+    private var lastCountry: String = ""
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
 
     override fun resetSession() {
@@ -27,6 +28,7 @@ internal class StripeHostedPlacesClientProxy(
             lastQueryLength = 0
             sessionStartReported = false
             lastSource = null
+            lastCountry = ""
             predictionCache.clear()
         }
     }
@@ -43,10 +45,11 @@ internal class StripeHostedPlacesClientProxy(
             isFirstQuery = !sessionStartReported
             sessionStartReported = true
             lastQueryLength = q.length
+            lastCountry = country
             sessionToken
         }
         if (isFirstQuery) {
-            eventReporter.onAutocompleteSessionStarted(token)
+            eventReporter.onAutocompleteSessionStarted(country = country, sessionToken = token)
         }
         eventReporter.onAutocompleteFetchStarted()
         var responseSource: String? = null
@@ -73,13 +76,13 @@ internal class StripeHostedPlacesClientProxy(
             )
         }.onSuccess { response ->
             eventReporter.onAutocompleteSuggestionsReturned(
+                country = country,
                 sessionToken = token,
-                queryLength = q.length,
                 resultCount = response.autocompletePredictions.size,
                 source = responseSource,
             )
         }.onFailure { error ->
-            eventReporter.onAutocompleteError(sessionToken = token, error = error)
+            eventReporter.onAutocompleteError(country = country, sessionToken = token, error = error)
         }
     }
 
@@ -88,14 +91,17 @@ internal class StripeHostedPlacesClientProxy(
         val token: String
         val queryLength: Int
         val source: String?
+        val country: String
         synchronized(lock) {
             cached = predictionCache[placeId]
             token = sessionToken
             queryLength = lastQueryLength
             source = lastSource
+            country = lastCountry
         }
         if (cached?.address != null) {
             eventReporter.onAutocompleteSelected(
+                country = country,
                 sessionToken = token,
                 queryLength = queryLength,
                 placeId = placeId,
@@ -118,13 +124,14 @@ internal class StripeHostedPlacesClientProxy(
             }
         }.map { it.address.toAddress() }.onSuccess {
             eventReporter.onAutocompleteSelected(
+                country = country,
                 sessionToken = token,
                 queryLength = queryLength,
                 placeId = placeId,
                 source = source,
             )
         }.onFailure { error ->
-            eventReporter.onAutocompleteError(sessionToken = token, error = error)
+            eventReporter.onAutocompleteError(country = country, sessionToken = token, error = error)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxy.kt
@@ -19,7 +19,6 @@ internal class StripeHostedPlacesClientProxy(
     private var lastQueryLength: Int = 0
     private var sessionStartReported: Boolean = false
     private var lastSource: String? = null
-    private var lastCountry: String = ""
     private val predictionCache = mutableMapOf<String, AutocompleteSuggestion>()
 
     override fun resetSession() {
@@ -28,7 +27,6 @@ internal class StripeHostedPlacesClientProxy(
             lastQueryLength = 0
             sessionStartReported = false
             lastSource = null
-            lastCountry = ""
             predictionCache.clear()
         }
     }
@@ -45,11 +43,10 @@ internal class StripeHostedPlacesClientProxy(
             isFirstQuery = !sessionStartReported
             sessionStartReported = true
             lastQueryLength = q.length
-            lastCountry = country
             sessionToken
         }
         if (isFirstQuery) {
-            eventReporter.onAutocompleteSessionStarted(country = country, sessionToken = token)
+            eventReporter.onAutocompleteSessionStarted(token)
         }
         eventReporter.onAutocompleteFetchStarted()
         var responseSource: String? = null
@@ -76,13 +73,12 @@ internal class StripeHostedPlacesClientProxy(
             )
         }.onSuccess { response ->
             eventReporter.onAutocompleteSuggestionsReturned(
-                country = country,
                 sessionToken = token,
                 resultCount = response.autocompletePredictions.size,
                 source = responseSource,
             )
         }.onFailure { error ->
-            eventReporter.onAutocompleteError(country = country, sessionToken = token, error = error)
+            eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }
     }
 
@@ -91,17 +87,14 @@ internal class StripeHostedPlacesClientProxy(
         val token: String
         val queryLength: Int
         val source: String?
-        val country: String
         synchronized(lock) {
             cached = predictionCache[placeId]
             token = sessionToken
             queryLength = lastQueryLength
             source = lastSource
-            country = lastCountry
         }
         if (cached?.address != null) {
             eventReporter.onAutocompleteSelected(
-                country = country,
                 sessionToken = token,
                 queryLength = queryLength,
                 placeId = placeId,
@@ -124,14 +117,13 @@ internal class StripeHostedPlacesClientProxy(
             }
         }.map { it.address.toAddress() }.onSuccess {
             eventReporter.onAutocompleteSelected(
-                country = country,
                 sessionToken = token,
                 queryLength = queryLength,
                 placeId = placeId,
                 source = source,
             )
         }.onFailure { error ->
-            eventReporter.onAutocompleteError(country = country, sessionToken = token, error = error)
+            eventReporter.onAutocompleteError(sessionToken = token, error = error)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -37,30 +37,36 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
                 editDistance?.let {
                     data[FIELD_EDIT_DISTANCE] = it
                 }
-                timeToComplete?.let {
-                    data[FIELD_TIME_TO_COMPLETE] = it.toDouble(DurationUnit.SECONDS)
-                }
-                return mapOf(
+                val params = mutableMapOf<String, Any>(
                     FIELD_ADDRESS_DATA_BLOB to data
                 )
+                timeToComplete?.let {
+                    params[FIELD_MS_TO_COMPLETE] = it.toDouble(DurationUnit.MILLISECONDS)
+                }
+                return params
             }
     }
 
     class AutocompleteStarted(
+        private val country: String,
         private val autocompleteSessionToken: String,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_start"
         override val additionalParams: Map<String, Any>
-            get() = mapOf(
-                FIELD_ADDRESS_DATA_BLOB to mapOf(
-                    FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
+            get() = buildMap {
+                put(
+                    FIELD_ADDRESS_DATA_BLOB,
+                    buildMap {
+                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
+                    },
                 )
-            )
+                put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
+            }
     }
 
     class AutocompleteSuggestions(
+        private val country: String,
         private val autocompleteSessionToken: String,
-        private val queryLength: Int,
         private val timeToFetch: Duration?,
         private val resultCount: Int,
         private val sessionElapsed: Duration?,
@@ -68,20 +74,23 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_suggestions"
         override val additionalParams: Map<String, Any>
-            get() {
-                val data = mutableMapOf<String, Any>(
-                    FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
-                    FIELD_QUERY_LENGTH to queryLength,
-                    FIELD_RESULT_COUNT to resultCount,
+            get() = buildMap {
+                put(
+                    FIELD_ADDRESS_DATA_BLOB,
+                    buildMap {
+                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
+                    },
                 )
-                source?.let { data[FIELD_SOURCE] = it }
-                timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
-                sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
-                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
+                put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
+                put(FIELD_RESULT_COUNT, resultCount)
+                source?.let { put(FIELD_SOURCE, it) }
+                timeToFetch?.let { put(FIELD_MS_TO_FETCH, it.toDouble(DurationUnit.MILLISECONDS)) }
+                sessionElapsed?.let { put(FIELD_MS_SESSION_ELAPSED, it.toDouble(DurationUnit.MILLISECONDS)) }
             }
     }
 
     class AutocompleteSelected(
+        private val country: String,
         private val autocompleteSessionToken: String,
         private val queryLength: Int,
         private val placeId: String?,
@@ -91,31 +100,40 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_selected"
         override val additionalParams: Map<String, Any>
-            get() {
-                val data = mutableMapOf<String, Any>(
-                    FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
-                    FIELD_QUERY_LENGTH to queryLength,
+            get() = buildMap {
+                put(
+                    FIELD_ADDRESS_DATA_BLOB,
+                    buildMap {
+                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
+                    },
                 )
-                placeId?.let { data[FIELD_PLACE_ID] = it }
-                source?.let { data[FIELD_SOURCE] = it }
-                sessionElapsed?.let { data[FIELD_SESSION_ELAPSED] = it.toDouble(DurationUnit.SECONDS) }
-                timeToFetch?.let { data[FIELD_TIME_TO_FETCH] = it.toDouble(DurationUnit.SECONDS) }
-                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
+                put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
+                put(FIELD_QUERY_LENGTH, queryLength)
+                placeId?.let { put(FIELD_PLACE_ID, it) }
+                source?.let { put(FIELD_SOURCE, it) }
+                sessionElapsed?.let { put(FIELD_MS_SESSION_ELAPSED, it.toDouble(DurationUnit.MILLISECONDS)) }
+                timeToFetch?.let { put(FIELD_MS_TO_FETCH, it.toDouble(DurationUnit.MILLISECONDS)) }
             }
     }
 
     class AutocompleteError(
+        private val country: String,
         private val autocompleteSessionToken: String,
         private val error: Throwable,
+        private val sessionElapsed: Duration?,
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_error"
         override val additionalParams: Map<String, Any>
-            get() {
-                val data = buildMap<String, Any> {
-                    put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
-                    putAll(ErrorReporter.getAdditionalParamsFromError(error))
-                }
-                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
+            get() = buildMap {
+                put(
+                    FIELD_ADDRESS_DATA_BLOB,
+                    buildMap {
+                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
+                    },
+                )
+                put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
+                putAll(ErrorReporter.getAdditionalParamsFromError(error))
+                sessionElapsed?.let { put(FIELD_MS_SESSION_ELAPSED, it.toDouble(DurationUnit.MILLISECONDS)) }
             }
     }
 
@@ -124,11 +142,11 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         const val FIELD_ADDRESS_COUNTRY_CODE = "address_country_code"
         const val FIELD_AUTO_COMPLETE_RESULT_SELECTED = "auto_complete_result_selected"
         const val FIELD_EDIT_DISTANCE = "edit_distance"
-        const val FIELD_TIME_TO_COMPLETE = "time_to_complete"
+        const val FIELD_MS_TO_COMPLETE = "ms_to_complete"
         const val FIELD_AUTOCOMPLETE_SESSION_TOKEN = "autocomplete_session_token"
-        const val FIELD_TIME_TO_FETCH = "time_to_fetch"
+        const val FIELD_MS_TO_FETCH = "ms_to_fetch"
         const val FIELD_RESULT_COUNT = "result_count"
-        const val FIELD_SESSION_ELAPSED = "session_elapsed"
+        const val FIELD_MS_SESSION_ELAPSED = "ms_session_elapsed"
         const val FIELD_QUERY_LENGTH = "query_length"
         const val FIELD_PLACE_ID = "place_id"
         const val FIELD_SOURCE = "source"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEvent.kt
@@ -8,17 +8,16 @@ import kotlin.time.DurationUnit
 internal sealed class AddressLauncherEvent : AnalyticsEvent {
     abstract val additionalParams: Map<String, Any>
 
+    protected fun addressDataBlob(country: String): Map<String, Any> = buildMap {
+        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
+    }
+
     class Show(
         val country: String
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_show"
         override val additionalParams: Map<String, Any>
-            get() {
-                val data = buildMap<String, Any> {
-                    if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
-                }
-                return mapOf(FIELD_ADDRESS_DATA_BLOB to data)
-            }
+            get() = mapOf(FIELD_ADDRESS_DATA_BLOB to addressDataBlob(country))
     }
 
     class Completed(
@@ -53,15 +52,10 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
     ) : AddressLauncherEvent() {
         override val eventName: String = "mc_address_autocomplete_start"
         override val additionalParams: Map<String, Any>
-            get() = buildMap {
-                put(
-                    FIELD_ADDRESS_DATA_BLOB,
-                    buildMap {
-                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
-                    },
-                )
-                put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
-            }
+            get() = mapOf(
+                FIELD_ADDRESS_DATA_BLOB to addressDataBlob(country),
+                FIELD_AUTOCOMPLETE_SESSION_TOKEN to autocompleteSessionToken,
+            )
     }
 
     class AutocompleteSuggestions(
@@ -75,12 +69,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         override val eventName: String = "mc_address_autocomplete_suggestions"
         override val additionalParams: Map<String, Any>
             get() = buildMap {
-                put(
-                    FIELD_ADDRESS_DATA_BLOB,
-                    buildMap {
-                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
-                    },
-                )
+                put(FIELD_ADDRESS_DATA_BLOB, addressDataBlob(country))
                 put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
                 put(FIELD_RESULT_COUNT, resultCount)
                 source?.let { put(FIELD_SOURCE, it) }
@@ -101,12 +90,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         override val eventName: String = "mc_address_autocomplete_selected"
         override val additionalParams: Map<String, Any>
             get() = buildMap {
-                put(
-                    FIELD_ADDRESS_DATA_BLOB,
-                    buildMap {
-                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
-                    },
-                )
+                put(FIELD_ADDRESS_DATA_BLOB, addressDataBlob(country))
                 put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
                 put(FIELD_QUERY_LENGTH, queryLength)
                 placeId?.let { put(FIELD_PLACE_ID, it) }
@@ -125,12 +109,7 @@ internal sealed class AddressLauncherEvent : AnalyticsEvent {
         override val eventName: String = "mc_address_autocomplete_error"
         override val additionalParams: Map<String, Any>
             get() = buildMap {
-                put(
-                    FIELD_ADDRESS_DATA_BLOB,
-                    buildMap {
-                        if (country.isNotEmpty()) put(FIELD_ADDRESS_COUNTRY_CODE, country)
-                    },
-                )
+                put(FIELD_ADDRESS_DATA_BLOB, addressDataBlob(country))
                 put(FIELD_AUTOCOMPLETE_SESSION_TOKEN, autocompleteSessionToken)
                 putAll(ErrorReporter.getAdditionalParamsFromError(error))
                 sessionElapsed?.let { put(FIELD_MS_SESSION_ELAPSED, it.toDouble(DurationUnit.MILLISECONDS)) }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -9,12 +9,11 @@ internal interface AddressLauncherEventReporter {
         editDistance: Int?,
     )
 
-    fun onAutocompleteSessionStarted(country: String, sessionToken: String)
+    fun onAutocompleteSessionStarted(sessionToken: String)
 
     fun onAutocompleteFetchStarted()
 
     fun onAutocompleteSuggestionsReturned(
-        country: String,
         sessionToken: String,
         resultCount: Int,
         source: String?,
@@ -22,13 +21,7 @@ internal interface AddressLauncherEventReporter {
 
     fun onAutocompleteDetailsFetchStarted()
 
-    fun onAutocompleteSelected(
-        country: String,
-        sessionToken: String,
-        queryLength: Int,
-        placeId: String?,
-        source: String?,
-    )
+    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?)
 
-    fun onAutocompleteError(country: String, sessionToken: String, error: Throwable)
+    fun onAutocompleteError(sessionToken: String, error: Throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventReporter.kt
@@ -9,20 +9,26 @@ internal interface AddressLauncherEventReporter {
         editDistance: Int?,
     )
 
-    fun onAutocompleteSessionStarted(sessionToken: String)
+    fun onAutocompleteSessionStarted(country: String, sessionToken: String)
 
     fun onAutocompleteFetchStarted()
 
     fun onAutocompleteSuggestionsReturned(
+        country: String,
         sessionToken: String,
-        queryLength: Int,
         resultCount: Int,
         source: String?,
     )
 
     fun onAutocompleteDetailsFetchStarted()
 
-    fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?)
+    fun onAutocompleteSelected(
+        country: String,
+        sessionToken: String,
+        queryLength: Int,
+        placeId: String?,
+        source: String?,
+    )
 
-    fun onAutocompleteError(sessionToken: String, error: Throwable)
+    fun onAutocompleteError(country: String, sessionToken: String, error: Throwable)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -18,7 +18,10 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
     @IOContext private val workContext: CoroutineContext
 ) : AddressLauncherEventReporter {
 
+    private var lastCountry: String = ""
+
     override fun onShow(country: String) {
+        lastCountry = country
         durationProvider.start(DurationProvider.Key.AddressElementCompletion, reset = true)
         fireEvent(
             AddressLauncherEvent.Show(
@@ -43,11 +46,11 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteSessionStarted(country: String, sessionToken: String) {
+    override fun onAutocompleteSessionStarted(sessionToken: String) {
         durationProvider.start(DurationProvider.Key.AddressAutocompleteSession, reset = true)
         fireEvent(
             AddressLauncherEvent.AutocompleteStarted(
-                country = country,
+                country = lastCountry,
                 autocompleteSessionToken = sessionToken,
             )
         )
@@ -62,7 +65,6 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
     }
 
     override fun onAutocompleteSuggestionsReturned(
-        country: String,
         sessionToken: String,
         resultCount: Int,
         source: String?,
@@ -71,7 +73,7 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteSuggestions(
-                country = country,
+                country = lastCountry,
                 autocompleteSessionToken = sessionToken,
                 timeToFetch = fetchDuration,
                 resultCount = resultCount,
@@ -81,18 +83,12 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteSelected(
-        country: String,
-        sessionToken: String,
-        queryLength: Int,
-        placeId: String?,
-        source: String?,
-    ) {
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) {
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         val timeToFetch = durationProvider.end(DurationProvider.Key.AddressAutocompleteDetailsFetch)
         fireEvent(
             AddressLauncherEvent.AutocompleteSelected(
-                country = country,
+                country = lastCountry,
                 autocompleteSessionToken = sessionToken,
                 queryLength = queryLength,
                 placeId = placeId,
@@ -103,11 +99,11 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteError(country: String, sessionToken: String, error: Throwable) {
+    override fun onAutocompleteError(sessionToken: String, error: Throwable) {
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteError(
-                country = country,
+                country = lastCountry,
                 autocompleteSessionToken = sessionToken,
                 error = error,
                 sessionElapsed = sessionElapsed,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/DefaultAddressLauncherEventReporter.kt
@@ -43,11 +43,12 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteSessionStarted(sessionToken: String) {
+    override fun onAutocompleteSessionStarted(country: String, sessionToken: String) {
         durationProvider.start(DurationProvider.Key.AddressAutocompleteSession, reset = true)
         fireEvent(
             AddressLauncherEvent.AutocompleteStarted(
-                autocompleteSessionToken = sessionToken
+                country = country,
+                autocompleteSessionToken = sessionToken,
             )
         )
     }
@@ -61,8 +62,8 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
     }
 
     override fun onAutocompleteSuggestionsReturned(
+        country: String,
         sessionToken: String,
-        queryLength: Int,
         resultCount: Int,
         source: String?,
     ) {
@@ -70,8 +71,8 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteSuggestions(
+                country = country,
                 autocompleteSessionToken = sessionToken,
-                queryLength = queryLength,
                 timeToFetch = fetchDuration,
                 resultCount = resultCount,
                 sessionElapsed = sessionElapsed,
@@ -80,11 +81,18 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) {
+    override fun onAutocompleteSelected(
+        country: String,
+        sessionToken: String,
+        queryLength: Int,
+        placeId: String?,
+        source: String?,
+    ) {
         val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         val timeToFetch = durationProvider.end(DurationProvider.Key.AddressAutocompleteDetailsFetch)
         fireEvent(
             AddressLauncherEvent.AutocompleteSelected(
+                country = country,
                 autocompleteSessionToken = sessionToken,
                 queryLength = queryLength,
                 placeId = placeId,
@@ -95,11 +103,14 @@ internal class DefaultAddressLauncherEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onAutocompleteError(sessionToken: String, error: Throwable) {
+    override fun onAutocompleteError(country: String, sessionToken: String, error: Throwable) {
+        val sessionElapsed = durationProvider.elapsed(DurationProvider.Key.AddressAutocompleteSession)
         fireEvent(
             AddressLauncherEvent.AutocompleteError(
+                country = country,
                 autocompleteSessionToken = sessionToken,
                 error = error,
+                sessionElapsed = sessionElapsed,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -7,20 +7,21 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
         autocompleteResultSelected: Boolean,
         editDistance: Int?,
     ) = Unit
-    override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
+    override fun onAutocompleteSessionStarted(country: String, sessionToken: String) = Unit
     override fun onAutocompleteFetchStarted() = Unit
     override fun onAutocompleteSuggestionsReturned(
+        country: String,
         sessionToken: String,
-        queryLength: Int,
         resultCount: Int,
         source: String?,
     ) = Unit
     override fun onAutocompleteDetailsFetchStarted() = Unit
     override fun onAutocompleteSelected(
+        country: String,
         sessionToken: String,
         queryLength: Int,
         placeId: String?,
         source: String?,
     ) = Unit
-    override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
+    override fun onAutocompleteError(country: String, sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/analytics/NoOpAddressLauncherEventReporter.kt
@@ -7,21 +7,19 @@ internal object NoOpAddressLauncherEventReporter : AddressLauncherEventReporter 
         autocompleteResultSelected: Boolean,
         editDistance: Int?,
     ) = Unit
-    override fun onAutocompleteSessionStarted(country: String, sessionToken: String) = Unit
+    override fun onAutocompleteSessionStarted(sessionToken: String) = Unit
     override fun onAutocompleteFetchStarted() = Unit
     override fun onAutocompleteSuggestionsReturned(
-        country: String,
         sessionToken: String,
         resultCount: Int,
         source: String?,
     ) = Unit
     override fun onAutocompleteDetailsFetchStarted() = Unit
     override fun onAutocompleteSelected(
-        country: String,
         sessionToken: String,
         queryLength: Int,
         placeId: String?,
         source: String?,
     ) = Unit
-    override fun onAutocompleteError(country: String, sessionToken: String, error: Throwable) = Unit
+    override fun onAutocompleteError(sessionToken: String, error: Throwable) = Unit
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -304,9 +304,8 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
 
-        val call = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-        assertThat(call.sessionToken).isNotEmpty()
-        assertThat(call.country).isEqualTo("US")
+        val token = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(token).isNotEmpty()
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
@@ -342,7 +341,7 @@ class StripeHostedPlacesClientProxyTest {
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
-        val initialCall = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        val initialToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
@@ -350,8 +349,8 @@ class StripeHostedPlacesClientProxyTest {
         proxy.resetSession()
 
         proxy.findAutocompletePredictions(query = "456 Oak", country = "US", limit = 4)
-        val newCall = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-        assertThat(newCall.sessionToken).isNotEqualTo(initialCall.sessionToken)
+        val newToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(newToken).isNotEqualTo(initialToken)
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
@@ -372,7 +371,6 @@ class StripeHostedPlacesClientProxyTest {
 
         val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
         assertThat(suggestionsCall.resultCount).isEqualTo(1)
-        assertThat(suggestionsCall.country).isEqualTo("US")
         repository.ensureAllEventsConsumed()
         eventReporter.validate()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/StripeHostedPlacesClientProxyTest.kt
@@ -304,8 +304,9 @@ class StripeHostedPlacesClientProxyTest {
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
 
-        val token = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-        assertThat(token).isNotEmpty()
+        val call = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(call.sessionToken).isNotEmpty()
+        assertThat(call.country).isEqualTo("US")
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
@@ -341,7 +342,7 @@ class StripeHostedPlacesClientProxyTest {
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
 
         proxy.findAutocompletePredictions(query = "123 Main", country = "US", limit = 4)
-        val initialToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        val initialCall = eventReporter.autocompleteSessionStartedCalls.awaitItem()
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
@@ -349,8 +350,8 @@ class StripeHostedPlacesClientProxyTest {
         proxy.resetSession()
 
         proxy.findAutocompletePredictions(query = "456 Oak", country = "US", limit = 4)
-        val newToken = eventReporter.autocompleteSessionStartedCalls.awaitItem()
-        assertThat(newToken).isNotEqualTo(initialToken)
+        val newCall = eventReporter.autocompleteSessionStartedCalls.awaitItem()
+        assertThat(newCall.sessionToken).isNotEqualTo(initialCall.sessionToken)
         repository.findPredictionsCalls.awaitItem()
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
         eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
@@ -359,7 +360,7 @@ class StripeHostedPlacesClientProxyTest {
     }
 
     @Test
-    fun `findAutocompletePredictions success fires suggestions returned with query length`() = runTest {
+    fun `findAutocompletePredictions success fires suggestions returned with result count`() = runTest {
         val eventReporter = FakeAddressLauncherEventReporter()
         val repository = defaultRepository()
         val proxy = createProxy(repository = repository, eventReporter = eventReporter)
@@ -370,8 +371,8 @@ class StripeHostedPlacesClientProxyTest {
         eventReporter.autocompleteFetchStartedCalls.awaitItem()
 
         val suggestionsCall = eventReporter.autocompleteSuggestionsReturnedCalls.awaitItem()
-        assertThat(suggestionsCall.queryLength).isEqualTo("123 Main".length)
         assertThat(suggestionsCall.resultCount).isEqualTo(1)
+        assertThat(suggestionsCall.country).isEqualTo("US")
         repository.ensureAllEventsConsumed()
         eventReporter.validate()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventTest.kt
@@ -109,5 +109,4 @@ class AddressLauncherEventTest {
         assertThat(params["autocomplete_session_token"]).isEqualTo("token-err")
         assertThat(params["ms_session_elapsed"]).isEqualTo(5000.0)
     }
-
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/AddressLauncherEventTest.kt
@@ -1,0 +1,113 @@
+package com.stripe.android.paymentsheet.addresselement.analytics
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+class AddressLauncherEventTest {
+
+    @Test
+    fun `Show event payload contains country in address_data_blob`() {
+        val event = AddressLauncherEvent.Show(country = "US")
+
+        assertThat(event.eventName).isEqualTo("mc_address_show")
+        assertThat(event.additionalParams).isEqualTo(
+            mapOf("address_data_blob" to mapOf("address_country_code" to "US"))
+        )
+    }
+
+    @Test
+    fun `Completed event puts ms_to_complete at root level in milliseconds`() {
+        val event = AddressLauncherEvent.Completed(
+            country = "US",
+            autocompleteResultSelected = true,
+            editDistance = 3,
+            timeToComplete = 1500.milliseconds,
+        )
+
+        assertThat(event.eventName).isEqualTo("mc_address_completed")
+        val params = event.additionalParams
+        val blob = params["address_data_blob"] as Map<*, *>
+        assertThat(blob["address_country_code"]).isEqualTo("US")
+        assertThat(blob["auto_complete_result_selected"]).isEqualTo(true)
+        assertThat(blob["edit_distance"]).isEqualTo(3)
+        assertThat(params["ms_to_complete"]).isEqualTo(1500.0)
+    }
+
+    @Test
+    fun `AutocompleteStarted event has session token at root and country in blob`() {
+        val event = AddressLauncherEvent.AutocompleteStarted(
+            country = "CA",
+            autocompleteSessionToken = "token-123",
+        )
+
+        assertThat(event.eventName).isEqualTo("mc_address_autocomplete_start")
+        assertThat(event.additionalParams).isEqualTo(
+            mapOf(
+                "address_data_blob" to mapOf("address_country_code" to "CA"),
+                "autocomplete_session_token" to "token-123",
+            )
+        )
+    }
+
+    @Test
+    fun `AutocompleteSuggestions event has timing in ms at root level`() {
+        val event = AddressLauncherEvent.AutocompleteSuggestions(
+            country = "US",
+            autocompleteSessionToken = "token-abc",
+            timeToFetch = 250.milliseconds,
+            resultCount = 3,
+            sessionElapsed = 1200.milliseconds,
+            source = "stripe",
+        )
+
+        assertThat(event.eventName).isEqualTo("mc_address_autocomplete_suggestions")
+        val params = event.additionalParams
+        assertThat(params["address_data_blob"]).isEqualTo(mapOf("address_country_code" to "US"))
+        assertThat(params["autocomplete_session_token"]).isEqualTo("token-abc")
+        assertThat(params["result_count"]).isEqualTo(3)
+        assertThat(params["source"]).isEqualTo("stripe")
+        assertThat(params["ms_to_fetch"]).isEqualTo(250.0)
+        assertThat(params["ms_session_elapsed"]).isEqualTo(1200.0)
+    }
+
+    @Test
+    fun `AutocompleteSelected event has query_length and timing in ms at root`() {
+        val event = AddressLauncherEvent.AutocompleteSelected(
+            country = "GB",
+            autocompleteSessionToken = "token-xyz",
+            queryLength = 8,
+            placeId = "place_123",
+            source = "google",
+            sessionElapsed = 3000.milliseconds,
+            timeToFetch = 400.milliseconds,
+        )
+
+        assertThat(event.eventName).isEqualTo("mc_address_autocomplete_selected")
+        val params = event.additionalParams
+        assertThat(params["address_data_blob"]).isEqualTo(mapOf("address_country_code" to "GB"))
+        assertThat(params["autocomplete_session_token"]).isEqualTo("token-xyz")
+        assertThat(params["query_length"]).isEqualTo(8)
+        assertThat(params["place_id"]).isEqualTo("place_123")
+        assertThat(params["source"]).isEqualTo("google")
+        assertThat(params["ms_session_elapsed"]).isEqualTo(3000.0)
+        assertThat(params["ms_to_fetch"]).isEqualTo(400.0)
+    }
+
+    @Test
+    fun `AutocompleteError event has session elapsed and error params at root`() {
+        val event = AddressLauncherEvent.AutocompleteError(
+            country = "US",
+            autocompleteSessionToken = "token-err",
+            error = RuntimeException("Network timeout"),
+            sessionElapsed = 5000.milliseconds,
+        )
+
+        assertThat(event.eventName).isEqualTo("mc_address_autocomplete_error")
+        val params = event.additionalParams
+        assertThat(params["address_data_blob"]).isEqualTo(mapOf("address_country_code" to "US"))
+        assertThat(params["autocomplete_session_token"]).isEqualTo("token-err")
+        assertThat(params["ms_session_elapsed"]).isEqualTo(5000.0)
+    }
+
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -10,9 +10,8 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     private val _completedCalls = Turbine<CompletedCall>()
     val completedCalls: ReceiveTurbine<CompletedCall> = _completedCalls
 
-    private val _autocompleteSessionStartedCalls = Turbine<SessionStartedCall>()
-    val autocompleteSessionStartedCalls: ReceiveTurbine<SessionStartedCall> =
-        _autocompleteSessionStartedCalls
+    private val _autocompleteSessionStartedCalls = Turbine<String>()
+    val autocompleteSessionStartedCalls: ReceiveTurbine<String> = _autocompleteSessionStartedCalls
 
     private val _autocompleteFetchStartedCalls = Turbine<Unit>()
     val autocompleteFetchStartedCalls: ReceiveTurbine<Unit> = _autocompleteFetchStartedCalls
@@ -42,8 +41,8 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance))
     }
 
-    override fun onAutocompleteSessionStarted(country: String, sessionToken: String) {
-        _autocompleteSessionStartedCalls.add(SessionStartedCall(country, sessionToken))
+    override fun onAutocompleteSessionStarted(sessionToken: String) {
+        _autocompleteSessionStartedCalls.add(sessionToken)
     }
 
     override fun onAutocompleteFetchStarted() {
@@ -51,13 +50,12 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     }
 
     override fun onAutocompleteSuggestionsReturned(
-        country: String,
         sessionToken: String,
         resultCount: Int,
         source: String?,
     ) {
         _autocompleteSuggestionsReturnedCalls.add(
-            SuggestionsReturnedCall(country, sessionToken, resultCount, source)
+            SuggestionsReturnedCall(sessionToken, resultCount, source)
         )
     }
 
@@ -65,18 +63,12 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteDetailsFetchStartedCalls.add(Unit)
     }
 
-    override fun onAutocompleteSelected(
-        country: String,
-        sessionToken: String,
-        queryLength: Int,
-        placeId: String?,
-        source: String?,
-    ) {
-        _autocompleteSelectedCalls.add(SelectedCall(country, sessionToken, queryLength, placeId, source))
+    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) {
+        _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId, source))
     }
 
-    override fun onAutocompleteError(country: String, sessionToken: String, error: Throwable) {
-        _autocompleteErrorCalls.add(ErrorCall(country, sessionToken, error))
+    override fun onAutocompleteError(sessionToken: String, error: Throwable) {
+        _autocompleteErrorCalls.add(ErrorCall(sessionToken, error))
     }
 
     fun validate() {
@@ -96,25 +88,13 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         val editDistance: Int?,
     )
 
-    data class SessionStartedCall(
-        val country: String,
-        val sessionToken: String,
-    )
-
     data class SuggestionsReturnedCall(
-        val country: String,
         val sessionToken: String,
         val resultCount: Int,
         val source: String?,
     )
 
-    data class SelectedCall(
-        val country: String,
-        val sessionToken: String,
-        val queryLength: Int,
-        val placeId: String?,
-        val source: String?,
-    )
+    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String?, val source: String?)
 
-    data class ErrorCall(val country: String, val sessionToken: String, val error: Throwable)
+    data class ErrorCall(val sessionToken: String, val error: Throwable)
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/analytics/FakeAddressLauncherEventReporter.kt
@@ -10,8 +10,9 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     private val _completedCalls = Turbine<CompletedCall>()
     val completedCalls: ReceiveTurbine<CompletedCall> = _completedCalls
 
-    private val _autocompleteSessionStartedCalls = Turbine<String>()
-    val autocompleteSessionStartedCalls: ReceiveTurbine<String> = _autocompleteSessionStartedCalls
+    private val _autocompleteSessionStartedCalls = Turbine<SessionStartedCall>()
+    val autocompleteSessionStartedCalls: ReceiveTurbine<SessionStartedCall> =
+        _autocompleteSessionStartedCalls
 
     private val _autocompleteFetchStartedCalls = Turbine<Unit>()
     val autocompleteFetchStartedCalls: ReceiveTurbine<Unit> = _autocompleteFetchStartedCalls
@@ -41,8 +42,8 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _completedCalls.add(CompletedCall(country, autocompleteResultSelected, editDistance))
     }
 
-    override fun onAutocompleteSessionStarted(sessionToken: String) {
-        _autocompleteSessionStartedCalls.add(sessionToken)
+    override fun onAutocompleteSessionStarted(country: String, sessionToken: String) {
+        _autocompleteSessionStartedCalls.add(SessionStartedCall(country, sessionToken))
     }
 
     override fun onAutocompleteFetchStarted() {
@@ -50,13 +51,13 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
     }
 
     override fun onAutocompleteSuggestionsReturned(
+        country: String,
         sessionToken: String,
-        queryLength: Int,
         resultCount: Int,
         source: String?,
     ) {
         _autocompleteSuggestionsReturnedCalls.add(
-            SuggestionsReturnedCall(sessionToken, queryLength, resultCount, source)
+            SuggestionsReturnedCall(country, sessionToken, resultCount, source)
         )
     }
 
@@ -64,12 +65,18 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         _autocompleteDetailsFetchStartedCalls.add(Unit)
     }
 
-    override fun onAutocompleteSelected(sessionToken: String, queryLength: Int, placeId: String?, source: String?) {
-        _autocompleteSelectedCalls.add(SelectedCall(sessionToken, queryLength, placeId, source))
+    override fun onAutocompleteSelected(
+        country: String,
+        sessionToken: String,
+        queryLength: Int,
+        placeId: String?,
+        source: String?,
+    ) {
+        _autocompleteSelectedCalls.add(SelectedCall(country, sessionToken, queryLength, placeId, source))
     }
 
-    override fun onAutocompleteError(sessionToken: String, error: Throwable) {
-        _autocompleteErrorCalls.add(ErrorCall(sessionToken, error))
+    override fun onAutocompleteError(country: String, sessionToken: String, error: Throwable) {
+        _autocompleteErrorCalls.add(ErrorCall(country, sessionToken, error))
     }
 
     fun validate() {
@@ -89,14 +96,25 @@ internal class FakeAddressLauncherEventReporter : AddressLauncherEventReporter {
         val editDistance: Int?,
     )
 
-    data class SuggestionsReturnedCall(
+    data class SessionStartedCall(
+        val country: String,
         val sessionToken: String,
-        val queryLength: Int,
+    )
+
+    data class SuggestionsReturnedCall(
+        val country: String,
+        val sessionToken: String,
         val resultCount: Int,
         val source: String?,
     )
 
-    data class SelectedCall(val sessionToken: String, val queryLength: Int, val placeId: String?, val source: String?)
+    data class SelectedCall(
+        val country: String,
+        val sessionToken: String,
+        val queryLength: Int,
+        val placeId: String?,
+        val source: String?,
+    )
 
-    data class ErrorCall(val sessionToken: String, val error: Throwable)
+    data class ErrorCall(val country: String, val sessionToken: String, val error: Throwable)
 }


### PR DESCRIPTION


# Summary
<!-- Simple summary of what was changed. -->
 Fix address autocomplete analytics field naming and payload structure to match the spec.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
 The analytics events were using incorrect field names and payload structures that didn't match the
 agreed-upon spec. Specifically:

- Timing fields used seconds and generic names (time_to_fetch, session_elapsed, time_to_complete)
instead of millisecond-prefixed names (ms_to_fetch, ms_session_elapsed, ms_to_complete)
-  All fields were nested inside address_data_blob instead of only address_country_code being inside the blob with operational fields at the root level
- address_country_code was missing from autocomplete events
-  ms_session_elapsed was missing from error events query_length was incorrectly included in the suggestions event (it belongs only in the selected event)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

Updated StripeHostedPlacesClientProxyTest to assert on the new SessionStartedCall structure and verify country is passed through. Removed queryLength assertion from suggestions test. All existing tests pass with the updated interface signatures.
<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
