### PR TITLE
Fix Cash App authorization page wait

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -18,6 +18,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.Until
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
 import com.stripe.android.model.PaymentMethod.Type.Blik
@@ -156,19 +157,19 @@ internal class Selectors(
 
     val closeButton = UiAutomatorText("Close", device = device)
 
-    @OptIn(ExperimentalTestApi::class)
     fun blockUntilAuthorizationPageLoaded(isSetup: Boolean) {
         val authorizationText = requireNotNull(testParameters.authorizationAction).text(isSetup)
         val readinessText = authorizationText.ifBlank {
             "test ${if (isSetup) "setup" else "payment"} page"
         }
-        val authorizationSelector = UiSelector().textContains(readinessText)
 
-        composeTestRule.waitUntil(
-            conditionDescription = "authorization page content '$readinessText' to load",
-            timeoutMillis = HOOKS_PAGE_LOAD_TIMEOUT * 1000,
+        checkNotNull(
+            device.wait(
+                Until.findObject(By.textContains(readinessText)),
+                HOOKS_PAGE_LOAD_TIMEOUT * 1000,
+            )
         ) {
-            device.findObject(authorizationSelector).exists()
+            "Authorization page content '$readinessText' did not load"
         }
         device.waitForIdle()
     }


### PR DESCRIPTION
# Summary

Use UiAutomator polling when waiting for authorization-page content in external browser flows.

# Motivation

The Cash App confirmation-token embedded test intermittently timed out while waiting for `AUTHORIZE TEST PAYMENT` in Chrome. The wait was implemented through `ComposeTestRule.waitUntil`, even though the content belongs to the external Chrome accessibility tree. This change uses the native UiAutomator wait while preserving dynamic authorization text matching.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Validation performed:

- Focused managed-device test with 2 diagnostic Shampoo iterations: passed.
- Focused managed-device test with 50 diagnostic Shampoo iterations (`0`–`49`): passed with no failed iterations.
- Focused managed-device test with the normal `RetryRule` configuration: passed.

No tests were newly ignored.

# Screenshots

Not applicable: this changes test synchronization only and does not change user-facing UI.

# Changelog

Not applicable: this is an internal test stabilization change.
