### PR TITLE
Serialize checkout confirmation session refresh

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -357,6 +357,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         CHECKOUT_SELECTION_SET_BEFORE_LOAD(
             partialEventName = "checkout.selection_set_before_load"
+        ),
+        CHECKOUT_CONFIRMATION_SESSION_REFRESH_FAILED(
+            partialEventName = "checkout.confirmation_session_refresh_failed"
         );
 
         override val eventName: String

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -17,6 +17,7 @@
     <ID>FunctionOnlyReturningConstant:FlowControllerModule.kt:FlowControllerModule$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation</ID>
     <ID>FunctionOnlyReturningConstant:PaymentSheetLauncherModule.kt:PaymentSheetLauncherModule.Companion$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation</ID>
     <ID>LargeClass:CardDefinitionTest.kt:CardDefinitionTest</ID>
+    <ID>LargeClass:CheckoutOperationCoordinatorTest.kt:CheckoutOperationCoordinatorTest</ID>
     <ID>LargeClass:CheckoutTest.kt:CheckoutTest</ID>
     <ID>LargeClass:ConfirmationHandlerOptionKtxTest.kt:ConfirmationHandlerOptionKtxTest</ID>
     <ID>LargeClass:CustomerAdapterTest.kt:CustomerAdapterTest</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -76,7 +76,7 @@ class CheckoutController @Inject internal constructor(
 
     init {
         viewModelScope.launch {
-            operationCoordinator.observeConfirmationResults()
+            operationCoordinator.observeConfirmationResults(::commitConfirmedSession)
         }
     }
 
@@ -284,6 +284,16 @@ class CheckoutController @Inject internal constructor(
                 checkoutStateLoader.reload(newState)
             }
         }
+    }
+
+    /**
+     * Commits the [CheckoutSessionResponse] a successful confirmation returned, mirroring what
+     * [withCheckoutState] does with a mutation's response. Runs inside the operation gate, so the
+     * state read here is the latest committed one.
+     */
+    internal suspend fun commitConfirmedSession(response: CheckoutSessionResponse) {
+        val state = stateHolder.state ?: return
+        checkoutStateLoader.reload(state.copy(checkoutSessionResponse = response))
     }
 
     private fun requireMutableState(): kotlin.Result<Unit> {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -2,21 +2,32 @@
 
 package com.stripe.android.checkout
 
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+private val CONFIRMATION_REFRESH_TIMEOUT_MS = 10.seconds.inWholeMilliseconds
 
 @Singleton
 internal class CheckoutOperationCoordinator @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val sheetStateHolder: SheetStateHolder,
     private val resultCallback: CheckoutController.ResultCallback,
+    private val errorReporter: ErrorReporter,
 ) {
     private val admissionLock = Any()
     private var pendingMutations = 0
@@ -107,29 +118,71 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    suspend fun observeConfirmationResults() {
+    suspend fun observeConfirmationResults(
+        refreshCheckoutSession: suspend (CheckoutSessionResponse) -> Unit,
+    ) {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation(state.result.asCheckoutResult())
+                completeConfirmation(state.result, refreshCheckoutSession)
             }
         }
     }
 
     fun failConfirmation(error: Throwable) {
-        completeConfirmation(CheckoutController.Result.Failed(error))
+        if (claimCompletion()) {
+            deliverAndRelease(CheckoutController.Result.Failed(error))
+        }
     }
 
