### PR TITLE
Isolate express checkout reporting failures

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -20,14 +20,14 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val arguments = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
+        val operation = operationCoordinator.tryBeginConfirmation(::confirmationArgs) ?: return
         viewModelScope.launch {
             try {
-                confirmationHandler.start(arguments)
+                confirmationHandler.start(operation.arguments)
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                operationCoordinator.failConfirmation(error)
+                operationCoordinator.failConfirmation(operation, error)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -24,12 +24,14 @@ internal class CheckoutOperationCoordinator @Inject constructor(
 ) {
     private val admissionLock = Any()
     private var pendingMutations = 0
-    private var confirmationInFlight = confirmationHandler.hasReloadedFromProcessDeath ||
+    private val confirmationRestored = confirmationHandler.hasReloadedFromProcessDeath ||
         confirmationHandler.state.value is ConfirmationHandler.State.Confirming
+    private var nextConfirmationId = if (confirmationRestored) 1L else 0L
+    private var activeConfirmationId: Long? = if (confirmationRestored) 0L else null
     private var confirmationCompletionClaimed = false
-    private val mutex = Mutex(locked = confirmationInFlight)
+    private val mutex = Mutex(locked = activeConfirmationId != null)
 
-    private val _isUpdating = MutableStateFlow(confirmationInFlight)
+    private val _isUpdating = MutableStateFlow(activeConfirmationId != null)
     val isUpdating: StateFlow<Boolean> = _isUpdating.asStateFlow()
 
     suspend fun <T> runMutation(
@@ -57,7 +59,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     ): Result<T> {
         return synchronized(admissionLock) {
             when {
-                confirmationInFlight -> Result.failure(
+                activeConfirmationId != null -> Result.failure(
                     IllegalStateException("Cannot mutate checkout session while confirmation is in progress.")
                 )
                 pendingMutations > 0 -> Result.failure(
@@ -79,25 +81,29 @@ internal class CheckoutOperationCoordinator @Inject constructor(
 
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
-    ): ConfirmationHandler.Args? {
+    ): ConfirmationOperation? {
         return synchronized(admissionLock) {
-            if (sheetStateHolder.sheetIsOpen || pendingMutations > 0 || confirmationInFlight) {
+            if (sheetStateHolder.sheetIsOpen || pendingMutations > 0 || activeConfirmationId != null) {
                 return@synchronized null
             }
             val confirmationArguments = arguments() ?: return@synchronized null
             check(mutex.tryLock()) {
                 "Checkout operation gate should be available after confirmation admission."
             }
-            confirmationInFlight = true
+            val operation = ConfirmationOperation(
+                id = nextConfirmationId++,
+                arguments = confirmationArguments,
+            )
+            activeConfirmationId = operation.id
             updateIsUpdating()
-            confirmationArguments
+            operation
         }
     }
 
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
-                completeConfirmation {
+                completeConfirmation(expectedConfirmationId = null) {
                     if (state.result !is ConfirmationHandler.Result.Succeeded) {
                         refreshSession()
                     }
@@ -107,16 +113,24 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    suspend fun failConfirmation(error: Throwable) {
-        completeConfirmation {
+    suspend fun failConfirmation(
+        operation: ConfirmationOperation,
+        error: Throwable,
+    ) {
+        completeConfirmation(expectedConfirmationId = operation.id) {
             refreshSession()
             CheckoutController.Result.Failed(error)
         }
     }
 
-    private suspend fun completeConfirmation(result: suspend () -> CheckoutController.Result) {
+    private suspend fun completeConfirmation(
+        expectedConfirmationId: Long?,
+        result: suspend () -> CheckoutController.Result,
+    ) {
         val shouldComplete = synchronized(admissionLock) {
-            if (!confirmationInFlight || confirmationCompletionClaimed) {
+            val activeId = activeConfirmationId
+            val completionIsStale = expectedConfirmationId != null && expectedConfirmationId != activeId
+            if (activeId == null || completionIsStale || confirmationCompletionClaimed) {
                 false
             } else {
                 confirmationCompletionClaimed = true
@@ -125,16 +139,18 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
         if (!shouldComplete) return
 
-        try {
-            resultCallback.onResult(result())
+        val checkoutResult = try {
+            result()
         } finally {
             synchronized(admissionLock) {
-                confirmationInFlight = false
+                activeConfirmationId = null
                 confirmationCompletionClaimed = false
                 mutex.unlock()
                 updateIsUpdating()
             }
         }
+
+        resultCallback.onResult(checkoutResult)
     }
 
     /**
@@ -152,9 +168,13 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     }
 
     private fun updateIsUpdating() {
-        _isUpdating.value = confirmationInFlight || pendingMutations > 0
+        _isUpdating.value = activeConfirmationId != null || pendingMutations > 0
     }
 
+    internal class ConfirmationOperation(
+        internal val id: Long,
+        internal val arguments: ConfirmationHandler.Args,
+    )
 }
 
 private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -80,34 +80,17 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
     ): ConfirmationHandler.Args? {
-        val admission = synchronized(admissionLock) {
-            when {
-                sheetStateHolder.sheetIsOpen -> ConfirmationAdmission.Rejected(
-                    IllegalStateException("Cannot confirm checkout session while a payment flow is presented.")
-                )
-                pendingMutations > 0 || confirmationInFlight -> ConfirmationAdmission.Rejected(
-                    IllegalStateException("Cannot confirm checkout session while another mutation is in progress.")
-                )
-                else -> {
-                    val confirmationArguments = arguments()
-                        ?: return@synchronized ConfirmationAdmission.NoArguments
-                    check(mutex.tryLock()) {
-                        "Checkout operation gate should be available after confirmation admission."
-                    }
-                    confirmationInFlight = true
-                    updateIsUpdating()
-                    ConfirmationAdmission.Accepted(confirmationArguments)
-                }
+        return synchronized(admissionLock) {
+            if (sheetStateHolder.sheetIsOpen || pendingMutations > 0 || confirmationInFlight) {
+                return@synchronized null
             }
-        }
-
-        return when (admission) {
-            is ConfirmationAdmission.Accepted -> admission.arguments
-            is ConfirmationAdmission.Rejected -> {
-                resultCallback.onResult(CheckoutController.Result.Failed(admission.error))
-                null
+            val confirmationArguments = arguments() ?: return@synchronized null
+            check(mutex.tryLock()) {
+                "Checkout operation gate should be available after confirmation admission."
             }
-            is ConfirmationAdmission.NoArguments -> null
+            confirmationInFlight = true
+            updateIsUpdating()
+            confirmationArguments
         }
     }
 
@@ -172,11 +155,6 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         _isUpdating.value = confirmationInFlight || pendingMutations > 0
     }
 
-    private sealed interface ConfirmationAdmission {
-        data class Accepted(val arguments: ConfirmationHandler.Args) : ConfirmationAdmission
-        data class Rejected(val error: Throwable) : ConfirmationAdmission
-        data object NoArguments : ConfirmationAdmission
-    }
 }
 
 private fun ConfirmationHandler.Result.asCheckoutResult(): CheckoutController.Result {

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -31,7 +31,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val confirmationArgs = operationCoordinator.tryBeginConfirmation {
+        val operation = operationCoordinator.tryBeginConfirmation {
             val state = stateHolder.state ?: run {
                 errorReporter.report(
                     ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
@@ -51,7 +51,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
 
         viewModelScope.launch {
             try {
-                confirmationHandler.start(confirmationArgs)
+                confirmationHandler.start(operation.arguments)
 
                 when (val result = confirmationHandler.awaitResult()) {
                     is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
@@ -62,7 +62,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                operationCoordinator.failConfirmation(error)
+                operationCoordinator.failConfirmation(operation, error)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -50,19 +50,21 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         } ?: return
 
         viewModelScope.launch {
-            try {
+            val result = try {
                 confirmationHandler.start(operation.arguments)
-
-                when (val result = confirmationHandler.awaitResult()) {
-                    is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
-                    is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
-                    is ConfirmationHandler.Result.Canceled,
-                    null -> Unit
-                }
+                confirmationHandler.awaitResult()
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
                 operationCoordinator.failConfirmation(operation, error)
+                return@launch
+            }
+
+            when (result) {
+                is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
+                is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
+                is ConfirmationHandler.Result.Canceled,
+                null -> Unit
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.isInstanceOf
@@ -79,6 +80,22 @@ internal class CheckoutConfirmationPerformerTest {
         assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
     }
 
+    @Test
+    fun `confirm delivers failure when confirmation start throws`() {
+        val expected = IllegalStateException("Start failed")
+        runScenario(
+            state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+            startError = expected,
+        ) {
+            performer.confirm()
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
     private fun googlePayState(
         paymentSelection: PaymentSelection?,
     ): CheckoutControllerState {
@@ -94,9 +111,11 @@ internal class CheckoutConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         statusBarColor: Int? = null,
+        startError: Throwable? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
+        val confirmationHandler = FakeConfirmationHandler(startError = startError)
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
@@ -105,7 +124,7 @@ internal class CheckoutConfirmationPerformerTest {
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = {},
             logger = Logger.noop(),
-            resultCallback = {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
         )
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,
@@ -119,15 +138,18 @@ internal class CheckoutConfirmationPerformerTest {
             performer = performer,
             confirmationHandler = confirmationHandler,
             stateHolder = stateHolder,
+            resultTurbine = resultTurbine,
         ).block()
 
         confirmationHandler.validate()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val performer: CheckoutConfirmationPerformer,
         val confirmationHandler: FakeConfirmationHandler,
         val stateHolder: CheckoutControllerStateHolder,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -215,22 +215,18 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `confirmation returns failure when a payment flow is presented`() = runScenario(
+    fun `confirmation is ignored when a payment flow is presented`() = runScenario(
         sheetIsOpen = true,
     ) {
         val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while a payment flow is presented.")
+        resultTurbine.expectNoEvents()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
-    fun `confirmation returns failure while a mutation is in flight`() = runScenario {
+    fun `confirmation is ignored while a mutation is in flight`() = runScenario {
         val mutationStarted = CompletableDeferred<Unit>()
         val finishMutation = CompletableDeferred<Unit>()
         val mutation = async {
@@ -245,28 +241,25 @@ internal class CheckoutOperationCoordinatorTest {
         val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+        resultTurbine.expectNoEvents()
 
         finishMutation.complete(Unit)
         mutation.await()
     }
 
     @Test
-    fun `second confirmation returns failure while confirmation is in flight`() = runScenario {
+    fun `second confirmation is ignored while confirmation is in flight`() = runScenario {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
 
         val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         assertThat(arguments).isNull()
-        val result = resultTurbine.awaitItem()
-        assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
-        val failure = result as CheckoutController.Result.Failed
-        assertThat(failure.error).hasMessageThat()
-            .isEqualTo("Cannot confirm checkout session while another mutation is in progress.")
+        resultTurbine.expectNoEvents()
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -284,6 +284,76 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
+    fun `result callback can synchronously start another confirmation`() {
+        val results = Turbine<CheckoutController.Result>()
+        lateinit var coordinatorReference: CheckoutOperationCoordinator
+        lateinit var secondOperation: CheckoutOperationCoordinator.ConfirmationOperation
+
+        runScenario(
+            resultCallback = CheckoutController.ResultCallback { result ->
+                results.add(result)
+                if (result is CheckoutController.Result.Canceled) {
+                    assertThat(coordinatorReference.isUpdating.value).isFalse()
+                    secondOperation = checkNotNull(
+                        coordinatorReference.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+                    )
+                }
+            },
+        ) {
+            coordinatorReference = coordinator
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Canceled(
+                    ConfirmationHandler.Result.Canceled.Action.None
+                )
+            )
+            refreshCalls.awaitItem()
+            assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+            assertThat(secondOperation).isNotNull()
+
+            confirmationState.value = ConfirmationHandler.State.Confirming(
+                CONFIRMATION_PARAMETERS.confirmationOption
+            )
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+            assertThat(results.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        }
+
+        results.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `stale failure does not complete a newer confirmation`() = runScenario {
+        val firstOperation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Canceled(
+                ConfirmationHandler.Result.Canceled.Action.None
+            )
+        )
+        refreshCalls.awaitItem()
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
+
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        coordinator.failConfirmation(firstOperation, IllegalStateException("Stale failure"))
+
+        resultTurbine.expectNoEvents()
+        refreshCalls.expectNoEvents()
+        assertThat(coordinator.isUpdating.value).isTrue()
+
+        confirmationState.value = ConfirmationHandler.State.Confirming(
+            CONFIRMATION_PARAMETERS.confirmationOption
+        )
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+        )
+        assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+    }
+
+    @Test
     fun `mutation waits for confirmation to complete without loading state flicker`() = runScenario {
         coordinator.isUpdating.test {
             assertThat(awaitItem()).isFalse()
@@ -366,9 +436,11 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `confirmation start failure releases the operation gate`() = runScenario {
         val expected = IllegalStateException("Start failed")
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
 
-        coordinator.failConfirmation(expected)
+        coordinator.failConfirmation(operation, expected)
 
         refreshCalls.awaitItem()
         val result = resultTurbine.awaitItem()
@@ -442,10 +514,12 @@ internal class CheckoutOperationCoordinatorTest {
     fun `refresh cancellation propagates and still releases the operation gate`() = runScenario(
         onRefresh = { throw CancellationException("Refresh canceled") },
     ) {
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        val operation = checkNotNull(
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        )
 
         assertFailsWith<CancellationException> {
-            coordinator.failConfirmation(IllegalStateException("Start failed"))
+            coordinator.failConfirmation(operation, IllegalStateException("Start failed"))
         }
 
         refreshCalls.awaitItem()
@@ -467,10 +541,12 @@ internal class CheckoutOperationCoordinatorTest {
             },
         ) {
             val expected = IllegalStateException("Start failed")
-            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+            val operation = checkNotNull(
+                coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            )
 
             val failureCompletion = async(Dispatchers.Default) {
-                coordinator.failConfirmation(expected)
+                coordinator.failConfirmation(operation, expected)
             }
             assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.elements.ece
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.checkout.CheckoutController
@@ -27,6 +28,11 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFacto
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -179,6 +185,62 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         assertThat(failureCall.error.cause.message).isEqualTo("Payment failed")
     }
 
+    @Test
+    fun `confirm delivers failure when confirmation start throws`() {
+        val expected = IllegalStateException("Start failed")
+        runScenario(
+            state = googlePayState(),
+            expressButton = createGooglePayExpressButton(),
+            startError = expected,
+        ) {
+            performer.confirm(expressButton)
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
+    @Test
+    fun `confirm delivers failure when awaiting confirmation result throws`() {
+        val expected = IllegalStateException("Await failed")
+        runScenario(
+            state = googlePayState(),
+            expressButton = createGooglePayExpressButton(),
+            awaitResultError = expected,
+        ) {
+            performer.confirm(expressButton)
+
+            confirmationHandler.startTurbine.awaitItem()
+            val result = resultTurbine.awaitItem()
+            assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
+            assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
+        }
+    }
+
+    @Test
+    fun `ECE reporting failure is not delivered as a confirmation failure`() {
+        val expected = IllegalStateException("Reporting failed")
+        runScenario(
+            state = googlePayState(),
+            expressButton = createGooglePayExpressButton(),
+            paymentSuccessError = expected,
+        ) {
+            confirmationHandler.awaitResultTurbine.add(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+
+            performer.confirm(expressButton)
+
+            confirmationHandler.startTurbine.awaitItem()
+            assertThat(eventReporter.calls.awaitItem())
+                .isEqualTo(FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentSuccess(expressButton))
+            assertThat(uncaughtErrors.awaitItem()).isSameInstanceAs(expected)
+            resultTurbine.expectNoEvents()
+        }
+    }
+
     private fun googlePayState(
         allowedShippingCountries: List<String>? = null,
     ): CheckoutControllerState {
@@ -209,11 +271,26 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         expressButton: ExpressButton,
+        startError: Throwable? = null,
+        awaitResultError: Throwable? = null,
+        paymentSuccessError: Throwable? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
-        val eventReporter = FakeExpressCheckoutElementEventReporter()
+        val confirmationHandler = FakeConfirmationHandler(
+            startError = startError,
+            awaitResultError = awaitResultError,
+        )
+        val eventReporter = FakeExpressCheckoutElementEventReporter(
+            paymentSuccessError = paymentSuccessError,
+        )
         val errorReporter = FakeErrorReporter()
+        val resultTurbine = Turbine<CheckoutController.Result>()
+        val uncaughtErrors = Turbine<Throwable>()
+        val performerScope = CoroutineScope(
+            SupervisorJob() + StandardTestDispatcher(testScheduler) + CoroutineExceptionHandler { _, error ->
+                uncaughtErrors.add(error)
+            }
+        )
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
@@ -222,7 +299,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = {},
             logger = Logger.noop(),
-            resultCallback = {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
             stateHolder = stateHolder,
@@ -231,7 +308,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             statusBarColor = null,
-            viewModelScope = backgroundScope,
+            viewModelScope = performerScope,
         )
 
         Scenario(
@@ -241,11 +318,16 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             errorReporter = errorReporter,
             stateHolder = stateHolder,
             expressButton = expressButton,
+            resultTurbine = resultTurbine,
+            uncaughtErrors = uncaughtErrors,
         ).block()
 
+        performerScope.cancel()
         confirmationHandler.validate()
         eventReporter.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
+        resultTurbine.ensureAllEventsConsumed()
+        uncaughtErrors.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -255,5 +337,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val errorReporter: FakeErrorReporter,
         val stateHolder: CheckoutControllerStateHolder,
         val expressButton: ExpressButton,
+        val resultTurbine: Turbine<CheckoutController.Result>,
+        val uncaughtErrors: Turbine<Throwable>,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/FakeExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/FakeExpressCheckoutElementEventReporter.kt
@@ -3,7 +3,9 @@ package com.stripe.android.elements.ece
 import app.cash.turbine.Turbine
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 
-internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementEventReporter {
+internal class FakeExpressCheckoutElementEventReporter(
+    private val paymentSuccessError: Throwable? = null,
+) : ExpressCheckoutElementEventReporter {
     val calls = Turbine<Call>()
 
     override fun onEceDisplayed() {
@@ -16,6 +18,7 @@ internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementE
 
     override fun onEcePaymentSuccess(expressButton: ExpressButton) {
         calls.add(Call.OnEcePaymentSuccess(expressButton))
+        paymentSuccessError?.let { throw it }
     }
 
     override fun onEcePaymentFailure(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
@@ -8,7 +8,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class FakeConfirmationHandler(
     override val hasReloadedFromProcessDeath: Boolean = false,
-    override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle)
+    override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle),
+    private val startError: Throwable? = null,
 ) : ConfirmationHandler {
     val registerTurbine: Turbine<RegisterCall> = Turbine()
     val startTurbine: Turbine<ConfirmationHandler.Args> = Turbine()
@@ -30,6 +31,7 @@ internal class FakeConfirmationHandler(
 
     override suspend fun start(arguments: ConfirmationHandler.Args) {
         startTurbine.add(arguments)
+        startError?.let { throw it }
     }
 
     override suspend fun awaitResult(): ConfirmationHandler.Result? {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
@@ -10,6 +10,7 @@ internal class FakeConfirmationHandler(
     override val hasReloadedFromProcessDeath: Boolean = false,
     override val state: MutableStateFlow<ConfirmationHandler.State> = MutableStateFlow(ConfirmationHandler.State.Idle),
     private val startError: Throwable? = null,
+    private val awaitResultError: Throwable? = null,
 ) : ConfirmationHandler {
     val registerTurbine: Turbine<RegisterCall> = Turbine()
     val startTurbine: Turbine<ConfirmationHandler.Args> = Turbine()
@@ -35,6 +36,7 @@ internal class FakeConfirmationHandler(
     }
 
     override suspend fun awaitResult(): ConfirmationHandler.Result? {
+        awaitResultError?.let { throw it }
         return awaitResultTurbine.awaitItem()
     }
 


### PR DESCRIPTION
# Summary

Limits Express Checkout exception handling to confirmation start and result awaiting. This is layer 3 of a three-PR stack and depends on `checkout-confirmation-operation-results`.

# Motivation

Express Checkout analytics callbacks previously ran inside the confirmation catch block. An analytics failure could therefore be delivered to the integrator as a payment failure. Reporting now runs outside that boundary while genuine confirmation exceptions still complete the admitted operation with a failure.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.elements.ece.DefaultExpressCheckoutElementConfirmationPerformerTest`
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:detekt --rerun-tasks`
- `git diff --check`

# Screenshots

Not applicable — no UI changes.

# Changelog

Not applicable — internal `CheckoutSessionPreview` behavior hardening.
