### PR TITLE
Fix hCaptcha token test synchronization

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
@@ -116,7 +116,6 @@ internal class HCaptchaTokenTest {
 
     private fun navigateToFormForLpm() {
         val verticalModePage = createPaymentSheetPage()
-        verticalModePage.waitUntilVisible()
         verticalModePage.fillOutCardDetails()
     }
 


### PR DESCRIPTION
# Summary

Fix the PaymentSheet passive hCaptcha token integration test's form-readiness synchronization.

# Motivation

The test could time out while waiting five seconds for a generic primary-button tag before it began waiting for the Card Number field. The card-form helper already waits for that precise form state for up to 15 seconds. Removing the redundant precondition prevents the shorter, less-specific wait from failing first.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused managed-device test:

`CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.paymentsheet.HCaptchaTokenTest#paymentMethodCreation_withPassiveCaptchaEnabled_includesHCaptchaTokenInCreateRequest' :paymentsheet:pixel2api33DebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`

Passed once in normal configuration. Diagnostic-only Shampoo runs also passed 2 and 50 iterations; Shampoo was restored and is absent from this diff.

# Screenshots

Not applicable: test-only synchronization change with no product UI change.

# Changelog

Not applicable: this only changes an internal instrumentation test.
