### PR TITLE
Fix payment cancellation test flakes

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.lpm
 
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -17,11 +16,9 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_ACCOUNT_DETAILS
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
-import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -65,9 +62,8 @@ internal class TestInstantDebits : BasePlaygroundTest() {
             testParameters = makeLinkTestParameters(email).copy(
                 authorizationAction = AuthorizeAction.Cancel,
             ),
-            afterAuthorization = { _, _ ->
-                ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
-                    .waitFor(isEnabled())
+            afterAuthorization = { selectors, _ ->
+                selectors.buyButton.waitProcessingComplete()
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.lpm
 
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -16,11 +15,9 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_ACCOUNT_DETAILS
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
-import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -64,9 +61,8 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
             testParameters = makeLinkTestParameters(email).copy(
                 authorizationAction = AuthorizeAction.Cancel,
             ),
-            afterAuthorization = { _, _ ->
-                ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
-                    .waitFor(isEnabled())
+            afterAuthorization = { selectors, _ ->
+                selectors.buyButton.waitProcessingComplete()
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -208,9 +208,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
             testParameters = testParameters.copy(
                 authorizationAction = AuthorizeAction.Cancel,
             ),
-            afterAuthorization = { _, _ ->
-                ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
-                    .waitFor(isEnabled())
+            afterAuthorization = { selectors, _ ->
+                selectors.buyButton.waitProcessingComplete()
             }
         )
     }
@@ -225,9 +224,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
                 }.copy(
                     authorizationAction = AuthorizeAction.Cancel,
                 ),
-            afterAuthorization = { _, _ ->
-                ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
-                    .waitFor(isEnabled())
+            afterAuthorization = { selectors, _ ->
+                selectors.buyButton.waitProcessingComplete()
             }
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -782,6 +782,7 @@ internal class PlaygroundTestDriver(
         )
 
         isSelectPaymentMethodScreen()
+        selectors.buyButton.waitProcessingComplete()
         selectors.buyButton.isEnabled()
 
         teardown()


### PR DESCRIPTION
# Summary
Synchronize PaymentSheet cancellation E2E tests with completion of the primary button processing state.

# Motivation
After external authorization cancellation, Compose can still be recomposing the PaymentSheet while the test reads the primary button semantics tree. This caused intermittent `ArrayIndexOutOfBoundsException` failures in `SlotWriter.moveSlotGapTo`.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Focused managed-device tests on `pixel2api33chrome`:
- All five cancellation tests passed with diagnostic Shampoo(2): external payment method, US bank account, US bank account Lite, Instant Debits, and Link card brand.
- `testExternalPaymentMethod_Cancel` passed Shampoo(50); Shampoo was diagnostic-only and restored before the final diff.
- All five cancellation tests passed once with the normal `RetryRule` configuration.
- `git diff --check` passed.

# Screenshots
Not applicable: this changes test synchronization only and does not change UI appearance.

# Changelog
Not applicable: this is an instrumentation-test flake fix with no user-facing behavior change.
