### PR TITLE
Remove unnecessary body part param in CheckoutSessionTaxRegionUpdater…

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -37,7 +37,6 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
             bodyPart("tax_region[city]", "San Francisco"),
             bodyPart("tax_region[state]", "CA"),
             bodyPart("tax_region[postal_code]", "94103"),
-            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
         ) { response ->
             response.testBodyFromFile("checkout-session-init.json")
         }


### PR DESCRIPTION
…Test

# Summary
<!-- Simple summary of what was changed. -->
Remove unnecessary body part param in CheckoutSessionTaxRegionUpdaterTest

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/13945#discussion_r3778834447

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
