### PR TITLE
Fix PMO SFU saved card test flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -383,7 +383,7 @@ internal class TestCard : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText("4242", substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )


### PR DESCRIPTION
# Summary

Use the standard UI timeout while waiting for the selected saved card in `TestCard.testCardWithPmoSfu`.

# Motivation

The card is saved by the first PaymentSheet confirmation and then fetched by a second PaymentSheet instance. On the Chrome-enabled managed device, that exact saved-card state can legitimately arrive after the previous five-second limit, causing a Compose timeout before the card ending in `4242` is displayed.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused managed-device test:

- `CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestCard#testCardWithPmoSfu' :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`
- Diagnostic-only ShampooRule soak: 2 iterations passed, then 50/50 iterations passed. Shampoo instrumentation was restored before commit.
- Normal rule configuration: passed.

# Screenshots

Not applicable — test-only timeout adjustment with no product UI change.

# Changelog

Not applicable — this is an internal E2E test stabilization and does not affect the SDK's user-facing behavior.
