### PR TITLE
Consolidate PaymentSheet E2E into one Bitrise job

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,21 +16,18 @@ app:
 pipelines:
   main-trigger-pipeline:
     workflows:
-      check: { }
-      test: { }
+      check-and-test: { }
       run-instrumentation-tests: { }
       run-paymentsheet-instrumentation-tests: { }
       run-paymentsheet-ime-instrumentation-tests: { }
-      run-financial-connections-instrumentation-tests: { }
+      run-financial-connections-and-crypto-instrumentation-tests: { }
       run-connections-e2e-payments-tests-on-push: { }
       run-connections-e2e-token-tests-on-push: { }
       run-connections-e2e-data-tests-on-push: { }
       run-cardscan-instrumentation-tests: { }
-      run-crypto-onramp-example-e2e-tests: { }
       run-paymentsheet-e2e: { }
       run-paymentsheet-google-pay-e2e: { }
-      check-dependencies: { }
-      verify-publish-pom: { }
+      check-dependencies-and-publish-pom: { }
   pipeline-connect-e2e-debug-tests:
     stages:
       - stage-run-connect-e2e-tests: { }
@@ -66,17 +63,7 @@ stages:
     workflows:
       - notify-connections-e2e-failure: { }
 workflows:
-  check:
-    before_run:
-      - prepare_all
-    after_run:
-      - conclude_all
-    steps:
-      - script@1:
-          timeout: 1200
-          inputs:
-            - content: ./gradlew detekt lintRelease apiCheck verifyReleaseResources
-  test:
+  check-and-test:
     envs:
       - opts:
           is_expand: false
@@ -92,9 +79,10 @@ workflows:
       - conclude_all
     steps:
       - script@1:
+          title: Run static analysis, unit, and screenshot tests
           timeout: 1200
           inputs:
-            - content: ./gradlew runUnitAndScreenshotTests --init-script build-configuration/unit-test-init.gradle --continue
+            - content: ./gradlew detekt lintRelease apiCheck verifyReleaseResources runUnitAndScreenshotTests --init-script build-configuration/unit-test-init.gradle --continue
       - bundle::export_unit_test_results:
           title: Export unit & screenshot test results
           inputs:
@@ -350,7 +338,7 @@ workflows:
           title: Export PaymentSheet IME instrumentation test results
           inputs:
             - test_title: PaymentSheet IME instrumentation tests
-  run-financial-connections-instrumentation-tests:
+  run-financial-connections-and-crypto-instrumentation-tests:
     before_run:
       - start_emulator
       - prepare_all
@@ -361,7 +349,7 @@ workflows:
           title: Assemble Instrumentation tests
           timeout: 600
           inputs:
-            - content: ./gradlew :financial-connections:assembleAndroidTest :financial-connections-example:assembleAndroidTest
+            - content: ./gradlew :financial-connections:assembleAndroidTest :financial-connections-example:assembleAndroidTest :crypto-onramp-example:assembleDebug :crypto-onramp-example:assembleDebugAndroidTest
       - wait-for-android-emulator@1:
           inputs:
             - boot_timeout: 600
@@ -369,11 +357,15 @@ workflows:
           title: Execute instrumentation tests
           timeout: 1200
           inputs:
-            - content: ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew :financial-connections:connectedAndroidTest :financial-connections-example:connectedAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
+            - content: ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew :financial-connections:connectedAndroidTest :financial-connections-example:connectedAndroidTest :crypto-onramp-example:connectedDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle --continue
       - bundle::export_instrumentation_test_results:
-          title: Export FC instrumentation test results
+          title: Export FC and Crypto instrumentation test results
           inputs:
-            - test_title: FC instrumentation tests
+            - test_title: FC and Crypto instrumentation tests
+    meta:
+      bitrise.io:
+        stack: ubuntu-resolute-26.04-bitrise-2026-android
+        machine_type_id: g2.linux.x-large
   run-cardscan-instrumentation-tests:
     before_run:
       - start_cardscan_emulator
@@ -485,30 +477,7 @@ workflows:
       bitrise.io:
         stack: ubuntu-resolute-26.04-bitrise-2026-android
         machine_type_id: g2.linux.x-large
-  run-crypto-onramp-example-e2e-tests:
-    before_run:
-      - start_emulator
-      - prepare_all
-    after_run:
-      - conclude_all
-    steps:
-      - script@1:
-          timeout: 1200
-          inputs:
-            - content: ./scripts/retry.sh 3 ./gradlew :crypto-onramp-example:assembleDebug :crypto-onramp-example:assembleDebugAndroidTest
-      - wait-for-android-emulator@1:
-          inputs:
-            - boot_timeout: 600
-      - script@1:
-          title: Run Crypto Onramp Example E2E Tests
-          timeout: 1200
-          inputs:
-            - content: ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew :crypto-onramp-example:connectedDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
-      - bundle::export_instrumentation_test_results:
-          title: Export Crypto Onramp Example E2E test results
-          inputs:
-            - test_title: Crypto Onramp E2E tests
-  check-dependencies:
+  check-dependencies-and-publish-pom:
     envs:
       - INCLUDE_DEPENDENCIES_ON_FAILURE: true
     before_run:
