### PR TITLE
Move checkout response into integration metadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod
 
 import android.os.Parcelable
 import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import kotlinx.parcelize.Parcelize
 
 internal sealed class IntegrationMetadata : Parcelable {
@@ -51,5 +52,6 @@ internal sealed class IntegrationMetadata : Parcelable {
     data class CheckoutSession(
         val id: String,
         val instancesKey: String,
+        val checkoutSessionResponse: CheckoutSessionResponse,
     ) : IntegrationMetadata()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -34,7 +34,6 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.toPaymentMethodIncentive
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.LinkDisabledState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.LinkStateResult
@@ -99,12 +98,13 @@ internal data class PaymentMethodMetadata(
     val disableSsdOcrCardScan: Boolean,
     val cardArts: List<PaymentMethod.Card.CardArt>,
     val shouldUseAutocompleteProxyEndpoints: Boolean,
-    val checkoutSessionResponse: CheckoutSessionResponse?,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
 ) : Parcelable {
 
     val requiresBillingAddressForAutomaticTax: Boolean
-        get() = checkoutSessionResponse?.collectsTaxFromBillingAddress == true
+        get() = (integrationMetadata as? IntegrationMetadata.CheckoutSession)
+            ?.checkoutSessionResponse
+            ?.collectsTaxFromBillingAddress == true
 
     fun paymentMethodOrientation(): PaymentMethodOrientation {
         return when (paymentMethodLayout) {
@@ -443,9 +443,6 @@ internal data class PaymentMethodMetadata(
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = cardArts,
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
-                checkoutSessionResponse =
-                    (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
-                        ?.checkoutSessionResponse,
                 paymentMethodLayout = paymentMethodLayout,
             )
         }
@@ -517,7 +514,6 @@ internal data class PaymentMethodMetadata(
                 disableSsdOcrCardScan = elementsSession.disableSsdOcrCardScan,
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
-                checkoutSessionResponse = null,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactory.kt
@@ -3,13 +3,15 @@ package com.stripe.android.paymentelement.confirmation.gpay
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
 internal object GooglePayDisplayItemsFactory {
 
     fun create(paymentMethodMetadata: PaymentMethodMetadata): List<GooglePayDisplayItem> {
-        val response = paymentMethodMetadata.checkoutSessionResponse ?: return emptyList()
+        val response = (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
+            ?.checkoutSessionResponse ?: return emptyList()
 
         val items = mutableListOf<GooglePayDisplayItem>()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -230,6 +230,7 @@ internal interface PaymentElementLoader {
                 return IntegrationMetadata.CheckoutSession(
                     id = checkoutSessionResponse.id,
                     instancesKey = instancesKey,
+                    checkoutSessionResponse = checkoutSessionResponse,
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
@@ -122,7 +122,6 @@ internal class PaymentMethodScreenScreenshotTest {
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
             ),
-            checkoutSessionResponse = null,
         )
         val uiDefinitionArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -20,7 +20,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.LinkStateResult
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
@@ -82,7 +81,6 @@ internal object PaymentMethodMetadataFactory {
         disableSsdOcrCardScan: Boolean = false,
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
-        checkoutSessionResponse: CheckoutSessionResponse? = null,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
@@ -156,7 +154,6 @@ internal object PaymentMethodMetadataFactory {
             disableSsdOcrCardScan = disableSsdOcrCardScan,
             cardArts = cardArts,
             shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
-            checkoutSessionResponse = checkoutSessionResponse,
             paymentMethodLayout = paymentMethodLayout,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1221,7 +1221,6 @@ internal class PaymentMethodMetadataTest {
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
-            checkoutSessionResponse = null,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
 
@@ -1382,7 +1381,6 @@ internal class PaymentMethodMetadataTest {
             disableSsdOcrCardScan = false,
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
-            checkoutSessionResponse = null,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -2175,16 +2173,21 @@ internal class PaymentMethodMetadataTest {
 
     @Test
     fun `createForPaymentElement requires automatic tax billing address when tax status requires it`() {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            taxStatus = CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS,
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
         val metadata = createPaymentElementMetadata(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "key",
-                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                    taxStatus = CheckoutSessionResponse.TaxStatus.REQUIRES_BILLING_ADDRESS,
-                    automaticTaxEnabled = true,
-                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-                ),
+                checkoutSessionResponse = checkoutSessionResponse,
             ),
-            integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_123",
+                instancesKey = "key",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
         )
 
         assertThat(metadata.requiresBillingAddressForAutomaticTax).isTrue()
@@ -2192,16 +2195,21 @@ internal class PaymentMethodMetadataTest {
 
     @Test
     fun `createForPaymentElement requires automatic tax billing address when tax status is ready`() {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            taxStatus = CheckoutSessionResponse.TaxStatus.READY,
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
         val metadata = createPaymentElementMetadata(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "key",
-                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                    taxStatus = CheckoutSessionResponse.TaxStatus.READY,
-                    automaticTaxEnabled = true,
-                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-                ),
+                checkoutSessionResponse = checkoutSessionResponse,
             ),
-            integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_123",
+                instancesKey = "key",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
         )
 
         assertThat(metadata.requiresBillingAddressForAutomaticTax).isTrue()
@@ -2209,15 +2217,20 @@ internal class PaymentMethodMetadataTest {
 
     @Test
     fun `createForPaymentElement does not require automatic tax billing address when automatic tax is disabled`() {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = false,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
         val metadata = createPaymentElementMetadata(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "key",
-                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                    automaticTaxEnabled = false,
-                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-                ),
+                checkoutSessionResponse = checkoutSessionResponse,
             ),
-            integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_123",
+                instancesKey = "key",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
         )
 
         assertThat(metadata.requiresBillingAddressForAutomaticTax).isFalse()
@@ -2225,15 +2238,20 @@ internal class PaymentMethodMetadataTest {
 
     @Test
     fun `createForPaymentElement does not require automatic tax billing address when tax uses shipping`() {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
+        )
         val metadata = createPaymentElementMetadata(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "key",
-                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                    automaticTaxEnabled = true,
-                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
-                ),
+                checkoutSessionResponse = checkoutSessionResponse,
             ),
-            integrationMetadata = IntegrationMetadata.CheckoutSession(id = "cs_123", instancesKey = "key"),
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_123",
+                instancesKey = "key",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
         )
 
         assertThat(metadata.requiresBillingAddressForAutomaticTax).isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
@@ -798,12 +799,19 @@ class CardDefinitionTest {
     private fun createAutomaticCardBillingAddressElement(
         checkoutSessionResponse: CheckoutSessionResponse?,
     ): BillingAddressElement {
+        val integrationMetadata = checkoutSessionResponse?.let { response ->
+            IntegrationMetadata.CheckoutSession(
+                id = response.id,
+                instancesKey = "CardDefinitionTest",
+                checkoutSessionResponse = response,
+            )
+        } ?: IntegrationMetadata.IntentFirst("pi_123_secret_456")
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
                 ),
-                checkoutSessionResponse = checkoutSessionResponse,
+                integrationMetadata = integrationMetadata,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionTest.kt
@@ -64,7 +64,6 @@ class KlarnaDefinitionTest {
                 defaultBillingDetails = PaymentSheet.BillingDetails(
                     address = PaymentSheet.Address(country = "DE"),
                 ),
-                checkoutSessionResponse = null,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProviderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProviderTest.kt
@@ -5,6 +5,8 @@ import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import org.junit.Test
 
 class GooglePayBillingEmailOverrideProviderTest {
@@ -54,9 +56,11 @@ class GooglePayBillingEmailOverrideProviderTest {
     }
 
     private fun checkoutSessionMetadata(): IntegrationMetadata.CheckoutSession {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create()
         return IntegrationMetadata.CheckoutSession(
-            id = "cs_test_123",
+            id = checkoutSessionResponse.id,
             instancesKey = "checkout_instances_123",
+            checkoutSessionResponse = checkoutSessionResponse,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProviderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayBillingEmailOverrideProviderTest.kt
@@ -5,7 +5,6 @@ import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import org.junit.Test
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItemsFactoryTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -16,7 +17,7 @@ class GooglePayDisplayItemsFactoryTest {
 
     @Test
     fun `returns empty list when checkoutSessionResponse is null`() {
-        val metadata = PaymentMethodMetadataFactory.create(checkoutSessionResponse = null)
+        val metadata = PaymentMethodMetadataFactory.create()
 
         val result = GooglePayDisplayItemsFactory.create(metadata)
 
@@ -214,10 +215,15 @@ class GooglePayDisplayItemsFactoryTest {
         lineItems: List<CheckoutSessionResponse.LineItem>,
         totalSummary: CheckoutSessionResponse.TotalSummaryResponse? = null,
     ): List<GooglePayJsonFactory.DisplayItem> {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            lineItems = lineItems,
+            totalSummary = totalSummary,
+        )
         val metadata = PaymentMethodMetadataFactory.create(
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-                lineItems = lineItems,
-                totalSummary = totalSummary,
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = checkoutSessionResponse.id,
+                instancesKey = "GooglePayDisplayItemsFactoryTest",
+                checkoutSessionResponse = checkoutSessionResponse,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayIsEmailRequiredProviderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayIsEmailRequiredProviderTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import org.junit.Test
 
 class GooglePayIsEmailRequiredProviderTest {
@@ -101,9 +102,11 @@ class GooglePayIsEmailRequiredProviderTest {
     }
 
     private fun checkoutSessionMetadata(): IntegrationMetadata.CheckoutSession {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create()
         return IntegrationMetadata.CheckoutSession(
-            id = "cs_test_123",
+            id = checkoutSessionResponse.id,
             instancesKey = "checkout_instances_123",
+            checkoutSessionResponse = checkoutSessionResponse,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentelement.confirmation.intent
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
-import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
@@ -378,10 +379,13 @@ class CheckoutSessionConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create()
+
         val interceptor = CheckoutSessionConfirmationInterceptor(
             integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = DEFAULT_CHECKOUT_SESSION_ID,
+                id = checkoutSessionResponse.id,
                 instancesKey = "test_key",
+                checkoutSessionResponse = checkoutSessionResponse,
             ),
             customerMetadata = customerMetadata,
             clientAttributionMetadata = ClientAttributionMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.intent
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1863,8 +1863,9 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(checkoutSession.integrationMetadata(null))
             .isEqualTo(
                 IntegrationMetadata.CheckoutSession(
-                    id = DEFAULT_CHECKOUT_SESSION_ID,
+                    id = checkoutSession.checkoutSessionResponse.id,
                     instancesKey = "DefaultPaymentElementLoaderTest",
+                    checkoutSessionResponse = checkoutSession.checkoutSessionResponse,
                 )
             )
     }


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary
<!-- Simple summary of what was changed. -->
Move checkout response into integration metadata

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
So that we can access the checkout session response from the checkout session confirmation interceptor
also better modeling! We only have a checkout session response in a checkout session integration, and if we're in a checkout session integration, we always have a checkout session response

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

No behavior change, just a mechanical refactor

