### PR TITLE
Add checkout session response refresh

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 /**
@@ -13,17 +14,30 @@ internal fun interface CheckoutSessionRefresher {
 }
 
 @OptIn(CheckoutSessionPreview::class)
-internal class DefaultCheckoutSessionRefresher @Inject constructor(
+internal class DefaultCheckoutSessionRefresher internal constructor(
     private val stateHolder: CheckoutControllerStateHolder,
-    private val checkoutSessionRepository: CheckoutSessionRepository,
-    private val checkoutStateLoader: CheckoutStateLoader,
+    private val fetchResponse: suspend (String, Boolean) -> Result<CheckoutSessionResponse>,
+    private val reloadState: suspend (CheckoutControllerState) -> Unit,
 ) : CheckoutSessionRefresher {
+
+    @Inject
+    internal constructor(
+        stateHolder: CheckoutControllerStateHolder,
+        checkoutSessionRepository: CheckoutSessionRepository,
+        checkoutStateLoader: CheckoutStateLoader,
+    ) : this(
+        stateHolder = stateHolder,
+        fetchResponse = checkoutSessionRepository::init,
+        reloadState = checkoutStateLoader::reload,
+    )
+
     override suspend fun refresh() {
         val state = stateHolder.state ?: return
-        val response = checkoutSessionRepository.init(
-            sessionId = state.checkoutSessionResponse.id,
-            adaptivePricingAllowed = state.configuration.adaptivePricingAllowed,
+        val response = fetchResponse(
+            state.checkoutSessionResponse.id,
+            state.configuration.adaptivePricingAllowed,
         ).getOrThrow()
-        checkoutStateLoader.reload(state.copy(checkoutSessionResponse = response))
+        val latestState = stateHolder.state ?: return
+        reloadState(latestState.copy(checkoutSessionResponse = response))
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -100,10 +100,11 @@ internal class CheckoutConfirmationPerformerTest {
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
+        val sessionRefresher = FakeCheckoutSessionRefresher()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
-            sessionRefresher = {},
+            sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
             resultCallback = {},
         )
@@ -122,6 +123,7 @@ internal class CheckoutConfirmationPerformerTest {
         ).block()
 
         confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -272,12 +272,13 @@ internal class CheckoutOperationCoordinatorTest {
     @Test
     fun `second confirmation can start after first confirmation completes`() = runScenario {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
                 ConfirmationHandler.Result.Canceled.Action.None
             )
         )
-        refreshCalls.awaitItem()
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
         assertThat(coordinator.isUpdating.value).isFalse()
 
@@ -309,6 +310,7 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(mutationStarted.isCompleted).isFalse()
             expectNoEvents()
 
+            enqueueRefreshAction {}
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
                     ConfirmationHandler.Result.Canceled.Action.None
@@ -339,13 +341,14 @@ internal class CheckoutOperationCoordinatorTest {
     fun `canceled confirmation is delivered as canceled`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
                 ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
             )
         )
 
-        refreshCalls.awaitItem()
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Canceled>()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
@@ -355,6 +358,7 @@ internal class CheckoutOperationCoordinatorTest {
         val expected = IllegalStateException("Confirmation failed")
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Failed(
                 cause = expected,
@@ -363,7 +367,7 @@ internal class CheckoutOperationCoordinatorTest {
             )
         )
 
-        refreshCalls.awaitItem()
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         val result = resultTurbine.awaitItem()
         assertThat(result).isInstanceOf<CheckoutController.Result.Failed>()
         assertThat((result as CheckoutController.Result.Failed).error).isSameInstanceAs(expected)
@@ -375,6 +379,7 @@ internal class CheckoutOperationCoordinatorTest {
         val expected = IllegalStateException("Start failed")
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction {}
         coordinator.failConfirmation(expected)
 
         refreshCalls.awaitItem()
@@ -389,9 +394,10 @@ internal class CheckoutOperationCoordinatorTest {
         val releaseRefresh = CompletableDeferred<Unit>()
         val expected = IllegalStateException("Confirmation failed")
 
-        runScenario(onRefresh = { releaseRefresh.await() }) {
+        runScenario {
             coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+            enqueueRefreshAction { releaseRefresh.await() }
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Failed(
                     cause = expected,
@@ -425,12 +431,11 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `refresh failure still delivers the confirmation result`() = runScenario(
-        onRefresh = { error("Refresh failed") },
-    ) {
+    fun `refresh failure still delivers the confirmation result`() = runScenario {
         val expected = IllegalStateException("Confirmation failed")
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction { error("Refresh failed") }
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Failed(
                 cause = expected,
@@ -446,11 +451,10 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `refresh cancellation propagates and still releases the operation gate`() = runScenario(
-        onRefresh = { throw CancellationException("Refresh canceled") },
-    ) {
+    fun `refresh cancellation propagates and still releases the operation gate`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction { throw CancellationException("Refresh canceled") }
         assertFailsWith<CancellationException> {
             coordinator.failConfirmation(IllegalStateException("Start failed"))
         }
@@ -476,6 +480,7 @@ internal class CheckoutOperationCoordinatorTest {
             val expected = IllegalStateException("Start failed")
             assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
 
+            enqueueRefreshAction {}
             val failureCompletion = async(Dispatchers.Default) {
                 coordinator.failConfirmation(expected)
             }
@@ -518,6 +523,7 @@ internal class CheckoutOperationCoordinatorTest {
         runCurrent()
         assertThat(mutationStarted.isCompleted).isFalse()
 
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
                 ConfirmationHandler.Result.Canceled.Action.None
@@ -610,7 +616,6 @@ internal class CheckoutOperationCoordinatorTest {
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
         hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
-        onRefresh: suspend () -> Unit = {},
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationState = MutableStateFlow(initialConfirmationState)
@@ -622,14 +627,11 @@ internal class CheckoutOperationCoordinatorTest {
             this.sheetIsOpen = sheetIsOpen
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
-        val refreshCalls = Turbine<Unit>()
+        val sessionRefresher = FakeCheckoutSessionRefresher()
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
-            sessionRefresher = {
-                refreshCalls.add(Unit)
-                onRefresh()
-            },
+            sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
         )
@@ -642,20 +644,22 @@ internal class CheckoutOperationCoordinatorTest {
             coordinator = coordinator,
             confirmationState = confirmationState,
             resultTurbine = resultTurbine,
-            refreshCalls = refreshCalls,
+            refreshCalls = sessionRefresher.calls,
+            sessionRefresher = sessionRefresher,
             testScope = this,
         ).block()
 
         confirmationHandler.validate()
         resultTurbine.ensureAllEventsConsumed()
-        refreshCalls.ensureAllEventsConsumed()
+        sessionRefresher.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val coordinator: CheckoutOperationCoordinator,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
-        val refreshCalls: Turbine<Unit>,
+        val refreshCalls: Turbine<FakeCheckoutSessionRefresher.Call>,
+        private val sessionRefresher: FakeCheckoutSessionRefresher,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
         val backgroundScope = testScope.backgroundScope
@@ -663,6 +667,10 @@ internal class CheckoutOperationCoordinatorTest {
 
         fun runCurrent() {
             testScheduler.runCurrent()
+        }
+
+        fun enqueueRefreshAction(action: suspend () -> Unit) {
+            sessionRefresher.enqueueRefreshAction(action)
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutSessionRefresherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutSessionRefresherTest.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultCheckoutSessionRefresherTest {
+
+    @Test
+    fun `refresh without response fetches and commits latest session`() = runScenario {
+        val response = CheckoutSessionResponseFactory.create(id = "cs_fetched")
+        val stateAtCommit = initialState.copy(temporarySelection = "card")
+        refreshActions.enqueueFetchResponse {
+            stateHolder.state = stateAtCommit
+            Result.success(response)
+        }
+
+        refresher.refresh()
+
+        assertThat(refreshActions.fetchCalls.awaitItem()).isEqualTo(
+            FakeCheckoutSessionRefreshActions.FetchCall(
+                sessionId = initialState.checkoutSessionResponse.id,
+                adaptivePricingAllowed = initialState.configuration.adaptivePricingAllowed,
+            )
+        )
+        assertThat(refreshActions.reloadCalls.awaitItem())
+            .isEqualTo(stateAtCommit.copy(checkoutSessionResponse = response))
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
+        val initialState = CheckoutControllerStateFactory.create()
+        stateHolder.state = initialState
+        val refreshActions = FakeCheckoutSessionRefreshActions()
+        val refresher = DefaultCheckoutSessionRefresher(
+            stateHolder = stateHolder,
+            fetchResponse = refreshActions::fetch,
+            reloadState = refreshActions::reload,
+        )
+
+        Scenario(
+            refresher = refresher,
+            stateHolder = stateHolder,
+            initialState = initialState,
+            refreshActions = refreshActions,
+        ).block()
+
+        refreshActions.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val refresher: DefaultCheckoutSessionRefresher,
+        val stateHolder: CheckoutControllerStateHolder,
+        val initialState: CheckoutControllerState,
+        val refreshActions: FakeCheckoutSessionRefreshActions,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefreshActions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefreshActions.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+
+internal class FakeCheckoutSessionRefreshActions {
+    val fetchCalls = Turbine<FetchCall>()
+    val reloadCalls = Turbine<CheckoutControllerState>()
+    private val fetchResponses = Turbine<() -> Result<CheckoutSessionResponse>>()
+
+    fun enqueueFetchResponse(response: () -> Result<CheckoutSessionResponse>) {
+        fetchResponses.add(response)
+    }
+
+    suspend fun fetch(
+        sessionId: String,
+        adaptivePricingAllowed: Boolean,
+    ): Result<CheckoutSessionResponse> {
+        fetchCalls.add(FetchCall(sessionId, adaptivePricingAllowed))
+        return fetchResponses.awaitItem().invoke()
+    }
+
+    suspend fun reload(state: CheckoutControllerState) {
+        reloadCalls.add(state)
+    }
+
+    fun ensureAllEventsConsumed() {
+        fetchCalls.ensureAllEventsConsumed()
+        reloadCalls.ensureAllEventsConsumed()
+        fetchResponses.ensureAllEventsConsumed()
+    }
+
+    data class FetchCall(
+        val sessionId: String,
+        val adaptivePricingAllowed: Boolean,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefresher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefresher.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.checkout
+
+import app.cash.turbine.Turbine
+
+internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
+    val calls = Turbine<Call>()
+    private val refreshActions = Turbine<suspend () -> Unit>()
+
+    fun enqueueRefreshAction(action: suspend () -> Unit) {
+        refreshActions.add(action)
+    }
+
+    override suspend fun refresh() {
+        record(Call.Fetch)
+    }
+
+    fun ensureAllEventsConsumed() {
+        calls.ensureAllEventsConsumed()
+        refreshActions.ensureAllEventsConsumed()
+    }
+
+    private suspend fun record(call: Call) {
+        calls.add(call)
+        refreshActions.awaitItem().invoke()
+    }
+
+    sealed interface Call {
+        data object Fetch : Call
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.checkout.CheckoutControllerState
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutOperationCoordinator
+import com.stripe.android.checkout.FakeCheckoutSessionRefresher
 import com.stripe.android.checkout.GooglePayConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.resolvableString
@@ -217,10 +218,11 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
+        val sessionRefresher = FakeCheckoutSessionRefresher()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
-            sessionRefresher = {},
+            sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
             resultCallback = {},
         )
@@ -244,6 +246,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         ).block()
 
         confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
         eventReporter.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
     }


### PR DESCRIPTION
# Summary

Adds a direct-response overload to the internal `CheckoutSessionRefresher` and implements it by reloading the latest controller state without issuing an `/init` request. Adds a reusable Turbine-backed fake and updates direct coordinator constructor tests for the expanded interface.

This is the bottom layer of a two-PR stack. It provides the refresh primitive used by the confirmation behavior in the next layer.

# Motivation

Checkout confirmation already returns an updated checkout-session response. The controller needs a reusable way to commit that response directly while retaining the existing no-argument fetch path for failed and canceled confirmations.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated this layer independently with focused refresher, coordinator, confirmation performer, and ECE performer unit tests, plus `./gradlew :paymentsheet:detekt`.

No tests were ignored.

# Screenshots

Not applicable: this layer changes internal state-loading infrastructure and tests only, with no visual changes.

# Changelog

Not applicable: this layer does not change public API or user-visible behavior.
