### PR TITLE
[ApiConfiguration 1/8] Add PaymentConfiguration compatibility bridge

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.payments.core.injection
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.networking.ApiRequest
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module(includes = [PaymentConfigurationModule::class])
+class ApiConfigurationFromPaymentConfigurationModule {
+    @Provides
+    fun provideApiConfigurationStateProvider(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> ApiConfiguration.State {
+        return {
+            val config = paymentConfiguration.get()
+            ApiConfiguration.State(
+                publishableKey = config.publishableKey,
+                stripeAccountId = config.stripeAccountId,
+            )
+        }
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class ApiRequestOptionsModule {
+    @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigurationProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options {
+        return {
+            val state = apiConfigurationProvider()
+            ApiRequest.Options(
+                apiKey = state.publishableKey,
+                stripeAccount = state.stripeAccountId,
+            )
+        }
+    }
+
+    @Provides
+    fun provideApiRequestOptions(
+        apiRequestOptionsProvider: () -> ApiRequest.Options
+    ): ApiRequest.Options = apiRequestOptionsProvider()
+}


### PR DESCRIPTION
# Summary
Introduces the compatibility bridge used by the ApiConfiguration migration. The new Dagger modules lazily derive `ApiConfiguration.State` and `ApiRequest.Options` from the existing global `PaymentConfiguration`.

This is PR 1 of 8 in the ApiConfiguration migration stack.

# Motivation
SDK internals currently depend on separately named publishable-key and Stripe-account providers. A typed configuration object is needed before a future public API can supply per-instance credentials. This additive bridge lets consumers migrate incrementally while preserving existing global configuration behavior.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Validated by downstream stack tests:
- `./gradlew :payments-core:testDebugUnitTest`
- `./gradlew :paymentsheet:testDebugUnitTest`

# Screenshots
Not applicable; internal configuration refactor only.

# Changelog
None; no public behavior changes.
