### PR TITLE
Add analytics payload field test helper

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -128,6 +128,10 @@ object RequestMatchers {
         }
     }
 
+    fun analyticsPayloadField(key: String, value: String): RequestMatcher {
+        return query(key, value)
+    }
+
     fun method(method: String): RequestMatcher {
         return ToStringRequestMatcher("method($method)") { request ->
             request.method == method

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -13,7 +13,7 @@ import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
-import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.createConfirmationToken
 import com.stripe.android.networktesting.elementsSession
@@ -81,13 +81,13 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
-            query(Uri.encode("mpe_config[form_sheet_action]"), "confirm"),
-            query(Uri.encode("mpe_config[row_selection_behavior]"), "default"),
-            query(Uri.encode("mpe_config[embedded_view_displays_mandate_text]"), "true"),
-            query(Uri.encode("mpe_config[open_card_scan_automatically]"), "false"),
-            query(Uri.encode("mpe_config[appearance][embedded_payment_element][row_style]"), "flat_with_radio"),
-            query(Uri.encode("mpe_config[appearance][colorsDark]"), "false"),
+            analyticsPayloadField(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[form_sheet_action]"), "confirm"),
+            analyticsPayloadField(Uri.encode("mpe_config[row_selection_behavior]"), "default"),
+            analyticsPayloadField(Uri.encode("mpe_config[embedded_view_displays_mandate_text]"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[open_card_scan_automatically]"), "false"),
+            analyticsPayloadField(Uri.encode("mpe_config[appearance][embedded_payment_element][row_style]"), "flat_with_radio"),
+            analyticsPayloadField(Uri.encode("mpe_config[appearance][colorsDark]"), "false"),
         )
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(eventName = "mc_carousel_payment_method_tapped")
@@ -96,12 +96,12 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", ""),
-            query(
+            analyticsPayloadField("hidden_payment_methods", ""),
+            analyticsPayloadField(
                 "visible_payment_methods",
                 Uri.encode("link,card,afterpay_clearpay,klarna,cashapp,affirm,alipay,wechat_pay")
             ),
-            query("payment_method_layout", "vertical")
+            analyticsPayloadField("payment_method_layout", "vertical")
         )
 
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
@@ -152,20 +152,20 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "mc_embedded_payment_success",
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "mc_dismiss")
 
@@ -195,7 +195,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
         )
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(eventName = "mc_carousel_payment_method_tapped")
@@ -252,19 +252,19 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "mc_embedded_payment_success",
-            query("is_confirmation_tokens", "true")
+            analyticsPayloadField("is_confirmation_tokens", "true")
         )
         validateAnalyticsRequest(eventName = "mc_dismiss")
 
@@ -304,9 +304,9 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", ""),
-            query("visible_payment_methods", Uri.encode("saved,card,cashapp")),
-            query("payment_method_layout", "vertical")
+            analyticsPayloadField("hidden_payment_methods", ""),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("saved,card,cashapp")),
+            analyticsPayloadField("payment_method_layout", "vertical")
         )
 
         testContext.configure {
@@ -336,15 +336,15 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "mc_embedded_payment_success")
 
@@ -382,9 +382,9 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", ""),
-            query("visible_payment_methods", Uri.encode("saved,card,cashapp")),
-            query("payment_method_layout", "vertical"),
+            analyticsPayloadField("hidden_payment_methods", ""),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("saved,card,cashapp")),
+            analyticsPayloadField("payment_method_layout", "vertical"),
         )
 
         testContext.configure {
@@ -443,9 +443,9 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_embedded_sheet_newpm_show")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", ""),
-            query("visible_payment_methods", Uri.encode("saved,card,cashapp")),
-            query("payment_method_layout", "vertical"),
+            analyticsPayloadField("hidden_payment_methods", ""),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("saved,card,cashapp")),
+            analyticsPayloadField("payment_method_layout", "vertical"),
         )
 
         testContext.configure {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
-import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CustomPaymentMethodResult
@@ -62,15 +62,15 @@ class CustomPaymentMethodsAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query("mpe_config[custom_payment_methods]", "cpmt_123")
+            analyticsPayloadField("mpe_config[custom_payment_methods]", "cpmt_123")
         )
         validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
         validateAnalyticsRequest(eventName = "mc_form_shown")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", ""),
-            query("visible_payment_methods", Uri.encode("cpmt_123,card")),
-            query("payment_method_layout", "horizontal"),
+            analyticsPayloadField("hidden_payment_methods", ""),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("cpmt_123,card")),
+            analyticsPayloadField("payment_method_layout", "horizontal"),
         )
 
         context.presentPaymentSheet {
@@ -95,11 +95,11 @@ class CustomPaymentMethodsAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "paymentsheet.custom_payment_method.launch_success",
-            query("custom_payment_method_type", "cpmt_123")
+            analyticsPayloadField("custom_payment_method_type", "cpmt_123")
         )
         validateAnalyticsRequest(
             eventName = "mc_complete_payment_newpm_success",
-            query("selected_lpm", "cpmt_123")
+            analyticsPayloadField("selected_lpm", "cpmt_123")
         )
 
         page.clickPrimaryButton()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
