### PR TITLE
Fix deferred PMO SFU test timeout

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethod
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_SELECTOR_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
+import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -412,7 +413,7 @@ internal class TestCard : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText("4242", substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )


### PR DESCRIPTION
# Summary

Use the shared PaymentSheet UI timeout when waiting for the saved card in the deferred PMO SFU E2E test.

# Motivation

`testCardWithPmoSfuDeferred` intermittently timed out after five seconds before the selected saved card ending in 4242 appeared. The assertion remains exact; this gives the server-backed PaymentSheet state the standard 15-second UI deadline.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Baseline diagnostic-only ShampooRule(2) run passed both iterations. Candidate 2- and 50-iteration managed-device soaks, plus the final normal run, were blocked when `pixel2api33chrome` stalled during instrumentation; no diagnostic rule changes are included in this PR.

# Screenshots

Not applicable — instrumentation-test-only timeout change.

# Changelog

Not applicable — test-only change with no customer-facing behavior.
