### PR TITLE
Fix V2 analytics reporter leak

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -643,14 +643,13 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     private fun fireV2Event(event: PaymentSheetEvent) {
+        val request = analyticsRequestV2Factory.createRequest(
+            eventName = event.eventName,
+            additionalParams = defaultParams(paymentMethodMetadataProvider.get()) + event.params,
+        )
+
         CoroutineScope(workContext).launch {
-            val paymentMethodMetadata = paymentMethodMetadataProvider.get()
-            analyticsRequestV2Executor.enqueue(
-                analyticsRequestV2Factory.createRequest(
-                    eventName = event.eventName,
-                    additionalParams = defaultParams(paymentMethodMetadata) + event.params,
-                )
-            )
+            analyticsRequestV2Executor.enqueue(request)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -7,6 +7,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -19,6 +20,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ElementsSession.ExperimentAssignment
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -60,6 +62,36 @@ class DefaultEventReporterTest {
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_init")
+    }
+
+    @Test
+    fun `onExperimentExposure enqueues V2 event`() = runScenario {
+        paymentMethodMetadataStack.push(null)
+
+        eventReporter.onExperimentExposure(
+            LoggableExperiment.LinkHoldback(
+                arbId = "arb_123",
+                group = "treatment",
+                experiment = ExperimentAssignment.LINK_GLOBAL_HOLD_BACK,
+                isReturningLinkUser = false,
+                useLinkNative = true,
+                emailRecognitionSource = null,
+                providedDefaultValues = LoggableExperiment.LinkHoldback.ProvidedDefaultValues(
+                    email = false,
+                    name = false,
+                    phone = false,
+                ),
+                spmEnabled = false,
+                integrationShape = "payment_sheet",
+                linkDisplayed = true,
+                elementsSessionId = "elements_session_123",
+                mobileSdkVersion = "1.0.0",
+                mobileSessionId = "mobile_session_123",
+            )
+        )
+
+        val request = analyticsRequestV2Executor.enqueueCalls.awaitItem()
+        assertThat(request.eventName).isEqualTo("elements.experiment_exposure")
     }
 
     @Test


### PR DESCRIPTION
# Summary
Build V2 analytics requests before launching their coroutine, preventing the coroutine from retaining `DefaultEventReporter` and the cleared `PaymentSheetViewModel` reachable through its metadata provider. Adds regression coverage for experiment-exposure V2 reporting.

# Motivation
LeakCanary reported that `DefaultEventReporter$fireV2Event$1` retained a cleared `PaymentSheetViewModel` through `paymentMethodMetadataProvider` after a PaymentSheet example instrumentation test. Preparing the request synchronously leaves the dispatched coroutine with only the request and executor.

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.analytics.DefaultEventReporterTest' --rerun-tasks`

`CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestConfirmationToken#testBankAccountWithConfirmationTokenInCustomFlow_withCSC' :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`

Diagnostic-only ShampooRule: 2 iterations passed with no leak. The 50-iteration attempt was blocked by a Gradle packaging hang before test execution and is not counted as soak evidence. Shampoo instrumentation was restored and is absent from this diff.

No tests were newly ignored.

# Screenshots

Not applicable — no UI changes.

# Changelog

Not applicable — internal lifecycle/test-stability fix with no user-facing API or behavior change.
