### PR TITLE
Use production prefill inputs for LPM billing tests

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitLpmBillingAddressTestCases.kt
@@ -4,19 +4,31 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.paymentsheet.PaymentSheet
 
-private val bacsDebitFullRawValues = mapOf(
-    IdentifierSpec.Generic("bacs_debit[sort_code]") to "108800",
-    IdentifierSpec.Generic("bacs_debit[account_number]") to "00012345",
-    IdentifierSpec.BacsDebitConfirmed to "true",
-    IdentifierSpec.Name to "Jenny Rosen",
-    IdentifierSpec.Email to "jenny.rosen@example.com",
-    IdentifierSpec.Line1 to "10 Downing Street",
-    IdentifierSpec.Line2 to "Westminster",
-    IdentifierSpec.City to "London",
-    IdentifierSpec.PostalCode to "SW1A 2AA",
-    IdentifierSpec.Country to "GB",
+private val bacsDebitBillingDetails = PaymentSheet.BillingDetails(
+    name = "Jenny Rosen",
+    email = "jenny.rosen@example.com",
+    address = PaymentSheet.Address(
+        line1 = "10 Downing Street",
+        line2 = "Westminster",
+        city = "London",
+        postalCode = "SW1A 2AA",
+        country = "GB",
+    ),
+)
+
+private val bacsDebitPaymentMethodCreateParams = PaymentMethodCreateParams.create(
+    bacsDebit = PaymentMethodCreateParams.BacsDebit(
+        accountNumber = "00012345",
+        sortCode = "108800",
+    ),
+    billingDetails = PaymentMethod.BillingDetails(),
+)
+
+private val bacsDebitPaymentMethodExtraParams = PaymentMethodExtraParams.BacsDebit(
+    confirmed = true,
 )
 
 private val bacsDebitBankDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(
@@ -77,21 +89,27 @@ internal val bacsDebitTestCases = listOf(
         name = "Bacs Debit Never",
         paymentMethodType = PaymentMethod.Type.BacsDebit,
         mode = LpmBillingAddressBaselineMode.Never,
-        rawValues = bacsDebitFullRawValues,
+        defaultBillingDetails = bacsDebitBillingDetails,
+        paymentMethodCreateParams = bacsDebitPaymentMethodCreateParams,
+        paymentMethodExtraParams = bacsDebitPaymentMethodExtraParams,
         expectedPaymentMethodParams = bacsDebitBankDetailsExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Bacs Debit Automatic without tax",
         paymentMethodType = PaymentMethod.Type.BacsDebit,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
-        rawValues = bacsDebitFullRawValues,
+        defaultBillingDetails = bacsDebitBillingDetails,
+        paymentMethodCreateParams = bacsDebitPaymentMethodCreateParams,
+        paymentMethodExtraParams = bacsDebitPaymentMethodExtraParams,
         expectedPaymentMethodParams = bacsDebitWithBillingAddressExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Bacs Debit Full",
         paymentMethodType = PaymentMethod.Type.BacsDebit,
         mode = LpmBillingAddressBaselineMode.Full,
-        rawValues = bacsDebitFullRawValues,
+        defaultBillingDetails = bacsDebitBillingDetails,
+        paymentMethodCreateParams = bacsDebitPaymentMethodCreateParams,
+        paymentMethodExtraParams = bacsDebitPaymentMethodExtraParams,
         expectedPaymentMethodParams = bacsDebitWithBillingAddressExpectedPaymentMethodParams,
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoLpmBillingAddressTestCases.kt
@@ -4,21 +4,32 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.PaymentSheet
 
-private val boletoNoBillingAddressRawValues = mapOf(
-    IdentifierSpec.Generic("boleto[tax_id]") to "123.456.789-09",
+private val boletoBillingDetails = PaymentSheet.BillingDetails(
+    name = "Jane Doe",
+    email = "jane@example.com",
+    address = PaymentSheet.Address(
+        line1 = "Avenida Paulista 123",
+        line2 = "Apto 45",
+        city = "Sao Paulo",
+        state = "SP",
+        country = "BR",
+        postalCode = "01311000",
+    ),
 )
 
-private val boletoWithBillingAddressRawValues = boletoNoBillingAddressRawValues + mapOf(
-    IdentifierSpec.Name to "Jane Doe",
-    IdentifierSpec.Email to "jane@example.com",
-    IdentifierSpec.Line1 to "Avenida Paulista 123",
-    IdentifierSpec.Line2 to "Apto 45",
-    IdentifierSpec.City to "Sao Paulo",
-    IdentifierSpec.State to "SP",
-    IdentifierSpec.Country to "BR",
-    IdentifierSpec.PostalCode to "01311000",
+private val boletoPaymentMethodCreateParams = PaymentMethodCreateParams.createWithOverride(
+    code = PaymentMethod.Type.Boleto.code,
+    billingDetails = null,
+    requiresMandate = false,
+    overrideParamMap = mapOf(
+        "type" to PaymentMethod.Type.Boleto.code,
+        "boleto" to mapOf("tax_id" to "123.456.789-09"),
+    ),
+    productUsage = emptySet(),
+    allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
+    clientAttributionMetadata = CLIENT_ATTRIBUTION_METADATA,
 )
 
 private val boletoNoBillingAddressExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(
@@ -75,21 +86,27 @@ internal val boletoTestCases = listOf(
         name = "Boleto Never",
         paymentMethodType = PaymentMethod.Type.Boleto,
         mode = LpmBillingAddressBaselineMode.Never,
-        rawValues = boletoNoBillingAddressRawValues,
+        defaultBillingDetails = boletoBillingDetails,
+        paymentMethodCreateParams = boletoPaymentMethodCreateParams,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = boletoNoBillingAddressExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Boleto Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Boleto,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
-        rawValues = boletoWithBillingAddressRawValues,
+        defaultBillingDetails = boletoBillingDetails,
+        paymentMethodCreateParams = boletoPaymentMethodCreateParams,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = boletoWithBillingAddressExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Boleto Full",
         paymentMethodType = PaymentMethod.Type.Boleto,
         mode = LpmBillingAddressBaselineMode.Full,
-        rawValues = boletoWithBillingAddressRawValues,
+        defaultBillingDetails = boletoBillingDetails,
+        paymentMethodCreateParams = boletoPaymentMethodCreateParams,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = boletoWithBillingAddressExpectedPaymentMethodParams,
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaLpmBillingAddressTestCases.kt
@@ -4,15 +4,17 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.PaymentSheet
 
-private val klarnaFullRawValues = mapOf(
-    IdentifierSpec.Country to "DE",
-    IdentifierSpec.Email to "jane@example.com",
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Wohnung 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.PostalCode to "10117",
+private val klarnaBillingDetails = PaymentSheet.BillingDetails(
+    email = "jane@example.com",
+    address = PaymentSheet.Address(
+        line1 = "Unter den Linden 1",
+        line2 = "Wohnung 2",
+        city = "Berlin",
+        country = "DE",
+        postalCode = "10117",
+    ),
 )
 
 private val klarnaCountryOnlyExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(
@@ -89,21 +91,27 @@ internal val klarnaTestCases = listOf(
         name = "Klarna Never",
         paymentMethodType = PaymentMethod.Type.Klarna,
         mode = LpmBillingAddressBaselineMode.Never,
-        rawValues = klarnaFullRawValues,
+        defaultBillingDetails = klarnaBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = klarnaCountryOnlyExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Klarna Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Klarna,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
-        rawValues = klarnaFullRawValues,
+        defaultBillingDetails = klarnaBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = klarnaWithEmailAndCountryExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Klarna Full",
         paymentMethodType = PaymentMethod.Type.Klarna,
         mode = LpmBillingAddressBaselineMode.Full,
-        rawValues = klarnaFullRawValues,
+        defaultBillingDetails = klarnaBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = klarnaWithBillingAddressExpectedPaymentMethodParams,
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -10,14 +10,12 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
-import com.stripe.android.uicore.elements.AddressFieldsElement
-import com.stripe.android.uicore.elements.CheckboxFieldElement
-import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -37,50 +35,41 @@ internal class LpmBillingAddressFormValuesToParamsTest {
     ) = runTest {
         assertThat(
             createPaymentMethodCreateParamsFromFormValues(
-                paymentMethodType = testCase.paymentMethodType,
-                mode = testCase.mode,
-                rawValues = testCase.rawValues,
+                testCase = testCase,
             ),
         ).isEqualTo(testCase.expectedPaymentMethodParams)
     }
 
     private suspend fun createPaymentMethodCreateParamsFromFormValues(
-        paymentMethodType: PaymentMethod.Type,
-        mode: LpmBillingAddressBaselineMode,
-        rawValues: Map<IdentifierSpec, String?>,
+        testCase: LpmBillingAddressFormValuesToParamsTestCase,
     ): PaymentMethodCreateParams {
-        val metadata = createMetadata(paymentMethodType, mode)
+        val metadata = createMetadata(
+            paymentMethodType = testCase.paymentMethodType,
+            mode = testCase.mode,
+            defaultBillingDetails = testCase.defaultBillingDetails,
+        )
         val formViewModel = createFormViewModel(
-            paymentMethodType = paymentMethodType,
+            paymentMethodType = testCase.paymentMethodType,
             metadata = metadata,
-            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
+            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(
+                paymentMethodCreateParams = testCase.paymentMethodCreateParams,
+                paymentMethodExtraParams = testCase.paymentMethodExtraParams,
+            ),
         )
 
-        val sectionFields = formViewModel.elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-
-        sectionFields.forEach { it.setRawValue(rawValues) }
-        sectionFields
-            .filterIsInstance<AddressFieldsElement>()
-            .forEach { it.countryElement.setRawValue(rawValues) }
-        formViewModel.elements
-            .filterIsInstance<CheckboxFieldElement>()
-            .forEach { element ->
-                rawValues[element.identifier]?.let { element.controller.onValueChange(it.toBoolean()) }
-            }
-
-        return formViewModel.createPaymentMethodCreateParams(paymentMethodType, metadata)
+        return formViewModel.createPaymentMethodCreateParams(testCase.paymentMethodType, metadata)
     }
 
     private fun createMetadata(
         paymentMethodType: PaymentMethod.Type,
         mode: LpmBillingAddressBaselineMode,
+        defaultBillingDetails: PaymentSheet.BillingDetails,
     ) = PaymentMethodMetadataFactory.create(
         stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
             paymentMethodTypes = listOf(paymentMethodType.code),
         ),
         billingDetailsCollectionConfiguration = mode.billingDetailsCollectionConfiguration(),
+        defaultBillingDetails = defaultBillingDetails,
     )
 
     private fun createFormViewModel(
@@ -137,7 +126,9 @@ internal data class LpmBillingAddressFormValuesToParamsTestCase(
     val name: String,
     val paymentMethodType: PaymentMethod.Type,
     val mode: LpmBillingAddressBaselineMode,
-    val rawValues: Map<IdentifierSpec, String?>,
+    val defaultBillingDetails: PaymentSheet.BillingDetails,
+    val paymentMethodCreateParams: PaymentMethodCreateParams?,
+    val paymentMethodExtraParams: PaymentMethodExtraParams?,
     val expectedPaymentMethodParams: PaymentMethodCreateParams,
 ) {
     override fun toString(): String = name

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoLpmBillingAddressTestCases.kt
@@ -4,17 +4,19 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.PaymentSheet
 
-private val oxxoFullRawValues = mapOf(
-    IdentifierSpec.Name to "Ana Garcia",
-    IdentifierSpec.Email to "ana.garcia@example.com",
-    IdentifierSpec.Line1 to "Paseo de la Reforma 222",
-    IdentifierSpec.Line2 to "Piso 3",
-    IdentifierSpec.City to "Ciudad de Mexico",
-    IdentifierSpec.State to "CDMX",
-    IdentifierSpec.PostalCode to "06600",
-    IdentifierSpec.Country to "MX",
+private val oxxoBillingDetails = PaymentSheet.BillingDetails(
+    name = "Ana Garcia",
+    email = "ana.garcia@example.com",
+    address = PaymentSheet.Address(
+        line1 = "Paseo de la Reforma 222",
+        line2 = "Piso 3",
+        city = "Ciudad de Mexico",
+        state = "CDMX",
+        postalCode = "06600",
+        country = "MX",
+    ),
 )
 
 private val oxxoNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(
@@ -89,21 +91,27 @@ internal val oxxoTestCases = listOf(
         name = "OXXO Never",
         paymentMethodType = PaymentMethod.Type.Oxxo,
         mode = LpmBillingAddressBaselineMode.Never,
-        rawValues = oxxoFullRawValues,
+        defaultBillingDetails = oxxoBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = oxxoNoBillingDetailsExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "OXXO Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Oxxo,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
-        rawValues = oxxoFullRawValues,
+        defaultBillingDetails = oxxoBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = oxxoWithContactDetailsExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "OXXO Full",
         paymentMethodType = PaymentMethod.Type.Oxxo,
         mode = LpmBillingAddressBaselineMode.Full,
-        rawValues = oxxoFullRawValues,
+        defaultBillingDetails = oxxoBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = oxxoWithBillingAddressExpectedPaymentMethodParams,
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitLpmBillingAddressTestCases.kt
@@ -4,20 +4,24 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.PaymentSheet
 
-private val sepaDebitNoBillingAddressRawValues = mapOf(
-    IdentifierSpec.Generic("sepa_debit[iban]") to "DE89370400440532013000",
+private val sepaDebitBillingDetails = PaymentSheet.BillingDetails(
+    name = "Jane Doe",
+    email = "jane@example.com",
+    address = PaymentSheet.Address(
+        line1 = "Unter den Linden 1",
+        line2 = "Wohnung 2",
+        city = "Berlin",
+        country = "DE",
+        postalCode = "10117",
+    ),
 )
 
-private val sepaDebitWithBillingAddressRawValues = sepaDebitNoBillingAddressRawValues + mapOf(
-    IdentifierSpec.Name to "Jane Doe",
-    IdentifierSpec.Email to "jane@example.com",
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Wohnung 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.Country to "DE",
-    IdentifierSpec.PostalCode to "10117",
+private val sepaDebitPaymentMethodCreateParams = PaymentMethodCreateParams.create(
+    sepaDebit = PaymentMethodCreateParams.SepaDebit(
+        iban = "DE89370400440532013000",
+    ),
 )
 
 private val sepaDebitNoBillingAddressExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(
@@ -73,21 +77,27 @@ internal val sepaDebitTestCases = listOf(
         name = "SEPA Debit Never",
         paymentMethodType = PaymentMethod.Type.SepaDebit,
         mode = LpmBillingAddressBaselineMode.Never,
-        rawValues = sepaDebitNoBillingAddressRawValues,
+        defaultBillingDetails = sepaDebitBillingDetails,
+        paymentMethodCreateParams = sepaDebitPaymentMethodCreateParams,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = sepaDebitNoBillingAddressExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "SEPA Debit Automatic without tax",
         paymentMethodType = PaymentMethod.Type.SepaDebit,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
-        rawValues = sepaDebitWithBillingAddressRawValues,
+        defaultBillingDetails = sepaDebitBillingDetails,
+        paymentMethodCreateParams = sepaDebitPaymentMethodCreateParams,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = sepaDebitWithBillingAddressExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "SEPA Debit Full",
         paymentMethodType = PaymentMethod.Type.SepaDebit,
         mode = LpmBillingAddressBaselineMode.Full,
-        rawValues = sepaDebitWithBillingAddressRawValues,
+        defaultBillingDetails = sepaDebitBillingDetails,
+        paymentMethodCreateParams = sepaDebitPaymentMethodCreateParams,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = sepaDebitWithBillingAddressExpectedPaymentMethodParams,
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroLpmBillingAddressTestCases.kt
@@ -4,17 +4,20 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.PaymentSheet
 
-private val weroCountryOnlyRawValues = mapOf(
-    IdentifierSpec.Country to "DE",
+private val weroCountryOnlyBillingDetails = PaymentSheet.BillingDetails(
+    address = PaymentSheet.Address(country = "DE"),
 )
 
-private val weroWithBillingAddressRawValues = weroCountryOnlyRawValues + mapOf(
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Wohnung 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.PostalCode to "10117",
+private val weroFullBillingDetails = PaymentSheet.BillingDetails(
+    address = PaymentSheet.Address(
+        line1 = "Unter den Linden 1",
+        line2 = "Wohnung 2",
+        city = "Berlin",
+        country = "DE",
+        postalCode = "10117",
+    ),
 )
 
 private val weroCountryOnlyExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(
@@ -68,21 +71,27 @@ internal val weroTestCases = listOf(
         name = "Wero Never",
         paymentMethodType = PaymentMethod.Type.Wero,
         mode = LpmBillingAddressBaselineMode.Never,
-        rawValues = weroCountryOnlyRawValues,
+        defaultBillingDetails = weroCountryOnlyBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = weroCountryOnlyExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Wero Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Wero,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
-        rawValues = weroCountryOnlyRawValues,
+        defaultBillingDetails = weroCountryOnlyBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = weroCountryOnlyExpectedPaymentMethodParams,
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Wero Full",
         paymentMethodType = PaymentMethod.Type.Wero,
         mode = LpmBillingAddressBaselineMode.Full,
-        rawValues = weroWithBillingAddressRawValues,
+        defaultBillingDetails = weroFullBillingDetails,
+        paymentMethodCreateParams = null,
+        paymentMethodExtraParams = null,
         expectedPaymentMethodParams = weroWithBillingAddressExpectedPaymentParams,
     ),
 )


### PR DESCRIPTION
# Summary

Refactors the 18 LPM billing-address payload cases to populate production form elements through PaymentSheet billing defaults and typed create or extra params, when applicable, instead of mutating element controllers directly.

The tests continue through production form construction, `FormViewModel.completeFormValues`, and `transformToPaymentMethodCreateParams`. Every existing exact expected-params assertion remains unchanged.

This changes seven test files only. No production, public API, snapshot, changelog, or user-visible behavior changes.

# Motivation

Using the same typed prefill inputs and downstream form path as production makes these payload baselines representative without test-specific element traversal.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- `git diff --check origin/master...HEAD`: passed
- `./gradlew :paymentsheet:detekt :paymentsheet:apiCheck`: passed
- Focused `LpmBillingAddressFormValuesToParamsTest`: blocked before test execution by unresolved generated `DaggerCheckoutControllerComponent` and `StripeAndroidPrimaryButtonBinding` classes. The unrelated classpath failure reproduced after cleaning and on the earlier master baseline.

# Screenshots

Not applicable. No snapshots changed.

# Changelog

None. Test-only refactor.
