### PR TITLE
Harden checkout confirmation result delivery

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -20,14 +20,14 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val arguments = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
+        val operation = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
         viewModelScope.launch {
             try {
-                confirmationHandler.start(arguments)
+                confirmationHandler.start(operation.arguments)
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                operationCoordinator.failConfirmation(error)
+                operationCoordinator.failConfirmation(operation, error)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -25,13 +25,15 @@ internal class CheckoutOperationCoordinator @Inject constructor(
 ) {
     private val admissionLock = Any()
     private var pendingMutations = 0
-    private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
+    private val confirmationRestored = confirmationHandler.hasReloadedFromProcessDeath ||
         confirmationHandler.state.value is ConfirmationHandler.State.Confirming
     private var confirmationWasRestored = confirmationHandler.hasReloadedFromProcessDeath
+    private var nextConfirmationId = if (confirmationRestored) 1L else 0L
+    private var activeConfirmationId: Long? = if (confirmationRestored) 0L else null
     private var confirmationCompletionClaimed = false
-    private val mutex = Mutex(locked = confirmationInFlight)
+    private val mutex = Mutex(locked = activeConfirmationId != null)
 
-    private val _isUpdating = MutableStateFlow(confirmationInFlight)
+    private val _isUpdating = MutableStateFlow(activeConfirmationId != null)
     val isUpdating: StateFlow<Boolean> = _isUpdating.asStateFlow()
 
     suspend fun <T> runMutation(
@@ -59,7 +61,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     ): Result<T> {
         return synchronized(admissionLock) {
             when {
-                confirmationInFlight -> Result.failure(
+                activeConfirmationId != null -> Result.failure(
                     IllegalStateException("Cannot mutate checkout session while confirmation is in progress.")
                 )
                 pendingMutations > 0 -> Result.failure(
@@ -81,26 +83,30 @@ internal class CheckoutOperationCoordinator @Inject constructor(
 
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
-    ): ConfirmationHandler.Args? {
+    ): ConfirmationOperation? {
         return synchronized(admissionLock) {
-            if (sheetStateHolder.sheetIsOpen || pendingMutations > 0 || confirmationInFlight) {
+            if (sheetStateHolder.sheetIsOpen || pendingMutations > 0 || activeConfirmationId != null) {
                 return@synchronized null
             }
             val confirmationArguments = arguments() ?: return@synchronized null
             check(mutex.tryLock()) {
                 "Checkout operation gate should be available after confirmation admission."
             }
-            confirmationInFlight = true
+            val operation = ConfirmationOperation(
+                id = nextConfirmationId++,
+                arguments = confirmationArguments,
+            )
+            activeConfirmationId = operation.id
             confirmationWasRestored = false
             updateIsUpdating()
-            confirmationArguments
+            operation
         }
     }
 
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation { wasRestored ->
+                completeConfirmation(expectedConfirmationId = null) { wasRestored ->
                     when (val result = state.result) {
                         is ConfirmationHandler.Result.Succeeded -> {
                             result.metadata[CheckoutSessionResponseKey]?.let { response ->
@@ -116,18 +122,24 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    suspend fun failConfirmation(error: Throwable) {
-        completeConfirmation {
+    suspend fun failConfirmation(
+        operation: ConfirmationOperation,
+        error: Throwable,
+    ) {
+        completeConfirmation(expectedConfirmationId = operation.id) {
             refreshSession { sessionRefresher.refresh() }
             CheckoutController.Result.Failed(error)
         }
     }
 
     private suspend fun completeConfirmation(
-        mapResult: suspend (confirmationWasRestored: Boolean) -> CheckoutController.Result?,
+        expectedConfirmationId: Long?,
+        result: suspend (confirmationWasRestored: Boolean) -> CheckoutController.Result?,
     ) {
         val wasRestored = synchronized(admissionLock) {
-            if (!confirmationInFlight || confirmationCompletionClaimed) {
+            val activeId = activeConfirmationId
+            val completionIsStale = expectedConfirmationId != null && expectedConfirmationId != activeId
+            if (activeId == null || completionIsStale || confirmationCompletionClaimed) {
                 return
             } else {
                 confirmationCompletionClaimed = true
@@ -135,17 +147,19 @@ internal class CheckoutOperationCoordinator @Inject constructor(
             }
         }
 
-        try {
-            mapResult(wasRestored)?.let(resultCallback::onResult)
+        val checkoutResult = try {
+            result(wasRestored)
         } finally {
             synchronized(admissionLock) {
-                confirmationInFlight = false
+                activeConfirmationId = null
                 confirmationWasRestored = false
                 confirmationCompletionClaimed = false
                 mutex.unlock()
                 updateIsUpdating()
             }
         }
+
+        checkoutResult?.let(resultCallback::onResult)
     }
 
     /**
@@ -163,8 +177,13 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     }
 
     private fun updateIsUpdating() {
-        _isUpdating.value = confirmationInFlight || pendingMutations > 0
+        _isUpdating.value = activeConfirmationId != null || pendingMutations > 0
     }
+
+    internal class ConfirmationOperation(
+        internal val id: Long,
+        internal val arguments: ConfirmationHandler.Args,
+    )
 }
 
 private fun ConfirmationHandler.Result.asCheckoutResult(

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -31,7 +31,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val confirmationArgs = operationCoordinator.tryBeginConfirmation {
+        val operation = operationCoordinator.tryBeginConfirmation {
             val state = stateHolder.state ?: run {
                 errorReporter.report(
                     ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
@@ -51,7 +51,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
 
         viewModelScope.launch {
             try {
-                confirmationHandler.start(confirmationArgs)
+                confirmationHandler.start(operation.arguments)
 
                 when (val result = confirmationHandler.awaitResult()) {
                     is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
@@ -62,7 +62,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                operationCoordinator.failConfirmation(error)
+                operationCoordinator.failConfirmation(operation, error)
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.isInstanceOf
@@ -79,6 +80,22 @@ internal class CheckoutConfirmationPerformerTest {
         assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
     }
 
+    @Test
+    fun `confirm delivers failure when confirmation start throws`() {
+        val expected = IllegalStateException("Start failed")
+        runScenario(
+            state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+            startError = expected,
+        ) {
+            performer.confirm()
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
     private fun googlePayState(
         paymentSelection: PaymentSelection?,
     ): CheckoutControllerState {
@@ -94,9 +111,11 @@ internal class CheckoutConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         statusBarColor: Int? = null,
+        startError: Throwable? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
+        val confirmationHandler = FakeConfirmationHandler(startError = startError)
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
@@ -106,7 +125,7 @@ internal class CheckoutConfirmationPerformerTest {
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
-            resultCallback = {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
         )
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,
@@ -120,16 +139,19 @@ internal class CheckoutConfirmationPerformerTest {
             performer = performer,
             confirmationHandler = confirmationHandler,
             stateHolder = stateHolder,
+            resultTurbine = resultTurbine,
         ).block()
 
         confirmationHandler.validate()
         sessionRefresher.ensureAllEventsConsumed()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val performer: CheckoutConfirmationPerformer,
         val confirmationHandler: FakeConfirmationHandler,
         val stateHolder: CheckoutControllerStateHolder,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -292,6 +292,76 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
+    fun `result callback can synchronously start another confirmation`() {
+        val results = Turbine<CheckoutController.Result>()
+        lateinit var coordinatorReference: CheckoutOperationCoordinator
+        lateinit var secondOperation: CheckoutOperationCoordinator.ConfirmationOperation
+
+        runScenario(
+            resultCallback = CheckoutController.ResultCallback { result ->
+                results.add(result)
+                if (result is CheckoutController.Result.Canceled) {
+                    assertThat(coordinatorReference.isUpdating.value).isFalse()
+                    secondOperation = checkNotNull(
+                        coordinatorReference.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+                    )
+                }
+            },
+        ) {
+            coordinatorReference = coordinator
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Canceled(
+                    ConfirmationHandler.Result.Canceled.Action.None
+                )
+            )
+            refreshCalls.awaitItem()
+            assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+            assertThat(secondOperation).isNotNull()
+
+            confirmationState.value = ConfirmationHandler.State.Confirming(
+                CONFIRMATION_PARAMETERS.confirmationOption
+            )
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+            assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        }
+
+        results.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `stale failure does not complete a newer confirmation`() = runScenario {
+        val firstOperation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                ConfirmationHandler.Result.Canceled.Action.None
+            )
+        )
+        refreshCalls.awaitItem()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        coordinator.failConfirmation(firstOperation, IllegalStateException("Stale failure"))
+
+        resultTurbine.expectNoEvents()
+        refreshCalls.expectNoEvents()
+        assertThat(coordinator.isUpdating.value).isTrue()
+
+        confirmationState.value = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
     fun `mutation waits for confirmation to complete without loading state flicker`() = runScenario {
         coordinator.isUpdating.test {
             assertThat(awaitItem()).isFalse()
@@ -398,10 +468,12 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `confirmation start failure releases the operation gate`() = runScenario {
         val expected = IllegalStateException("Start failed")
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
 
         enqueueRefreshAction {}
-        coordinator.failConfirmation(expected)
+        coordinator.failConfirmation(operation, expected)
 
         refreshCalls.awaitItem()
         val result = resultTurbine.awaitItem()
@@ -521,7 +593,13 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(refreshCalls.awaitItem())
                 .isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
 
-            coordinator.failConfirmation(IllegalStateException("Competing failure"))
+            coordinator.failConfirmation(
+                CheckoutOperationCoordinator.ConfirmationOperation(
+                    id = 0L,
+                    arguments = CONFIRMATION_PARAMETERS,
+                ),
+                IllegalStateException("Competing failure"),
+            )
             refreshCalls.expectNoEvents()
             resultTurbine.expectNoEvents()
 
@@ -567,11 +645,14 @@ internal class CheckoutOperationCoordinatorTest {
 
     @Test
     fun `refresh cancellation propagates and still releases the operation gate`() = runScenario {
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+    fun `refresh cancellation propagates and still releases the operation gate`() = runScenario {
+        val operation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
 
         enqueueRefreshAction { throw CancellationException("Refresh canceled") }
         assertFailsWith<CancellationException> {
-            coordinator.failConfirmation(IllegalStateException("Start failed"))
+            coordinator.failConfirmation(operation, IllegalStateException("Start failed"))
         }
 
         refreshCalls.awaitItem()
@@ -593,11 +674,13 @@ internal class CheckoutOperationCoordinatorTest {
             },
         ) {
             val expected = IllegalStateException("Start failed")
-            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+            val operation = checkNotNull(
+                coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            )
 
             enqueueRefreshAction {}
             val failureCompletion = async(Dispatchers.Default) {
-                coordinator.failConfirmation(expected)
+                coordinator.failConfirmation(operation, expected)
             }
             assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
@@ -8,7 +8,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class FakeConfirmationHandler(
     override val hasReloadedFromProcessDeath: Boolean = false,
-    override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle)
+    override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle),
+    private val startError: Throwable? = null,
 ) : ConfirmationHandler {
     val registerTurbine: Turbine<RegisterCall> = Turbine()
     val startTurbine: Turbine<ConfirmationHandler.Args> = Turbine()
@@ -30,6 +31,7 @@ internal class FakeConfirmationHandler(
 
     override suspend fun start(arguments: ConfirmationHandler.Args) {
         startTurbine.add(arguments)
+        startError?.let { throw it }
     }
 
     override suspend fun awaitResult(): ConfirmationHandler.Result? {


### PR DESCRIPTION
# Summary

Scopes checkout confirmation failures to the admitted operation and releases the operation gate before delivering its callback. This is layer 2 of a three-PR stack and depends on `checkout-confirmation-ignore-conflicts`.

# Motivation

A delayed failure from an older confirmation could complete a newer operation, and callbacks ran while the operation gate was still armed. The tokenized coordinator now delivers at most one result for the matching operation while allowing a callback to synchronously begin another confirmation.

Failed and canceled confirmations continue refreshing the checkout session before callback delivery.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutOperationCoordinatorTest --tests com.stripe.android.checkout.CheckoutConfirmationPerformerTest --tests com.stripe.android.elements.ece.DefaultExpressCheckoutElementConfirmationPerformerTest`
- `git diff --check`

# Screenshots

Not applicable — no UI changes.

# Changelog

Not applicable — internal `CheckoutSessionPreview` behavior hardening.
