### PR TITLE
Stop asserting analytics params via URL substrings

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -383,31 +383,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 )
             )
 
-        // Verify URL contains all expected parameters including timestamp
-        val url = analyticsRequest.url
-        assertThat(url).contains("https://q.stripe.com?")
-        assertThat(url).contains("publishable_key=pk_abc123")
-        assertThat(url).contains("app_version=0")
-        assertThat(url).contains("bindings_version=$sdkVersion")
-        assertThat(url).contains("os_version=30")
-        assertThat(url).contains("session_id=${AnalyticsRequestFactory.sessionId}")
-        assertThat(url).contains("os_release=11")
-        assertThat(url).contains("device_type=robolectric_robolectric_robolectric")
-        assertThat(url).contains("source_type=card")
-        assertThat(url).contains("locale=en_US")
-        assertThat(url).contains("app_name=com.stripe.android.test")
-        assertThat(url).contains("analytics_ua=analytics.stripe_android-1.0")
-        assertThat(url).contains("os_name=REL")
-        assertThat(url).contains("network_type=2G")
-        assertThat(url).contains("event=stripe_android.payment_method_creation")
-        assertThat(url).contains("is_development=true")
-        assertThat(url).contains("timestamp=")
-
-        // Verify timestamp is a valid number
-        val timestampParam = url.substringAfter("timestamp=").substringBefore("&")
-        val timestamp = timestampParam.toDoubleOrNull()
-        assertThat(timestamp).isNotNull()
-        assertThat(timestamp).isGreaterThan(0.0)
+        assertThat(analyticsRequest.url).startsWith("https://q.stripe.com?")
     }
 
     @Test


### PR DESCRIPTION
## Summary

`PaymentAnalyticsRequestFactoryTest.create should create object with expected url and headers` asserted 16 analytics params by substring-matching the request URL's query string (`assertThat(url).contains("os_version=30")`), then hand-parsed `timestamp` back out of it.

`getPaymentMethodCreationParams`, ~250 lines up in the same file, already asserts the full param map of the same factory call (`createPaymentMethodCreation`) with exact equality — every field the substring block checked, with the same expected values, plus the `timestamp > 0` check. So this drops the duplicated coverage and leaves the test asserting the url and headers its name describes.

Splitting this out of an upcoming q.stripe.com → r.stripe.com migration, where these params move from the query string into a POST body and every one of those `contains(...)` assertions would have needed rewriting.

## Testing

`./gradlew :payments-core:testDebugUnitTest --tests '*PaymentAnalyticsRequestFactoryTest*' :payments-core:detekt` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)