### PR TITLE
Fix confirmation token bank account test flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -901,7 +901,7 @@ internal class PlaygroundTestDriver(
             testParameters = testParameters,
             executeFlow = { doUSBankAccountAuthorization(testParameters.authorizationAction) },
             afterCollectingBankInfo = {
-                composeTestRule.waitUntil { selectors.buyButton.checkEnabled() }
+                selectors.buyButton.waitProcessingComplete()
                 selectors.buyButton.click()
                 selectors.playgroundBuyButton.apply {
                     waitFor(isEnabled())


### PR DESCRIPTION
# Summary

Use the existing `BuyButton.waitProcessingComplete()` synchronization in the custom US bank account confirmation-token flow before clicking the PaymentSheet primary button.

# Motivation

The flow previously used Compose `waitUntil` with its default 1-second timeout while waiting for the primary button to become enabled. Bank-account authorization can legitimately take longer, causing `ComposeTimeoutException` before the tested purchase behavior runs.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Focused managed-device command:

```text
CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestConfirmationToken#testBankAccountWithConfirmationTokenInCustomFlow_withCSC' :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
```

- Diagnostic Shampoo smoke run: 2/2 iterations passed.
- Diagnostic 50-iteration run: 47 iterations passed; iteration 47 hit the managed-device 90-second Compose/Espresso timeout during Chrome/device instability. Shampoo was diagnostic-only and restored before submission.
- Normal configuration: 1/1 focused test passed.
- `git diff --check`: passed.

# Screenshots

Not applicable: this changes test synchronization only and does not change product UI.

# Changelog

Not applicable: internal test-only flake fix.
