### PR TITLE
Emit session complete signal via controller result callback only.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -41,6 +41,9 @@ internal class CheckoutControllerExampleViewModel(
         savedStateHandle = savedStateHandle,
     ).resultCallback { result ->
         Log.d(TAG, "Result: $result")
+        if (result is CheckoutController.Result.Completed) {
+            _sessionComplete.tryEmit(Unit)
+        }
     }.build()
 
     init {
@@ -50,9 +53,6 @@ internal class CheckoutControllerExampleViewModel(
         viewModelScope.launch {
             controller.session.collect { session ->
                 updateConfiguredState { it.copy(session = session) }
-                if (session?.status == Session.Status.Complete) {
-                    _sessionComplete.tryEmit(Unit)
-                }
             }
         }
     }


### PR DESCRIPTION
# Summary
Moved emission of the `_sessionComplete` signal to the controller result callback, and removed emission based on session status in the session collector.
