### PR TITLE
Fix Bancontact test Chrome cleanup race

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
@@ -4,7 +4,9 @@ import android.app.UiAutomation
 import android.os.Build
 import android.os.ParcelFileDescriptor
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -29,6 +31,7 @@ internal object CleanupChromeRule : TestRule {
                 } finally {
                     val command = "am force-stop com.android.chrome"
                     instrumentation.uiAutomation.executeShellCommand(command).close()
+                    device.wait(Until.gone(By.pkg("com.android.chrome")), CHROME_SHUTDOWN_TIMEOUT_MS)
 
                     // Force-stopping Chrome leaves no window focused; restore focus so the next
                     // test's Espresso RootViewPicker doesn't time out waiting for it.
@@ -56,4 +59,6 @@ internal object CleanupChromeRule : TestRule {
         }
         ParcelFileDescriptor.AutoCloseInputStream(descriptors[0]).use { it.readBytes() }
     }
+
+    private const val CHROME_SHUTDOWN_TIMEOUT_MS = 5_000L
 }


### PR DESCRIPTION
# Summary

Wait for Chrome's package to fully shut down after force-stopping it in PaymentSheet example instrumentation-test cleanup.

# Motivation

Bancontact tests could begin while the previous Chrome custom-tab transition was still unwinding. This caused the setup flow to miss its authorization page and time out waiting for `AUTHORIZE TEST SETUP`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Validation:

- `CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestBancontact' :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`
- Shampoo=2: all 3 Bancontact methods passed, 6 actual executions.
- Shampoo=50: `testBancontactSfu` completed iterations 0–49 without failure. The managed-device runner stalled between test methods before the remaining class soak could complete.
- Normal configuration: all 3 Bancontact methods passed.

# Screenshots

Not applicable; this change affects instrumentation-test lifecycle cleanup only.

# Changelog

Not applicable; this is internal test infrastructure and has no user-facing behavior change.
