### PR TITLE
Remove phone number from CheckoutController

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCollectedDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCollectedDetails.kt
@@ -10,8 +10,6 @@ import kotlinx.parcelize.Parcelize
 internal data class CheckoutCollectedDetails(
     val shippingName: String? = null,
     val billingName: String? = null,
-    val shippingPhoneNumber: String? = null,
-    val billingPhoneNumber: String? = null,
     val shippingAddress: Address.State? = null,
     val billingAddress: Address.State? = null,
 ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -34,12 +34,10 @@ internal fun CheckoutCollectedDetails.toBillingDetails(
     address = billingAddress?.asPaymentSheet(),
     email = checkoutSessionResponse.customerEmail,
     name = billingName,
-    phone = billingPhoneNumber,
 )
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutCollectedDetails.toShippingDetails(): AddressDetails = AddressDetails(
     name = shippingName,
     address = shippingAddress?.asPaymentSheet(),
-    phoneNumber = shippingPhoneNumber,
 )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -156,12 +156,10 @@ class CheckoutController @Inject internal constructor(
      * to compute updated tax amounts.
      *
      * @param name The recipient's name.
-     * @param phoneNumber The recipient's phone number.
      * @param address The shipping address.
      */
     suspend fun updateShippingAddress(
         name: String?,
-        phoneNumber: String?,
         address: Address,
     ): kotlin.Result<Unit> {
         stateHolder.state?.checkoutSessionResponse
@@ -171,7 +169,6 @@ class CheckoutController @Inject internal constructor(
             copy(
                 collectedDetails = collectedDetails.copy(
                     shippingName = name,
-                    shippingPhoneNumber = phoneNumber,
                     shippingAddress = it,
                 ),
             )
@@ -192,13 +189,11 @@ class CheckoutController @Inject internal constructor(
 
     internal suspend fun updateBillingAddress(
         name: String?,
-        phoneNumber: String?,
         address: Address,
     ): kotlin.Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.BILLING, address) {
         copy(
             collectedDetails = collectedDetails.copy(
                 billingName = name,
-                billingPhoneNumber = phoneNumber,
                 billingAddress = it,
             ),
         )
@@ -691,10 +686,6 @@ class CheckoutController @Inject internal constructor(
          * The customer's full name.
          */
         val name: String?,
-        /**
-         * The customer's phone number, without formatting (e.g. 5551234567).
-         */
-        val phone: String?,
     ) {
         /**
          * A billing address.
@@ -991,33 +982,26 @@ class CheckoutController @Inject internal constructor(
             )
 
             /**
-             * A name, phone number, and postal address for a customer.
+             * A name and postal address for a customer.
              */
             @CheckoutSessionPreview
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             class ContactDetails {
                 private var name: String? = null
-                private var phoneNumber: String? = null
                 private var address: Address? = null
 
                 fun name(name: String?): ContactDetails = apply { this.name = name }
-
-                fun phoneNumber(phoneNumber: String?): ContactDetails = apply {
-                    this.phoneNumber = phoneNumber
-                }
 
                 fun address(address: Address): ContactDetails = apply { this.address = address }
 
                 @Parcelize
                 internal data class State(
                     val name: String?,
-                    val phoneNumber: String?,
                     val address: Address.State?,
                 ) : Parcelable
 
                 internal fun build(): State = State(
                     name = name,
-                    phoneNumber = phoneNumber,
                     address = address?.build(),
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -93,6 +93,5 @@ private fun PaymentMethod.BillingDetails.toCheckoutBillingDetails(): CheckoutCon
         },
         email = email,
         name = name,
-        phone = phone,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -146,8 +146,6 @@ private fun CheckoutController.Configuration.State.asInitialCollectedDetails(): 
     return CheckoutCollectedDetails(
         shippingName = defaults.shippingDetails?.name,
         billingName = defaults.billingDetails?.name,
-        shippingPhoneNumber = defaults.shippingDetails?.phoneNumber,
-        billingPhoneNumber = defaults.billingDetails?.phoneNumber,
         shippingAddress = defaults.shippingDetails?.address,
         billingAddress = defaults.billingDetails?.address,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -100,18 +100,12 @@ class PaymentElement @Inject internal constructor(
         class BillingDetailsCollectionConfiguration {
 
             private var name: CollectionMode = CollectionMode.Automatic
-            private var phone: CollectionMode = CollectionMode.Automatic
             private var email: CollectionMode = CollectionMode.Automatic
             private var address: AddressCollectionMode = AddressCollectionMode.Automatic
 
             /** How to collect the name field. */
             fun name(name: CollectionMode): BillingDetailsCollectionConfiguration = apply {
                 this.name = name
-            }
-
-            /** How to collect the phone field. */
-            fun phone(phone: CollectionMode): BillingDetailsCollectionConfiguration = apply {
-                this.phone = phone
             }
 
             /** How to collect the email field. */
@@ -134,7 +128,7 @@ class PaymentElement @Inject internal constructor(
 
             internal fun build(): State = State(
                 name = name,
-                phone = phone,
+                phone = CollectionMode.Automatic,
                 email = email,
                 address = address,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
@@ -50,14 +50,13 @@ internal class BillingDetailsCollectionConfigurationMapperTest {
     fun `all CollectionMode fields map 1 to 1`() {
         val mapped = BillingDetailsCollectionConfiguration()
             .name(BillingDetailsCollectionConfiguration.CollectionMode.Always)
-            .phone(BillingDetailsCollectionConfiguration.CollectionMode.Never)
             .email(BillingDetailsCollectionConfiguration.CollectionMode.Always)
             .build()
             .asPaymentSheet()
         assertThat(mapped.name)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
         assertThat(mapped.phone)
-            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
         assertThat(mapped.email)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -42,10 +42,8 @@ internal class CheckoutCommonConfigurationFactoryTest {
         )
         val collectedDetails = collectedDetails(
             billingName = "Jane Billing",
-            billingPhoneNumber = "5559876543",
             billingAddress = address(),
             shippingName = "John Shipping",
-            shippingPhoneNumber = "5551234567",
             shippingAddress = address(),
         )
 
@@ -202,16 +200,12 @@ internal class CheckoutCommonConfigurationFactoryTest {
     private fun collectedDetails(
         shippingName: String? = null,
         billingName: String? = null,
-        shippingPhoneNumber: String? = null,
-        billingPhoneNumber: String? = null,
         shippingAddress: Address.State? = null,
         billingAddress: Address.State? = null,
     ): CheckoutCollectedDetails {
         return CheckoutCollectedDetails(
             shippingName = shippingName,
             billingName = billingName,
-            shippingPhoneNumber = shippingPhoneNumber,
-            billingPhoneNumber = billingPhoneNumber,
             shippingAddress = shippingAddress,
             billingAddress = billingAddress,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -658,14 +658,12 @@ internal class CheckoutControllerTest {
 
             val result = controller.updateShippingAddress(
                 name = "John",
-                phoneNumber = "5551234567",
                 address = fullAddress,
             )
 
             result.getOrThrow()
             val state = committedState()
             assertThat(state.collectedDetails.shippingName).isEqualTo("John")
-            assertThat(state.collectedDetails.shippingPhoneNumber).isEqualTo("5551234567")
             assertThat(state.collectedDetails.shippingAddress).isEqualTo(fullAddress.build())
         }
 
@@ -683,7 +681,7 @@ internal class CheckoutControllerTest {
             )
 
             val address = Address().country("US").postalCode("80202")
-            val result = controller.updateShippingAddress(name = null, phoneNumber = null, address = address)
+            val result = controller.updateShippingAddress(name = null, address = address)
 
             assertThat(result.isSuccess).isTrue()
         }
@@ -693,7 +691,7 @@ internal class CheckoutControllerTest {
         runMutationScenario {
             // No checkoutUpdate is enqueued: with automatic tax off, the address is stored locally
             // and the payment element is reloaded from the existing response, firing no request.
-            val result = controller.updateShippingAddress(name = "John", phoneNumber = null, address = fullAddress)
+            val result = controller.updateShippingAddress(name = "John", address = fullAddress)
 
             result.getOrThrow()
             val state = committedState()
@@ -709,7 +707,7 @@ internal class CheckoutControllerTest {
                 response.setBody("""{"error": {"message": "Invalid address"}}""")
             }
 
-            val result = controller.updateShippingAddress(name = "John", phoneNumber = null, address = fullAddress)
+            val result = controller.updateShippingAddress(name = "John", address = fullAddress)
 
             assertThat(result.isFailure).isTrue()
             val state = committedState()
@@ -721,7 +719,7 @@ internal class CheckoutControllerTest {
     fun `updateShippingAddress does not send tax_region when automatic tax targets billing`() =
         runMutationScenario(initModifier = automaticTaxFor("billing")) {
             // Automatic tax targets billing, so a shipping address update stays local: no request.
-            val result = controller.updateShippingAddress(name = "John", phoneNumber = null, address = fullAddress)
+            val result = controller.updateShippingAddress(name = "John", address = fullAddress)
 
             result.getOrThrow()
             val state = committedState()
@@ -742,14 +740,12 @@ internal class CheckoutControllerTest {
 
             val result = controller.updateBillingAddress(
                 name = "Jane",
-                phoneNumber = "5559876543",
                 address = fullAddress,
             )
 
             result.getOrThrow()
             val state = committedState()
             assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingPhoneNumber).isEqualTo("5559876543")
             assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
         }
 
@@ -757,7 +753,7 @@ internal class CheckoutControllerTest {
     fun `updateBillingAddress does not send tax_region when automatic tax targets shipping`() =
         runMutationScenario(initModifier = automaticTaxFor("shipping")) {
             // Automatic tax targets shipping, so a billing address update stays local: no request.
-            val result = controller.updateBillingAddress(name = "Jane", phoneNumber = null, address = fullAddress)
+            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
 
             result.getOrThrow()
             val state = committedState()
@@ -770,7 +766,7 @@ internal class CheckoutControllerTest {
         runMutationScenario {
             // No checkoutUpdate is enqueued: with automatic tax off, the address is stored locally
             // and the payment element is reloaded from the existing response, firing no request.
-            val result = controller.updateBillingAddress(name = "Jane", phoneNumber = null, address = fullAddress)
+            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
 
             result.getOrThrow()
             val state = committedState()
@@ -786,7 +782,7 @@ internal class CheckoutControllerTest {
                 response.setBody("""{"error": {"message": "Invalid address"}}""")
             }
 
-            val result = controller.updateBillingAddress(name = "Jane", phoneNumber = null, address = fullAddress)
+            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
 
             assertThat(result.isFailure).isTrue()
             val state = committedState()
@@ -987,7 +983,6 @@ internal class CheckoutControllerTest {
 
             val result = controller.updateShippingAddress(
                 name = null,
-                phoneNumber = null,
                 address = Address().country("US"),
             )
 
@@ -1007,7 +1002,6 @@ internal class CheckoutControllerTest {
 
             val result = controller.updateShippingAddress(
                 name = null,
-                phoneNumber = null,
                 address = Address().country("DE"),
             )
 
@@ -1026,7 +1020,6 @@ internal class CheckoutControllerTest {
             // No allowlist set, so any country passes.
             val result = controller.updateShippingAddress(
                 name = null,
-                phoneNumber = null,
                 address = Address().country("DE"),
             )
 
@@ -1040,7 +1033,6 @@ internal class CheckoutControllerTest {
 
             val result = controller.updateShippingAddress(
                 name = null,
-                phoneNumber = null,
                 address = Address().country("US"),
             )
 
@@ -1058,7 +1050,6 @@ internal class CheckoutControllerTest {
         runMutationScenario(initModifier = allowedShippingCountries(listOf("US"))) {
             val result = controller.updateBillingAddress(
                 name = null,
-                phoneNumber = null,
                 address = Address().country("DE"),
             )
 
@@ -1071,7 +1062,7 @@ internal class CheckoutControllerTest {
             // Address.build() requires a country and throws synchronously, before the allowlist is
             // ever consulted, so the call is wrapped to capture the thrown exception.
             val result = runCatching {
-                controller.updateShippingAddress(name = null, phoneNumber = null, address = Address())
+                controller.updateShippingAddress(name = null, address = Address())
             }
 
             assertThat(result.isFailure).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -177,7 +177,6 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = collectedDetails(
                 billingName = "Jane Billing",
-                billingPhoneNumber = "5559876543",
                 billingAddress = Address.State(
                     city = "Denver",
                     country = "US",
@@ -191,7 +190,6 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
 
         val billingDetails = requireNotNull(result.defaultBillingDetails)
         assertThat(billingDetails.name).isEqualTo("Jane Billing")
-        assertThat(billingDetails.phone).isEqualTo("5559876543")
         val address = requireNotNull(billingDetails.address)
         assertThat(address.city).isEqualTo("Denver")
         assertThat(address.country).isEqualTo("US")
@@ -208,7 +206,6 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = collectedDetails(
                 shippingName = "John Shipping",
-                shippingPhoneNumber = "5551234567",
                 shippingAddress = Address.State(
                     city = "Denver",
                     country = "US",
@@ -221,7 +218,6 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         )
 
         assertThat(result.shippingDetails?.name).isEqualTo("John Shipping")
-        assertThat(result.shippingDetails?.phoneNumber).isEqualTo("5551234567")
         val address = requireNotNull(result.shippingDetails?.address)
         assertThat(address.city).isEqualTo("Denver")
         assertThat(address.country).isEqualTo("US")
@@ -266,16 +262,12 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     private fun collectedDetails(
         shippingName: String? = null,
         billingName: String? = null,
-        shippingPhoneNumber: String? = null,
-        billingPhoneNumber: String? = null,
         shippingAddress: Address.State? = null,
         billingAddress: Address.State? = null,
     ): CheckoutCollectedDetails {
         return CheckoutCollectedDetails(
             shippingName = shippingName,
             billingName = billingName,
-            shippingPhoneNumber = shippingPhoneNumber,
-            billingPhoneNumber = billingPhoneNumber,
             shippingAddress = shippingAddress,
             billingAddress = billingAddress,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -108,7 +108,6 @@ internal class CheckoutStateLoaderTest {
                     .billingDetails(
                         CheckoutController.Configuration.Defaults.ContactDetails()
                             .name("Jane Billing")
-                            .phoneNumber("5559876543")
                             .address(CheckoutController.Address().country("US").city("Denver")),
                     )
                     .shippingDetails(
@@ -121,7 +120,6 @@ internal class CheckoutStateLoaderTest {
 
         val collected = requireNotNull(stateHolder.state).collectedDetails
         assertThat(collected.billingName).isEqualTo("Jane Billing")
-        assertThat(collected.billingPhoneNumber).isEqualTo("5559876543")
         assertThat(collected.billingAddress?.country).isEqualTo("US")
         assertThat(collected.billingAddress?.city).isEqualTo("Denver")
         assertThat(collected.shippingName).isEqualTo("John Shipping")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
@@ -91,7 +91,6 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
         val billingDetails = requireNotNull(option?.billingDetails)
         assertThat(billingDetails.name).isEqualTo("Jenny Rosen")
         assertThat(billingDetails.email).isEqualTo("jenny.rosen@example.com")
-        assertThat(billingDetails.phone).isEqualTo("123-456-7890")
         assertThat(billingDetails.address?.line1).isEqualTo("1234 Main Street")
         assertThat(billingDetails.address?.city).isEqualTo("San Francisco")
         assertThat(billingDetails.address?.state).isEqualTo("CA")
@@ -114,7 +113,6 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
                     billingDetails = PaymentMethod.BillingDetails(
                         name = "Jenny Rosen",
                         email = "jenny.rosen@example.com",
-                        phone = "123-456-7890",
                         address = null,
                     ),
                 ),
@@ -125,7 +123,6 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
         val billingDetails = requireNotNull(option?.billingDetails)
         assertThat(billingDetails.name).isEqualTo("Jenny Rosen")
         assertThat(billingDetails.email).isEqualTo("jenny.rosen@example.com")
-        assertThat(billingDetails.phone).isEqualTo("123-456-7890")
         assertThat(billingDetails.address).isNull()
     }
 


### PR DESCRIPTION
# Summary

Remove phone-number data from CheckoutController and its transitive checkout state, mappers, and billing-details projection.

# Motivation

Phone isn't supported for private preview.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ignored tests: Not applicable.

# Screenshots

Not applicable; this change removes checkout data plumbing and does not change UI rendering.

# Changelog

Not applicable; this is an internal CheckoutController API change.