@@ -520,22 +489,26 @@ workflows:
           inputs:
             - content: asdf install ruby 3.2.4
       - script@1:
+          title: Check dependencies and published POMs
+          timeout: 1200
           inputs:
-            - content: ruby scripts/dependencies/update_transitive_dependencies.rb
-      - script@1:
-          inputs:
-            - content: ruby scripts/dependencies/check_transitive_dependencies.rb
-  verify-publish-pom:
-    before_run:
-      - prepare_all
-    after_run:
-      - conclude_all
-    steps:
-      - script@1:
-          title: Verify Maven publish POMs
-          timeout: 1800
-          inputs:
-            - content: bash ./scripts/verify_publish_pom.sh
+            - content: |-
+                #!/usr/bin/env bash
+                set +e
+
+                ruby scripts/dependencies/update_transitive_dependencies.rb
+                dependencies_status=$?
+                if [ "$dependencies_status" -eq 0 ]; then
+                  ruby scripts/dependencies/check_transitive_dependencies.rb
+                  dependencies_status=$?
+                fi
+
+                bash ./scripts/verify_publish_pom.sh
+                publish_pom_status=$?
+
+                if [ "$dependencies_status" -ne 0 ] || [ "$publish_pom_status" -ne 0 ]; then
+                  exit 1
+                fi
   start_connections_emulator:
     steps:
       - avd-manager@2:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,7 +11,7 @@ app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
     # Run PaymentSheet E2E tests in parallel on one machine so Bitrise bills a single job.
-    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 8
+    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 6
 
 pipelines:
   main-trigger-pipeline:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,7 +11,7 @@ app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
     # Run PaymentSheet E2E tests in parallel on one machine so Bitrise bills a single job.
-    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 6
+    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 8
 
 pipelines:
   main-trigger-pipeline:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,9 +10,8 @@ trigger_map:
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
-    # Number of parallel machines for run-paymentsheet-e2e. Must stay in sync with the
-    # --num-shards passed to get_shard_test_classes.py so every test class is assigned once.
-    - PAYMENTSHEET_E2E_SHARD_COUNT: 6
+    # Run PaymentSheet E2E tests in parallel on one machine so Bitrise bills a single job.
+    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 6
 
 pipelines:
   main-trigger-pipeline:
@@ -28,11 +27,7 @@ pipelines:
       run-connections-e2e-data-tests-on-push: { }
       run-cardscan-instrumentation-tests: { }
       run-crypto-onramp-example-e2e-tests: { }
-      build-paymentsheet-e2e: { }
-      run-paymentsheet-e2e:
-        parallel: $PAYMENTSHEET_E2E_SHARD_COUNT
-        depends_on:
-          - build-paymentsheet-e2e
+      run-paymentsheet-e2e: { }
       run-paymentsheet-google-pay-e2e: { }
       check-dependencies: { }
       verify-publish-pom: { }
@@ -407,15 +402,6 @@ workflows:
       bitrise.io:
         stack: ubuntu-resolute-26.04-bitrise-2026-android
         machine_type_id: g2.linux.x-large
-  build-paymentsheet-e2e:
-    before_run:
-      - prepare_all
-    steps:
-      - script@1:
-          title: Compile PaymentSheet E2E tests
-          timeout: 1200
-          inputs:
-            - content: ./gradlew :paymentsheet-example:assembleBaseDebugAndroidTest
   run-paymentsheet-e2e:
     before_run:
       - prepare_all
@@ -429,14 +415,14 @@ workflows:
             - content: |-
                 #!/usr/bin/env bash
                 set -euo pipefail
-                envman add --key PAYMENTSHEET_E2E_SHARD_DISPLAY --value "$((BITRISE_IO_PARALLEL_INDEX + 1))"
-                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$BITRISE_IO_PARALLEL_INDEX" --num-shards "$PAYMENTSHEET_E2E_SHARD_COUNT")
+                # Keep the explicit class list so tests with dedicated workflows stay excluded.
+                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index 0 --num-shards 1)
 
-                ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
+                ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=$PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=$PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
       - bundle::export_instrumentation_test_results:
           title: Export PaymentSheet E2E test results
           inputs:
-            - test_title: "PaymentSheet E2E tests (shard $PAYMENTSHEET_E2E_SHARD_DISPLAY)"
+            - test_title: PaymentSheet E2E tests
     meta:
       bitrise.io:
         stack: ubuntu-resolute-26.04-bitrise-2026-android


### PR DESCRIPTION
# Summary

Combine E2E tests into one parallel job, and group a few other smaller jobs together.

# Motivation

Reducing build count