-    private fun completeConfirmation(result: CheckoutController.Result) {
-        val shouldComplete = synchronized(admissionLock) {
-            if (!confirmationInFlight || confirmationCompletionClaimed) {
-                false
-            } else {
-                confirmationCompletionClaimed = true
-                true
-            }
-        }
-        if (!shouldComplete) return
+    private suspend fun completeConfirmation(
+        result: ConfirmationHandler.Result,
+        refreshCheckoutSession: suspend (CheckoutSessionResponse) -> Unit,
+    ) {
+        // Claim before refreshing so a racing failConfirmation cannot deliver a second result.
+        if (!claimCompletion()) return
 
+        val confirmedSession = (result as? ConfirmationHandler.Result.Succeeded)
+            ?.metadata
+            ?.get(CheckoutSessionResponseKey)
+
+        if (confirmedSession != null) {
+            refreshOrReport(refreshCheckoutSession, confirmedSession)
+        }
+
+        deliverAndRelease(result.asCheckoutResult())
+    }
+
+    private suspend fun refreshOrReport(
+        refreshCheckoutSession: suspend (CheckoutSessionResponse) -> Unit,
+        confirmedSession: CheckoutSessionResponse,
+    ) {
+        try {
+            withTimeout(CONFIRMATION_REFRESH_TIMEOUT_MS) {
+                refreshCheckoutSession(confirmedSession)
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            // Losing our own scope (e.g. destroy()) must not deliver a result, so let that
+            // cancellation through. Everything else is a refresh failure — including a timeout and
+            // a CancellationException the reload surfaced as a value, neither of which cancelled
+            // us. Rethrowing those would strand the gate locked with no result ever delivered.
+            currentCoroutineContext().ensureActive()
+            errorReporter.report(
+                errorEvent = ErrorReporter.UnexpectedErrorEvent.CHECKOUT_CONFIRMATION_SESSION_REFRESH_FAILED,
+                stripeException = StripeException.create(error),
+            )
+        }
+    }
+
+    private fun claimCompletion(): Boolean = synchronized(admissionLock) {
+        if (!confirmationInFlight || confirmationCompletionClaimed) {
+            false
+        } else {
+            confirmationCompletionClaimed = true
+            true
+        }
+    }
+
+    private fun deliverAndRelease(result: CheckoutController.Result) {
         try {
             resultCallback.onResult(result)
         } finally {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -103,6 +104,7 @@ internal class CheckoutConfirmationPerformerTest {
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             resultCallback = {},
+            errorReporter = FakeErrorReporter(),
         )
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import kotlinx.coroutines.CoroutineScope
@@ -806,6 +807,25 @@ internal class CheckoutControllerTest {
 
         result.getOrThrow()
         assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(8000)
+    }
+
+    @Test
+    fun `confirmed session response updates the controller session`() = runMutationScenario {
+        val confirmedResponse = committedState().checkoutSessionResponse.copy(
+            totalSummary = CheckoutSessionResponse.TotalSummaryResponse(
+                subtotal = 2000,
+                totalDueToday = 2000,
+                totalAmountDue = 2000,
+                discountAmounts = emptyList(),
+                taxAmounts = emptyList(),
+                shippingRate = null,
+                appliedBalance = null,
+            ),
+        )
+
+        controller.commitConfirmedSession(confirmedResponse)
+
+        assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(2000)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -12,10 +12,18 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -331,6 +339,188 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
+    fun `successful confirmation refreshes before delivering the result`() = runScenario(
+        refresher = RecordingRefresher(CompletableDeferred()),
+    ) {
+        val response = CheckoutSessionResponseFactory.create()
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession(response))
+
+        assertThat(refresher.refreshCalls.awaitItem()).isEqualTo(response)
+        resultTurbine.expectNoEvents()
+        refresher.release()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
+    fun `isUpdating stays true across a confirmation refresh`() = runScenario(
+        refresher = RecordingRefresher(CompletableDeferred()),
+    ) {
+        coordinator.isUpdating.test {
+            assertThat(awaitItem()).isFalse()
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            assertThat(awaitItem()).isTrue()
+            confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+            refresher.refreshCalls.awaitItem()
+            expectNoEvents()
+            refresher.release()
+            resultTurbine.awaitItem()
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `succeeded confirmation without a session response does not refresh`() = runScenario {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED),
+        )
+        resultTurbine.awaitItem()
+        refresher.refreshCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `canceled confirmation does not refresh`() = runScenario {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None),
+        )
+        resultTurbine.awaitItem()
+        refresher.refreshCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `failed confirmation does not refresh`() = runScenario {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Failed(
+                cause = IllegalStateException("failed"),
+                message = "failed".resolvableString,
+                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            ),
+        )
+        resultTurbine.awaitItem()
+        refresher.refreshCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `refresh failure still delivers confirmation result and releases the gate`() = runScenario(
+        refresher = RecordingRefresher(error = IllegalStateException("refresh failed")),
+    ) {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+        refresher.refreshCalls.awaitItem()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(errorReporter.awaitCall().errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.CHECKOUT_CONFIRMATION_SESSION_REFRESH_FAILED)
+        assertThat(coordinator.isUpdating.value).isFalse()
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+    }
+
+    @Test
+    fun `refresh failing with a cancellation still delivers the confirmation result`() = runScenario(
+        // A reload can surface a CancellationException as a value rather than cancelling us — see
+        // CoroutineContext.runCatching. Rethrowing it would strand the gate with no result.
+        refresher = RecordingRefresher(error = CancellationException("reload timed out")),
+    ) {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+        refresher.refreshCalls.awaitItem()
+
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(errorReporter.awaitCall().errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.CHECKOUT_CONFIRMATION_SESSION_REFRESH_FAILED)
+        assertThat(coordinator.isUpdating.value).isFalse()
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+    }
+
+    @Test
+    fun `a refresh that never finishes times out and still delivers the result`() = runScenario(
+        // Gate is never released, so the refresh only ends by timing out.
+        refresher = RecordingRefresher(CompletableDeferred()),
+    ) {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+        refresher.refreshCalls.awaitItem()
+        resultTurbine.expectNoEvents()
+
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(errorReporter.awaitCall().errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.CHECKOUT_CONFIRMATION_SESSION_REFRESH_FAILED)
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `confirmation refresh updates the session before delivering the result`() = runTest {
+        val response = CheckoutSessionResponseFactory.create()
+        val refresher = RecordingRefresher()
+        val callbackInvoked = CompletableDeferred<Unit>()
+
+        runScenario(
+            refresher = refresher,
+            resultCallback = CheckoutController.ResultCallback {
+                assertThat(refresher.committedSession).isEqualTo(response)
+                callbackInvoked.complete(Unit)
+            },
+        ) {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession(response))
+            refresher.refreshCalls.awaitItem()
+            callbackInvoked.await()
+        }
+    }
+
+    @Test
+    fun `mutation waits for confirmation refresh to complete`() = runScenario(
+        refresher = RecordingRefresher(CompletableDeferred()),
+    ) {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+        refresher.refreshCalls.awaitItem()
+
+        val mutationStarted = CompletableDeferred<Unit>()
+        val mutation = async {
+            coordinator.runMutation {
+                mutationStarted.complete(Unit)
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+        assertThat(mutationStarted.isCompleted).isFalse()
+
+        refresher.release()
+        resultTurbine.awaitItem()
+        assertThat(mutation.await().isSuccess).isTrue()
+        assertThat(mutationStarted.isCompleted).isTrue()
+    }
+
+    @Test
+    fun `cancelling observer during refresh does not deliver a result`() = runScenario(
+        refresher = RecordingRefresher(CompletableDeferred()),
+    ) {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+        refresher.refreshCalls.awaitItem()
+        observerJob.cancelAndJoin()
+        resultTurbine.expectNoEvents()
+    }
+
+    @Test
+    fun `restored confirmation refreshes before delivering its result`() = runScenario(
+        initialConfirmationState = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption,
+        ),
+        hasReloadedFromProcessDeath = true,
+        refresher = RecordingRefresher(CompletableDeferred()),
+    ) {
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession())
+        refresher.refreshCalls.awaitItem()
+        resultTurbine.expectNoEvents()
+        refresher.release()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
     fun `canceled confirmation is delivered as canceled`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
@@ -399,11 +589,12 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
 
             confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+                succeededWithSession()
             )
             runCurrent()
 
             assertThat(deliveredResults).hasSize(1)
+            refresher.refreshCalls.expectNoEvents()
             releaseCallback.countDown()
             failureCompletion.await()
 
@@ -525,6 +716,8 @@ internal class CheckoutOperationCoordinatorTest {
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
         hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
+        refresher: RecordingRefresher = RecordingRefresher(),
+        errorReporter: FakeErrorReporter = FakeErrorReporter(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationState = MutableStateFlow(initialConfirmationState)
@@ -540,9 +733,10 @@ internal class CheckoutOperationCoordinatorTest {
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+            errorReporter = errorReporter,
         )
-        backgroundScope.launch {
-            coordinator.observeConfirmationResults()
+        val observerJob = backgroundScope.launch {
+            coordinator.observeConfirmationResults(refresher::refresh)
         }
         testScheduler.runCurrent()
 
@@ -550,17 +744,25 @@ internal class CheckoutOperationCoordinatorTest {
             coordinator = coordinator,
             confirmationState = confirmationState,
             resultTurbine = resultTurbine,
+            refresher = refresher,
+            observerJob = observerJob,
+            errorReporter = errorReporter,
             testScope = this,
         ).block()
 
         confirmationHandler.validate()
         resultTurbine.ensureAllEventsConsumed()
+        refresher.ensureAllEventsConsumed()
+        errorReporter.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val coordinator: CheckoutOperationCoordinator,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
+        val refresher: RecordingRefresher,
+        val observerJob: Job,
+        val errorReporter: FakeErrorReporter,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
         val backgroundScope = testScope.backgroundScope
@@ -570,4 +772,32 @@ internal class CheckoutOperationCoordinatorTest {
             testScheduler.runCurrent()
         }
     }
+
+    private class RecordingRefresher(
+        private val gate: CompletableDeferred<Unit>? = null,
+        private val error: Throwable? = null,
+    ) {
+        val refreshCalls = Turbine<CheckoutSessionResponse>()
+        var committedSession: CheckoutSessionResponse? = null
+
+        suspend fun refresh(response: CheckoutSessionResponse) {
+            refreshCalls.add(response)
+            committedSession = response
+            gate?.await()
+            error?.let { throw it }
+        }
+
+        fun release() {
+            gate?.complete(Unit)
+        }
+
+        fun ensureAllEventsConsumed() = refreshCalls.ensureAllEventsConsumed()
+    }
+
+    private fun succeededWithSession(
+        response: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
+    ) = ConfirmationHandler.Result.Succeeded(
+        intent = PaymentIntentFixtures.PI_SUCCEEDED,
+        metadata = MutableConfirmationMetadata().apply { set(CheckoutSessionResponseKey, response) },
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -220,6 +220,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             resultCallback = {},
+            errorReporter = errorReporter,
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
             stateHolder = stateHolder,


### PR DESCRIPTION
# Summary

Serialize Checkout Session confirmation refreshes through the operation coordinator and commit the session returned by confirmation before delivering the merchant result.

# Motivation

After a successful Checkout Session confirmation, the confirmation response already contains the updated session, but it was not committed. Merchant callbacks could therefore observe the pre-confirmation session. Refreshing under the confirmation gate keeps session state current and prevents mutations from interleaving during the refresh.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused unit tests run:

`./gradlew :paymentsheet:testDebugUnitTest --tests '*CheckoutOperationCoordinatorTest*' --tests '*CheckoutControllerTest*' --tests '*CheckoutSessionConfirmationInterceptorTest*'`

Also ran `./gradlew :paymentsheet:detekt`.

No tests were newly ignored.

# Screenshots

Not applicable: this changes confirmation/session state coordination and has no UI changes.

# Changelog

Not applicable: this is an internal correctness fix with no new public API or user-facing UI change.
