### PR TITLE
Route checkout teardown through state loader

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -333,7 +333,7 @@ class CheckoutController @Inject internal constructor(
      */
     fun destroy() {
         viewModelScope.cancel()
-        stateHolder.state = null
+        checkoutStateLoader.clear()
         savedState.clear()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -41,6 +41,11 @@ internal class CheckoutStateLoader @Inject constructor(
         )
     }
 
+    fun clear() {
+        stateHolder.state = null
+        customerStateHolder.setCustomerState(null)
+    }
+
     private suspend fun commit(
         configuration: CheckoutController.Configuration.State,
         response: CheckoutSessionResponse,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -163,6 +163,19 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `clear removes controller and customer state`() = runScenario(
+        customer = savedCustomer(),
+    ) {
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        loader.clear()
+
+        assertThat(stateHolder.state).isNull()
+        assertThat(customerStateHolder.customer.value).isNull()
+        assertThat(customerStateHolder.paymentMethods.value).isEmpty()
+    }
+
+    @Test
     fun `reload routes the selection through the chooser`() = runScenario(
         loaderSelection = PaymentSelection.GooglePay,
         chosenSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,


### PR DESCRIPTION
# Summary
Route `CheckoutController.destroy()` through `CheckoutStateLoader.clear()` so the loader owns teardown of both the checkout controller state and customer state.

This is the only layer in the stack and targets `master`.

# Motivation
`CheckoutStateLoader` owns both holders when checkout state is loaded, so teardown should use the same seam. This makes state clearing consistent with the loader ownership model and supports correct mid-lifecycle clearing. Existing `destroy()` behavior already clears the saved-state namespace.

# Testing
`./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutStateLoaderTest`

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — this change affects controller state teardown and has no UI changes.

# Changelog
Not applicable — this is an internal implementation change with no user-facing API or behavior change.
