### PR TITLE
Refresh checkout state after confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -4,6 +4,7 @@ package com.stripe.android.checkout
 
 import com.stripe.android.core.Logger
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -117,8 +118,14 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
                 completeConfirmation { wasRestored ->
-                    if (state.result !is ConfirmationHandler.Result.Succeeded) {
-                        refreshSession()
+                    when (val result = state.result) {
+                        is ConfirmationHandler.Result.Succeeded -> {
+                            result.metadata[CheckoutSessionResponseKey]?.let { response ->
+                                refreshSession { sessionRefresher.refresh(response) }
+                            }
+                        }
+
+                        else -> refreshSession { sessionRefresher.refresh() }
                     }
                     state.result.asCheckoutResult(wasRestored)
                 }
@@ -128,7 +135,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
 
     suspend fun failConfirmation(error: Throwable) {
         completeConfirmation {
-            refreshSession()
+            refreshSession { sessionRefresher.refresh() }
             CheckoutController.Result.Failed(error)
         }
     }
@@ -162,9 +169,9 @@ internal class CheckoutOperationCoordinator @Inject constructor(
      * The refreshed state has to be committed before the result reaches the integrator, but a failed
      * refresh must not replace the confirmation result the integrator is waiting on.
      */
-    private suspend fun refreshSession() {
+    private suspend fun refreshSession(refresh: suspend () -> Unit) {
         try {
-            sessionRefresher.refresh()
+            refresh()
         } catch (error: CancellationException) {
             throw error
         } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
@@ -6,11 +6,13 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 /**
- * Re-fetches the current checkout session and reloads the controller's state from the fresh
- * response, so state that was loaded before a confirmation doesn't outlive it.
+ * Reloads the controller's state after confirmation, either by fetching the current checkout
+ * session or by committing a response returned by confirmation.
  */
-internal fun interface CheckoutSessionRefresher {
+internal interface CheckoutSessionRefresher {
     suspend fun refresh()
+
+    suspend fun refresh(response: CheckoutSessionResponse)
 }
 
 @OptIn(CheckoutSessionPreview::class)
@@ -37,7 +39,12 @@ internal class DefaultCheckoutSessionRefresher internal constructor(
             state.checkoutSessionResponse.id,
             state.configuration.adaptivePricingAllowed,
         ).getOrThrow()
-        val latestState = stateHolder.state ?: return
-        reloadState(latestState.copy(checkoutSessionResponse = response))
+
+        refresh(response)
+    }
+
+    override suspend fun refresh(response: CheckoutSessionResponse) {
+        val state = stateHolder.state ?: return
+        reloadState(state.copy(checkoutSessionResponse = response))
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -13,11 +13,17 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
+import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +36,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertFailsWith
 
+@Suppress("LargeClass")
 internal class CheckoutOperationCoordinatorTest {
 
     @Test
@@ -440,7 +447,101 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `successful confirmation does not refresh the checkout session`() = runScenario {
+    fun `successful response is committed under operation gate before delivering result`() {
+        val releaseCommit = CompletableDeferred<Unit>()
+        runScenario {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+            assertThat(coordinator.isUpdating.value).isTrue()
+
+            enqueueRefreshAction { releaseCommit.await() }
+            confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession(response))
+            assertThat(refreshCalls.awaitItem())
+                .isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
+            resultTurbine.expectNoEvents()
+
+            val mutationStarted = CompletableDeferred<Unit>()
+            val mutation = backgroundScope.async {
+                coordinator.runMutation {
+                    mutationStarted.complete(Unit)
+                    Result.success(Unit)
+                }
+            }
+            runCurrent()
+
+            assertThat(mutationStarted.isCompleted).isFalse()
+            assertThat(coordinator.isUpdating.value).isTrue()
+
+            releaseCommit.complete(Unit)
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+            assertThat(mutation.await().isSuccess).isTrue()
+            assertThat(coordinator.isUpdating.value).isFalse()
+        }
+    }
+
+    @Test
+    fun `commit failure is logged and still delivers result and releases gate`() {
+        val expected = IllegalStateException("Commit failed")
+        val logger = FakeLogger()
+        runScenario(logger = logger) {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+            enqueueRefreshAction { throw expected }
+            confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession(response))
+
+            refreshCalls.awaitItem()
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+            assertThat(logger.errorLogs).containsExactly(
+                "Failed to refresh the checkout session after confirmation." to expected
+            )
+            assertThat(coordinator.isUpdating.value).isFalse()
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        }
+    }
+
+    @Test
+    fun `commit cancellation suppresses result and releases gate`() = runScenario {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+        enqueueRefreshAction { throw CancellationException("Commit canceled") }
+        confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession(response))
+        refreshCalls.awaitItem()
+        observerJob.join()
+
+        resultTurbine.expectNoEvents()
+        assertThat(observerJob.isCancelled).isTrue()
+        assertThat(coordinator.isUpdating.value).isFalse()
+        assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+    }
+
+    @Test
+    fun `restored confirmation ignores competing completion while committing`() {
+        val releaseCommit = CompletableDeferred<Unit>()
+        runScenario(
+            initialConfirmationState = ConfirmationHandler.State.Confirming(
+                CONFIRMATION_PARAMETERS.confirmationOption
+            ),
+            hasReloadedFromProcessDeath = true,
+        ) {
+            enqueueRefreshAction { releaseCommit.await() }
+            confirmationState.value = ConfirmationHandler.State.Complete(succeededWithSession(response))
+
+            assertThat(refreshCalls.awaitItem())
+                .isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
+
+            coordinator.failConfirmation(IllegalStateException("Competing failure"))
+            refreshCalls.expectNoEvents()
+            resultTurbine.expectNoEvents()
+
+            releaseCommit.complete(Unit)
+
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+            resultTurbine.expectNoEvents()
+            refreshCalls.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `successful confirmation without response does not refresh the checkout session`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         confirmationState.value = ConfirmationHandler.State.Complete(
@@ -637,6 +738,7 @@ internal class CheckoutOperationCoordinatorTest {
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
         hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
+        logger: Logger = Logger.noop(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationState = MutableStateFlow(initialConfirmationState)
@@ -653,10 +755,10 @@ internal class CheckoutOperationCoordinatorTest {
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
-            logger = Logger.noop(),
+            logger = logger,
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
         )
-        backgroundScope.launch {
+        val observerJob = backgroundScope.launch {
             coordinator.observeConfirmationResults()
         }
         testScheduler.runCurrent()
@@ -667,6 +769,7 @@ internal class CheckoutOperationCoordinatorTest {
             resultTurbine = resultTurbine,
             refreshCalls = sessionRefresher.calls,
             sessionRefresher = sessionRefresher,
+            observerJob = observerJob,
             testScope = this,
         ).block()
 
@@ -681,8 +784,10 @@ internal class CheckoutOperationCoordinatorTest {
         val resultTurbine: Turbine<CheckoutController.Result>,
         val refreshCalls: Turbine<FakeCheckoutSessionRefresher.Call>,
         private val sessionRefresher: FakeCheckoutSessionRefresher,
+        val observerJob: Job,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
+        val response = CheckoutSessionResponseFactory.create(id = "cs_confirmed")
         val backgroundScope = testScope.backgroundScope
         val testScheduler = testScope.testScheduler
 
@@ -694,4 +799,13 @@ internal class CheckoutOperationCoordinatorTest {
             sessionRefresher.enqueueRefreshAction(action)
         }
     }
+
+    private fun succeededWithSession(
+        response: CheckoutSessionResponse,
+    ) = ConfirmationHandler.Result.Succeeded(
+        intent = PaymentIntentFixtures.PI_SUCCEEDED,
+        metadata = MutableConfirmationMetadata().apply {
+            set(CheckoutSessionResponseKey, response)
+        },
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutSessionRefresherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutSessionRefresherTest.kt
@@ -14,6 +14,16 @@ import org.robolectric.RobolectricTestRunner
 internal class DefaultCheckoutSessionRefresherTest {
 
     @Test
+    fun `refresh with response commits it without fetching`() = runScenario {
+        val response = CheckoutSessionResponseFactory.create(id = "cs_confirmed")
+
+        refresher.refresh(response)
+
+        assertThat(refreshActions.reloadCalls.awaitItem())
+            .isEqualTo(initialState.copy(checkoutSessionResponse = response))
+    }
+
+    @Test
     fun `refresh without response fetches and commits latest session`() = runScenario {
         val response = CheckoutSessionResponseFactory.create(id = "cs_fetched")
         val stateAtCommit = initialState.copy(temporarySelection = "card")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefresher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefresher.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import app.cash.turbine.Turbine
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
 internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
     val calls = Turbine<Call>()
@@ -12,6 +13,10 @@ internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
 
     override suspend fun refresh() {
         record(Call.Fetch)
+    }
+
+    override suspend fun refresh(response: CheckoutSessionResponse) {
+        record(Call.Commit(response))
     }
 
     fun ensureAllEventsConsumed() {
@@ -26,5 +31,6 @@ internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
 
     sealed interface Call {
         data object Fetch : Call
+        data class Commit(val response: CheckoutSessionResponse) : Call
     }
 }


### PR DESCRIPTION
# Summary

Commits a checkout-session response returned in successful confirmation metadata before delivering `Completed`, while the checkout operation gate remains held. Successful confirmations without response metadata keep the existing no-refresh behavior; failed and canceled confirmations continue fetching through `/init`.

This is the top layer of a two-PR stack and depends on `fix/checkout-session-refresher`.

# Motivation

Without committing the response returned by confirmation, controller state loaded before confirmation can remain stale after the successful result is delivered. Serializing the commit under the existing operation gate keeps callbacks and competing mutations from observing stale state.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Validated with focused refresher, coordinator, confirmation interceptor, confirmation performer, and ECE performer unit tests. The final success-refresh test class passes all four cases, and `./gradlew :paymentsheet:detekt` reports no findings.

No tests were ignored.

# Screenshots

Not applicable: this changes internal confirmation state coordination with no visual changes.

# Changelog

Not applicable: this is an internal CheckoutSession preview implementation fix with no public API change.
