### PR TITLE
Refresh checkout session state after non-successful confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -2,8 +2,10 @@
 
 package com.stripe.android.checkout
 
+import com.stripe.android.core.Logger
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +18,8 @@ import javax.inject.Singleton
 internal class CheckoutOperationCoordinator @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val sheetStateHolder: SheetStateHolder,
+    private val sessionRefresher: CheckoutSessionRefresher,
+    private val logger: Logger,
     private val resultCallback: CheckoutController.ResultCallback,
 ) {
     private val admissionLock = Any()
@@ -110,16 +114,24 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation(state.result.asCheckoutResult())
+                completeConfirmation {
+                    if (state.result !is ConfirmationHandler.Result.Succeeded) {
+                        refreshSession()
+                    }
+                    state.result.asCheckoutResult()
+                }
             }
         }
     }
 
-    fun failConfirmation(error: Throwable) {
-        completeConfirmation(CheckoutController.Result.Failed(error))
+    suspend fun failConfirmation(error: Throwable) {
+        completeConfirmation {
+            refreshSession()
+            CheckoutController.Result.Failed(error)
+        }
     }
 
-    private fun completeConfirmation(result: CheckoutController.Result) {
+    private suspend fun completeConfirmation(result: suspend () -> CheckoutController.Result) {
         val shouldComplete = synchronized(admissionLock) {
             if (!confirmationInFlight || confirmationCompletionClaimed) {
                 false
@@ -131,7 +143,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         if (!shouldComplete) return
 
         try {
-            resultCallback.onResult(result)
+            resultCallback.onResult(result())
         } finally {
             synchronized(admissionLock) {
                 confirmationInFlight = false
@@ -139,6 +151,20 @@ internal class CheckoutOperationCoordinator @Inject constructor(
                 mutex.unlock()
                 updateIsUpdating()
             }
+        }
+    }
+
+    /**
+     * The refreshed state has to be committed before the result reaches the integrator, but a failed
+     * refresh must not replace the confirmation result the integrator is waiting on.
+     */
+    private suspend fun refreshSession() {
+        try {
+            sessionRefresher.refresh()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            logger.error("Failed to refresh the checkout session after confirmation.", error)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import javax.inject.Inject
+
+/**
+ * Re-fetches the current checkout session and reloads the controller's state from the fresh
+ * response, so state that was loaded before a confirmation doesn't outlive it.
+ */
+internal fun interface CheckoutSessionRefresher {
+    suspend fun refresh()
+}
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutSessionRefresher @Inject constructor(
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val checkoutSessionRepository: CheckoutSessionRepository,
+    private val checkoutStateLoader: CheckoutStateLoader,
+) : CheckoutSessionRefresher {
+    override suspend fun refresh() {
+        val state = stateHolder.state ?: return
+        val response = checkoutSessionRepository.init(
+            sessionId = state.checkoutSessionResponse.id,
+            adaptivePricingAllowed = state.configuration.adaptivePricingAllowed,
+        ).getOrThrow()
+        checkoutStateLoader.reload(state.copy(checkoutSessionResponse = response))
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -12,7 +12,9 @@ import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerSavedState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutPaymentOptionDisplayDataFactory
+import com.stripe.android.checkout.CheckoutSessionRefresher
 import com.stripe.android.checkout.DefaultCheckoutPaymentOptionDisplayDataFactory
+import com.stripe.android.checkout.DefaultCheckoutSessionRefresher
 import com.stripe.android.checkout.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.checkout.ece.DefaultAvailableExpressButtonTypesFactory
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
@@ -208,6 +210,9 @@ internal interface CheckoutControllerModule {
     fun bindsAvailableExpressButtonTypesFactory(
         impl: DefaultAvailableExpressButtonTypesFactory
     ): AvailableExpressButtonTypesFactory
+
+    @Binds
+    fun bindsCheckoutSessionRefresher(impl: DefaultCheckoutSessionRefresher): CheckoutSessionRefresher
 
     companion object {
         @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
@@ -102,6 +103,8 @@ internal class CheckoutConfirmationPerformerTest {
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
+            sessionRefresher = {},
+            logger = Logger.noop(),
             resultCallback = {},
         )
         val performer = CheckoutConfirmationPerformer(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntentFixtures
@@ -13,6 +14,7 @@ import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,6 +28,7 @@ import org.junit.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
 
 internal class CheckoutOperationCoordinatorTest {
 
@@ -274,6 +277,7 @@ internal class CheckoutOperationCoordinatorTest {
                 ConfirmationHandler.Result.Canceled.Action.None
             )
         )
+        refreshCalls.awaitItem()
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
         assertThat(coordinator.isUpdating.value).isFalse()
 
@@ -310,6 +314,7 @@ internal class CheckoutOperationCoordinatorTest {
                     ConfirmationHandler.Result.Canceled.Action.None
                 )
             )
+            refreshCalls.awaitItem()
             assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
             mutation.await()
 
@@ -340,6 +345,7 @@ internal class CheckoutOperationCoordinatorTest {
             )
         )
 
+        refreshCalls.awaitItem()
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
@@ -357,6 +363,7 @@ internal class CheckoutOperationCoordinatorTest {
             )
         )
 
+        refreshCalls.awaitItem()
         val result = resultTurbine.awaitItem()
         assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
         assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
@@ -370,9 +377,85 @@ internal class CheckoutOperationCoordinatorTest {
 
         coordinator.failConfirmation(expected)
 
+        refreshCalls.awaitItem()
         val result = resultTurbine.awaitItem()
         assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
         assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `failed confirmation refreshes the checkout session before delivering the result`() {
+        val releaseRefresh = CompletableDeferred<Unit>()
+        val expected = IllegalStateException("Confirmation failed")
+
+        runScenario(onRefresh = { releaseRefresh.await() }) {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Failed(
+                    cause = expected,
+                    message = "Confirmation failed".resolvableString,
+                    type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                )
+            )
+
+            refreshCalls.awaitItem()
+            resultTurbine.expectNoEvents()
+            assertThat(coordinator.isUpdating.value).isTrue()
+
+            releaseRefresh.complete(Unit)
+
+            val result = resultTurbine.awaitItem()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+            assertThat(coordinator.isUpdating.value).isFalse()
+        }
+    }
+
+    @Test
+    fun `successful confirmation does not refresh the checkout session`() = runScenario {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        refreshCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `refresh failure still delivers the confirmation result`() = runScenario(
+        onRefresh = { error("Refresh failed") },
+    ) {
+        val expected = IllegalStateException("Confirmation failed")
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Failed(
+                cause = expected,
+                message = "Confirmation failed".resolvableString,
+                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            )
+        )
+
+        refreshCalls.awaitItem()
+        val result = resultTurbine.awaitItem()
+        assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        assertThat(coordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
+    fun `refresh cancellation propagates and still releases the operation gate`() = runScenario(
+        onRefresh = { throw CancellationException("Refresh canceled") },
+    ) {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        assertFailsWith<CancellationException> {
+            coordinator.failConfirmation(IllegalStateException("Start failed"))
+        }
+
+        refreshCalls.awaitItem()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
@@ -406,6 +489,7 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(deliveredResults).hasSize(1)
             releaseCallback.countDown()
             failureCompletion.await()
+            refreshCalls.awaitItem()
 
             assertThat(deliveredResults).hasSize(1)
             val result = deliveredResults.single()
@@ -439,6 +523,7 @@ internal class CheckoutOperationCoordinatorTest {
                 ConfirmationHandler.Result.Canceled.Action.None
             )
         )
+        refreshCalls.awaitItem()
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
         mutation.await()
 
@@ -525,6 +610,7 @@ internal class CheckoutOperationCoordinatorTest {
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
         hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
+        onRefresh: suspend () -> Unit = {},
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationState = MutableStateFlow(initialConfirmationState)
@@ -536,9 +622,15 @@ internal class CheckoutOperationCoordinatorTest {
             this.sheetIsOpen = sheetIsOpen
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
+        val refreshCalls = Turbine<Unit>()
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
+            sessionRefresher = {
+                refreshCalls.add(Unit)
+                onRefresh()
+            },
+            logger = Logger.noop(),
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
         )
         backgroundScope.launch {
@@ -550,17 +642,20 @@ internal class CheckoutOperationCoordinatorTest {
             coordinator = coordinator,
             confirmationState = confirmationState,
             resultTurbine = resultTurbine,
+            refreshCalls = refreshCalls,
             testScope = this,
         ).block()
 
         confirmationHandler.validate()
         resultTurbine.ensureAllEventsConsumed()
+        refreshCalls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val coordinator: CheckoutOperationCoordinator,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
+        val refreshCalls: Turbine<Unit>,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
         val backgroundScope = testScope.backgroundScope

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutOperationCoordinator
 import com.stripe.android.checkout.GooglePayConfiguration
+import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
@@ -219,6 +220,8 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
+            sessionRefresher = {},
+            logger = Logger.noop(),
             resultCallback = {},
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(


### PR DESCRIPTION
# Summary

Re-fetches the checkout session and reloads the controller's state before delivering a failed or canceled confirmation result.

- New `CheckoutSessionRefresher` re-runs `CheckoutSessionRepository.init` for the current session and pipes the fresh response through `CheckoutStateLoader.reload`.
- `CheckoutOperationCoordinator` refreshes on every non-`Succeeded` terminal path: `Failed`, all three `Canceled.Action`s, and the start failure delivered through `failConfirmation`.
- Refresh failures are logged and swallowed, so they can't replace the confirmation result the integrator is waiting on. `CancellationException` propagates.
- The success path takes no refresh and no extra `/init` round-trip.

The refresh runs inside `completeConfirmation` — after the completion is claimed, before the result callback — so it can't fire for a completion the gate treats as a no-op, and no mutation can interleave with it. `completeConfirmation` and `failConfirmation` are now `suspend`; both `failConfirmation` call sites are already inside `viewModelScope.launch { try/catch }`.

# Motivation

After a failed or canceled confirmation, the controller kept serving the state it loaded *before* confirmation. That state can be stale in ways that matter: a decline may change payment method availability, the session may have been partially updated server-side, or the saved payment methods list may have changed. Refreshing first means whatever the integrator or customer does next starts from current server state.

The cost is an `/init` round-trip on every failed and canceled path, including `Canceled.Action.ModifyPaymentDetails`.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Added to `CheckoutOperationCoordinatorTest`:

- A failed confirmation refreshes before the result is delivered, with the operation gate still held during the refresh.
- A successful confirmation does not refresh.
- A refresh failure still delivers the confirmation result.
- A refresh cancellation propagates and still releases the operation gate.

Seven existing tests that complete non-successfully now consume a refresh event, so a missing or unexpected refresh fails the test.

`:paymentsheet:testDebugUnitTest` for `com.stripe.android.checkout`: 319 tests, 0 failures. `:paymentsheet:detekt` clean.

# Changelog

N/A — all changed types are `internal`.