-import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.CustomerSheetTestType
@@ -88,13 +88,13 @@ internal class CustomerSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.payment_method_creation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "seti_12345"),
+            analyticsPayloadField("intent_id", "seti_12345"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.setup_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "seti_12345"),
+            analyticsPayloadField("intent_id", "seti_12345"),
         )
         validateAnalyticsRequest(eventName = "cs_add_payment_method_via_setup_intent_success")
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.networktesting.RequestMatchers.hasQueryParam
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
-import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.createConfirmationToken
 import com.stripe.android.networktesting.elementsSession
@@ -89,7 +89,7 @@ internal class FlowControllerAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
         )
         validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
         validateAnalyticsRequest(eventName = "mc_form_shown")
@@ -97,9 +97,9 @@ internal class FlowControllerAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", Uri.encode("cashapp,affirm,alipay,wechat_pay")),
-            query("visible_payment_methods", Uri.encode("card,afterpay_clearpay,klarna")),
-            query("payment_method_layout", "horizontal"),
+            analyticsPayloadField("hidden_payment_methods", Uri.encode("cashapp,affirm,alipay,wechat_pay")),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("card,afterpay_clearpay,klarna")),
+            analyticsPayloadField("payment_method_layout", "horizontal"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
 
@@ -138,20 +138,20 @@ internal class FlowControllerAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(
             eventName = "mc_custom_payment_newpm_success",
             hasQueryParam("duration"),
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 
@@ -182,8 +182,8 @@ internal class FlowControllerAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("visible_payment_methods", Uri.encode("link,card,afterpay_clearpay,klarna,cashapp,affirm,alipay,wechat_pay")),
-            query("payment_method_layout", "vertical"),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("link,card,afterpay_clearpay,klarna,cashapp,affirm,alipay,wechat_pay")),
+            analyticsPayloadField("payment_method_layout", "vertical"),
         )
 
         testContext.configureFlowController {
@@ -224,15 +224,15 @@ internal class FlowControllerAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(
             eventName = "mc_custom_payment_newpm_success",
@@ -264,16 +264,16 @@ internal class FlowControllerAnalyticsTest {
         }
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
-            query(Uri.encode("is_decoupled"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
+            analyticsPayloadField(Uri.encode("is_decoupled"), "true"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
         validateAnalyticsRequest(eventName = "mc_custom_paymentoption_newpm_select")
         validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
         validateAnalyticsRequest(
             eventName = "mc_form_shown",
-            query(Uri.encode("is_decoupled"), "true"),
-            query(Uri.encode("is_confirmation_tokens"), "true"),
+            analyticsPayloadField(Uri.encode("is_decoupled"), "true"),
+            analyticsPayloadField(Uri.encode("is_confirmation_tokens"), "true"),
         )
         // cardscan is not available in test mode
         validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
@@ -332,19 +332,19 @@ internal class FlowControllerAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(
             eventName = "mc_custom_payment_newpm_success",
-            query("is_confirmation_tokens", "true"),
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("is_confirmation_tokens", "true"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "mc_billing_address_completed")
         page.clickPrimaryButton()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
@@ -4,7 +4,7 @@ import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
-import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 
 internal fun NetworkRule.validateAnalyticsRequest(
     eventName: String,
@@ -14,8 +14,8 @@ internal fun NetworkRule.validateAnalyticsRequest(
     enqueue(
         host("q.stripe.com"),
         method("GET"),
-        query("event", eventName),
-        query("product_usage", productUsage.joinToString(",")),
+        analyticsPayloadField("event", eventName),
+        analyticsPayloadField("product_usage", productUsage.joinToString(",")),
         *requestMatchers,
     ) { response ->
         response.status = "HTTP/1.1 200 OK"

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -13,7 +13,7 @@ import com.stripe.android.networktesting.RequestMatchers.hasQueryParam
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
-import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.createConfirmationToken
 import com.stripe.android.networktesting.elementsSession
@@ -83,7 +83,7 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_load_started")
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
         )
         validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
         validateAnalyticsRequest(eventName = "mc_form_shown")
@@ -91,9 +91,9 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("hidden_payment_methods", Uri.encode("cashapp,affirm,alipay,wechat_pay")),
-            query("visible_payment_methods", Uri.encode("link,card,afterpay_clearpay,klarna")),
-            query("payment_method_layout", "horizontal"),
+            analyticsPayloadField("hidden_payment_methods", Uri.encode("cashapp,affirm,alipay,wechat_pay")),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("link,card,afterpay_clearpay,klarna")),
+            analyticsPayloadField("payment_method_layout", "horizontal"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
 
@@ -126,20 +126,20 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(
             eventName = "mc_complete_payment_newpm_success",
             hasQueryParam("duration"),
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "mc_billing_address_completed")
 
@@ -170,8 +170,8 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
         validateAnalyticsRequest(
             eventName = "mc_initial_displayed_payment_methods",
-            query("visible_payment_methods", Uri.encode("link,card,afterpay_clearpay,klarna,cashapp,affirm,alipay,wechat_pay")),
-            query("payment_method_layout", "vertical"),
+            analyticsPayloadField("visible_payment_methods", Uri.encode("link,card,afterpay_clearpay,klarna,cashapp,affirm,alipay,wechat_pay")),
+            analyticsPayloadField("payment_method_layout", "vertical"),
         )
 
         testContext.presentPaymentSheet {
@@ -205,15 +205,15 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(
             eventName = "mc_complete_payment_newpm_success",
@@ -243,11 +243,11 @@ internal class PaymentSheetAnalyticsTest {
         }
         validateAnalyticsRequest(
             eventName = "mc_load_succeeded",
-            query(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
-            query(Uri.encode("mpe_config[payment_method_layout]"), "horizontal"),
-            query(Uri.encode("is_confirmation_tokens"), "true"),
-            query(Uri.encode("is_decoupled"), "true"),
-            query(Uri.encode("intent_type"), "deferred_payment_intent"),
+            analyticsPayloadField(Uri.encode("mpe_config[analytic_callback_set]"), "true"),
+            analyticsPayloadField(Uri.encode("mpe_config[payment_method_layout]"), "horizontal"),
+            analyticsPayloadField(Uri.encode("is_confirmation_tokens"), "true"),
+            analyticsPayloadField(Uri.encode("is_decoupled"), "true"),
+            analyticsPayloadField(Uri.encode("intent_type"), "deferred_payment_intent"),
         )
 
         validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
@@ -305,19 +305,19 @@ internal class PaymentSheetAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
-            query("intent_id", "pi_example"),
-            query("payment_method_type", "card"),
+            analyticsPayloadField("intent_id", "pi_example"),
+            analyticsPayloadField("payment_method_type", "card"),
         )
         validateAnalyticsRequest(
             eventName = "mc_complete_payment_newpm_success",
-            query("is_confirmation_tokens", "true"),
-            query("intent_id", "pi_example"),
+            analyticsPayloadField("is_confirmation_tokens", "true"),
+            analyticsPayloadField("intent_id", "pi_example"),
         )
         validateAnalyticsRequest(eventName = "mc_billing_address_completed")
         page.clickPrimaryButton()

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTestHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityAnalyticsTestHelpers.kt
@@ -2,9 +2,9 @@ package com.stripe.android.common.nfcscan
 
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
-import com.stripe.android.networktesting.RequestMatchers.query
 
 private const val ANALYTICS_HOST = "q.stripe.com"
 private const val EVENT_PREFIX = "mc_"
@@ -36,7 +36,7 @@ internal fun NetworkRule.expectNfcScanAttemptFailed(
     expectAnalyticsEvent(
         eventName = "${EVENT_PREFIX}nfc_scan_attempt_failed",
         matchers = listOf(
-            query("error_code", errorCode),
+            analyticsPayloadField("error_code", errorCode),
         ) + errorMatchers,
     )
 }
@@ -47,8 +47,8 @@ internal fun createApduErrorMatchers(
     sw2: String
 ): List<RequestMatcher> {
     return listOf(
-        query("sw1", sw1),
-        query("sw2", sw2),
+        analyticsPayloadField("sw1", sw1),
+        analyticsPayloadField("sw2", sw2),
         RequestMatcher { request ->
             request.queryParameterValues("executed_commands[]") == executedCommands
         },
@@ -62,7 +62,7 @@ private fun NetworkRule.expectAnalyticsEvent(
     val matchers = buildList {
         add(host(ANALYTICS_HOST))
         add(method("GET"))
-        add(query("event", eventName))
+        add(analyticsPayloadField("event", eventName))
         addAll(matchers)
     }
 


### PR DESCRIPTION
# Summary

Adds `analyticsPayloadField(key, value)` for analytics request assertions and updates existing analytics tests to use it. The helper currently delegates to query matching, so this is a preparatory, single-layer change targeting `master`.

# Motivation

The upcoming v1 analytics transport migration will move payload fields from the URL query to the request body. Centralizing these assertions now reduces that later migration to changing the helper implementation rather than every affected analytics test.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran `./gradlew :paymentsheet:compileDebugAndroidTestKotlin` successfully.

# Screenshots

Not applicable — this changes test infrastructure only and has no user-interface impact.

# Changelog

Not applicable — this is an internal test-only refactor with no SDK behavior change.
