### PR TITLE
Add shipping address callback for Google Pay for Checkout Sessions

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -406,7 +406,7 @@ class GooglePayJsonFactory internal constructor(
 
     @Parcelize
     @Poko
-    class TransactionInfo internal constructor(
+    class TransactionInfo @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(
         internal val currencyCode: String,
         internal val totalPriceStatus: TotalPriceStatus,
         internal val countryCode: String?,

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -407,14 +407,22 @@ class GooglePayJsonFactory internal constructor(
     @Parcelize
     @Poko
     class TransactionInfo @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(
-        internal val currencyCode: String,
-        internal val totalPriceStatus: TotalPriceStatus,
-        internal val countryCode: String?,
-        internal val transactionId: String?,
-        internal val totalPrice: Long?,
-        internal val totalPriceLabel: String?,
-        internal val checkoutOption: CheckoutOption?,
-        internal val displayItems: List<DisplayItem> = emptyList(),
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val currencyCode: String,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val totalPriceStatus: TotalPriceStatus,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val countryCode: String?,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val transactionId: String?,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val totalPrice: Long?,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val totalPriceLabel: String?,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val checkoutOption: CheckoutOption?,
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val displayItems: List<DisplayItem> = emptyList(),
     ) : Parcelable {
 
         /**

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdate.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdate.kt
@@ -1,8 +1,15 @@
 package com.stripe.android.googlepaylauncher
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.CountryCode
 import dev.drewhamilton.poko.Poko
 
+/**
+ * Represents an update in the Google Pay sheet that requires a response on how to change the sheet
+ *
+ * @param callbackTrigger represents what change to the sheet caused a callback trigger
+ * @param shippingAddress represents the shipping address selected in teh sheet
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Poko
 class GooglePayPaymentDataUpdate(
@@ -11,12 +18,38 @@ class GooglePayPaymentDataUpdate(
 ) {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class CallbackTrigger {
+        /**
+         * Callback is called when the Google Pay sheet is initialized
+         */
         Initialize,
+
+        /**
+         * Callback is called when the shipping address changes in the sheet
+         */
         ShippingAddress,
+
+        /**
+         * Callback is called when the shipping option changes in the sheet
+         */
         ShippingOption,
+
+        /**
+         * Callback is called when the offer changes in the sheet
+         */
         Offer,
     }
 
+    /**
+     * Represents an update in the Google Pay sheet that requires a response on how to change the sheet
+     *
+     * @param administrativeArea country subdivision, such as a state or province
+     * @param countryCode ISO 3166-1 alpha-2 country code
+     * @param locality City, town, neighborhood, or suburb
+     * @param postalCode The redacted postal code based on the country. For Canada and the UK, this contains
+     *   only the first three characters. For US, this contains the first five digits.
+     * @param iso3166AdministrativeArea ISO 3166-2 administrative area code corresponding to administrativeArea.
+     *   Only present if the shipping address format is FULL-ISO3166.
+     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Poko
     class ShippingAddress(
@@ -25,5 +58,31 @@ class GooglePayPaymentDataUpdate(
         val locality: String,
         val postalCode: String,
         val iso3166AdministrativeArea: String?,
-    )
+    ) {
+        /*
+         * Google Pay returns `administrativeArea` as a freeform string (whatever the buyer saved in their wallet),
+         * which can be a full state name like "CALIFORNIA" instead of the ISO code "CA". When we request the
+         * FULL-ISO3166 address format, Google additionally returns `iso3166AdministrativeArea` with the ISO 3166-2
+         * subdivision code (e.g. "US-CA"). For US addresses we parse the subdivision out of that code so the
+         * state is consistently a 2-char ISO code. We scope this to the US to avoid changing behavior for other
+         * countries. See RUN_OCSBUYERXP-1121.
+         */
+        val normalizedAdministrativeArea: String
+            get() {
+                val separated = iso3166AdministrativeArea?.split(SEPARATOR)?.takeIf { it.size >= 2 }
+                    ?: return administrativeArea
+
+                val (country, subdivision) = separated
+
+                return if (country == CountryCode.US.value) {
+                    subdivision.uppercase()
+                } else {
+                    administrativeArea
+                }
+            }
+
+        private companion object {
+            const val SEPARATOR = "-"
+        }
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdate.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdate.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.annotation.RestrictTo
+import dev.drewhamilton.poko.Poko
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Poko
+class GooglePayPaymentDataUpdate(
+    val callbackTrigger: CallbackTrigger,
+    val shippingAddress: ShippingAddress?,
+) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class CallbackTrigger {
+        Initialize,
+        ShippingAddress,
+        ShippingOption,
+        Offer,
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Poko
+    class ShippingAddress(
+        val administrativeArea: String,
+        val countryCode: String,
+        val locality: String,
+        val postalCode: String,
+        val iso3166AdministrativeArea: String?,
+    )
+}

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallback.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface GooglePayPaymentDataUpdateCallback {
+    suspend fun onPaymentDataChanged(
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): GooglePayPaymentDataUpdateResponse
+}

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateResponse.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateResponse.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.GooglePayJsonFactory
+import dev.drewhamilton.poko.Poko
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Poko
+class GooglePayPaymentDataUpdateResponse(
+    val newTransactionInfo: GooglePayJsonFactory.TransactionInfo?,
+    val error: GooglePayPaymentDataError?,
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Poko
+class GooglePayPaymentDataError(
+    val reason: Reason,
+    val message: String,
+    val intent: Intent = Intent.ShippingAddress,
+) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class Reason(val code: String) {
+        ShippingAddressInvalid("SHIPPING_ADDRESS_INVALID"),
+        OtherError("OTHER_ERROR"),
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    enum class Intent(val code: String) {
+        ShippingAddress("SHIPPING_ADDRESS"),
+        Offer("OFFER"),
+        ShippingOption("SHIPPING_OPTION"),
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -357,6 +357,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         CHECKOUT_SELECTION_SET_BEFORE_LOAD(
             partialEventName = "checkout.selection_set_before_load"
+        ),
+        CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER(
+            partialEventName = "checkout.google_pay.unexpected_callback_trigger"
         );
 
         override val eventName: String

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateAddressBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateAddressBuilder.kt
@@ -1,20 +1,16 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
-import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
 internal interface CheckoutGooglePayPaymentDataUpdateAddressBuilder {
     sealed interface Result {
-        data class Success(
-            val address: CheckoutController.Address.State,
-        ) : Result
+        data object Unavailable : Result
 
-        data class Failed(
-            val response: GooglePayPaymentDataUpdateResponse,
+        data class Available(
+            val address: CheckoutController.Address.State,
         ) : Result
     }
 
@@ -28,39 +24,14 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder @Inject c
         paymentDataUpdate: GooglePayPaymentDataUpdate
     ): CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result {
         val shippingAddress = paymentDataUpdate.shippingAddress
-            ?: return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
-                GooglePayPaymentDataUpdateResponse(
-                    newTransactionInfo = null,
-                    error = GooglePayPaymentDataError(
-                        reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                        message = "Shipping address is required.",
-                        intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-                    ),
-                )
-            )
+            ?: return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Unavailable
 
-        if (shippingAddress.countryCode.isBlank()) {
-            return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
-                GooglePayPaymentDataUpdateResponse(
-                    newTransactionInfo = null,
-                    error = GooglePayPaymentDataError(
-                        reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                        message = "Country is required.",
-                        intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-                    ),
-                )
-            )
-        }
-
-        return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success(
+        return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available(
             address = CheckoutController.Address()
                 .country(shippingAddress.countryCode)
                 .city(shippingAddress.locality.takeIf { it.isNotEmpty() })
                 .postalCode(shippingAddress.postalCode.takeIf { it.isNotEmpty() })
-                .state(
-                    shippingAddress.iso3166AdministrativeArea?.takeIf { it.isNotEmpty() }
-                        ?: shippingAddress.administrativeArea.takeIf { it.isNotEmpty() },
-                )
+                .state(shippingAddress.normalizedAdministrativeArea.takeIf { it.isNotEmpty() })
                 .build()
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateAddressBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateAddressBuilder.kt
@@ -1,0 +1,67 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal interface CheckoutGooglePayPaymentDataUpdateAddressBuilder {
+    sealed interface Result {
+        data class Success(
+            val address: CheckoutController.Address.State,
+        ) : Result
+
+        data class Failed(
+            val response: GooglePayPaymentDataUpdateResponse,
+        ) : Result
+    }
+
+    fun build(paymentDataUpdate: GooglePayPaymentDataUpdate): Result
+}
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder @Inject constructor() :
+    CheckoutGooglePayPaymentDataUpdateAddressBuilder {
+    override fun build(
+        paymentDataUpdate: GooglePayPaymentDataUpdate
+    ): CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result {
+        val shippingAddress = paymentDataUpdate.shippingAddress
+            ?: return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
+                GooglePayPaymentDataUpdateResponse(
+                    newTransactionInfo = null,
+                    error = GooglePayPaymentDataError(
+                        reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                        message = "Shipping address is required.",
+                        intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+                    ),
+                )
+            )
+
+        if (shippingAddress.countryCode.isBlank()) {
+            return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
+                GooglePayPaymentDataUpdateResponse(
+                    newTransactionInfo = null,
+                    error = GooglePayPaymentDataError(
+                        reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                        message = "Country is required.",
+                        intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+                    ),
+                )
+            )
+        }
+
+        return CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success(
+            address = CheckoutController.Address()
+                .country(shippingAddress.countryCode)
+                .city(shippingAddress.locality.takeIf { it.isNotEmpty() })
+                .postalCode(shippingAddress.postalCode.takeIf { it.isNotEmpty() })
+                .state(
+                    shippingAddress.iso3166AdministrativeArea?.takeIf { it.isNotEmpty() }
+                        ?: shippingAddress.administrativeArea.takeIf { it.isNotEmpty() },
+                )
+                .build()
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallback.kt
@@ -1,42 +1,57 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.common.model.CommonConfiguration
+import android.content.Context
+import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
+    private val context: Context,
     private val taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
     private val stateHolder: CheckoutControllerStateHolder,
     private val addressBuilder: CheckoutGooglePayPaymentDataUpdateAddressBuilder,
     private val mapper: CheckoutGooglePayPaymentDataUpdateMapper,
+    private val errorReporter: ErrorReporter,
 ) : GooglePayPaymentDataUpdateCallback {
     override suspend fun onPaymentDataChanged(
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse {
-        val currentState = stateHolder.state ?: return GooglePayPaymentDataUpdateResponse(
-            newTransactionInfo = null,
-            error = GooglePayPaymentDataError(
-                reason = GooglePayPaymentDataError.Reason.OtherError,
-                message = "Checkout sessions not configured",
-                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-            )
-        )
+        val currentState = stateHolder.state ?: run {
+            return notConfiguredResponse()
+        }
 
-        return when (paymentDataUpdate.callbackTrigger) {
+        val googlePayConfiguration = currentState.commonConfiguration.googlePay ?: run {
+            reportUnexpectedCallbackTrigger(VALUE_WITHOUT_CONFIG)
+
+            return notConfiguredResponse()
+        }
+
+        return when (val trigger = paymentDataUpdate.callbackTrigger) {
             GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
             GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress -> {
-                updateShippingAddress(currentState, paymentDataUpdate)
+                updateShippingAddress(googlePayConfiguration, currentState, paymentDataUpdate)
             }
             GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption,
             GooglePayPaymentDataUpdate.CallbackTrigger.Offer -> {
+                reportUnexpectedCallbackTrigger(
+                    if (trigger == GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption) {
+                        VALUE_SHIPPING_OPTION_TRIGGER
+                    } else {
+                        VALUE_OFFER_TRIGGER
+                    }
+                )
+
                 mapToResponse(
-                    configuration = currentState.commonConfiguration,
+                    configuration = googlePayConfiguration,
                     response = currentState.checkoutSessionResponse,
                     paymentDataUpdate = paymentDataUpdate,
                 )
@@ -45,14 +60,19 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
     }
 
     private suspend fun updateShippingAddress(
+        googlePayConfiguration: PaymentSheet.GooglePayConfiguration,
         currentState: CheckoutControllerState,
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse {
         val address = when (val result = addressBuilder.build(paymentDataUpdate)) {
-            is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed -> {
-                return result.response
+            is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Unavailable -> {
+                return mapToResponse(
+                    configuration = googlePayConfiguration,
+                    response = currentState.checkoutSessionResponse,
+                    paymentDataUpdate = paymentDataUpdate,
+                )
             }
-            is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success -> {
+            is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available -> {
                 result.address
             }
         }
@@ -63,14 +83,14 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
             address = address,
         ).fold(
             onSuccess = { response ->
-                mapToResponse(currentState.commonConfiguration, response, paymentDataUpdate)
+                mapToResponse(googlePayConfiguration, response, paymentDataUpdate)
             },
             onFailure = { error ->
                 GooglePayPaymentDataUpdateResponse(
                     newTransactionInfo = null,
                     error = GooglePayPaymentDataError(
                         reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                        message = error.message ?: "Unable to update shpping address",
+                        message = error.stripeErrorMessage(context),
                         intent = GooglePayPaymentDataError.Intent.ShippingAddress,
                     ),
                 )
@@ -79,10 +99,37 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
     }
 
     private fun mapToResponse(
-        configuration: CommonConfiguration,
+        configuration: PaymentSheet.GooglePayConfiguration,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate
     ): GooglePayPaymentDataUpdateResponse {
         return mapper.toResponse(configuration, response, paymentDataUpdate)
+    }
+
+    private fun reportUnexpectedCallbackTrigger(trigger: String) {
+        errorReporter.report(
+            errorEvent = ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER,
+            additionalNonPiiParams = mapOf(
+                FIELD_UNEXPECTED_TRIGGER_TYPE to trigger
+            )
+        )
+    }
+
+    private fun notConfiguredResponse(): GooglePayPaymentDataUpdateResponse {
+        return GooglePayPaymentDataUpdateResponse(
+            newTransactionInfo = null,
+            error = GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.OtherError,
+                message = context.getString(R.string.stripe_something_went_wrong),
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            )
+        )
+    }
+
+    private companion object {
+        const val FIELD_UNEXPECTED_TRIGGER_TYPE = "unexpected_trigger_type"
+        const val VALUE_SHIPPING_OPTION_TRIGGER = "shipping_option"
+        const val VALUE_OFFER_TRIGGER = "offer"
+        const val VALUE_WITHOUT_CONFIG = "without_config"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallback.kt
@@ -1,0 +1,88 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
+    private val taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val addressBuilder: CheckoutGooglePayPaymentDataUpdateAddressBuilder,
+    private val mapper: CheckoutGooglePayPaymentDataUpdateMapper,
+) : GooglePayPaymentDataUpdateCallback {
+    override suspend fun onPaymentDataChanged(
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): GooglePayPaymentDataUpdateResponse {
+        val currentState = stateHolder.state ?: return GooglePayPaymentDataUpdateResponse(
+            newTransactionInfo = null,
+            error = GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.OtherError,
+                message = "Checkout sessions not configured",
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            )
+        )
+
+        return when (paymentDataUpdate.callbackTrigger) {
+            GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+            GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress -> {
+                updateShippingAddress(currentState, paymentDataUpdate)
+            }
+            GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption,
+            GooglePayPaymentDataUpdate.CallbackTrigger.Offer -> {
+                mapToResponse(
+                    configuration = currentState.commonConfiguration,
+                    response = currentState.checkoutSessionResponse,
+                    paymentDataUpdate = paymentDataUpdate,
+                )
+            }
+        }
+    }
+
+    private suspend fun updateShippingAddress(
+        currentState: CheckoutControllerState,
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): GooglePayPaymentDataUpdateResponse {
+        val address = when (val result = addressBuilder.build(paymentDataUpdate)) {
+            is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed -> {
+                return result.response
+            }
+            is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success -> {
+                result.address
+            }
+        }
+
+        return taxRegionUpdater.updateServerStateIfNeeded(
+            checkoutSessionResponse = currentState.checkoutSessionResponse,
+            addressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
+            address = address,
+        ).fold(
+            onSuccess = { response ->
+                mapToResponse(currentState.commonConfiguration, response, paymentDataUpdate)
+            },
+            onFailure = { error ->
+                GooglePayPaymentDataUpdateResponse(
+                    newTransactionInfo = null,
+                    error = GooglePayPaymentDataError(
+                        reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                        message = error.message ?: "Unable to update shpping address",
+                        intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+                    ),
+                )
+            },
+        )
+    }
+
+    private fun mapToResponse(
+        configuration: CommonConfiguration,
+        response: CheckoutSessionResponse,
+        paymentDataUpdate: GooglePayPaymentDataUpdate
+    ): GooglePayPaymentDataUpdateResponse {
+        return mapper.toResponse(configuration, response, paymentDataUpdate)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateMapper.kt
@@ -3,19 +3,19 @@ package com.stripe.android.checkout
 import android.content.Context
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.R
-import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
 internal interface CheckoutGooglePayPaymentDataUpdateMapper {
     fun toResponse(
-        configuration: CommonConfiguration,
+        configuration: PaymentSheet.GooglePayConfiguration,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse
@@ -26,7 +26,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapper @Inject construct
     private val context: Context,
 ) : CheckoutGooglePayPaymentDataUpdateMapper {
     override fun toResponse(
-        configuration: CommonConfiguration,
+        configuration: PaymentSheet.GooglePayConfiguration,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate
     ): GooglePayPaymentDataUpdateResponse {
@@ -36,7 +36,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapper @Inject construct
             newTransactionInfo = GooglePayJsonFactory.TransactionInfo(
                 currencyCode = response.currency.uppercase(),
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
-                countryCode = merchantCountryCode(configuration, response)?.takeIf { it.isNotEmpty() },
+                countryCode = configuration.countryCode.takeIf { it.isNotEmpty() },
                 transactionId = response.stripeIntent()?.id,
                 totalPrice = response.totalSummary?.totalAmountDue ?: response.amount,
                 totalPriceLabel = context.getString(R.string.stripe_google_pay_total),
@@ -45,13 +45,6 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapper @Inject construct
             ),
             error = null,
         )
-    }
-
-    private fun merchantCountryCode(
-        configuration: CommonConfiguration,
-        response: CheckoutSessionResponse,
-    ): String? {
-        return configuration.googlePay?.countryCode ?: response.merchantCountry
     }
 
     private fun CheckoutSessionResponse.stripeIntent(): StripeIntent? {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateMapper.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.checkout
+
+import android.content.Context
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.R
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import javax.inject.Inject
+
+@OptIn(CheckoutSessionPreview::class)
+internal interface CheckoutGooglePayPaymentDataUpdateMapper {
+    fun toResponse(
+        configuration: CommonConfiguration,
+        response: CheckoutSessionResponse,
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): GooglePayPaymentDataUpdateResponse
+}
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutGooglePayPaymentDataUpdateMapper @Inject constructor(
+    private val context: Context,
+) : CheckoutGooglePayPaymentDataUpdateMapper {
+    override fun toResponse(
+        configuration: CommonConfiguration,
+        response: CheckoutSessionResponse,
+        paymentDataUpdate: GooglePayPaymentDataUpdate
+    ): GooglePayPaymentDataUpdateResponse {
+        val displayItems = GooglePayDisplayItemsFactory.create(response, context)
+
+        return GooglePayPaymentDataUpdateResponse(
+            newTransactionInfo = GooglePayJsonFactory.TransactionInfo(
+                currencyCode = response.currency.uppercase(),
+                totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
+                countryCode = merchantCountryCode(configuration, response)?.takeIf { it.isNotEmpty() },
+                transactionId = response.stripeIntent()?.id,
+                totalPrice = response.totalSummary?.totalAmountDue ?: response.amount,
+                totalPriceLabel = context.getString(R.string.stripe_google_pay_total),
+                checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
+                displayItems = displayItems,
+            ),
+            error = null,
+        )
+    }
+
+    private fun merchantCountryCode(
+        configuration: CommonConfiguration,
+        response: CheckoutSessionResponse,
+    ): String? {
+        return configuration.googlePay?.countryCode ?: response.merchantCountry
+    }
+
+    private fun CheckoutSessionResponse.stripeIntent(): StripeIntent? {
+        return paymentIntent ?: setupIntent
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -105,6 +105,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         ElementsSessionClientParamsModule::class,
         StripeRepositoryModule::class,
+        CheckoutGooglePayModule::class,
         GooglePayLauncherModule::class,
         TapToAddConnectionStarterModule::class,
         TapToAddConnectionModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutGooglePayModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutGooglePayModule.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.checkout.injection
+
+import com.stripe.android.checkout.CheckoutGooglePayPaymentDataUpdateAddressBuilder
+import com.stripe.android.checkout.CheckoutGooglePayPaymentDataUpdateCallback
+import com.stripe.android.checkout.CheckoutGooglePayPaymentDataUpdateMapper
+import com.stripe.android.checkout.DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder
+import com.stripe.android.checkout.DefaultCheckoutGooglePayPaymentDataUpdateMapper
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
+import dagger.Binds
+import dagger.Module
+
+@Module
+internal interface CheckoutGooglePayModule {
+    @Binds
+    fun bindsCheckoutGooglePayPaymentDataUpdateAddressBuilder(
+        builder: DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder
+    ): CheckoutGooglePayPaymentDataUpdateAddressBuilder
+
+    @Binds
+    fun bindsCheckoutGooglePayPaymentDataUpdateMapper(
+        mapper: DefaultCheckoutGooglePayPaymentDataUpdateMapper
+    ): CheckoutGooglePayPaymentDataUpdateMapper
+
+    @Binds
+    fun bindsGooglePayPaymentDataUpdateCallback(
+        callback: CheckoutGooglePayPaymentDataUpdateCallback
+    ): GooglePayPaymentDataUpdateCallback
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -17,6 +17,13 @@ internal object GooglePayDisplayItemsFactory {
         val response = (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
             ?.checkoutSessionResponse ?: return emptyList()
 
+        return create(response, context)
+    }
+
+    fun create(
+        response: CheckoutSessionResponse,
+        context: Context,
+    ): List<GooglePayJsonFactory.DisplayItem> {
         val items = mutableListOf<GooglePayJsonFactory.DisplayItem>()
 
         items += response.lineItems.map { it.asDisplayItem(context) }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallbackTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallbackTest.kt
@@ -1,22 +1,32 @@
 package com.stripe.android.checkout
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import java.util.UUID
 
 @OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
 internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
     @Test
     fun `onPaymentDataChanged returns error when state is not loaded`() = runScenario(
@@ -30,82 +40,66 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
         )
 
         assertThat(response.newTransactionInfo).isNull()
-        assertThat(response.error).isEqualTo(
-            GooglePayPaymentDataError(
-                reason = GooglePayPaymentDataError.Reason.OtherError,
-                message = "Checkout sessions not configured",
-                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-            )
-        )
-        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
-        addressBuilder.buildCalls.ensureAllEventsConsumed()
-        mapper.toResponseCalls.ensureAllEventsConsumed()
+
+        val error = response.error
+        assertThat(error).isNotNull()
+        assertThat(error?.reason).isEqualTo(GooglePayPaymentDataError.Reason.OtherError)
+        assertThat(error?.message).isEqualTo("Something went wrong")
+        assertThat(error?.intent).isEqualTo(GooglePayPaymentDataError.Intent.ShippingAddress)
     }
 
     @Test
-    fun `onPaymentDataChanged returns addressBuilder failure for Initialize trigger`() = runScenario(
-        addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
-            ADDRESS_BUILDER_FAILURE_RESPONSE,
+    fun `onPaymentDataChanged returns error and reports when google pay is not configured`() = runScenario(
+        state = CheckoutControllerStateFactory.create(
+            commonConfiguration = CommonConfigurationFactory.create(
+                googlePay = null,
+            ),
         ),
     ) {
-        val paymentDataUpdate = GooglePayPaymentDataUpdate(
-            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
-            shippingAddress = null,
+        val response = callback.onPaymentDataChanged(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+                shippingAddress = null,
+            )
         )
 
-        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+        assertThat(response.newTransactionInfo).isNull()
 
-        assertThat(response).isEqualTo(ADDRESS_BUILDER_FAILURE_RESPONSE)
-        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
-        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
-        mapper.toResponseCalls.ensureAllEventsConsumed()
+        val error = response.error
+        assertThat(error).isNotNull()
+        assertThat(error?.reason).isEqualTo(GooglePayPaymentDataError.Reason.OtherError)
+        assertThat(error?.message).isEqualTo("Something went wrong")
+        assertThat(error?.intent).isEqualTo(GooglePayPaymentDataError.Intent.ShippingAddress)
+
+        val call = errorReporter.awaitCall()
+        assertThat(call.errorEvent).isEqualTo(
+            ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER
+        )
+        assertThat(call.additionalNonPiiParams)
+            .isEqualTo(mapOf("unexpected_trigger_type" to "without_config"))
     }
 
     @Test
-    fun `onPaymentDataChanged returns addressBuilder failure for ShippingAddress trigger`() = runScenario(
-        addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
-            ADDRESS_BUILDER_FAILURE_RESPONSE,
-        ),
-    ) {
-        val paymentDataUpdate = GooglePayPaymentDataUpdate(
-            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
-            shippingAddress = null,
+    fun `onPaymentDataChanged maps state without building an address for initialization when unavailable`() =
+        addressUnavailableTest(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize
         )
-
-        val response = callback.onPaymentDataChanged(paymentDataUpdate)
-
-        assertThat(response).isEqualTo(ADDRESS_BUILDER_FAILURE_RESPONSE)
-        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
-        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
-        mapper.toResponseCalls.ensureAllEventsConsumed()
-    }
 
     @Test
-    fun `onPaymentDataChanged updates tax region and returns mapper response on success`() = runScenario {
-        val paymentDataUpdate = GooglePayPaymentDataUpdate(
-            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
-            shippingAddress = SHIPPING_ADDRESS,
+    fun `onPaymentDataChanged maps state without building an address for shipping address changes when unavailable`() =
+        addressUnavailableTest(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress
         )
 
-        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+    @Test
+    fun `onPaymentDataChanged updates tax region & responds successfully for initialization`() = successTest(
+        callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+    )
 
-        assertThat(response).isEqualTo(providedMapperResponse)
-        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
-        assertThat(taxRegionUpdater.updateServerStateIfNeededCalls.awaitItem()).isEqualTo(
-            FakeCheckoutSessionTaxRegionUpdater.UpdateServerStateIfNeededCall(
-                checkoutSessionResponse = requireState.checkoutSessionResponse,
-                addressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
-                address = ADDRESS,
-            )
-        )
-        assertThat(mapper.toResponseCalls.awaitItem()).isEqualTo(
-            FakeCheckoutGooglePayPaymentDataUpdateMapper.ToResponseCall(
-                configuration = requireState.commonConfiguration,
-                response = requireUpdatedCheckoutSessionResponse,
-                paymentDataUpdate = paymentDataUpdate,
-            )
-        )
-    }
+    @Test
+    fun `onPaymentDataChanged updates tax region & responds successfully for shipping address change`() = successTest(
+        callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+    )
 
     @Test
     fun `onPaymentDataChanged returns error when updating tax region fails`() = runScenario(
@@ -119,73 +113,145 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
         val response = callback.onPaymentDataChanged(paymentDataUpdate)
 
         assertThat(response.newTransactionInfo).isNull()
-        assertThat(response.error).isEqualTo(
-            GooglePayPaymentDataError(
-                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                message = "Unable to compute tax",
-                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-            )
-        )
-        addressBuilder.buildCalls.awaitItem()
-        taxRegionUpdater.updateServerStateIfNeededCalls.awaitItem()
-        mapper.toResponseCalls.ensureAllEventsConsumed()
+
+        val error = response.error
+        assertThat(error).isNotNull()
+        assertThat(error?.reason).isEqualTo(GooglePayPaymentDataError.Reason.ShippingAddressInvalid)
+        assertThat(error?.message).isEqualTo("Something went wrong")
+        assertThat(error?.intent).isEqualTo(GooglePayPaymentDataError.Intent.ShippingAddress)
+
+        assertThat(addressBuilder.buildCalls.awaitItem()).isNotNull()
+        assertThat(taxRegionUpdater.updateServerStateIfNeededCalls.awaitItem()).isNotNull()
     }
 
     @Test
-    fun `onPaymentDataChanged for shipping option maps state without building an address`() = runScenario {
+    fun `onPaymentDataChanged for shipping option maps state without updating tax region`() = unsupportedCallbackTest(
+        callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption,
+        expectedTriggerParam = "shipping_option",
+    )
+
+    @Test
+    fun `onPaymentDataChanged for offer maps state without updating tax region`() = unsupportedCallbackTest(
+        callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Offer,
+        expectedTriggerParam = "offer",
+    )
+
+    private fun unsupportedCallbackTest(
+        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger,
+        expectedTriggerParam: String,
+    ) = runScenario(
+        mapperResponse = GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null),
+    ) {
         val paymentDataUpdate = GooglePayPaymentDataUpdate(
-            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption,
+            callbackTrigger = callbackTrigger,
             shippingAddress = null,
         )
 
         val response = callback.onPaymentDataChanged(paymentDataUpdate)
 
-        assertThat(response).isEqualTo(providedMapperResponse)
-        assertThat(mapper.toResponseCalls.awaitItem()).isEqualTo(
-            FakeCheckoutGooglePayPaymentDataUpdateMapper.ToResponseCall(
-                configuration = requireState.commonConfiguration,
-                response = requireState.checkoutSessionResponse,
-                paymentDataUpdate = paymentDataUpdate,
-            )
+        assertThat(response.newTransactionInfo).isNull()
+        assertThat(response.error).isNull()
+
+        val toResponseCall = mapper.toResponseCalls.awaitItem()
+
+        assertThat(toResponseCall.configuration).isEqualTo(providedState?.commonConfiguration?.googlePay)
+        assertThat(toResponseCall.response).isEqualTo(providedState?.checkoutSessionResponse)
+        assertThat(toResponseCall.paymentDataUpdate).isEqualTo(paymentDataUpdate)
+
+        val call = errorReporter.awaitCall()
+        assertThat(call.errorEvent).isEqualTo(
+            ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER
         )
-        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
-        addressBuilder.buildCalls.ensureAllEventsConsumed()
+        assertThat(call.additionalNonPiiParams)
+            .isEqualTo(mapOf("unexpected_trigger_type" to expectedTriggerParam))
     }
 
-    @Test
-    fun `onPaymentDataChanged for offer maps state without building an address`() = runScenario {
-        val paymentDataUpdate = GooglePayPaymentDataUpdate(
-            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Offer,
-            shippingAddress = null,
-        )
-
-        val response = callback.onPaymentDataChanged(paymentDataUpdate)
-
-        assertThat(response).isEqualTo(providedMapperResponse)
-        assertThat(mapper.toResponseCalls.awaitItem()).isEqualTo(
-            FakeCheckoutGooglePayPaymentDataUpdateMapper.ToResponseCall(
-                configuration = requireState.commonConfiguration,
-                response = requireState.checkoutSessionResponse,
-                paymentDataUpdate = paymentDataUpdate,
+    private fun addressUnavailableTest(
+        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger
+    ) {
+        runScenario(
+            addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Unavailable,
+            mapperResponse = GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null),
+        ) {
+            val paymentDataUpdate = GooglePayPaymentDataUpdate(
+                callbackTrigger = callbackTrigger,
+                shippingAddress = null,
             )
-        )
-        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
-        addressBuilder.buildCalls.ensureAllEventsConsumed()
+
+            val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+            val buildCall = addressBuilder.buildCalls.awaitItem()
+
+            assertThat(buildCall.shippingAddress).isNull()
+            assertThat(buildCall.callbackTrigger).isEqualTo(callbackTrigger)
+
+            assertThat(response).isEqualTo(providedMapperResponse)
+
+            val toResponseCall = mapper.toResponseCalls.awaitItem()
+            assertThat(toResponseCall.configuration).isEqualTo(providedState?.commonConfiguration?.googlePay)
+            assertThat(toResponseCall.response).isEqualTo(providedState?.checkoutSessionResponse)
+            assertThat(toResponseCall.paymentDataUpdate).isEqualTo(paymentDataUpdate)
+        }
+    }
+
+    private fun successTest(
+        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger
+    ) {
+        runScenario(
+            addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available(ADDRESS),
+            state = CheckoutControllerStateFactory.create(
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    id = UUID.randomUUID().toString(),
+                )
+            ),
+            mapperResponse = GooglePayPaymentDataUpdateResponse(
+                newTransactionInfo = TRANSACTION_INFO,
+                error = null,
+            )
+        ) {
+            val paymentDataUpdate = GooglePayPaymentDataUpdate(
+                callbackTrigger = callbackTrigger,
+                shippingAddress = SHIPPING_ADDRESS,
+            )
+
+            val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+            assertThat(response).isEqualTo(providedMapperResponse)
+
+            val buildCall = addressBuilder.buildCalls.awaitItem()
+            assertThat(buildCall.callbackTrigger).isEqualTo(callbackTrigger)
+            assertThat(buildCall.shippingAddress).isEqualTo(SHIPPING_ADDRESS)
+
+            val updateCall = taxRegionUpdater.updateServerStateIfNeededCalls.awaitItem()
+            assertThat(updateCall.addressSource).isEqualTo(CheckoutSessionResponse.TaxAddressSource.SHIPPING)
+            assertThat(updateCall.address).isEqualTo(ADDRESS)
+            assertThat(updateCall.checkoutSessionResponse).isEqualTo(providedState?.checkoutSessionResponse)
+
+            val toResponseCall = mapper.toResponseCalls.awaitItem()
+            assertThat(toResponseCall.configuration).isEqualTo(providedState?.commonConfiguration?.googlePay)
+            assertThat(toResponseCall.response).isEqualTo(providedUpdateResult.getOrNull())
+            assertThat(toResponseCall.paymentDataUpdate.callbackTrigger).isEqualTo(callbackTrigger)
+            assertThat(toResponseCall.paymentDataUpdate.shippingAddress).isEqualTo(SHIPPING_ADDRESS)
+        }
     }
 
     private fun runScenario(
         state: CheckoutControllerState? = CheckoutControllerStateFactory.create(),
         addressBuilderResult: CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result =
-            CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success(ADDRESS),
+            CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available(ADDRESS),
         mapperResponse: GooglePayPaymentDataUpdateResponse =
             GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null),
         updateResult: Result<CheckoutSessionResponse> = Result.success(UPDATED_CHECKOUT_SESSION_RESPONSE),
         block: suspend Scenario.() -> Unit
     ) = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
         val addressBuilder = FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder(addressBuilderResult)
         val mapper = FakeCheckoutGooglePayPaymentDataUpdateMapper(mapperResponse)
         val taxRegionUpdater = FakeCheckoutSessionTaxRegionUpdater(updateResult)
+        val errorReporter = FakeErrorReporter()
+
         val callback = CheckoutGooglePayPaymentDataUpdateCallback(
+            context = context,
             taxRegionUpdater = taxRegionUpdater.mocked,
             stateHolder = CheckoutControllerStateFactory.createStateHolder(
                 savedStateHandle = SavedStateHandle(),
@@ -194,6 +260,7 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
             },
             addressBuilder = addressBuilder,
             mapper = mapper,
+            errorReporter = errorReporter,
         )
 
         block(
@@ -202,15 +269,17 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
                 addressBuilder = addressBuilder,
                 mapper = mapper,
                 taxRegionUpdater = taxRegionUpdater,
+                errorReporter = errorReporter,
                 providedMapperResponse = mapperResponse,
                 providedState = state,
-                updatedCheckoutSessionResponse = updateResult.getOrNull(),
+                providedUpdateResult = updateResult,
             )
         )
 
         addressBuilder.ensureAllEventsConsumed()
         mapper.ensureAllEventsConsumed()
         taxRegionUpdater.ensureAllEventsConsumed()
+        errorReporter.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -218,14 +287,11 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
         val addressBuilder: FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder,
         val mapper: FakeCheckoutGooglePayPaymentDataUpdateMapper,
         val taxRegionUpdater: FakeCheckoutSessionTaxRegionUpdater,
+        val errorReporter: FakeErrorReporter,
         val providedMapperResponse: GooglePayPaymentDataUpdateResponse,
         val providedState: CheckoutControllerState?,
-        val updatedCheckoutSessionResponse: CheckoutSessionResponse?,
-    ) {
-        val requireState: CheckoutControllerState get() = requireNotNull(providedState)
-        val requireUpdatedCheckoutSessionResponse: CheckoutSessionResponse
-            get() = requireNotNull(updatedCheckoutSessionResponse)
-    }
+        val providedUpdateResult: Result<CheckoutSessionResponse>,
+    )
 
     private class FakeCheckoutSessionTaxRegionUpdater(
         updateResult: Result<CheckoutSessionResponse>
@@ -282,13 +348,14 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
 
         val UPDATED_CHECKOUT_SESSION_RESPONSE = CheckoutSessionResponseFactory.create(merchantCountry = "US")
 
-        val ADDRESS_BUILDER_FAILURE_RESPONSE = GooglePayPaymentDataUpdateResponse(
-            newTransactionInfo = null,
-            error = GooglePayPaymentDataError(
-                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                message = "Shipping address is required.",
-                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-            ),
+        val TRANSACTION_INFO = GooglePayJsonFactory.TransactionInfo(
+            currencyCode = "USD",
+            totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
+            countryCode = "US",
+            transactionId = "transaction_id",
+            totalPrice = 1000L,
+            totalPriceLabel = "Total",
+            checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallbackTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallbackTest.kt
@@ -1,0 +1,294 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
+    @Test
+    fun `onPaymentDataChanged returns error when state is not loaded`() = runScenario(
+        state = null,
+    ) {
+        val response = callback.onPaymentDataChanged(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+                shippingAddress = null,
+            )
+        )
+
+        assertThat(response.newTransactionInfo).isNull()
+        assertThat(response.error).isEqualTo(
+            GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.OtherError,
+                message = "Checkout sessions not configured",
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            )
+        )
+        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
+        addressBuilder.buildCalls.ensureAllEventsConsumed()
+        mapper.toResponseCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `onPaymentDataChanged returns addressBuilder failure for Initialize trigger`() = runScenario(
+        addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
+            ADDRESS_BUILDER_FAILURE_RESPONSE,
+        ),
+    ) {
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+            shippingAddress = null,
+        )
+
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+        assertThat(response).isEqualTo(ADDRESS_BUILDER_FAILURE_RESPONSE)
+        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
+        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
+        mapper.toResponseCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `onPaymentDataChanged returns addressBuilder failure for ShippingAddress trigger`() = runScenario(
+        addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed(
+            ADDRESS_BUILDER_FAILURE_RESPONSE,
+        ),
+    ) {
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+            shippingAddress = null,
+        )
+
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+        assertThat(response).isEqualTo(ADDRESS_BUILDER_FAILURE_RESPONSE)
+        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
+        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
+        mapper.toResponseCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `onPaymentDataChanged updates tax region and returns mapper response on success`() = runScenario {
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+            shippingAddress = SHIPPING_ADDRESS,
+        )
+
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+        assertThat(response).isEqualTo(providedMapperResponse)
+        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
+        assertThat(taxRegionUpdater.updateServerStateIfNeededCalls.awaitItem()).isEqualTo(
+            FakeCheckoutSessionTaxRegionUpdater.UpdateServerStateIfNeededCall(
+                checkoutSessionResponse = requireState.checkoutSessionResponse,
+                addressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
+                address = ADDRESS,
+            )
+        )
+        assertThat(mapper.toResponseCalls.awaitItem()).isEqualTo(
+            FakeCheckoutGooglePayPaymentDataUpdateMapper.ToResponseCall(
+                configuration = requireState.commonConfiguration,
+                response = requireUpdatedCheckoutSessionResponse,
+                paymentDataUpdate = paymentDataUpdate,
+            )
+        )
+    }
+
+    @Test
+    fun `onPaymentDataChanged returns error when updating tax region fails`() = runScenario(
+        updateResult = Result.failure(IllegalStateException("Unable to compute tax")),
+    ) {
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+            shippingAddress = SHIPPING_ADDRESS,
+        )
+
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+        assertThat(response.newTransactionInfo).isNull()
+        assertThat(response.error).isEqualTo(
+            GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                message = "Unable to compute tax",
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            )
+        )
+        addressBuilder.buildCalls.awaitItem()
+        taxRegionUpdater.updateServerStateIfNeededCalls.awaitItem()
+        mapper.toResponseCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `onPaymentDataChanged for shipping option maps state without building an address`() = runScenario {
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption,
+            shippingAddress = null,
+        )
+
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+        assertThat(response).isEqualTo(providedMapperResponse)
+        assertThat(mapper.toResponseCalls.awaitItem()).isEqualTo(
+            FakeCheckoutGooglePayPaymentDataUpdateMapper.ToResponseCall(
+                configuration = requireState.commonConfiguration,
+                response = requireState.checkoutSessionResponse,
+                paymentDataUpdate = paymentDataUpdate,
+            )
+        )
+        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
+        addressBuilder.buildCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `onPaymentDataChanged for offer maps state without building an address`() = runScenario {
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Offer,
+            shippingAddress = null,
+        )
+
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
+
+        assertThat(response).isEqualTo(providedMapperResponse)
+        assertThat(mapper.toResponseCalls.awaitItem()).isEqualTo(
+            FakeCheckoutGooglePayPaymentDataUpdateMapper.ToResponseCall(
+                configuration = requireState.commonConfiguration,
+                response = requireState.checkoutSessionResponse,
+                paymentDataUpdate = paymentDataUpdate,
+            )
+        )
+        taxRegionUpdater.updateServerStateIfNeededCalls.ensureAllEventsConsumed()
+        addressBuilder.buildCalls.ensureAllEventsConsumed()
+    }
+
+    private fun runScenario(
+        state: CheckoutControllerState? = CheckoutControllerStateFactory.create(),
+        addressBuilderResult: CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result =
+            CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success(ADDRESS),
+        mapperResponse: GooglePayPaymentDataUpdateResponse =
+            GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null),
+        updateResult: Result<CheckoutSessionResponse> = Result.success(UPDATED_CHECKOUT_SESSION_RESPONSE),
+        block: suspend Scenario.() -> Unit
+    ) = runTest {
+        val addressBuilder = FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder(addressBuilderResult)
+        val mapper = FakeCheckoutGooglePayPaymentDataUpdateMapper(mapperResponse)
+        val taxRegionUpdater = FakeCheckoutSessionTaxRegionUpdater(updateResult)
+        val callback = CheckoutGooglePayPaymentDataUpdateCallback(
+            taxRegionUpdater = taxRegionUpdater.mocked,
+            stateHolder = CheckoutControllerStateFactory.createStateHolder(
+                savedStateHandle = SavedStateHandle(),
+            ).apply {
+                this.state = state
+            },
+            addressBuilder = addressBuilder,
+            mapper = mapper,
+        )
+
+        block(
+            Scenario(
+                callback = callback,
+                addressBuilder = addressBuilder,
+                mapper = mapper,
+                taxRegionUpdater = taxRegionUpdater,
+                providedMapperResponse = mapperResponse,
+                providedState = state,
+                updatedCheckoutSessionResponse = updateResult.getOrNull(),
+            )
+        )
+
+        addressBuilder.ensureAllEventsConsumed()
+        mapper.ensureAllEventsConsumed()
+        taxRegionUpdater.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val callback: CheckoutGooglePayPaymentDataUpdateCallback,
+        val addressBuilder: FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder,
+        val mapper: FakeCheckoutGooglePayPaymentDataUpdateMapper,
+        val taxRegionUpdater: FakeCheckoutSessionTaxRegionUpdater,
+        val providedMapperResponse: GooglePayPaymentDataUpdateResponse,
+        val providedState: CheckoutControllerState?,
+        val updatedCheckoutSessionResponse: CheckoutSessionResponse?,
+    ) {
+        val requireState: CheckoutControllerState get() = requireNotNull(providedState)
+        val requireUpdatedCheckoutSessionResponse: CheckoutSessionResponse
+            get() = requireNotNull(updatedCheckoutSessionResponse)
+    }
+
+    private class FakeCheckoutSessionTaxRegionUpdater(
+        updateResult: Result<CheckoutSessionResponse>
+    ) {
+        val mocked = mock<CheckoutSessionTaxRegionUpdater>()
+        val updateServerStateIfNeededCalls = Turbine<UpdateServerStateIfNeededCall>()
+
+        init {
+            whenever {
+                mocked.updateServerStateIfNeeded(
+                    checkoutSessionResponse = any(),
+                    addressSource = any(),
+                    address = any()
+                )
+            } doAnswer { invocation ->
+                updateServerStateIfNeededCalls.add(
+                    UpdateServerStateIfNeededCall(
+                        checkoutSessionResponse = invocation.component1(),
+                        addressSource = invocation.component2(),
+                        address = invocation.component3(),
+                    )
+                )
+
+                updateResult
+            }
+        }
+
+        fun ensureAllEventsConsumed() {
+            updateServerStateIfNeededCalls.ensureAllEventsConsumed()
+        }
+
+        data class UpdateServerStateIfNeededCall(
+            val checkoutSessionResponse: CheckoutSessionResponse,
+            val addressSource: CheckoutSessionResponse.TaxAddressSource,
+            val address: CheckoutController.Address.State,
+        )
+    }
+
+    private companion object {
+        val SHIPPING_ADDRESS = GooglePayPaymentDataUpdate.ShippingAddress(
+            administrativeArea = "CA",
+            countryCode = "US",
+            locality = "South San Francisco",
+            postalCode = "94080",
+            iso3166AdministrativeArea = null,
+        )
+
+        val ADDRESS = CheckoutController.Address()
+            .country("US")
+            .city("South San Francisco")
+            .postalCode("94080")
+            .state("CA")
+            .build()
+
+        val UPDATED_CHECKOUT_SESSION_RESPONSE = CheckoutSessionResponseFactory.create(merchantCountry = "US")
+
+        val ADDRESS_BUILDER_FAILURE_RESPONSE = GooglePayPaymentDataUpdateResponse(
+            newTransactionInfo = null,
+            error = GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                message = "Shipping address is required.",
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            ),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest.kt
@@ -1,18 +1,16 @@
 package com.stripe.android.checkout
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @OptIn(CheckoutSessionPreview::class)
 internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest {
-    private val builder = DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder()
-
     @Test
-    fun `build returns failure when shipping address is missing`() {
+    fun `build returns unavailable when shipping address is missing`() = runScenario {
         val result = builder.build(
             GooglePayPaymentDataUpdate(
                 callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
@@ -20,41 +18,11 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest {
             )
         )
 
-        val failure = result.assertFailed()
-
-        assertThat(failure.response.newTransactionInfo).isNull()
-        assertThat(failure.response.error).isEqualTo(
-            GooglePayPaymentDataError(
-                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                message = "Shipping address is required.",
-                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-            )
-        )
+        assertThat(result).isEqualTo(CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Unavailable)
     }
 
     @Test
-    fun `build returns failure when country code is blank`() {
-        val result = builder.build(
-            GooglePayPaymentDataUpdate(
-                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
-                shippingAddress = shippingAddress(countryCode = ""),
-            )
-        )
-
-        val failure = result.assertFailed()
-
-        assertThat(failure.response.newTransactionInfo).isNull()
-        assertThat(failure.response.error).isEqualTo(
-            GooglePayPaymentDataError(
-                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
-                message = "Country is required.",
-                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
-            )
-        )
-    }
-
-    @Test
-    fun `build returns address from shipping address fields`() {
+    fun `build returns address from shipping address fields`() = runScenario {
         val result = builder.build(
             GooglePayPaymentDataUpdate(
                 callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
@@ -68,34 +36,52 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest {
             )
         )
 
-        val success = result.assertSuccess()
+        val available = result.assertAvailable()
 
-        assertThat(success.address.country).isEqualTo("US")
-        assertThat(success.address.city).isEqualTo("South San Francisco")
-        assertThat(success.address.postalCode).isEqualTo("94080")
-        assertThat(success.address.state).isEqualTo("CA")
+        assertThat(available.address.country).isEqualTo("US")
+        assertThat(available.address.city).isEqualTo("South San Francisco")
+        assertThat(available.address.postalCode).isEqualTo("94080")
+        assertThat(available.address.state).isEqualTo("CA")
     }
 
     @Test
-    fun `build prefers iso3166AdministrativeArea over administrativeArea`() {
+    fun `build uses normalized iso3166AdministrativeArea subdivision for US addresses`() = runScenario {
         val result = builder.build(
             GooglePayPaymentDataUpdate(
                 callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
                 shippingAddress = shippingAddress(
-                    administrativeArea = "CA",
+                    administrativeArea = "California",
                     countryCode = "US",
-                    iso3166AdministrativeArea = "US-CA",
+                    iso3166AdministrativeArea = "US-ca",
                 ),
             )
         )
 
-        val success = result.assertSuccess()
+        val available = result.assertAvailable()
 
-        assertThat(success.address.state).isEqualTo("US-CA")
+        assertThat(available.address.state).isEqualTo("CA")
     }
 
     @Test
-    fun `build treats empty locality and postal code as unset`() {
+    fun `build falls back to administrativeArea for non-US addresses`() = runScenario {
+        val result = builder.build(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+                shippingAddress = shippingAddress(
+                    administrativeArea = "Ontario",
+                    countryCode = "CA",
+                    iso3166AdministrativeArea = "CA-ON",
+                ),
+            )
+        )
+
+        val available = result.assertAvailable()
+
+        assertThat(available.address.state).isEqualTo("Ontario")
+    }
+
+    @Test
+    fun `build treats empty locality and postal code as unset`() = runScenario {
         val result = builder.build(
             GooglePayPaymentDataUpdate(
                 callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
@@ -103,22 +89,30 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest {
             )
         )
 
-        val success = result.assertSuccess()
+        val available = result.assertAvailable()
 
-        assertThat(success.address.city).isNull()
-        assertThat(success.address.postalCode).isNull()
+        assertThat(available.address.city).isNull()
+        assertThat(available.address.postalCode).isNull()
     }
 
-    private fun CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.assertSuccess():
-        CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success {
-        assertThat(this).isInstanceOf<CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success>()
-        return this as CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit
+    ) = runTest {
+        block(
+            Scenario(
+                builder = DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder()
+            )
+        )
     }
 
-    private fun CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.assertFailed():
-        CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed {
-        assertThat(this).isInstanceOf<CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed>()
-        return this as CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed
+    private class Scenario(
+        val builder: DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder
+    )
+
+    private fun CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.assertAvailable():
+        CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available {
+        assertThat(this).isInstanceOf<CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available>()
+        return this as CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Available
     }
 
     private fun shippingAddress(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest.kt
@@ -1,0 +1,137 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilderTest {
+    private val builder = DefaultCheckoutGooglePayPaymentDataUpdateAddressBuilder()
+
+    @Test
+    fun `build returns failure when shipping address is missing`() {
+        val result = builder.build(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+                shippingAddress = null,
+            )
+        )
+
+        val failure = result.assertFailed()
+
+        assertThat(failure.response.newTransactionInfo).isNull()
+        assertThat(failure.response.error).isEqualTo(
+            GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                message = "Shipping address is required.",
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            )
+        )
+    }
+
+    @Test
+    fun `build returns failure when country code is blank`() {
+        val result = builder.build(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+                shippingAddress = shippingAddress(countryCode = ""),
+            )
+        )
+
+        val failure = result.assertFailed()
+
+        assertThat(failure.response.newTransactionInfo).isNull()
+        assertThat(failure.response.error).isEqualTo(
+            GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.ShippingAddressInvalid,
+                message = "Country is required.",
+                intent = GooglePayPaymentDataError.Intent.ShippingAddress,
+            )
+        )
+    }
+
+    @Test
+    fun `build returns address from shipping address fields`() {
+        val result = builder.build(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+                shippingAddress = shippingAddress(
+                    administrativeArea = "CA",
+                    countryCode = "US",
+                    locality = "South San Francisco",
+                    postalCode = "94080",
+                    iso3166AdministrativeArea = null,
+                ),
+            )
+        )
+
+        val success = result.assertSuccess()
+
+        assertThat(success.address.country).isEqualTo("US")
+        assertThat(success.address.city).isEqualTo("South San Francisco")
+        assertThat(success.address.postalCode).isEqualTo("94080")
+        assertThat(success.address.state).isEqualTo("CA")
+    }
+
+    @Test
+    fun `build prefers iso3166AdministrativeArea over administrativeArea`() {
+        val result = builder.build(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+                shippingAddress = shippingAddress(
+                    administrativeArea = "CA",
+                    countryCode = "US",
+                    iso3166AdministrativeArea = "US-CA",
+                ),
+            )
+        )
+
+        val success = result.assertSuccess()
+
+        assertThat(success.address.state).isEqualTo("US-CA")
+    }
+
+    @Test
+    fun `build treats empty locality and postal code as unset`() {
+        val result = builder.build(
+            GooglePayPaymentDataUpdate(
+                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress,
+                shippingAddress = shippingAddress(countryCode = "US"),
+            )
+        )
+
+        val success = result.assertSuccess()
+
+        assertThat(success.address.city).isNull()
+        assertThat(success.address.postalCode).isNull()
+    }
+
+    private fun CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.assertSuccess():
+        CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success {
+        assertThat(this).isInstanceOf<CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success>()
+        return this as CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Success
+    }
+
+    private fun CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.assertFailed():
+        CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed {
+        assertThat(this).isInstanceOf<CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed>()
+        return this as CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Failed
+    }
+
+    private fun shippingAddress(
+        administrativeArea: String = "",
+        countryCode: String = "US",
+        locality: String = "",
+        postalCode: String = "",
+        iso3166AdministrativeArea: String? = null,
+    ) = GooglePayPaymentDataUpdate.ShippingAddress(
+        administrativeArea = administrativeArea,
+        countryCode = countryCode,
+        locality = locality,
+        postalCode = postalCode,
+        iso3166AdministrativeArea = iso3166AdministrativeArea,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateMapperTest.kt
@@ -1,0 +1,194 @@
+package com.stripe.android.checkout
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.R
+import com.stripe.android.common.model.CommonConfigurationFactory
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val mapper = DefaultCheckoutGooglePayPaymentDataUpdateMapper(context)
+
+    @Test
+    fun `toResponse returns transaction info built from response`() {
+        val response = CheckoutSessionResponseFactory.create(
+            currency = "usd",
+            amount = 1500L,
+            merchantCountry = "US",
+            paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        )
+
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(),
+            response = response,
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.error).isNull()
+        assertThat(result.newTransactionInfo).isEqualTo(
+            expectedTransactionInfo(
+                countryCode = "US",
+                totalPrice = 1500L,
+                transactionId = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.id,
+            )
+        )
+    }
+
+    @Test
+    fun `toResponse uses country code from common configuration google pay when present`() {
+        val configuration = CommonConfigurationFactory.create(
+            googlePay = PaymentSheet.GooglePayConfiguration(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                countryCode = "CA",
+            ),
+        )
+
+        val result = mapper.toResponse(
+            configuration = configuration,
+            response = CheckoutSessionResponseFactory.create(merchantCountry = "US"),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(countryCode = "CA"))
+    }
+
+    @Test
+    fun `toResponse falls back to checkout session merchant country when common configuration has no google pay`() {
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(googlePay = null),
+            response = CheckoutSessionResponseFactory.create(merchantCountry = "GB"),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(countryCode = "GB"))
+    }
+
+    @Test
+    fun `toResponse returns null country code when neither common configuration nor merchant country are set`() {
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(googlePay = null),
+            response = CheckoutSessionResponseFactory.create(merchantCountry = null),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(countryCode = null))
+    }
+
+    @Test
+    fun `toResponse uses total summary total amount due over checkout session amount when present`() {
+        val response = CheckoutSessionResponseFactory.create(
+            amount = 1000L,
+            totalSummary = totalSummary(totalAmountDue = 2500L),
+        )
+
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(),
+            response = response,
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(
+            expectedTransactionInfo(
+                totalPrice = 2500L,
+                displayItems = GooglePayDisplayItemsFactory.create(response).map { it.resolve(context) },
+            )
+        )
+    }
+
+    @Test
+    fun `toResponse uses checkout session amount when total summary is absent`() {
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(),
+            response = CheckoutSessionResponseFactory.create(
+                amount = 1000L,
+                totalSummary = null,
+            ),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(totalPrice = 1000L))
+    }
+
+    @Test
+    fun `toResponse uses payment intent id as transaction id`() {
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(),
+            response = CheckoutSessionResponseFactory.create(
+                paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                setupIntent = null,
+            ),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(
+            expectedTransactionInfo(transactionId = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.id)
+        )
+    }
+
+    @Test
+    fun `toResponse uses setup intent id as transaction id when no payment intent`() {
+        val result = mapper.toResponse(
+            configuration = CommonConfigurationFactory.create(),
+            response = CheckoutSessionResponseFactory.create(
+                paymentIntent = null,
+                setupIntent = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
+            ),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isEqualTo(
+            expectedTransactionInfo(transactionId = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.id)
+        )
+    }
+
+    private fun expectedTransactionInfo(
+        countryCode: String? = "US",
+        totalPrice: Long? = 1000L,
+        transactionId: String? = null,
+        displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
+    ) = GooglePayJsonFactory.TransactionInfo(
+        currencyCode = "USD",
+        totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
+        countryCode = countryCode,
+        transactionId = transactionId,
+        totalPrice = totalPrice,
+        totalPriceLabel = context.getString(R.string.stripe_google_pay_total),
+        checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
+        displayItems = displayItems,
+    )
+
+    private fun totalSummary(
+        totalAmountDue: Long,
+    ) = CheckoutSessionResponse.TotalSummaryResponse(
+        subtotal = 1000L,
+        totalDueToday = totalAmountDue,
+        totalAmountDue = totalAmountDue,
+        discountAmounts = emptyList(),
+        taxAmounts = emptyList(),
+        shippingRate = null,
+        appliedBalance = null,
+    )
+
+    private companion object {
+        val PAYMENT_DATA_UPDATE = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+            shippingAddress = null,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateMapperTest.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.R
-import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
@@ -30,64 +29,51 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
         val response = CheckoutSessionResponseFactory.create(
             currency = "usd",
             amount = 1500L,
-            merchantCountry = "US",
             paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         )
 
         val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(),
+            configuration = googlePayConfiguration(countryCode = "US"),
             response = response,
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
         assertThat(result.error).isNull()
-        assertThat(result.newTransactionInfo).isEqualTo(
-            expectedTransactionInfo(
-                countryCode = "US",
-                totalPrice = 1500L,
-                transactionId = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.id,
-            )
-        )
+
+        val transactionInfo = result.newTransactionInfo
+        assertThat(transactionInfo).isNotNull()
+        assertThat(transactionInfo?.currencyCode).isEqualTo("USD")
+        assertThat(transactionInfo?.totalPriceStatus)
+            .isEqualTo(GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated)
+        assertThat(transactionInfo?.countryCode).isEqualTo("US")
+        assertThat(transactionInfo?.transactionId).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.id)
+        assertThat(transactionInfo?.totalPrice).isEqualTo(1500L)
+        assertThat(transactionInfo?.totalPriceLabel).isEqualTo(context.getString(R.string.stripe_google_pay_total))
+        assertThat(transactionInfo?.checkoutOption)
+            .isEqualTo(GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default)
     }
 
     @Test
-    fun `toResponse uses country code from common configuration google pay when present`() {
-        val configuration = CommonConfigurationFactory.create(
-            googlePay = PaymentSheet.GooglePayConfiguration(
-                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                countryCode = "CA",
-            ),
-        )
-
+    fun `toResponse uses country code from configuration`() {
         val result = mapper.toResponse(
-            configuration = configuration,
-            response = CheckoutSessionResponseFactory.create(merchantCountry = "US"),
+            configuration = googlePayConfiguration(countryCode = "CA"),
+            response = CheckoutSessionResponseFactory.create(),
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
-        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(countryCode = "CA"))
+        assertThat(result.newTransactionInfo?.countryCode).isEqualTo("CA")
     }
 
     @Test
-    fun `toResponse falls back to checkout session merchant country when common configuration has no google pay`() {
+    fun `toResponse returns null country code when configuration country code is blank`() {
         val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(googlePay = null),
-            response = CheckoutSessionResponseFactory.create(merchantCountry = "GB"),
+            configuration = googlePayConfiguration(countryCode = ""),
+            response = CheckoutSessionResponseFactory.create(),
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
-        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(countryCode = "GB"))
-    }
-
-    @Test
-    fun `toResponse returns null country code when neither common configuration nor merchant country are set`() {
-        val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(googlePay = null),
-            response = CheckoutSessionResponseFactory.create(merchantCountry = null),
-            paymentDataUpdate = PAYMENT_DATA_UPDATE,
-        )
-
-        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(countryCode = null))
+        assertThat(result.newTransactionInfo).isNotNull()
+        assertThat(result.newTransactionInfo?.countryCode).isNull()
     }
 
     @Test
@@ -98,23 +84,18 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
         )
 
         val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(),
+            configuration = googlePayConfiguration(),
             response = response,
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
-        assertThat(result.newTransactionInfo).isEqualTo(
-            expectedTransactionInfo(
-                totalPrice = 2500L,
-                displayItems = GooglePayDisplayItemsFactory.create(response).map { it.resolve(context) },
-            )
-        )
+        assertThat(result.newTransactionInfo?.totalPrice).isEqualTo(2500L)
     }
 
     @Test
     fun `toResponse uses checkout session amount when total summary is absent`() {
         val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(),
+            configuration = googlePayConfiguration(),
             response = CheckoutSessionResponseFactory.create(
                 amount = 1000L,
                 totalSummary = null,
@@ -122,13 +103,13 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
-        assertThat(result.newTransactionInfo).isEqualTo(expectedTransactionInfo(totalPrice = 1000L))
+        assertThat(result.newTransactionInfo?.totalPrice).isEqualTo(1000L)
     }
 
     @Test
     fun `toResponse uses payment intent id as transaction id`() {
         val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(),
+            configuration = googlePayConfiguration(),
             response = CheckoutSessionResponseFactory.create(
                 paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 setupIntent = null,
@@ -136,15 +117,14 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
-        assertThat(result.newTransactionInfo).isEqualTo(
-            expectedTransactionInfo(transactionId = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.id)
-        )
+        assertThat(result.newTransactionInfo?.transactionId)
+            .isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.id)
     }
 
     @Test
     fun `toResponse uses setup intent id as transaction id when no payment intent`() {
         val result = mapper.toResponse(
-            configuration = CommonConfigurationFactory.create(),
+            configuration = googlePayConfiguration(),
             response = CheckoutSessionResponseFactory.create(
                 paymentIntent = null,
                 setupIntent = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
@@ -152,25 +132,31 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
 
-        assertThat(result.newTransactionInfo).isEqualTo(
-            expectedTransactionInfo(transactionId = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.id)
-        )
+        assertThat(result.newTransactionInfo?.transactionId)
+            .isEqualTo(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT.id)
     }
 
-    private fun expectedTransactionInfo(
-        countryCode: String? = "US",
-        totalPrice: Long? = 1000L,
-        transactionId: String? = null,
-        displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
-    ) = GooglePayJsonFactory.TransactionInfo(
-        currencyCode = "USD",
-        totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
+    @Test
+    fun `toResponse uses display items built from response`() {
+        val response = CheckoutSessionResponseFactory.create(
+            totalSummary = totalSummary(totalAmountDue = 2500L),
+        )
+
+        val result = mapper.toResponse(
+            configuration = googlePayConfiguration(),
+            response = response,
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo?.displayItems)
+            .isEqualTo(GooglePayDisplayItemsFactory.create(response, context))
+    }
+
+    private fun googlePayConfiguration(
+        countryCode: String = "US",
+    ) = PaymentSheet.GooglePayConfiguration(
+        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
         countryCode = countryCode,
-        transactionId = transactionId,
-        totalPrice = totalPrice,
-        totalPriceLabel = context.getString(R.string.stripe_google_pay_total),
-        checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default,
-        displayItems = displayItems,
     )
 
     private fun totalSummary(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+
+@OptIn(CheckoutSessionPreview::class)
+internal class FakeCheckoutGooglePayPaymentDataUpdateAddressBuilder(
+    private val result: CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result,
+) : CheckoutGooglePayPaymentDataUpdateAddressBuilder {
+    val buildCalls = Turbine<GooglePayPaymentDataUpdate>()
+
+    override fun build(
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result {
+        buildCalls.add(paymentDataUpdate)
+        return result
+    }
+
+    fun ensureAllEventsConsumed() {
+        buildCalls.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateMapper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateMapper.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.checkout
 
 import app.cash.turbine.Turbine
-import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
 @OptIn(CheckoutSessionPreview::class)
@@ -14,7 +14,7 @@ internal class FakeCheckoutGooglePayPaymentDataUpdateMapper(
     val toResponseCalls = Turbine<ToResponseCall>()
 
     override fun toResponse(
-        configuration: CommonConfiguration,
+        configuration: PaymentSheet.GooglePayConfiguration,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse {
@@ -33,7 +33,7 @@ internal class FakeCheckoutGooglePayPaymentDataUpdateMapper(
     }
 
     data class ToResponseCall(
-        val configuration: CommonConfiguration,
+        val configuration: PaymentSheet.GooglePayConfiguration,
         val response: CheckoutSessionResponse,
         val paymentDataUpdate: GooglePayPaymentDataUpdate,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateMapper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateMapper.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+
+@OptIn(CheckoutSessionPreview::class)
+internal class FakeCheckoutGooglePayPaymentDataUpdateMapper(
+    private val response: GooglePayPaymentDataUpdateResponse,
+) : CheckoutGooglePayPaymentDataUpdateMapper {
+    val toResponseCalls = Turbine<ToResponseCall>()
+
+    override fun toResponse(
+        configuration: CommonConfiguration,
+        response: CheckoutSessionResponse,
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): GooglePayPaymentDataUpdateResponse {
+        toResponseCalls.add(
+            ToResponseCall(
+                configuration = configuration,
+                response = response,
+                paymentDataUpdate = paymentDataUpdate,
+            )
+        )
+        return this.response
+    }
+
+    fun ensureAllEventsConsumed() {
+        toResponseCalls.ensureAllEventsConsumed()
+    }
+
+    data class ToResponseCall(
+        val configuration: CommonConfiguration,
+        val response: CheckoutSessionResponse,
+        val paymentDataUpdate: GooglePayPaymentDataUpdate,
+    )
+}


### PR DESCRIPTION
# Summary
Add shipping address callback for Google Pay for Checkout Sessions by:
- Added `GooglePayPaymentDataUpdate`, `GooglePayPaymentDataResponse`, and `GooglePayPaymentDataUpdateCallback` APIs for respresenting callback handling with the base Stripe Google Pay APIs. May change as public APIs evolve.
- Adding `CheckoutGooglePayPaymentDataUpdateCallback` which converts a `GooglePayDataUpdate` into a `CheckoutSession.Address` that can be used with the `TaxRegionUpdater` to get updates the checkout session transaction state.
- Added `CheckoutGooglePayPaymentDataUpdateAddressBuilder` which builds an address for `CheckoutGooglePayPaymentDataUpdateCallback` using the provided `GooglePayPaymentDataUpdate` to send to `TaxRegionUpdater`.
- Added `CheckoutGooglePayPaymentDataUpdateMapper` which maps the checkout response received from `TaxRegionUpdater` to a response that can be mapped to the Google Pay API response.

# Motivation
Initial support for Google Pay dynamic callbacks for Checkout Sessions

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified