### PR TITLE
Reject AnalyticsRequestV2 explicitly in NetworkRule

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -145,6 +145,15 @@ private class NetworkStatement(
             request: StripeRequest,
             callback: HttpURLConnection.(request: StripeRequest) -> Unit
         ): HttpsURLConnection {
+            // No test asserts on v2 analytics, since no test tracks its host. Reject the request
+            // type explicitly so the reason is clear even once the host is tracked.
+            if (request is AnalyticsRequestV2) {
+                throw RequestNotFoundException(
+                    "Test request attempted to reach AnalyticsRequestV2, which is not asserted on. " +
+                        "Url: ${request.url}"
+                )
+            }
+
             val requestHost = request.url.hostFromUrl()
             if (!hostsToTrack.contains(requestHost)) {
                 throw RequestNotFoundException(


### PR DESCRIPTION
## Summary

No test adds `r.stripe.com` to `hostsToTrack`, so v2 analytics requests already fail `NetworkRule`'s host check with the generic `"Test request attempted to reach a non test endpoint"` message. This names the request type in the failure instead.

Behavior-preserving today — same exception type, from the same place, for the same set of requests. It matters for an upcoming q.stripe.com → r.stripe.com migration of v1 analytics: once both versions share a host, host tracking can no longer tell them apart, and a stray v2 request would silently consume a queued v1 expectation instead of failing. Landing the guard now keeps that diff focused on the migration itself.

## Testing

`./gradlew :network-testing:compileDebugKotlin :network-testing:detekt` — green.

Note: `:paymentsheet:testDebugUnitTest` (the widest `NetworkRule` consumer) does not compile on master right now — `CheckoutControllerTest.kt:1188` passes `Status.Open` where a `Status` is expected, from cc1dc79991. Unrelated to this change, but it blocked a broader smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)