### PR TITLE
Use buildList for LPM billing test cases

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -119,13 +119,15 @@ internal class LpmBillingAddressFormValuesToParamsTest {
 
     private companion object {
         object TestCaseProvider : TestParameterValuesProvider() {
-            override fun provideValues(context: Context?): List<LpmBillingAddressFormValuesToParamsTestCase> {
-                return boletoTestCases +
-                    sepaDebitTestCases +
-                    weroTestCases +
-                    klarnaTestCases +
-                    bacsDebitTestCases +
-                    oxxoTestCases
+            override fun provideValues(
+                context: Context?,
+            ): List<LpmBillingAddressFormValuesToParamsTestCase> = buildList {
+                addAll(boletoTestCases)
+                addAll(sepaDebitTestCases)
+                addAll(weroTestCases)
+                addAll(klarnaTestCases)
+                addAll(bacsDebitTestCases)
+                addAll(oxxoTestCases)
             }
         }
     }


### PR DESCRIPTION
# Summary

Use `buildList` to assemble the shared LPM billing-address test cases in a
stable, explicit order.

# Motivation

This is a follow-up to the review discussion on #13959:
https://github.com/stripe/stripe-android/pull/13959#discussion_r3779470950.
The previous `+` chain made future payment-method additions harder to review.
One `addAll` call per provider keeps the test-case diff localized and preserves
the existing order.

This is a test-only refactor. It does not change production behavior, APIs,
screenshots, changelog entries, or stack topology.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

```text
./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.LpmBillingAddressFormValuesToParamsTest'
./gradlew :paymentsheet:apiCheck :paymentsheet:detekt
git diff --check
```

- Focused PaymentSheet unit test passed.
- `:paymentsheet:apiCheck` and `:paymentsheet:detekt` passed, including the
  path-aware pre-push checks.

# Screenshots

Not applicable. This refactor does not change UI output.

# Changelog

No entry. This PR changes only test organization.
