### PR TITLE
Wire checkoutSessionResponse into CheckoutSessionConfirmationInterceptor

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -43,6 +43,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     @Assisted private val integrationMetadata: IntegrationMetadata.CheckoutSession,
     @Assisted private val customerMetadata: CustomerMetadata?,
     @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
+    @Assisted private val checkoutSessionResponse: CheckoutSessionResponse?,
     context: Context,
     private val stripeRepository: StripeRepository,
     private val checkoutSessionRepository: CheckoutSessionRepository,
@@ -188,6 +189,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             integrationMetadata: IntegrationMetadata.CheckoutSession,
             customerMetadata: CustomerMetadata?,
             clientAttributionMetadata: ClientAttributionMetadata,
+            checkoutSessionResponse: CheckoutSessionResponse?,
         ): CheckoutSessionConfirmationInterceptor
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
@@ -16,6 +16,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -130,7 +131,8 @@ internal class CustomerSheetIntentConfirmationInterceptorFactory @Inject constru
     override suspend fun create(
         integrationMetadata: IntegrationMetadata,
         customerMetadata: CustomerMetadata?,
-        clientAttributionMetadata: ClientAttributionMetadata
+        clientAttributionMetadata: ClientAttributionMetadata,
+        checkoutSessionResponse: CheckoutSessionResponse?,
     ): IntentConfirmationInterceptor {
         return when (integrationMetadata) {
             is IntegrationMetadata.CustomerSheet -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -46,6 +46,7 @@ internal class IntentConfirmationDefinition(
                 integrationMetadata = paymentMethodMetadata.integrationMetadata,
                 customerMetadata = paymentMethodMetadata.customerMetadata,
                 clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+                checkoutSessionResponse = paymentMethodMetadata.checkoutSessionResponse,
             )
         } catch (e: CallbackNotFoundException) {
             return ConfirmationDefinition.Action.Fail(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 internal interface IntentConfirmationInterceptor {
@@ -33,6 +34,7 @@ internal interface IntentConfirmationInterceptor {
             integrationMetadata: IntegrationMetadata,
             customerMetadata: CustomerMetadata?,
             clientAttributionMetadata: ClientAttributionMetadata,
+            checkoutSessionResponse: CheckoutSessionResponse?,
         ): IntentConfirmationInterceptor
     }
 
@@ -54,6 +56,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
         integrationMetadata: IntegrationMetadata,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        checkoutSessionResponse: CheckoutSessionResponse?,
     ): IntentConfirmationInterceptor {
         return when (integrationMetadata) {
             is IntegrationMetadata.CustomerSheet -> {
@@ -98,6 +101,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                     integrationMetadata = integrationMetadata,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    checkoutSessionResponse = checkoutSessionResponse,
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -40,6 +40,7 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssisted
 import com.stripe.android.paymentsheet.cvcrecollection.RecordingCvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -91,6 +92,7 @@ internal interface CustomerSheetTestHelper {
                     integrationMetadata: IntegrationMetadata,
                     customerMetadata: CustomerMetadata?,
                     clientAttributionMetadata: ClientAttributionMetadata,
+                    checkoutSessionResponse: CheckoutSessionResponse?,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor().apply {
                         enqueueCompleteStep(true)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -46,6 +46,7 @@ import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImp
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.AbsFakeStripeRepository
@@ -147,11 +148,13 @@ internal suspend fun createIntentConfirmationInterceptor(
                 integrationMetadata: IntegrationMetadata.CheckoutSession,
                 customerMetadata: CustomerMetadata?,
                 clientAttributionMetadata: ClientAttributionMetadata,
+                checkoutSessionResponse: CheckoutSessionResponse?,
             ): CheckoutSessionConfirmationInterceptor {
                 return CheckoutSessionConfirmationInterceptor(
                     integrationMetadata = integrationMetadata,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    checkoutSessionResponse = null,
                     context = ApplicationProvider.getApplicationContext(),
                     stripeRepository = stripeRepository,
                     checkoutSessionRepository = CheckoutSessionRepository(
@@ -176,6 +179,7 @@ internal suspend fun createIntentConfirmationInterceptor(
         integrationMetadata = integrationMetadata,
         customerMetadata = customerMetadata,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+        checkoutSessionResponse = null,
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakePaymentLauncher
 import com.stripe.android.utils.FakeActivityResultLauncher
@@ -511,6 +512,7 @@ class IntentConfirmationDefinitionTest {
                     integrationMetadata: IntegrationMetadata,
                     customerMetadata: CustomerMetadata?,
                     clientAttributionMetadata: ClientAttributionMetadata,
+                    checkoutSessionResponse: CheckoutSessionResponse?,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor()
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.FakePaymentLauncher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -277,6 +278,7 @@ internal class IntentConfirmationFlowTest {
                     integrationMetadata: IntegrationMetadata,
                     customerMetadata: CustomerMetadata?,
                     clientAttributionMetadata: ClientAttributionMetadata,
+                    checkoutSessionResponse: CheckoutSessionResponse?,
                 ): IntentConfirmationInterceptor {
                     return createIntentConfirmationInterceptor(
                         integrationMetadata = integrationMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -390,6 +390,7 @@ class CheckoutSessionConfirmationInterceptorTest {
                 paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
                 checkoutSessionId = null,
             ),
+            checkoutSessionResponse = null,
             context = applicationContext,
             stripeRepository = stripeRepository,
             checkoutSessionRepository = checkoutSessionRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 
 internal open class FakeIntentConfirmationInterceptorFactory(
@@ -14,6 +15,7 @@ internal open class FakeIntentConfirmationInterceptorFactory(
         integrationMetadata: IntegrationMetadata,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        checkoutSessionResponse: CheckoutSessionResponse?,
     ): IntentConfirmationInterceptor {
         interceptor = FakeIntentConfirmationInterceptor().apply(enqueueStep)
         return interceptor

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -83,6 +83,7 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSaved
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
@@ -1313,6 +1314,7 @@ internal class PaymentSheetActivityTest {
                             integrationMetadata: IntegrationMetadata,
                             customerMetadata: CustomerMetadata?,
                             clientAttributionMetadata: ClientAttributionMetadata,
+                            checkoutSessionResponse: CheckoutSessionResponse?,
                         ): IntentConfirmationInterceptor {
                             return fakeIntentConfirmationInterceptor
                         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Wire checkoutSessionResponse into CheckoutSessionConfirmationInterceptor

Mechanical only refactor to get access to a checkout session response within the checkout session confirmation interceptor.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I need this to verify some information about the checkout session (e.g. is automatic tax enabled) before making tax region updates. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

No behavior changes