### PR TITLE
Fix custom payment method cancel flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -835,7 +835,7 @@ internal class PlaygroundTestDriver(
             selectors.customPaymentMethodCancelButton,
         )
 
-        isSelectPaymentMethodScreen()
+        waitForPaymentSheetActivity()
         selectors.buyButton.waitProcessingComplete()
         selectors.buyButton.isEnabled()
 
@@ -1772,6 +1772,10 @@ internal class PlaygroundTestDriver(
         return runCatching {
             composeTestRule.onNodeWithText("Select your payment method").assertIsDisplayed()
         }.isSuccess
+    }
+
+    private fun waitForPaymentSheetActivity() {
+        awaitActivityClass("com.stripe.android.paymentsheet.PaymentSheetActivity")
     }
 
     private fun addPaymentMethodNode(): SemanticsNodeInteraction {


### PR DESCRIPTION
# Summary

Fixes the custom-payment-method cancellation E2E test by waiting for `PaymentSheetActivity` to resume before asserting the Buy button state.

# Motivation

The custom payment method activity can destroy its Compose hierarchy while the cancellation flow returns to PaymentSheet. The test previously queried Compose during that transition and intermittently failed with `No compose hierarchies found in the app`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran the focused Chrome managed-device test with diagnostic-only ShampooRule: 2/2 and 50/50 serial executions passed. Ran the focused test once more with the normal RetryRule configuration: passed.

# Screenshots

Not applicable — instrumentation-test synchronization change with no product UI change.

# Changelog

Not applicable — test-only flake fix with no user-facing SDK change.
