### PR TITLE
Rename checkout payment element APIs

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -76,7 +76,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                                 if (session.isExpressCheckoutElementAvailable) {
                                     presenter.expressCheckoutElement().Content()
                                 }
-                                paymentElement.PaymentOptionsContent()
+                                paymentElement.Content()
                             }
                         }
                     }
@@ -86,7 +86,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                     PaymentOptionRow(configured?.session?.paymentOptionDisplayData)
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(
-                        onClick = { paymentElement.presentPaymentOptions() },
+                        onClick = { paymentElement.present() },
                         enabled = configured != null,
                         modifier = Modifier.fillMaxWidth(),
                     ) {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTestRunner.kt
@@ -80,7 +80,7 @@ internal fun runCheckoutPaymentElementTest(
             val paymentElement = presenter.paymentElement()
             activity.setContent {
                 Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                    paymentElement.PaymentOptionsContent()
+                    paymentElement.Content()
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -23,7 +23,7 @@ class PaymentElement @Inject internal constructor(
      * It can present a sheet to collect more details or display saved payment methods.
      */
     @Composable
-    fun PaymentOptionsContent() {
+    fun Content() {
         val embeddedContent by contentHelper.embeddedContent.collectAsState()
         embeddedContent?.Content()
     }
@@ -31,7 +31,7 @@ class PaymentElement @Inject internal constructor(
     /**
      * Presents a sheet for the customer to select or manage their payment method.
      */
-    fun presentPaymentOptions() {
+    fun present() {
         contentHelper.presentPaymentOptions()
     }
 
@@ -44,7 +44,7 @@ class PaymentElement @Inject internal constructor(
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
 
         /**
-         * Controls whether [PaymentOptionsContent] displays mandate text below the payment methods.
+         * Controls whether [Content] displays mandate text below the payment methods.
          * Defaults to `true`.
          *
          * When set to `false`, you must display
@@ -69,7 +69,7 @@ class PaymentElement @Inject internal constructor(
         /**
          * The layout of payment methods in the sheet. Defaults to [PaymentMethodLayout.Automatic].
          *
-         * Note: Only used if you call `presentPaymentOptions`.
+         * Note: Only used if you call [present].
          *
          * @see [PaymentMethodLayout] for the list of available layouts.
          */

--- a/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
@@ -29,30 +29,30 @@ internal class PaymentElementTest {
     val composeCleanupRule = createComposeCleanupRule()
 
     @Test
-    fun `presentPaymentOptions delegates to the content helper`() = runTest {
+    fun `present delegates to the content helper`() = runTest {
         val contentHelper = FakeEmbeddedContentHelper()
         val paymentElement = PaymentElement(contentHelper)
 
-        paymentElement.presentPaymentOptions()
+        paymentElement.present()
 
         contentHelper.presentPaymentOptionsCalls.awaitItem()
         contentHelper.presentPaymentOptionsCalls.ensureAllEventsConsumed()
     }
 
     @Test
-    fun `PaymentOptionsContent renders nothing when there is no embedded content`() {
+    fun `Content renders nothing when there is no embedded content`() {
         val contentHelper = FakeEmbeddedContentHelper(embeddedContent = MutableStateFlow(null))
         val paymentElement = PaymentElement(contentHelper)
 
         composeRule.setContent {
-            paymentElement.PaymentOptionsContent()
+            paymentElement.Content()
         }
 
         composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertDoesNotExist()
     }
 
     @Test
-    fun `PaymentOptionsContent renders the current embedded content`() {
+    fun `Content renders the current embedded content`() {
         val content = EmbeddedContent(
             interactor = FakePaymentMethodVerticalLayoutInteractor.create(
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
@@ -65,7 +65,7 @@ internal class PaymentElementTest {
         val paymentElement = PaymentElement(contentHelper)
 
         composeRule.setContent {
-            paymentElement.PaymentOptionsContent()
+            paymentElement.Content()
         }
 
         composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertIsDisplayed()


### PR DESCRIPTION
# Summary

Rename the checkout `PaymentElement` APIs to `Content()` and `present()` and update all in-repository call sites and tests.

# Motivation

Use concise, idiomatic names for the composable content and presentation APIs.

# Testing

Verified the rename with repository-wide reference searches and `git diff --check`.
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ignored Tests: Not applicable; no tests were newly ignored.

# Screenshots

Not applicable; this is an API naming-only change with no intended visual change.

# Changelog

Not applicable; this is an internal checkout API rename currently under development.
