### PR TITLE
Use FlowController appearance for payment option icons

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -64,6 +64,7 @@ internal class DefaultCheckoutPaymentOptionDisplayDataFactory @Inject constructo
                     drawableResourceIdNight = selection.drawableResourceIdNight,
                     lightThemeIconUrl = selection.lightThemeIconUrl,
                     darkThemeIconUrl = selection.darkThemeIconUrl,
+                    useDarkThemeIcon = null,
                 )
             },
             label = selection.label(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -622,7 +622,7 @@ class CustomerSheet internal constructor(
             return when (this) {
                 is PaymentSelection.GooglePay -> {
                     PaymentOptionSelection.GooglePay(
-                        paymentOption = paymentOptionFactory.create(this, null),
+                        paymentOption = paymentOptionFactory.create(this, null, appearance = null),
                     ).takeIf {
                         canUseGooglePay
                     }
@@ -630,7 +630,7 @@ class CustomerSheet internal constructor(
                 is PaymentSelection.Saved -> {
                     PaymentOptionSelection.PaymentMethod(
                         paymentMethod = this.paymentMethod,
-                        paymentOption = paymentOptionFactory.create(this, null)
+                        paymentOption = paymentOptionFactory.create(this, null, appearance = null)
                     )
                 }
                 else -> null

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -865,6 +865,7 @@ internal fun PaymentMethodPreviewDetails.toPreview(
                 drawableResourceIdNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
+                useDarkThemeIcon = null,
             )
         },
         label = label,
@@ -912,6 +913,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
                 drawableResourceIdNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
+                useDarkThemeIcon = null,
             )
         },
         label = label,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactory.kt
@@ -59,6 +59,7 @@ internal class PaymentOptionDisplayDataFactory @Inject constructor(
                     drawableResourceIdNight = selection.drawableResourceIdNight,
                     lightThemeIconUrl = selection.lightThemeIconUrl,
                     darkThemeIconUrl = selection.darkThemeIconUrl,
+                    useDarkThemeIcon = null,
                 )
             },
             billingDetails = selection.billingDetails?.toPaymentSheetBillingDetails(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -35,6 +35,7 @@ import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
@@ -255,8 +256,19 @@ internal class DefaultFlowController @Inject internal constructor(
             val linkBrand = viewModel.state?.paymentSheetState?.paymentMethodMetadata?.effectiveLinkBrand(
                 linkAccountHolder.linkAccountInfo.value.account
             )
-            paymentOptionFactory.create(it, linkBrand)
+            createPaymentOption(it, linkBrand)
         }
+    }
+
+    private fun createPaymentOption(
+        selection: PaymentSelection,
+        linkBrand: LinkBrand?,
+    ): PaymentOption {
+        return paymentOptionFactory.create(
+            selection = selection,
+            linkBrand = linkBrand,
+            appearance = viewModel.state?.config?.appearance,
+        )
     }
 
     private fun withCurrentState(block: (State) -> Unit) {
@@ -421,7 +433,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 viewModel.paymentSelection = selection
                 paymentOptionResultCallback.onPaymentOptionResult(
                     PaymentOptionResult(
-                        paymentOption = paymentOptionFactory.create(selection, effectiveBrand),
+                        paymentOption = createPaymentOption(selection, effectiveBrand),
                         didCancel = false,
                     )
                 )
@@ -481,7 +493,7 @@ internal class DefaultFlowController @Inject internal constructor(
             val paymentOption = newSelection?.let {
                 val linkBrand = viewModel.state?.linkConfiguration
                     ?.effectiveLinkBrand(linkAccountHolder.linkAccountInfo.value.account)
-                paymentOptionFactory.create(it, linkBrand)
+                createPaymentOption(it, linkBrand)
             }
             val result = PaymentOptionResult(
                 paymentOption = paymentOption,
@@ -631,7 +643,7 @@ internal class DefaultFlowController @Inject internal constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
         val paymentOption = paymentSelection?.let {
             val linkBrand = viewModel.state?.linkConfiguration?.effectiveLinkBrand(linkAccount)
-            paymentOptionFactory.create(it, linkBrand)
+            createPaymentOption(it, linkBrand)
         }
 
         paymentOptionResultCallback.onPaymentOptionResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -1,10 +1,15 @@
 package com.stripe.android.paymentsheet.model
 
 import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.ui.MIN_LUMINANCE_FOR_LIGHT_ICON
+import com.stripe.android.paymentsheet.ui.isDarkTheme
+import com.stripe.android.uicore.isSystemDarkTheme
 import javax.inject.Inject
 
 internal class PaymentOptionFactory @Inject constructor(
@@ -12,7 +17,11 @@ internal class PaymentOptionFactory @Inject constructor(
     private val cardArtDrawableLoader: PaymentOptionCardArtDrawableLoader,
     private val context: Context,
 ) {
-    fun create(selection: PaymentSelection, linkBrand: LinkBrand?): PaymentOption {
+    fun create(
+        selection: PaymentSelection,
+        linkBrand: LinkBrand?,
+        appearance: PaymentSheet.Appearance?,
+    ): PaymentOption {
         val drawableResourceId = selection.drawableResourceId
         val lightThemeIconUrl = selection.lightThemeIconUrl
         val darkThemeIconUrl = selection.darkThemeIconUrl
@@ -30,9 +39,20 @@ internal class PaymentOptionFactory @Inject constructor(
                     drawableResourceIdNight = drawableResourceId,
                     lightThemeIconUrl = lightThemeIconUrl,
                     darkThemeIconUrl = darkThemeIconUrl,
+                    useDarkThemeIcon = useDarkThemeIcon(appearance),
                 )
             },
         )
+    }
+
+    private fun useDarkThemeIcon(appearance: PaymentSheet.Appearance?): Boolean? {
+        if (appearance == null) {
+            return null
+        }
+
+        val isDark = appearance.themeMode.isDarkTheme(context.isSystemDarkTheme())
+        val componentColor = Color(appearance.getColors(isDark).component)
+        return componentColor.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -300,12 +300,34 @@ internal sealed class PaymentSelection : Parcelable {
             lightThemeIconUrl: String?,
             darkThemeIconUrl: String?,
         ): Drawable {
+            return load(
+                drawableResourceId = drawableResourceId,
+                drawableResourceIdNight = drawableResourceIdNight,
+                lightThemeIconUrl = lightThemeIconUrl,
+                darkThemeIconUrl = darkThemeIconUrl,
+                useDarkThemeIcon = null,
+            )
+        }
+
+        suspend fun load(
+            @DrawableRes drawableResourceId: Int,
+            @DrawableRes drawableResourceIdNight: Int?,
+            lightThemeIconUrl: String?,
+            darkThemeIconUrl: String?,
+            useDarkThemeIcon: Boolean?,
+        ): Drawable {
+            val shouldUseDarkThemeIcon = useDarkThemeIcon ?: isDarkTheme()
+
             fun loadResource(): Drawable {
                 @Suppress("DEPRECATION")
                 return runCatching {
                     ResourcesCompat.getDrawable(
                         resources,
-                        if (!isDarkTheme()) drawableResourceId else drawableResourceIdNight ?: drawableResourceId,
+                        if (shouldUseDarkThemeIcon) {
+                            drawableResourceIdNight ?: drawableResourceId
+                        } else {
+                            drawableResourceId
+                        },
                         null
                     )
                 }.getOrNull() ?: emptyDrawable
@@ -319,7 +341,7 @@ internal sealed class PaymentSelection : Parcelable {
 
             // If the payment option has an icon URL, we prefer it.
             // Some payment options don't have an icon URL, and are loaded locally via resource.
-            return if (isDarkTheme() && darkThemeIconUrl != null) {
+            return if (shouldUseDarkThemeIcon && darkThemeIconUrl != null) {
                 loadIcon(darkThemeIconUrl)
             } else if (lightThemeIconUrl != null) {
                 loadIcon(lightThemeIconUrl)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -299,21 +299,6 @@ internal sealed class PaymentSelection : Parcelable {
             @DrawableRes drawableResourceIdNight: Int?,
             lightThemeIconUrl: String?,
             darkThemeIconUrl: String?,
-        ): Drawable {
-            return load(
-                drawableResourceId = drawableResourceId,
-                drawableResourceIdNight = drawableResourceIdNight,
-                lightThemeIconUrl = lightThemeIconUrl,
-                darkThemeIconUrl = darkThemeIconUrl,
-                useDarkThemeIcon = null,
-            )
-        }
-
-        suspend fun load(
-            @DrawableRes drawableResourceId: Int,
-            @DrawableRes drawableResourceIdNight: Int?,
-            lightThemeIconUrl: String?,
-            darkThemeIconUrl: String?,
             useDarkThemeIcon: Boolean?,
         ): Drawable {
             val shouldUseDarkThemeIcon = useDarkThemeIcon ?: isDarkTheme()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.model
 
 import android.content.Context
 import android.graphics.drawable.ShapeDrawable
+import androidx.compose.ui.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
@@ -13,16 +14,21 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.Test
 
+@OptIn(AppearanceAPIAdditionsPreview::class)
 @Suppress("DEPRECATION")
 @RunWith(RobolectricTestRunner::class)
 class PaymentOptionFactoryTest {
@@ -33,7 +39,7 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with GooglePay should return expected object`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.GooglePay, null)
+        val paymentOption = factory.create(PaymentSelection.GooglePay, null, appearance = null)
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_google_pay_mark)
         assertThat(paymentOption.label).isEqualTo("Google Pay")
         assertThat(paymentOption.paymentMethodType).isEqualTo("google_pay")
@@ -50,6 +56,7 @@ class PaymentOptionFactoryTest {
                 )
             ),
             null,
+            appearance = null,
         )
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
         assertThat(paymentOption.label).isEqualTo("···· 4242")
@@ -69,6 +76,7 @@ class PaymentOptionFactoryTest {
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
             ),
             null,
+            appearance = null,
         )
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
         assertThat(paymentOption.label).isEqualTo("···· 4242")
@@ -95,6 +103,7 @@ class PaymentOptionFactoryTest {
                 )
             ),
             null,
+            appearance = null,
         )
         assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
         assertThat(paymentOption.label).isEqualTo("···· 4242")
@@ -113,7 +122,7 @@ class PaymentOptionFactoryTest {
             .setCard(PaymentMethod.Card(last4 = "4242", brand = CardBrand.Visa, displayBrand = "visa"))
             .build()
 
-        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null)
+        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null, appearance = null)
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
     }
@@ -128,7 +137,7 @@ class PaymentOptionFactoryTest {
             .setCard(PaymentMethod.Card(last4 = "4242", brand = CardBrand.Visa, displayBrand = "visa"))
             .build()
 
-        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null)
+        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null, appearance = null)
 
         assertThat(paymentOption.billingDetails).isNull()
     }
@@ -149,6 +158,7 @@ class PaymentOptionFactoryTest {
                 darkThemeIconUrl = null
             ),
             null,
+            appearance = null,
         )
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
@@ -157,7 +167,7 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with Google Pay should not include billing details`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.GooglePay, null)
+        val paymentOption = factory.create(PaymentSelection.GooglePay, null, appearance = null)
 
         assertThat(paymentOption.billingDetails).isNull()
     }
@@ -165,7 +175,11 @@ class PaymentOptionFactoryTest {
     @Test
     fun `create() with Link should not include billing details`() {
         val factory = createFactory()
-        val paymentOption = factory.create(PaymentSelection.Link(brand = LinkBrand.Link), null)
+        val paymentOption = factory.create(
+            PaymentSelection.Link(brand = LinkBrand.Link),
+            null,
+            appearance = null,
+        )
 
         assertThat(paymentOption.billingDetails).isNull()
     }
@@ -182,6 +196,7 @@ class PaymentOptionFactoryTest {
                 darkThemeIconUrl = null,
             ),
             null,
+            appearance = null,
         )
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
@@ -200,6 +215,7 @@ class PaymentOptionFactoryTest {
                 darkThemeIconUrl = null,
             ),
             null,
+            appearance = null,
         )
 
         assertThat(paymentOption.billingDetails).isEqualTo(PAYMENT_SHEET_BILLING_DETAILS)
@@ -221,7 +237,7 @@ class PaymentOptionFactoryTest {
             .setCard(PaymentMethod.Card(last4 = "4242", brand = CardBrand.Visa, displayBrand = "visa"))
             .build()
 
-        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null)
+        val paymentOption = factory.create(PaymentSelection.Saved(paymentMethod), null, appearance = null)
 
         assertThat(paymentOption.billingDetails).isEqualTo(
             PaymentSheet.BillingDetails(
@@ -241,13 +257,57 @@ class PaymentOptionFactoryTest {
     }
 
     @Test
+    @Config(qualifiers = "notnight")
+    fun `always dark uses dark icon on light system`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysDark,
+        lightComponent = Color.White,
+        darkComponent = Color.Black,
+    ) {
+        assertThat(loadedUrl).isEqualTo(DARK_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `always light uses light icon on dark system`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysLight,
+        lightComponent = Color.White,
+        darkComponent = Color.Black,
+    ) {
+        assertThat(loadedUrl).isEqualTo(LIGHT_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "notnight")
+    fun `always dark with bright component uses light icon`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysDark,
+        lightComponent = Color.Black,
+        darkComponent = Color.White,
+    ) {
+        assertThat(loadedUrl).isEqualTo(LIGHT_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `always light with dark component uses dark icon`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysLight,
+        lightComponent = Color.Black,
+        darkComponent = Color.White,
+    ) {
+        assertThat(loadedUrl).isEqualTo(DARK_ICON_URL)
+    }
+
+    @Test
     fun `icon() returns card art drawable when loader provides one`() {
         val cardArtDrawable = ShapeDrawable()
         val factory = createFactory(
             cardArtDrawableLoader = { cardArtDrawable },
         )
 
-        val option = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD), null)
+        val option = factory.create(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            null,
+            appearance = null,
+        )
         val icon = option.icon()
 
         assertThat(icon.current).isEqualTo(cardArtDrawable)
@@ -259,10 +319,53 @@ class PaymentOptionFactoryTest {
             cardArtDrawableLoader = { null },
         )
 
-        val option = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD), null)
+        val option = factory.create(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            null,
+            appearance = null,
+        )
         val icon = option.icon()
 
         assertThat(icon.current).isNotInstanceOf(ShapeDrawable::class.java)
+    }
+
+    private fun runIconScenario(
+        themeMode: PaymentSheet.ThemeMode,
+        lightComponent: Color,
+        darkComponent: Color,
+        block: IconScenario.() -> Unit,
+    ) = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val imageLoader = FakeStripeImageLoader()
+        val factory = PaymentOptionFactory(
+            iconLoader = PaymentSelection.IconLoader(
+                resources = context.resources,
+                imageLoader = imageLoader,
+            ),
+            cardArtDrawableLoader = { null },
+            context = context,
+        )
+        val appearance = PaymentSheet.Appearance.Builder()
+            .colorsLight(PaymentSheet.Colors.Builder.light().component(lightComponent).build())
+            .colorsDark(PaymentSheet.Colors.Builder.dark().component(darkComponent).build())
+            .themeMode(themeMode)
+            .build()
+        val selection = PaymentSelection.CustomPaymentMethod(
+            id = "cpm_123",
+            billingDetails = null,
+            label = "CPM".resolvableString,
+            lightThemeIconUrl = LIGHT_ICON_URL,
+            darkThemeIconUrl = DARK_ICON_URL,
+        )
+
+        factory.create(
+            selection = selection,
+            linkBrand = null,
+            appearance = appearance,
+        ).icon()
+
+        IconScenario(loadedUrl = imageLoader.awaitLoadCall().url).apply(block)
+        imageLoader.ensureAllEventsConsumed()
     }
 
     private fun createFactory(
@@ -280,6 +383,9 @@ class PaymentOptionFactoryTest {
     }
 
     private companion object {
+        const val LIGHT_ICON_URL = "light_icon_url"
+        const val DARK_ICON_URL = "dark_icon_url"
+
         val PAYMENT_METHOD_BILLING_DETAILS = PaymentMethod.BillingDetails(
             address = Address(
                 city = "San Francisco",
@@ -308,4 +414,8 @@ class PaymentOptionFactoryTest {
             phone = "+15555555555"
         )
     }
+
+    private data class IconScenario(
+        val loadedUrl: String,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
@@ -170,22 +170,13 @@ internal class PaymentSelectionIconLoaderTest {
             resources = ApplicationProvider.getApplicationContext<Context>().resources,
             imageLoader = imageLoader,
         )
-        val drawable = if (useDarkThemeIcon == null) {
-            iconLoader.load(
-                drawableResourceId = iconRes ?: 0,
-                drawableResourceIdNight = iconResNight,
-                lightThemeIconUrl = iconUrl,
-                darkThemeIconUrl = darkIconUrl,
-            )
-        } else {
-            iconLoader.load(
-                drawableResourceId = iconRes ?: 0,
-                drawableResourceIdNight = iconResNight,
-                lightThemeIconUrl = iconUrl,
-                darkThemeIconUrl = darkIconUrl,
-                useDarkThemeIcon = useDarkThemeIcon,
-            )
-        }
+        val drawable = iconLoader.load(
+            drawableResourceId = iconRes ?: 0,
+            drawableResourceIdNight = iconResNight,
+            lightThemeIconUrl = iconUrl,
+            darkThemeIconUrl = darkIconUrl,
+            useDarkThemeIcon = useDarkThemeIcon,
+        )
         advanceUntilIdle()
 
         val expectedUrl = if (useDarkThemeIcon == true && darkIconUrl != null) darkIconUrl else iconUrl

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
@@ -17,13 +17,16 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentSelectionIconLoaderTest {
 
     private val workingUrl = "working url"
     private val brokenUrl = "broken url"
+    private val darkUrl = "dark url"
     private val simpleBitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
+    private val darkBitmap = Bitmap.createBitmap(20, 20, Bitmap.Config.ARGB_8888)
     private val testDispatcher = StandardTestDispatcher()
 
     @Test
@@ -69,30 +72,130 @@ internal class PaymentSelectionIconLoaderTest {
         assertThat(drawable.current).isEqualTo(PaymentSelection.IconLoader.emptyDrawable)
     }
 
+    @Test
+    fun loadPaymentOptionWithIconUrl_explicitDark_usesDarkIconFromUrl() = runExplicitScenario(
+        iconUrl = workingUrl,
+        darkIconUrl = darkUrl,
+        iconRes = R.drawable.stripe_ic_paymentsheet_card_unknown_day,
+        iconResNight = R.drawable.stripe_ic_paymentsheet_card_unknown_night,
+        useDarkThemeIcon = true,
+    ) {
+        assertThat(drawable.current).isInstanceOf<BitmapDrawable>()
+        assertThat((drawable.current as BitmapDrawable).bitmap).isEqualTo(darkBitmap)
+        assertThat(loadedUrl).isEqualTo(darkUrl)
+    }
+
+    @Test
+    fun loadPaymentOptionWithIconUrl_explicitLight_usesLightIconFromUrl() = runExplicitScenario(
+        iconUrl = workingUrl,
+        darkIconUrl = darkUrl,
+        iconRes = R.drawable.stripe_ic_paymentsheet_card_unknown_day,
+        iconResNight = R.drawable.stripe_ic_paymentsheet_card_unknown_night,
+        useDarkThemeIcon = false,
+    ) {
+        assertThat(drawable.current).isInstanceOf<BitmapDrawable>()
+        assertThat((drawable.current as BitmapDrawable).bitmap).isEqualTo(simpleBitmap)
+        assertThat(loadedUrl).isEqualTo(workingUrl)
+    }
+
+    @Test
+    fun loadPaymentOptionWithoutIconUrl_explicitDark_usesNightResource() = runExplicitScenario(
+        iconUrl = null,
+        darkIconUrl = null,
+        iconRes = R.drawable.stripe_ic_paymentsheet_card_unknown_day,
+        iconResNight = R.drawable.stripe_ic_paymentsheet_card_unknown_night,
+        useDarkThemeIcon = true,
+    ) {
+        assertThat(shadowOf(drawable.current).createdFromResId)
+            .isEqualTo(R.drawable.stripe_ic_paymentsheet_card_unknown_night)
+    }
+
+    @Test
+    fun loadPaymentOptionWithoutIconUrl_explicitLight_usesDayResource() = runExplicitScenario(
+        iconUrl = null,
+        darkIconUrl = null,
+        iconRes = R.drawable.stripe_ic_paymentsheet_card_unknown_day,
+        iconResNight = R.drawable.stripe_ic_paymentsheet_card_unknown_night,
+        useDarkThemeIcon = false,
+    ) {
+        assertThat(shadowOf(drawable.current).createdFromResId)
+            .isEqualTo(R.drawable.stripe_ic_paymentsheet_card_unknown_day)
+    }
+
     private fun runScenario(
         iconUrl: String?,
         iconRes: Int?,
         block: Scenario.() -> Unit,
+    ) = runScenario(
+        iconUrl = iconUrl,
+        darkIconUrl = null,
+        iconRes = iconRes,
+        iconResNight = null,
+        useDarkThemeIcon = null,
+        block = block,
+    )
+
+    private fun runExplicitScenario(
+        iconUrl: String?,
+        darkIconUrl: String?,
+        iconRes: Int?,
+        iconResNight: Int?,
+        useDarkThemeIcon: Boolean,
+        block: Scenario.() -> Unit,
+    ) = runScenario(
+        iconUrl = iconUrl,
+        darkIconUrl = darkIconUrl,
+        iconRes = iconRes,
+        iconResNight = iconResNight,
+        useDarkThemeIcon = useDarkThemeIcon,
+        block = block,
+    )
+
+    private fun runScenario(
+        iconUrl: String?,
+        darkIconUrl: String?,
+        iconRes: Int?,
+        iconResNight: Int?,
+        useDarkThemeIcon: Boolean?,
+        block: Scenario.() -> Unit,
     ) = runTest(testDispatcher) {
-        val drawable = PaymentSelection.IconLoader(
-            resources = ApplicationProvider.getApplicationContext<Context>().resources,
-            imageLoader = FakeStripeImageLoader(
-                loadResultByUrl = mapOf(
-                    workingUrl to Result.success(simpleBitmap),
-                    brokenUrl to Result.failure(Throwable()),
-                ),
+        val imageLoader = FakeStripeImageLoader(
+            loadResultByUrl = mapOf(
+                workingUrl to Result.success(simpleBitmap),
+                darkUrl to Result.success(darkBitmap),
+                brokenUrl to Result.failure(Throwable()),
             ),
-        ).load(
-            drawableResourceId = iconRes ?: 0,
-            drawableResourceIdNight = null,
-            lightThemeIconUrl = iconUrl,
-            darkThemeIconUrl = null,
         )
+        val iconLoader = PaymentSelection.IconLoader(
+            resources = ApplicationProvider.getApplicationContext<Context>().resources,
+            imageLoader = imageLoader,
+        )
+        val drawable = if (useDarkThemeIcon == null) {
+            iconLoader.load(
+                drawableResourceId = iconRes ?: 0,
+                drawableResourceIdNight = iconResNight,
+                lightThemeIconUrl = iconUrl,
+                darkThemeIconUrl = darkIconUrl,
+            )
+        } else {
+            iconLoader.load(
+                drawableResourceId = iconRes ?: 0,
+                drawableResourceIdNight = iconResNight,
+                lightThemeIconUrl = iconUrl,
+                darkThemeIconUrl = darkIconUrl,
+                useDarkThemeIcon = useDarkThemeIcon,
+            )
+        }
         advanceUntilIdle()
-        Scenario(drawable = drawable).apply { block() }
+
+        val expectedUrl = if (useDarkThemeIcon == true && darkIconUrl != null) darkIconUrl else iconUrl
+        val loadedUrl = expectedUrl?.let { imageLoader.awaitLoadCall().url }
+        Scenario(drawable = drawable, loadedUrl = loadedUrl).apply { block() }
+        imageLoader.ensureAllEventsConsumed()
     }
 
     private class Scenario(
-        val drawable: Drawable
+        val drawable: Drawable,
+        val loadedUrl: String?,
     )
 }


### PR DESCRIPTION
# Summary

- Uses the configured `PaymentSheet.Appearance` when FlowController creates payment-option icons.
- Selects light or dark icon assets from the effective appearance palette and component luminance.
- Preserves legacy icon-theme detection for CustomerSheet and other consumers that have not migrated yet.
- Leaves Link behavior unchanged.

# Motivation

FlowController payment-option icons previously selected their light or dark asset from the system theme or mutable global `StripeTheme` colors. This could disagree with PaymentSheet when `ThemeMode.AlwaysLight` or `ThemeMode.AlwaysDark` overrides the system setting, or when the selected appearance palette uses a component color with the opposite luminance.

This change passes FlowController's configured appearance to `PaymentOptionFactory` and lets the icon loader use an explicit appearance-derived icon variant. Passing no appearance retains the existing behavior so CustomerSheet can migrate separately.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `PaymentSelectionIconLoaderTest`
- `PaymentOptionFactoryTest`
- `DefaultFlowControllerTest`
- `LinkControllerPaymentMethodPreviewScreenshotTest` Paparazzi verification
- `:paymentsheet:compileDebugKotlin`
- `:paymentsheet:apiCheck`
- `:paymentsheet:detekt`

# Screenshots

No visual baseline changes are expected. The existing Link payment-method-preview Paparazzi snapshots pass.

# Changelog

No changelog entry. This is an internal theme-plumbing correction within the existing Appearance API.
