### PR TITLE
Migrate v1 analytics from q.stripe.com to r.stripe.com

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/AnalyticsRequestBody.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/AnalyticsRequestBody.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.networktesting
+
+import com.stripe.android.core.networking.AnalyticsRequest
+import java.io.ByteArrayOutputStream
+
+/**
+ * The raw form-encoded POST body of an [AnalyticsRequest].
+ */
+fun AnalyticsRequest.formBodyText(): String {
+    val outputStream = ByteArrayOutputStream()
+    outputStream.use { writePostBody(it) }
+    return outputStream.toString("UTF-8")
+}
+
+/**
+ * The form-encoded POST body of an [AnalyticsRequest], decoded into params.
+ *
+ * Repeated keys, such as `product_usage[]`, are collapsed to the last occurrence. Use
+ * [formBodyText] when the raw body matters.
+ */
+fun AnalyticsRequest.formBody(): Map<String, String> = parseUrlEncodedParams(formBodyText())

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -116,10 +116,7 @@ private class NetworkStatement(
 ) : Statement() {
     override fun evaluate() {
         try {
-            if (
-                !hostsToTrack.contains(AnalyticsRequest.HOST.hostFromUrl()) &&
-                !hostsToTrack.contains(AnalyticsRequestV2.ANALYTICS_HOST.hostFromUrl())
-            ) {
+            if (!hostsToTrack.contains(AnalyticsRequest.HOST.hostFromUrl())) {
                 AnalyticsRequestExecutor.ENABLED = false
             }
             setup()
@@ -145,6 +142,16 @@ private class NetworkStatement(
             request: StripeRequest,
             callback: HttpURLConnection.(request: StripeRequest) -> Unit
         ): HttpsURLConnection {
+            // v1 and v2 analytics now share r.stripe.com, so host tracking can no longer tell them
+            // apart. No test asserts v2 requests today — they were dropped because the v2 host was
+            // never tracked. Preserve that behavior explicitly.
+            if (request is AnalyticsRequestV2) {
+                throw RequestNotFoundException(
+                    "Test request attempted to reach AnalyticsRequestV2, which is not asserted on. " +
+                        "Url: ${request.url}"
+                )
+            }
+
             val requestHost = request.url.hostFromUrl()
             if (!hostsToTrack.contains(requestHost)) {
                 throw RequestNotFoundException(

--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -129,7 +129,7 @@ object RequestMatchers {
     }
 
     fun analyticsPayloadField(key: String, value: String): RequestMatcher {
-        return query(key, value)
+        return bodyPart(key, value)
     }
 
     fun method(method: String): RequestMatcher {
@@ -169,6 +169,12 @@ object RequestMatchers {
     fun hasQueryParam(param: String): RequestMatcher {
         return ToStringRequestMatcher("queryParam($param)") { request ->
             request.queryParameterValues(param).size == 1
+        }
+    }
+
+    fun hasBodyParam(param: String): RequestMatcher {
+        return ToStringRequestMatcher("bodyParam($param)") { request ->
+            request.bodyParameterValues(param).size == 1
         }
     }
 

--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestRecordedRequest.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestRecordedRequest.kt
@@ -43,4 +43,17 @@ class TestRecordedRequest(private val recordedRequest: RecordedRequest) {
             .build()
         return url.queryParameterValues(name)
     }
+
+    /**
+     * The body counterpart of [queryParameterValues]. Unlike [bodyParams], this can express a
+     * repeated key such as `executed_commands[]=a&executed_commands[]=b`.
+     */
+    fun bodyParameterValues(name: String): List<String?> {
+        val url = HttpUrl.Builder()
+            .scheme("https")
+            .host("example.com")
+            .encodedQuery(bodyText.takeIf { it.isNotEmpty() })
+            .build()
+        return url.queryParameterValues(name)
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -16,9 +16,11 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.Token
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networktesting.formBody
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -383,29 +385,34 @@ class PaymentAnalyticsRequestFactoryTest {
                 )
             )
 
-        // Verify URL contains all expected parameters including timestamp
-        val url = analyticsRequest.url
-        assertThat(url).contains("https://q.stripe.com?")
-        assertThat(url).contains("publishable_key=pk_abc123")
-        assertThat(url).contains("app_version=0")
-        assertThat(url).contains("bindings_version=$sdkVersion")
-        assertThat(url).contains("os_version=30")
-        assertThat(url).contains("session_id=${AnalyticsRequestFactory.sessionId}")
-        assertThat(url).contains("os_release=11")
-        assertThat(url).contains("device_type=robolectric_robolectric_robolectric")
-        assertThat(url).contains("source_type=card")
-        assertThat(url).contains("locale=en_US")
-        assertThat(url).contains("app_name=com.stripe.android.test")
-        assertThat(url).contains("analytics_ua=analytics.stripe_android-1.0")
-        assertThat(url).contains("os_name=REL")
-        assertThat(url).contains("network_type=2G")
-        assertThat(url).contains("event=stripe_android.payment_method_creation")
-        assertThat(url).contains("is_development=true")
-        assertThat(url).contains("timestamp=")
+        assertThat(analyticsRequest.url).isEqualTo("https://r.stripe.com/0")
+
+        // Verify the body contains all expected parameters including timestamp
+        val body = analyticsRequest.formBody()
+        assertThat(body).containsEntry("publishable_key", "pk_abc123")
+        assertThat(body).containsEntry("app_version", "0")
+        assertThat(body).containsEntry("bindings_version", sdkVersion)
+        assertThat(body).containsEntry("os_version", "30")
+        assertThat(body).containsEntry("session_id", AnalyticsRequestFactory.sessionId.toString())
+        assertThat(body).containsEntry("os_release", "11")
+        assertThat(body).containsEntry("device_type", "robolectric_robolectric_robolectric")
+        assertThat(body).containsEntry("source_type", "card")
+        assertThat(body).containsEntry("locale", "en_US")
+        assertThat(body).containsEntry("app_name", "com.stripe.android.test")
+        assertThat(body).containsEntry("analytics_ua", "analytics.stripe_android-1.0")
+        assertThat(body).containsEntry("os_name", "REL")
+        assertThat(body).containsEntry("network_type", "2G")
+        assertThat(body).containsEntry("event", "stripe_android.payment_method_creation")
+        assertThat(body).containsEntry("is_development", "true")
+
+        // Verify the params required by r.stripe.com
+        assertThat(body).containsEntry("client_id", "stripe-mobile-payments-sdk")
+        assertThat(body).containsEntry("event_name", "stripe_android.payment_method_creation")
+        assertThat(body).containsEntry("created", body["timestamp"])
+        assertNotNull(UUID.fromString(body["event_id"]))
 
         // Verify timestamp is a valid number
-        val timestampParam = url.substringAfter("timestamp=").substringBefore("&")
-        val timestamp = timestampParam.toDoubleOrNull()
+        val timestamp = body["timestamp"]?.toDoubleOrNull()
         assertThat(timestamp).isNotNull()
         assertThat(timestamp).isGreaterThan(0.0)
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
@@ -12,8 +12,8 @@ internal fun NetworkRule.validateAnalyticsRequest(
     vararg requestMatchers: RequestMatcher,
 ) {
     enqueue(
-        host("q.stripe.com"),
-        method("GET"),
+        host("r.stripe.com"),
+        method("POST"),
         analyticsPayloadField("event", eventName),
         analyticsPayloadField("product_usage", productUsage.joinToString(",")),
         *requestMatchers,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
-import com.stripe.android.networktesting.RequestMatchers.hasQueryParam
+import com.stripe.android.networktesting.RequestMatchers.hasBodyParam
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -138,7 +138,7 @@ internal class PaymentSheetAnalyticsTest {
         )
         validateAnalyticsRequest(
             eventName = "mc_complete_payment_newpm_success",
-            hasQueryParam("duration"),
+            hasBodyParam("duration"),
             analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "mc_billing_address_completed")
@@ -217,7 +217,7 @@ internal class PaymentSheetAnalyticsTest {
         )
         validateAnalyticsRequest(
             eventName = "mc_complete_payment_newpm_success",
-            hasQueryParam("duration")
+            hasBodyParam("duration")
         )
         validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTestHelpers.kt
@@ -6,7 +6,7 @@ import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 
-private const val ANALYTICS_HOST = "q.stripe.com"
+private const val ANALYTICS_HOST = "r.stripe.com"
 private const val EVENT_PREFIX = "mc_"
 
 internal fun NetworkRule.expectNfcScanStarted() {
@@ -50,7 +50,7 @@ internal fun createApduErrorMatchers(
         analyticsPayloadField("sw1", sw1),
         analyticsPayloadField("sw2", sw2),
         RequestMatcher { request ->
-            request.queryParameterValues("executed_commands[]") == executedCommands
+            request.bodyParameterValues("executed_commands[]") == executedCommands
         },
     )
 }
@@ -61,7 +61,7 @@ private fun NetworkRule.expectAnalyticsEvent(
 ) {
     val matchers = buildList {
         add(host(ANALYTICS_HOST))
-        add(method("GET"))
+        add(method("POST"))
         add(analyticsPayloadField("event", eventName))
         addAll(matchers)
     }

--- a/scripts/report_latency_synthetics.rb
+++ b/scripts/report_latency_synthetics.rb
@@ -12,8 +12,10 @@ require_relative 'latency_test_utils'
 
 PROJECT_ROOT = LatencyTestUtils::PROJECT_ROOT
 APP_PACKAGE = 'com.stripe.android.paymentsheet.example'
-ANALYTICS_HOST = ENV.fetch('STRIPE_SYNTHETICS_ANALYTICS_HOST', 'https://q.stripe.com')
+ANALYTICS_HOST = ENV.fetch('STRIPE_SYNTHETICS_ANALYTICS_HOST', 'https://r.stripe.com/0')
 ANALYTICS_UA = 'analytics.stripe_android-1.0'
+ANALYTICS_CLIENT_ID = 'stripe-mobile-payments-sdk'
+ANALYTICS_ORIGIN = 'stripe-mobile-payments-sdk-android'
 
 def adb_getprop(property)
   stdout, status = Open3.capture2e('adb', 'shell', 'getprop', property, chdir: PROJECT_ROOT)
@@ -61,6 +63,9 @@ def device_info
 end
 
 def analytics_params(test_name:, duration_seconds:, session_id:, publishable_key:, device_info:, app_name:)
+  timestamp = Time.now.to_f
+  event = 'mpe.synthetic_latency'
+
   {
     'analytics_ua' => ANALYTICS_UA,
     'os_name' => device_info.fetch(:os_name),
@@ -70,11 +75,16 @@ def analytics_params(test_name:, duration_seconds:, session_id:, publishable_key
     'bindings_version' => sdk_version,
     'is_development' => true,
     'session_id' => session_id,
-    'timestamp' => Time.now.to_f,
+    'timestamp' => timestamp,
     'app_name' => app_name,
-    'event' => 'mpe.synthetic_latency',
+    'event' => event,
     'test' => test_name,
-    'duration' => duration_seconds
+    'duration' => duration_seconds,
+    # Params required by r.stripe.com. event_name and created mirror event and timestamp.
+    'client_id' => ANALYTICS_CLIENT_ID,
+    'event_id' => SecureRandom.uuid,
+    'event_name' => event,
+    'created' => timestamp
   }.tap do |params|
     params['publishable_key'] = publishable_key if publishable_key && !publishable_key.empty?
   end
@@ -102,17 +112,21 @@ def emit_synthetics_events(results:, publishable_key:, dry_run:)
         device_info: device,
         app_name: app_name
       )
-      uri = URI("#{ANALYTICS_HOST}?#{encode_query(params)}")
+      uri = URI(ANALYTICS_HOST)
+      body = encode_query(params)
 
       if dry_run
-        puts "DRY_RUN analytics event #{test_name} sample #{index + 1}: #{uri}"
+        puts "DRY_RUN analytics event #{test_name} sample #{index + 1}: POST #{uri} #{body}"
         next
       end
 
-      request = Net::HTTP::Get.new(uri)
+      request = Net::HTTP::Post.new(uri)
       headers.each do |key, value|
         request[key] = value
       end
+      request['Content-Type'] = 'application/x-www-form-urlencoded'
+      request['Origin'] = ANALYTICS_ORIGIN
+      request.body = body
 
       response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         http.request(request)

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequest.kt
@@ -1,34 +1,72 @@
 package com.stripe.android.core.networking
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.HEADER_ORIGIN
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CLIENT_ID
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CREATED
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_EVENT_ID
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_EVENT_NAME
+import java.io.OutputStream
+import java.util.UUID
 
 /**
- * Analytics request sent to q.stripe.com, which is a legacy analytics service used mostly by
- * Payment SDK, analytics are saved in a shared DB table with payment-specific schema.
+ * Analytics request for the legacy Payment SDK analytics schema, POSTed to [HOST] (r.stripe.com) as
+ * a form-encoded body.
  *
- * For other SDKs, it is recommended to create a dedicated DB table just for the SDK and write to
- * this table through r.stripe.com. See [AnalyticsRequestV2] for details.
+ * The legacy params are sent verbatim, alongside the four params r.stripe.com requires:
+ * [PARAM_CLIENT_ID], [PARAM_CREATED], [PARAM_EVENT_NAME] and [PARAM_EVENT_ID]. [PARAM_EVENT_NAME]
+ * and [PARAM_CREATED] duplicate the legacy `event` and `timestamp` params so that the legacy schema
+ * keeps working.
+ *
+ * Analytics are saved in a shared DB table with a payment-specific schema. For other SDKs, prefer a
+ * dedicated table via [AnalyticsRequestV2].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AnalyticsRequest(
     val params: Map<String, *>,
     override val headers: Map<String, String>
 ) : StripeRequest() {
-    private val query: String = QueryStringFactory.createFromParamsWithEmptyValues(params)
+    /**
+     * Computed eagerly rather than in [writePostBody], because a 429 retry re-invokes
+     * [writePostBody] on the same instance and [PARAM_EVENT_ID] must be stable for dedup.
+     */
+    private val postBody: String =
+        QueryStringFactory.createFromParamsWithEmptyValues(params + rStripeParams())
 
-    override val method: Method = Method.GET
+    override val method: Method = Method.POST
 
     override val mimeType: MimeType = MimeType.Form
 
     override val retryResponseCodes: Iterable<Int> = HTTP_TOO_MANY_REQUESTS..HTTP_TOO_MANY_REQUESTS
 
-    override val url = listOfNotNull(
-        HOST,
-        query.takeIf { it.isNotEmpty() }
-    ).joinToString("?")
+    override val url: String = HOST
+
+    override var postHeaders: Map<String, String>? = mapOf(
+        HEADER_CONTENT_TYPE to "${MimeType.Form.code}; charset=${Charsets.UTF_8.name()}",
+        HEADER_ORIGIN to ORIGIN,
+    )
+
+    override fun writePostBody(outputStream: OutputStream) {
+        outputStream.write(postBody.toByteArray(Charsets.UTF_8))
+        outputStream.flush()
+    }
+
+    /**
+     * Params required by r.stripe.com. [PARAM_EVENT_NAME] and [PARAM_CREATED] mirror the legacy
+     * `event` and `timestamp` params, and are omitted when those are absent.
+     */
+    private fun rStripeParams(): Map<String, Any> = buildMap {
+        put(PARAM_CLIENT_ID, CLIENT_ID)
+        put(PARAM_EVENT_ID, UUID.randomUUID().toString())
+        params[AnalyticsFields.EVENT]?.let { put(PARAM_EVENT_NAME, it) }
+        params[AnalyticsFields.TIMESTAMP]?.let { put(PARAM_CREATED, it) }
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        const val HOST = "https://q.stripe.com"
+        const val HOST = "https://r.stripe.com/0"
+
+        private const val CLIENT_ID = "stripe-mobile-payments-sdk"
+        private const val ORIGIN = "stripe-mobile-payments-sdk-android"
     }
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestTest.kt
@@ -1,0 +1,122 @@
+package com.stripe.android.core.networking
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networktesting.formBody
+import com.stripe.android.networktesting.formBodyText
+import org.junit.Test
+import java.util.UUID
+
+class AnalyticsRequestTest {
+    @Test
+    fun `url is r stripe com`() = runScenario {
+        assertThat(request.url).isEqualTo("https://r.stripe.com/0")
+    }
+
+    @Test
+    fun `method is POST`() = runScenario {
+        assertThat(request.method).isEqualTo(StripeRequest.Method.POST)
+    }
+
+    @Test
+    fun `postHeaders contain content type and origin`() = runScenario {
+        assertThat(request.postHeaders).containsEntry(
+            "Content-Type",
+            "application/x-www-form-urlencoded; charset=UTF-8"
+        )
+        assertThat(request.postHeaders).containsEntry("origin", "stripe-mobile-payments-sdk-android")
+    }
+
+    @Test
+    fun `body preserves legacy params`() = runScenario {
+        val body = request.formBody()
+
+        assertThat(body).containsEntry("event", "stripe_android.test_event")
+        assertThat(body).containsEntry("timestamp", "1.7554E9")
+        assertThat(body).containsEntry("analytics_ua", "analytics.stripe_android-1.0")
+        assertThat(body).containsEntry("publishable_key", "pk_test_123")
+    }
+
+    @Test
+    fun `body contains client id required by r stripe com`() = runScenario {
+        assertThat(request.formBody()).containsEntry("client_id", "stripe-mobile-payments-sdk")
+    }
+
+    @Test
+    fun `event name mirrors legacy event param`() = runScenario {
+        assertThat(request.formBody()).containsEntry("event_name", "stripe_android.test_event")
+    }
+
+    @Test
+    fun `created mirrors legacy timestamp param`() = runScenario {
+        assertThat(request.formBody()).containsEntry("created", "1.7554E9")
+    }
+
+    @Test
+    fun `event id is a uuid`() = runScenario {
+        val eventId = requireNotNull(request.formBody()["event_id"])
+
+        assertThat(UUID.fromString(eventId).toString()).isEqualTo(eventId)
+    }
+
+    @Test
+    fun `event id is stable across repeated writes`() = runScenario {
+        assertThat(request.formBodyText()).isEqualTo(request.formBodyText())
+    }
+
+    @Test
+    fun `list params keep bracket encoding`() = runScenario(
+        params = DEFAULT_PARAMS + mapOf("product_usage" to listOf("PaymentSheet", "CardWidget")),
+    ) {
+        assertThat(request.formBodyText())
+            .contains("product_usage%5B%5D=PaymentSheet&product_usage%5B%5D=CardWidget")
+    }
+
+    @Test
+    fun `params are not modified`() = runScenario {
+        assertThat(request.params).isEqualTo(DEFAULT_PARAMS)
+    }
+
+    @Test
+    fun `event name is omitted when event is absent`() = runScenario(
+        params = DEFAULT_PARAMS - AnalyticsFields.EVENT,
+    ) {
+        assertThat(request.formBody()).doesNotContainKey("event_name")
+    }
+
+    @Test
+    fun `created is omitted when timestamp is absent`() = runScenario(
+        params = DEFAULT_PARAMS - AnalyticsFields.TIMESTAMP,
+    ) {
+        assertThat(request.formBody()).doesNotContainKey("created")
+    }
+
+    @Test
+    fun `empty params still produce the required params`() = runScenario(
+        params = emptyMap<String, Any>(),
+    ) {
+        val body = request.formBody()
+
+        assertThat(body.keys).containsExactly("client_id", "event_id")
+    }
+
+    private fun runScenario(
+        params: Map<String, *> = DEFAULT_PARAMS,
+        headers: Map<String, String> = emptyMap(),
+        block: Scenario.() -> Unit,
+    ) {
+        Scenario(request = AnalyticsRequest(params = params, headers = headers)).apply { block() }
+    }
+
+    private data class Scenario(
+        val request: AnalyticsRequest,
+    )
+
+    private companion object {
+        val DEFAULT_PARAMS: Map<String, *> = mapOf(
+            AnalyticsFields.EVENT to "stripe_android.test_event",
+            AnalyticsFields.TIMESTAMP to 1_755_400_000.0,
+            AnalyticsFields.ANALYTICS_UA to "analytics.stripe_android-1.0",
+            AnalyticsFields.PUBLISHABLE_KEY to "pk_test_123",
+        )
+    }
+}


### PR DESCRIPTION
# Summary

`AnalyticsRequest` (v1 analytics — every `stripe_android.*` and `mc_*` event, plus `RealErrorReporter`) now POSTs its params as a form-encoded body to `https://r.stripe.com/0` instead of GETing them as a query string to `q.stripe.com`.

- The legacy params (`event`, `timestamp`, `analytics_ua`, …) are sent verbatim, so the legacy schema keeps working.
- Adds the four params `r.stripe.com` requires: `client_id`, `event_id`, `event_name` and `created`. `event_name`/`created` mirror the legacy `event`/`timestamp`, and are omitted when those are absent rather than synthesized.
- The body reuses `QueryStringFactory.createFromParamsWithEmptyValues`, so the bytes are identical to today's query string — notably `product_usage[]=a&product_usage[]=b`, not `AnalyticsRequestV2`'s JSON-stringified nesting.
- `postBody` is computed eagerly: a 429 retry re-invokes `writePostBody` on the same instance, and `event_id` must stay stable for dedup.
- `params` is left untouched (a random `event_id` in a data-class component would poison `equals`/`hashCode`), and `headers` is unchanged — the r-only `Content-Type`/`origin` go in `postHeaders`, which `ConnectionFactory` applies only for POST.
- `scripts/report_latency_synthetics.rb` hand-rolls the same request, so it moves too or its `mpe.synthetic_latency` events stop landing.

Ports [stripe-ios#6605](https://github.com/stripe/stripe-ios/pull/6605), **without** its elements-session flag — v1 analytics switch over unconditionally. Simpler code, but it means there is no killswitch (see below) and the ~280 androidTest analytics assertions had to move from query-param matchers to body matchers in this same PR.

## Test-infrastructure change worth a look

v1 and v2 analytics now share `r.stripe.com`, so `NetworkRule` can no longer tell them apart by host. Today `AnalyticsRequestV2` requests are silently dropped in tests because the v2 host is never in `hostsToTrack`; once v1 moves, they'd start reaching the mock dispatcher and land in `unmatchedRequests`, failing every analytics test intermittently (v2 usually goes through WorkManager). `NetworkRuleConnectionOpener.open` now rejects `AnalyticsRequestV2` explicitly to preserve the existing behavior. No test opts into v2 assertions today.

# Motivation

`q.stripe.com` is the legacy analytics ingestion service; `r.stripe.com` is the preferred one, and Stripe is migrating the legacy table off `q`. Android already uses `r.stripe.com/0` for v2 analytics.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

New `AnalyticsRequestTest` covers url/method/`postHeaders`, legacy param passthrough, the four `r` params, `event_id` stability across repeated writes (the 429-retry dedup invariant), `product_usage%5B%5D=` bracket encoding, `params` immutability, and the omit/empty-map cases.

Ran green locally:

- `:stripe-core:testDebugUnitTest`, `:payments-core:testDebugUnitTest`, `:paymentsheet:testDebugUnitTest`
- `detekt`, `apiCheck` (both no-ops for the API surface — `AnalyticsRequest` is `@RestrictTo(LIBRARY_GROUP)` and absent from every `.api` dump)
- `run-paymentsheet-instrumentation-tests` as CI runs it (`:paymentsheet:pixel2api33DebugAndroidTest`, 6 shards, `notAnnotation=RequiresIme`): **364 tests, 0 failures**
- `run-instrumentation-and-ime-tests` as CI runs it, with the same exclusion list: 34 tests across `connect`, `payment-method-messaging`, `connect-example`, `payments-core`, 0 failures — this is the run that covers the global `NetworkRule` change from suites that don't track the analytics host

**Not yet verified, and blocking merge:** both of these fail *silently* — `r.stripe.com` drops the event and nothing surfaces it.

1. `client_id = "stripe-mobile-payments-sdk"` is the correct destination key (matches iOS; deliberately not Android's v2 value `stripe-mobile-sdk`, since the destination table is keyed on `client_id`).
2. `origin = "stripe-mobile-payments-sdk-android"` is allowlisted server-side.

Since there's no flag there's no killswitch: if either is wrong, v1 analytics are lost until a new SDK release ships. Also worth one confirmation with the pipeline owner that `created` arriving as `1.7554E9` parses — `AnalyticsFields.TIMESTAMP` holds a `Double` and `QueryStringFactory` uses `toString()`. That's already true of today's `q` `timestamp` and of `AnalyticsRequestV2`'s `created`, but a parse failure there drops 100% of events rather than degrading.

# Screenshots

n/a — no UI change.

# Changelog

No entry. Internal telemetry transport with no public API change; iOS shipped none either.