### PR TITLE
Pass shipping address callback & register to `InternalGooglePayPaymentMethodLauncher`

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -88,7 +88,7 @@ internal class OnrampPresenterCoordinator @Inject constructor(
     private val googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = googlePayConfig()?.let {
         GooglePayPaymentMethodLauncher(
             context = activity,
-            lifecycleScope = activity.lifecycleScope,
+            lifecycleOwner = activity,
             activityResultLauncher = googlePayActivityResultLauncher,
             config = it,
             readyCallback = ::handleGooglePayIsReady,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object GooglePayPaymentDataUpdateCallbackRegistry {
+    private val registeredCallbacks: MutableMap<String, GooglePayPaymentDataUpdateCallback> = mutableMapOf()
+    private val lock = Any()
+
+    fun register(key: String, callback: GooglePayPaymentDataUpdateCallback) {
+        synchronized(lock) {
+            registeredCallbacks[key] = callback
+        }
+    }
+
+    fun deregister(key: String) {
+        synchronized(lock) {
+            registeredCallbacks.remove(key)
+        }
+    }
+
+    fun get(key: String): GooglePayPaymentDataUpdateCallback? {
+        synchronized(lock) {
+            return registeredCallbacks[key]
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
@@ -1,27 +1,21 @@
 package com.stripe.android.googlepaylauncher
 
 import androidx.annotation.RestrictTo
+import java.util.Collections.synchronizedMap
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object GooglePayPaymentDataUpdateCallbackRegistry {
-    private val registeredCallbacks: MutableMap<String, GooglePayPaymentDataUpdateCallback> = mutableMapOf()
-    private val lock = Any()
+    private val registeredCallbacks = synchronizedMap(mutableMapOf<String, GooglePayPaymentDataUpdateCallback>())
 
     fun register(key: String, callback: GooglePayPaymentDataUpdateCallback) {
-        synchronized(lock) {
-            registeredCallbacks[key] = callback
-        }
+        registeredCallbacks[key] = callback
     }
 
     fun deregister(key: String) {
-        synchronized(lock) {
-            registeredCallbacks.remove(key)
-        }
+        registeredCallbacks.remove(key)
     }
 
     fun get(key: String): GooglePayPaymentDataUpdateCallback? {
-        synchronized(lock) {
-            return registeredCallbacks[key]
-        }
+        return registeredCallbacks[key]
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.CardBrandFilter
@@ -32,7 +33,6 @@ import com.stripe.android.model.ShippingInformation
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import dev.drewhamilton.poko.Poko
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -48,7 +48,7 @@ import java.util.Locale
  */
 @JvmSuppressWildcards
 class GooglePayPaymentMethodLauncher internal constructor(
-    lifecycleScope: CoroutineScope,
+    lifecycleOwner: LifecycleOwner,
     private val config: Config,
     readyCallback: ReadyCallback,
     activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
@@ -66,7 +66,10 @@ class GooglePayPaymentMethodLauncher internal constructor(
 ) {
     private var isReady = false
     private val internalLauncher = InternalGooglePayPaymentMethodLauncher(
+        instanceId = INSTANCE_ID,
+        lifecycleOwner = lifecycleOwner,
         activityResultLauncher = activityResultLauncher,
+        onPaymentDataChangedCallback = null,
         context = context,
         paymentAnalyticsRequestFactory = paymentAnalyticsRequestFactory,
         analyticsRequestExecutor = analyticsRequestExecutor,
@@ -90,7 +93,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         resultCallback: ResultCallback
     ) : this(
         activity,
-        activity.lifecycleScope,
+        activity,
         activity.registerForActivityResult(
             GooglePayPaymentMethodLauncherContractV2()
         ) {
@@ -112,7 +115,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         resultCallback: ResultCallback
     ) : this(
         activity,
-        activity.lifecycleScope,
+        activity,
         registerForReactNativeActivityResult(
             activity,
             signal,
@@ -144,7 +147,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         resultCallback: ResultCallback
     ) : this(
         fragment.requireContext(),
-        fragment.viewLifecycleOwner.lifecycleScope,
+        fragment.viewLifecycleOwner,
         fragment.registerForActivityResult(
             GooglePayPaymentMethodLauncherContractV2()
         ) {
@@ -159,14 +162,14 @@ class GooglePayPaymentMethodLauncher internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         context: Context,
-        lifecycleScope: CoroutineScope,
+        lifecycleOwner: LifecycleOwner,
         activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
         config: Config,
         readyCallback: ReadyCallback,
         cardBrandFilter: CardBrandFilter,
         cardFundingFilter: CardFundingFilter
     ) : this(
-        lifecycleScope,
+        lifecycleOwner,
         config,
         readyCallback,
         activityResultLauncher,
@@ -199,7 +202,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
 
     init {
         if (!skipReadyCheck) {
-            lifecycleScope.launch {
+            lifecycleOwner.lifecycleScope.launch {
                 val repository = googlePayRepositoryFactory(
                     environment = config.environment,
                     cardFundingFilter = cardFundingFilter,
@@ -407,6 +410,8 @@ class GooglePayPaymentMethodLauncher internal constructor(
     annotation class ErrorCode
 
     companion object {
+        private const val INSTANCE_ID = "GOOGLE_PAY_PAYMENT_METHOD_LAUNCHER"
+
         internal const val PRODUCT_USAGE_TOKEN = "GooglePayPaymentMethodLauncher"
         internal var HAS_SENT_INIT_ANALYTIC_EVENT: Boolean = false
 
@@ -445,7 +450,7 @@ fun rememberGooglePayPaymentMethodLauncher(
     val currentReadyCallback by rememberUpdatedState(readyCallback)
 
     val context = LocalContext.current
-    val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+    val lifecycleOwner = LocalLifecycleOwner.current
     val activityResultLauncher = rememberLauncherForActivityResult(
         GooglePayPaymentMethodLauncherContractV2(),
         resultCallback::onResult
@@ -454,7 +459,7 @@ fun rememberGooglePayPaymentMethodLauncher(
     return remember(config) {
         GooglePayPaymentMethodLauncher(
             context = context,
-            lifecycleScope = lifecycleScope,
+            lifecycleOwner = lifecycleOwner,
             activityResultLauncher = activityResultLauncher,
             config = config,
             readyCallback = {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
@@ -3,6 +3,8 @@ package com.stripe.android.googlepaylauncher
 import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
@@ -25,7 +27,10 @@ import dagger.assisted.AssistedInject
 @JvmSuppressWildcards
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructor(
+    @Assisted private val instanceId: String,
+    @Assisted private val lifecycleOwner: LifecycleOwner,
     @Assisted private val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+    @Assisted private val onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
     context: Context,
     paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
         context,
@@ -41,6 +46,21 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
                 paymentAnalyticsRequestFactory.createRequest(
                     PaymentAnalyticsEvent.GooglePayPaymentMethodLauncherInit
                 )
+            )
+        }
+
+        onPaymentDataChangedCallback?.let { callback ->
+            GooglePayPaymentDataUpdateCallbackRegistry.register(
+                key = instanceId,
+                callback = callback,
+            )
+
+            lifecycleOwner.lifecycle.addObserver(
+                object : DefaultLifecycleObserver {
+                    override fun onDestroy(owner: LifecycleOwner) {
+                        GooglePayPaymentDataUpdateCallbackRegistry.deregister(instanceId)
+                    }
+                }
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/InternalGooglePayPaymentMethodLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/InternalGooglePayPaymentMethodLauncherFactory.kt
@@ -2,6 +2,8 @@ package com.stripe.android.googlepaylauncher.injection
 
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
 import dagger.assisted.AssistedFactory
@@ -10,6 +12,9 @@ import dagger.assisted.AssistedFactory
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface InternalGooglePayPaymentMethodLauncherFactory {
     fun create(
+        instanceId: String,
+        lifecycleOwner: LifecycleOwner,
         activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
     ): InternalGooglePayPaymentMethodLauncher
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.googlepaylauncher
 
 import androidx.activity.ComponentActivity
-import androidx.lifecycle.lifecycleScope
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -46,7 +45,7 @@ class GooglePayPaymentMethodLauncherTest {
             val firedEvents = mutableListOf<String>()
 
             val launcher = GooglePayPaymentMethodLauncher(
-                lifecycleScope = activity.lifecycleScope,
+                lifecycleOwner = activity,
                 config = CONFIG,
                 readyCallback = mock(),
                 activityResultLauncher = mock(),
@@ -78,7 +77,7 @@ class GooglePayPaymentMethodLauncherTest {
             val firedEvents = mutableListOf<String>()
 
             GooglePayPaymentMethodLauncher(
-                lifecycleScope = activity.lifecycleScope,
+                lifecycleOwner = activity,
                 config = CONFIG,
                 readyCallback = mock(),
                 activityResultLauncher = mock(),
@@ -95,7 +94,7 @@ class GooglePayPaymentMethodLauncherTest {
             )
 
             GooglePayPaymentMethodLauncher(
-                lifecycleScope = activity.lifecycleScope,
+                lifecycleOwner = activity,
                 config = CONFIG,
                 readyCallback = mock(),
                 activityResultLauncher = mock(),

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncherTest.kt
@@ -1,0 +1,125 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.FakeActivityResultLauncher
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InternalGooglePayPaymentMethodLauncherTest {
+    @Test
+    fun `init registers callback with registry when callback is provided`() {
+        val callback = GooglePayPaymentDataUpdateCallback { _ ->
+            GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
+        }
+
+        createLauncher(instanceId = "instanceId", onPaymentDataChangedCallback = callback)
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isSameInstanceAs(callback)
+    }
+
+    @Test
+    fun `init does not register anything when callback is null`() {
+        createLauncher(instanceId = "instanceId", onPaymentDataChangedCallback = null)
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isNull()
+    }
+
+    @Test
+    fun `callback is deregistered when lifecycle owner is destroyed`() {
+        val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.CREATED)
+        val callback = GooglePayPaymentDataUpdateCallback { _ ->
+            GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
+        }
+
+        createLauncher(
+            instanceId = "instanceId",
+            lifecycleOwner = lifecycleOwner,
+            onPaymentDataChangedCallback = callback,
+        )
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isSameInstanceAs(callback)
+
+        lifecycleOwner.currentState = Lifecycle.State.DESTROYED
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isNull()
+    }
+
+    @Test
+    fun `present launches activity result launcher with expected args`() {
+        val activityResultLauncher = FakeActivityResultLauncher(GooglePayPaymentMethodLauncherContractV2())
+        val config = GooglePayPaymentMethodLauncher.Config(
+            environment = GooglePayEnvironment.Test,
+            merchantCountryCode = "US",
+            merchantName = "Widget Store",
+        )
+        val launcher = createLauncher(activityResultLauncher = activityResultLauncher)
+
+        launcher.present(
+            currencyCode = "usd",
+            amount = 1000L,
+            config = config,
+            cardBrandFilter = DefaultCardBrandFilter,
+            cardFundingFilter = DefaultCardFundingFilter,
+            clientAttributionMetadata = null,
+            transactionId = "pi_12345",
+            label = null,
+            isElements = true,
+            publishableKey = null,
+            displayItems = emptyList(),
+            billingEmailOverride = null,
+            shippingAddressParameters = null,
+        )
+
+        assertThat(activityResultLauncher.launchArgs[0]).isEqualTo(
+            GooglePayPaymentMethodLauncherContractV2.Args(
+                config = config,
+                currencyCode = "usd",
+                amount = 1000L,
+                label = null,
+                transactionId = "pi_12345",
+                cardBrandFilter = DefaultCardBrandFilter,
+                cardFundingFilter = DefaultCardFundingFilter,
+                clientAttributionMetadata = null,
+                isElements = true,
+                publishableKey = null,
+                displayItems = emptyList(),
+                billingEmailOverride = null,
+                shippingAddressParameters = null,
+            )
+        )
+    }
+
+    private fun createLauncher(
+        instanceId: String = "instanceId",
+        lifecycleOwner: TestLifecycleOwner = TestLifecycleOwner(),
+        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args> = mock(),
+        onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback? = null,
+        analyticsRequestExecutor: AnalyticsRequestExecutor = AnalyticsRequestExecutor { },
+    ): InternalGooglePayPaymentMethodLauncher {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        return InternalGooglePayPaymentMethodLauncher(
+            instanceId = instanceId,
+            lifecycleOwner = lifecycleOwner,
+            activityResultLauncher = activityResultLauncher,
+            onPaymentDataChangedCallback = onPaymentDataChangedCallback,
+            context = context,
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = context,
+                publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            ),
+            analyticsRequestExecutor = analyticsRequestExecutor,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
@@ -14,6 +15,7 @@ import com.stripe.android.googlepaylauncher.injection.InternalGooglePayPaymentMe
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
@@ -24,9 +26,11 @@ import javax.inject.Inject
 import com.stripe.android.R as PaymentsCoreR
 
 internal class GooglePayConfirmationDefinition @Inject constructor(
+    @PaymentElementCallbackIdentifier val instanceId: String,
     private val context: Context,
     private val googlePayPaymentMethodLauncherFactory: InternalGooglePayPaymentMethodLauncherFactory,
     private val userFacingLogger: UserFacingLogger?,
+    private val onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback? = null,
 ) : ConfirmationDefinition<
     GooglePayConfirmationOption,
     InternalGooglePayPaymentMethodLauncher,
@@ -76,7 +80,10 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
         )
 
         return googlePayPaymentMethodLauncherFactory.create(
+            instanceId = instanceId,
+            lifecycleOwner = lifecycleOwner,
             activityResultLauncher = activityResultLauncher,
+            onPaymentDataChangedCallback = onPaymentDataChangedCallback,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayPaymentDataUpdateNoOpModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayPaymentDataUpdateNoOpModule.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentelement.confirmation.gpay
+
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
+import dagger.Module
+import dagger.Provides
+
+@Module
+internal class GooglePayPaymentDataUpdateNoOpModule {
+    @Provides
+    fun providesGooglePayPaymentDataUpdateCallback() = CALLBACK
+
+    private companion object {
+        val CALLBACK: GooglePayPaymentDataUpdateCallback? = null
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -17,6 +17,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
@@ -64,6 +65,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         EmbeddedPaymentElementViewModelModule::class,
+        GooglePayPaymentDataUpdateNoOpModule::class,
         GooglePayLauncherModule::class,
         ExtendedPaymentElementConfirmationModule::class,
         TapToAddConnectionStarterModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -8,6 +8,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityModule
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
@@ -28,6 +29,7 @@ import javax.inject.Singleton
         EmbeddedCommonModule::class,
         ElementsSessionClientParamsModule::class,
         ExtendedPaymentElementConfirmationModule::class,
+        GooglePayPaymentDataUpdateNoOpModule::class,
         GooglePayLauncherModule::class,
         EmbeddedLinkExtrasModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
@@ -42,6 +43,7 @@ import javax.inject.Singleton
         PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,
+        GooglePayPaymentDataUpdateNoOpModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
         ResourceRepositoryModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
@@ -26,6 +27,7 @@ import javax.inject.Singleton
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,
+        GooglePayPaymentDataUpdateNoOpModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
         ResourceRepositoryModule::class,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.utils
 
 import android.app.Application
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
@@ -20,6 +21,7 @@ import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSourc
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.data.FakeCustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.FakeCustomerSheetSavedSelectionDataSource
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.injection.InternalGooglePayPaymentMethodLauncherFactory
@@ -149,8 +151,11 @@ internal interface CustomerSheetTestHelper {
                     },
                     googlePayPaymentMethodLauncherFactory = object : InternalGooglePayPaymentMethodLauncherFactory {
                         override fun create(
+                            instanceId: String,
+                            lifecycleOwner: LifecycleOwner,
                             activityResultLauncher:
                             ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+                            onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
                         ): InternalGooglePayPaymentMethodLauncher = mock()
                     },
                     statusBarColor = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -215,6 +215,7 @@ internal fun createTestConfirmationHandlerFactory(
                     bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
                 ),
                 GooglePayConfirmationDefinition(
+                    instanceId = paymentElementCallbackIdentifier,
                     context = ApplicationProvider.getApplicationContext(),
                     googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
                     userFacingLogger = FakeUserFacingLogger(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -42,6 +42,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -131,6 +132,7 @@ internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivit
         ExtendedPaymentElementConfirmationTestModule::class,
         GooglePayLauncherModule::class,
         PaymentOptionCardArtModule::class,
+        GooglePayPaymentDataUpdateNoOpModule::class,
     ]
 )
 @Singleton

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -41,6 +41,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -126,6 +127,7 @@ internal class PaymentElementConfirmationTestActivity : AppCompatActivity() {
         PaymentElementConfirmationModule::class,
         PaymentElementConfirmationTestModule::class,
         GooglePayLauncherModule::class,
+        GooglePayPaymentDataUpdateNoOpModule::class,
     ]
 )
 @Singleton

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
@@ -122,6 +123,33 @@ class GooglePayConfirmationDefinitionTest {
                 callback.onActivityResult(GooglePayPaymentMethodLauncher.Result.Completed(PaymentMethodFactory.card()))
 
                 assertThat(onResultCalled).isTrue()
+            }
+        }
+
+    @Test
+    fun `'createLauncher' should pass 'onPaymentDataChangedCallback' to launcher factory`() =
+        RecordingInternalGooglePayPaymentMethodLauncherFactory.test(mock()) {
+            val onPaymentDataChangedCallback = mock<GooglePayPaymentDataUpdateCallback>()
+            val definition = createGooglePayConfirmationDefinition(
+                googlePayPaymentMethodLauncherFactory = factory,
+                instanceId = "instanceId",
+                onPaymentDataChangedCallback = onPaymentDataChangedCallback,
+            )
+
+            DummyActivityResultCaller.test {
+                definition.createLauncher(
+                    activityResultCaller = activityResultCaller,
+                    lifecycleOwner = fakeLifecycleOwner(),
+                    onResult = {},
+                )
+
+                assertThat(awaitRegisterCall()).isNotNull()
+                assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+                val createCall = createGooglePayPaymentMethodLauncherCalls.awaitItem()
+
+                assertThat(createCall.instanceId).isEqualTo("instanceId")
+                assertThat(createCall.onPaymentDataChangedCallback).isEqualTo(onPaymentDataChangedCallback)
             }
         }
 
@@ -784,11 +812,15 @@ class GooglePayConfirmationDefinitionTest {
             RecordingInternalGooglePayPaymentMethodLauncherFactory.noOp(launcher = mock()),
         userFacingLogger: UserFacingLogger = FakeUserFacingLogger(),
         context: Context = ApplicationProvider.getApplicationContext(),
+        instanceId: String = "instanceId",
+        onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback? = null,
     ): GooglePayConfirmationDefinition {
         return GooglePayConfirmationDefinition(
+            instanceId = instanceId,
             context = context,
             googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
             userFacingLogger = userFacingLogger,
+            onPaymentDataChangedCallback = onPaymentDataChangedCallback,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -43,6 +43,7 @@ class GooglePayConfirmationFlowTest {
                 val mediator = ConfirmationMediator(
                     savedStateHandle = savedStateHandle,
                     definition = GooglePayConfirmationDefinition(
+                        instanceId = "instanceId",
                         context = ApplicationProvider.getApplicationContext<Context>(),
                         googlePayPaymentMethodLauncherFactory = factory,
                         userFacingLogger = null,
@@ -104,6 +105,7 @@ class GooglePayConfirmationFlowTest {
         confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
         parameters = CONFIRMATION_PARAMETERS,
         definition = GooglePayConfirmationDefinition(
+            instanceId = "instanceId",
             context = ApplicationProvider.getApplicationContext<Context>(),
             googlePayPaymentMethodLauncherFactory =
                 RecordingInternalGooglePayPaymentMethodLauncherFactory.noOp(mock()),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -38,6 +39,7 @@ import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
@@ -1378,7 +1380,10 @@ internal class PaymentSheetActivityTest {
     private fun createGooglePayPaymentMethodLauncherFactory() =
         object : InternalGooglePayPaymentMethodLauncherFactory {
             override fun create(
+                instanceId: String,
+                lifecycleOwner: LifecycleOwner,
                 activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+                onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
             ): InternalGooglePayPaymentMethodLauncher {
                 return mock<InternalGooglePayPaymentMethodLauncher>()
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingInternalGooglePayPaymentMethodLauncherFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/RecordingInternalGooglePayPaymentMethodLauncherFactory.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet.utils
 
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.injection.InternalGooglePayPaymentMethodLauncherFactory
@@ -14,15 +16,21 @@ internal class RecordingInternalGooglePayPaymentMethodLauncherFactory private co
     private val calls = Turbine<Call>()
 
     override fun create(
+        instanceId: String,
+        lifecycleOwner: LifecycleOwner,
         activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
     ): InternalGooglePayPaymentMethodLauncher {
-        calls.add(Call(activityResultLauncher))
+        calls.add(Call(instanceId, lifecycleOwner, activityResultLauncher, onPaymentDataChangedCallback))
 
         return launcher
     }
 
     data class Call(
+        val instanceId: String,
+        val lifecycleOwner: LifecycleOwner,
         val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+        val onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
     )
 
     class Scenario(


### PR DESCRIPTION
# Summary
Pass shipping address callback into `GooglePayConfirmationDefinition` to provide to the `InternalGooglePayPaymentMethodLauncherFactory`. After creating the launcher, the callback should be immediately registered in `GooglePayPaymentDataRegistry` and deregistered when the `GooglePayPaymentMethodLauncher`  instance is destroyed.

# Motivation
Support for dynamic callbacks with Google Pay

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>