### PR TITLE
Honor checkout confirmation cancellation actions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -26,6 +26,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private var pendingMutations = 0
     private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
         confirmationHandler.state.value is ConfirmationHandler.State.Confirming
+    private var confirmationWasRestored = confirmationHandler.hasReloadedFromProcessDeath
     private var confirmationCompletionClaimed = false
     private val mutex = Mutex(locked = confirmationInFlight)
 
@@ -95,6 +96,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
                         "Checkout operation gate should be available after confirmation admission."
                     }
                     confirmationInFlight = true
+                    confirmationWasRestored = false
                     updateIsUpdating()
                     ConfirmationAdmission.Accepted(confirmationArguments)
                 }
@@ -114,11 +116,11 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation {
+                completeConfirmation { wasRestored ->
                     if (state.result !is ConfirmationHandler.Result.Succeeded) {
                         refreshSession()
                     }
-                    state.result.asCheckoutResult()
+                    state.result.asCheckoutResult(wasRestored)
                 }
             }
         }
@@ -131,22 +133,24 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    private suspend fun completeConfirmation(result: suspend () -> CheckoutController.Result) {
-        val shouldComplete = synchronized(admissionLock) {
+    private suspend fun completeConfirmation(
+        mapResult: suspend (confirmationWasRestored: Boolean) -> CheckoutController.Result?,
+    ) {
+        val wasRestored = synchronized(admissionLock) {
             if (!confirmationInFlight || confirmationCompletionClaimed) {
-                false
+                return
             } else {
                 confirmationCompletionClaimed = true
-                true
+                confirmationWasRestored
             }
         }
-        if (!shouldComplete) return
 
         try {
-            resultCallback.onResult(result())
+            mapResult(wasRestored)?.let(resultCallback::onResult)
         } finally {
             synchronized(admissionLock) {
                 confirmationInFlight = false
+                confirmationWasRestored = false
                 confirmationCompletionClaimed = false
                 mutex.unlock()
                 updateIsUpdating()
@@ -179,10 +183,18 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     }
 }
 
-private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result {
+private fun ConfirmationHandler.Result.asCheckoutResult(
+    confirmationWasRestored: Boolean,
+): CheckoutController.Result? {
     return when (this) {
         is ConfirmationHandler.Result.Succeeded -> CheckoutController.Result.Completed()
-        is ConfirmationHandler.Result.Canceled -> CheckoutController.Result.Canceled()
+        is ConfirmationHandler.Result.Canceled -> when (action) {
+            ConfirmationHandler.Result.Canceled.Action.InformCancellation ->
+                CheckoutController.Result.Canceled()
+            ConfirmationHandler.Result.Canceled.Action.None ->
+                CheckoutController.Result.Canceled().takeIf { confirmationWasRestored }
+            ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails -> null
+        }
         is ConfirmationHandler.Result.Failed -> CheckoutController.Result.Failed(cause)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -275,7 +275,7 @@ internal class CheckoutOperationCoordinatorTest {
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
-                ConfirmationHandler.Result.Canceled.Action.None
+                ConfirmationHandler.Result.Canceled.Action.InformCancellation
             )
         )
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -313,7 +313,7 @@ internal class CheckoutOperationCoordinatorTest {
             enqueueRefreshAction {}
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
-                    ConfirmationHandler.Result.Canceled.Action.None
+                    ConfirmationHandler.Result.Canceled.Action.InformCancellation
                 )
             )
             refreshCalls.awaitItem()
@@ -338,19 +338,40 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `canceled confirmation is delivered as canceled`() = runScenario {
+    fun `canceled confirmation with modify payment details does not invoke callback and releases gate`() =
+        runScenario {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+            enqueueRefreshAction {}
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Canceled(
+                    ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
+                )
+            )
+            assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
+            runCurrent()
+
+            resultTurbine.expectNoEvents()
+            assertThat(coordinator.isUpdating.value).isFalse()
+            assertThat(coordinator.runSynchronousMutation { Result.success(Unit) }.isSuccess).isTrue()
+        }
+
+    @Test
+    fun `canceled confirmation with no action does not invoke callback and releases gate`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
-                ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
+                ConfirmationHandler.Result.Canceled.Action.None
             )
         )
-
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
-        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+        runCurrent()
+
+        resultTurbine.expectNoEvents()
         assertThat(coordinator.isUpdating.value).isFalse()
+        assertThat(coordinator.runSynchronousMutation { Result.success(Unit) }.isSuccess).isTrue()
     }
 
     @Test


### PR DESCRIPTION
# Summary

Honor `ConfirmationHandler.Result.Canceled.action` when translating Checkout confirmation results:

- `InformCancellation` produces `CheckoutController.Result.Canceled`.
- `None` suppresses the result callback, except when completing a confirmation restored after process death.
- `ModifyPaymentDetails` suppresses the result callback.

All cancellation actions continue to refresh the Checkout Session before the callback decision and release the operation gate after completion, including when no callback is delivered.

# Motivation

`CheckoutController` previously reported every confirmation cancellation as `Result.Canceled()`, ignoring whether the confirmation handler requested no action or payment-detail modification. This aligns Checkout with the existing `DefaultFlowController.handleCancellation()` behavior while preserving both the process-death fallback and the post-confirmation session refresh behavior.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Covered in `CheckoutOperationCoordinatorTest`:

- Informative cancellations deliver `CheckoutController.Result.Canceled`.
- `ModifyPaymentDetails` and ordinary `None` cancellations refresh session state, suppress the callback, and release the operation gate.
- A restored `None` cancellation still delivers `CheckoutController.Result.Canceled`.

Validation:

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutOperationCoordinatorTest`
- `./gradlew :paymentsheet:detekt`
- Rebased CI build and paymentsheet tests pass.

Ignored Tests: Not applicable; no tests were newly ignored.

# Screenshots

Not applicable; this is a non-visual controller behavior change.

# Changelog

Not applicable; this is a bug fix in internal `CheckoutController` result handling.
