### PR TITLE
Remove UNKNOWN status from CheckoutSession and require known status.

### DIFF
--- a/checkout-testing/src/main/resources/checkout-session-adaptive-pricing-default.json
+++ b/checkout-testing/src/main/resources/checkout-session-adaptive-pricing-default.json
@@ -1,6 +1,7 @@
 {
   "session_id": "cs_test_abc123",
   "ui_mode": "custom",
+  "status": "open",
   "currency": "usd",
   "total_summary": {
     "due": 5099

--- a/checkout-testing/src/main/resources/checkout-session-confirm-both-intents.json
+++ b/checkout-testing/src/main/resources/checkout-session-confirm-both-intents.json
@@ -1,6 +1,7 @@
 {
   "session_id": "cs_test_abc123",
   "ui_mode": "custom",
+  "status": "complete",
   "currency": "usd",
   "total_summary": {
     "subtotal": 5099,

--- a/checkout-testing/src/main/resources/checkout-session-confirm-setup.json
+++ b/checkout-testing/src/main/resources/checkout-session-confirm-setup.json
@@ -1,6 +1,7 @@
 {
   "session_id": "cs_test_abc123",
   "ui_mode": "custom",
+  "status": "complete",
   "currency": "usd",
   "mode": "setup",
   "total_summary": {

--- a/checkout-testing/src/main/resources/checkout-session-confirm.json
+++ b/checkout-testing/src/main/resources/checkout-session-confirm.json
@@ -1,6 +1,7 @@
 {
   "session_id": "cs_test_abc123",
   "ui_mode": "custom",
+  "status": "complete",
   "currency": "usd",
   "total_summary": {
     "subtotal": 5099,

--- a/checkout-testing/src/main/resources/checkout-session-init.json
+++ b/checkout-testing/src/main/resources/checkout-session-init.json
@@ -1,6 +1,7 @@
 {
   "session_id": "cs_test_abc123",
   "ui_mode": "custom",
+  "status": "open",
   "currency": "usd",
   "total_summary": {
     "due": 5099

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -419,26 +419,39 @@ class CheckoutController @Inject internal constructor(
          */
         @CheckoutSessionPreview
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        enum class Status {
+        sealed class Status {
             /**
              * The checkout session is still in progress. Payment processing has not started.
              */
-            Open,
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class Open internal constructor() : Status() {
+                override fun equals(other: Any?): Boolean = other is Open
+
+                override fun hashCode(): Int = Open::class.hashCode()
+            }
 
             /**
              * The checkout session is complete. Payment processing may still be in progress.
              */
-            Complete,
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class Complete internal constructor() : Status() {
+                override fun equals(other: Any?): Boolean = other is Complete
+
+                override fun hashCode(): Int = Complete::class.hashCode()
+            }
 
             /**
              * The checkout session has expired. No further processing will occur.
              */
-            Expired,
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class Expired internal constructor() : Status() {
+                override fun equals(other: Any?): Boolean = other is Expired
 
-            /**
-             * A status not recognized by this version of the SDK.
-             */
-            Unknown,
+                override fun hashCode(): Int = Expired::class.hashCode()
+            }
         }
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionMappers.kt
@@ -36,10 +36,9 @@ internal fun CheckoutSessionResponse.asCheckoutSession(
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.Status.asStatus(): Session.Status {
     return when (this) {
-        CheckoutSessionResponse.Status.OPEN -> Session.Status.Open
-        CheckoutSessionResponse.Status.COMPLETE -> Session.Status.Complete
-        CheckoutSessionResponse.Status.EXPIRED -> Session.Status.Expired
-        CheckoutSessionResponse.Status.UNKNOWN -> Session.Status.Unknown
+        CheckoutSessionResponse.Status.OPEN -> Session.Status.Open()
+        CheckoutSessionResponse.Status.COMPLETE -> Session.Status.Complete()
+        CheckoutSessionResponse.Status.EXPIRED -> Session.Status.Expired()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -129,7 +129,6 @@ internal data class CheckoutSessionResponse(
         OPEN,
         COMPLETE,
         EXPIRED,
-        UNKNOWN,
     }
 
     enum class TaxStatus {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -42,7 +42,7 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
             StripeJsonUtils.optCountryCode(it, FIELD_ACCOUNT_SETTINGS_COUNTRY)
         }
         val mode = parseMode(json.optString(FIELD_MODE))
-        val status = parseStatus(json.optString(FIELD_STATUS))
+        val status = parseStatus(json.optString(FIELD_STATUS)) ?: return null
         val liveMode = json.optBoolean(FIELD_LIVE_MODE, false)
         val taxContext = json.optJSONObject(FIELD_TAX_CONTEXT)
         val automaticTaxEnabled = taxContext?.optBoolean(FIELD_AUTOMATIC_TAX_ENABLED, false) ?: false
@@ -126,12 +126,12 @@ internal object CheckoutSessionResponseJsonParser : ModelJsonParser<CheckoutSess
         }
     }
 
-    private fun parseStatus(statusString: String): CheckoutSessionResponse.Status {
+    private fun parseStatus(statusString: String): CheckoutSessionResponse.Status? {
         return when (statusString) {
             "open" -> CheckoutSessionResponse.Status.OPEN
             "complete" -> CheckoutSessionResponse.Status.COMPLETE
             "expired" -> CheckoutSessionResponse.Status.EXPIRED
-            else -> CheckoutSessionResponse.Status.UNKNOWN
+            else -> null
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionMappersTest.kt
@@ -21,25 +21,19 @@ class CheckoutSessionMappersTest {
     @Test
     fun `maps status open`() {
         val session = createSession(status = CheckoutSessionResponse.Status.OPEN)
-        assertThat(session.status).isEqualTo(Session.Status.Open)
+        assertThat(session.status).isInstanceOf(Session.Status.Open::class.java)
     }
 
     @Test
     fun `maps status complete`() {
         val session = createSession(status = CheckoutSessionResponse.Status.COMPLETE)
-        assertThat(session.status).isEqualTo(Session.Status.Complete)
+        assertThat(session.status).isInstanceOf(Session.Status.Complete::class.java)
     }
 
     @Test
     fun `maps status expired`() {
         val session = createSession(status = CheckoutSessionResponse.Status.EXPIRED)
-        assertThat(session.status).isEqualTo(Session.Status.Expired)
-    }
-
-    @Test
-    fun `maps status unknown`() {
-        val session = createSession(status = CheckoutSessionResponse.Status.UNKNOWN)
-        assertThat(session.status).isEqualTo(Session.Status.Unknown)
+        assertThat(session.status).isInstanceOf(Session.Status.Expired::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1036,7 +1036,7 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
-    fun `parse status unknown for unrecognized value`() {
+    fun `fails to parse unrecognized status`() {
         val json = JSONObject(
             """
             {
@@ -1050,12 +1050,11 @@ class CheckoutSessionResponseJsonParserTest {
         )
         val result = CheckoutSessionResponseJsonParser.parse(json)
 
-        assertThat(result).isNotNull()
-        assertThat(result?.status).isEqualTo(CheckoutSessionResponse.Status.UNKNOWN)
+        assertThat(result).isNull()
     }
 
     @Test
-    fun `parse status defaults to unknown when missing`() {
+    fun `fails to parse missing status`() {
         val json = JSONObject(
             """
             {
@@ -1066,10 +1065,12 @@ class CheckoutSessionResponseJsonParserTest {
             }
             """.trimIndent()
         )
-        val result = CheckoutSessionResponseJsonParser.parse(json)
+        val result = CheckoutSessionResponseJsonParser.parse(
+            json = json,
+            addDefaultStatus = false,
+        )
 
-        assertThat(result).isNotNull()
-        assertThat(result?.status).isEqualTo(CheckoutSessionResponse.Status.UNKNOWN)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -1443,5 +1444,22 @@ class CheckoutSessionResponseJsonParserTest {
 
         assertThat(result).isNotNull()
         assertThat(result?.allowedShippingCountries).isEqualTo(emptyList<String>())
+    }
+
+    /**
+     * Most parser tests predate the required status field and exercise unrelated response fields.
+     * Give those fixtures a known status while allowing status-specific tests to opt out.
+     */
+    private object CheckoutSessionResponseJsonParser {
+        fun parse(
+            json: JSONObject,
+            addDefaultStatus: Boolean = true,
+        ): CheckoutSessionResponse? {
+            val responseJson = JSONObject(json.toString())
+            if (addDefaultStatus && !responseJson.has("status")) {
+                responseJson.put("status", "open")
+            }
+            return com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseJsonParser.parse(responseJson)
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -383,6 +383,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
                 {
                   "session_id": "cs_123",
                   "ui_mode": "custom",
+                  "status": "open",
                   "currency": "usd",
                   "total_summary": {
                     "due": 5099


### PR DESCRIPTION
# Summary
Remove the UNKNOWN status from `CheckoutSession` and its parsing logic. JSON parsing now fails when an unknown or missing checkout session status is encountered.

# Motivation
Prepping for API review.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
