### PR TITLE
[ApiConfiguration 4/8] Pass configuration through card scanning

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncher.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class CardScanStripeLauncher(
     context: Context,
     private val eventsReporter: CardScanEventsReporter,
+    private val publishableKey: String,
     private val enableMlKitCardScan: Boolean,
     private val elementsSessionId: String?,
     private val disableSsdOcrCardScan: Boolean,
@@ -53,6 +54,7 @@ internal class CardScanStripeLauncher(
             CardScanSheetParams(
                 CardScanConfiguration(
                     elementsSessionId = elementsSessionId,
+                    publishableKey = publishableKey,
                     enableMlKitTextRecognition = enableMlKitCardScan,
                     disableSsdOcr = disableSsdOcrCardScan,
                 )
@@ -113,6 +115,7 @@ internal class CardScanStripeLauncher(
         @Composable
         internal fun rememberCardScanStripeLauncher(
             eventsReporter: CardScanEventsReporter,
+            publishableKey: String,
             enableMlKitCardScan: Boolean = false,
             elementsSessionId: String? = null,
             disableSsdOcrCardScan: Boolean = false,
@@ -121,11 +124,12 @@ internal class CardScanStripeLauncher(
             val context = LocalContext.current.applicationContext
             val isLaunchingState = rememberSaveable { mutableStateOf(false) }
             val launcher = remember(
-                eventsReporter, context, enableMlKitCardScan, elementsSessionId, disableSsdOcrCardScan,
+                eventsReporter, context, publishableKey, enableMlKitCardScan, elementsSessionId, disableSsdOcrCardScan,
             ) {
                 CardScanStripeLauncher(
                     context = context,
                     eventsReporter = eventsReporter,
+                    publishableKey = publishableKey,
                     enableMlKitCardScan = enableMlKitCardScan,
                     elementsSessionId = elementsSessionId,
                     disableSsdOcrCardScan = disableSsdOcrCardScan,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/RememberCardScanLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/RememberCardScanLauncher.kt
@@ -14,6 +14,7 @@ internal fun rememberCardScanLauncher(
     isStripeCardScanAllowed: Boolean = false,
     enableMlKitCardScan: Boolean = false,
     disableSsdOcrCardScan: Boolean = false,
+    publishableKey: String,
     onResult: (CardScanResult) -> Unit,
     isStripeCardScanAvailable: IsStripeCardScanAvailable = DefaultIsStripeCardScanAvailable(),
 ): CardScanLauncher? {
@@ -27,6 +28,7 @@ internal fun rememberCardScanLauncher(
     return if (isStripeCardScanAllowed && isStripeCardScanAvailable() && hasActiveStripeScanner) {
         rememberCardScanStripeLauncher(
             eventsReporter = eventsReporter,
+            publishableKey = publishableKey,
             enableMlKitCardScan = enableMlKitCardScan,
             elementsSessionId = elementsSessionId,
             disableSsdOcrCardScan = disableSsdOcrCardScan,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
@@ -12,6 +12,7 @@ class CardScanAction(
     private val isStripeCardScanAllowed: Boolean,
     private val enableMlKitCardScan: Boolean,
     private val disableSsdOcrCardScan: Boolean,
+    private val publishableKey: String,
     val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
 ) : CardDetailsAction {
     @Composable
@@ -21,6 +22,7 @@ class CardScanAction(
             isStripeCardScanAllowed = isStripeCardScanAllowed,
             enableMlKitCardScan = enableMlKitCardScan,
             disableSsdOcrCardScan = disableSsdOcrCardScan,
+            publishableKey = publishableKey,
             onResult = { result ->
                 (result as? CardScanResult.Completed)?.scannedCard?.let { scannedCard ->
                     onScannedCard(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncherTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncherTest.kt
@@ -106,6 +106,7 @@ class CardScanStripeLauncherTest {
         val launcher = CardScanStripeLauncher(
             context = ApplicationProvider.getApplicationContext(),
             eventsReporter = fakeEventsReporter,
+            publishableKey = "pk_test_123",
             enableMlKitCardScan = false,
             elementsSessionId = null,
             disableSsdOcrCardScan = false,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
@@ -136,6 +136,7 @@ internal class CardScanActionTest {
             isStripeCardScanAllowed = false,
             enableMlKitCardScan = false,
             disableSsdOcrCardScan = false,
+            publishableKey = "pk_test_123",
             automaticallyLaunchedCardScanFormDataHelper = helper,
         )
         val scenario = Scenario(onScannedCardCalls = onScannedCardCalls)

--- a/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
+++ b/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
@@ -24,6 +24,7 @@ class CardScanDemoActivity : AppCompatActivity() {
                     elementsSessionId = null,
                     enableMlKitTextRecognition = viewBinding.enableMlKitCheckbox.isChecked,
                     disableSsdOcr = viewBinding.disableSsdOcrCheckbox.isChecked,
+                    publishableKey = "pk_123"
                 )
             )
         }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -221,7 +221,7 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             BundleCompat.getParcelable(it, INTENT_PARAM_REQUEST, CardScanSheetParams::class.java)
         }
         val cardScanConfiguration = cardScanSheetParams?.cardScanConfiguration
-            ?: CardScanConfiguration(elementsSessionId = null)
+            ?: CardScanConfiguration(elementsSessionId = null, publishableKey = "")
 
         scanFlow = createScanFlow(
             enableMlKitTextRecognition = cardScanConfiguration.enableMlKitTextRecognition,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanConfiguration.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanConfiguration.kt
@@ -8,6 +8,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class CardScanConfiguration(
     val elementsSessionId: String?,
+    val publishableKey: String,
     val enableMlKitTextRecognition: Boolean = false,
     val disableSsdOcr: Boolean = false,
 ) : Parcelable

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -148,7 +148,7 @@ class CardScanSheet private constructor() {
      * https://paper.dropbox.com/doc/Bouncer-Web-API-Review--BTOclListnApWjHdpv4DoaOuAg-Wy0HGlL0XfwAOz9hHuzS1#:h2=Creating-a-CardImageVerificati
      */
     fun present() {
-        present(CardScanConfiguration(elementsSessionId = null))
+        present(CardScanConfiguration(elementsSessionId = null, publishableKey = ""))
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/di/CardScanModule.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/di/CardScanModule.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.stripecardscan.di
 
 import android.app.Application
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -13,6 +11,7 @@ import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.stripecardscan.BuildConfig
+import com.stripe.android.stripecardscan.cardscan.CardScanConfiguration
 import com.stripe.android.stripecardscan.cardscan.CardScanEventsReporter
 import com.stripe.android.stripecardscan.cardscan.DefaultCardScanEventsReporter
 import dagger.Binds
@@ -39,12 +38,12 @@ internal interface CardScanModule {
         @Singleton
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String
+            configuration: CardScanConfiguration,
         ): AnalyticsRequestFactory = AnalyticsRequestFactory(
             packageManager = application.packageManager,
             packageName = application.packageName.orEmpty(),
             packageInfo = application.packageInfo,
-            publishableKeyProvider = publishableKeyProvider,
+            publishableKeyProvider = { configuration.publishableKey },
             networkTypeProvider = NetworkTypeDetector(application)::invoke,
         )
 
@@ -56,12 +55,6 @@ internal interface CardScanModule {
         @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            application: Application
-        ): () -> String = { PaymentConfiguration.getInstance(application.applicationContext).publishableKey }
 
         @Provides
         @Singleton

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -213,7 +213,7 @@ internal class DefaultCardScanEventsReporterTest {
                 pluginTypeProvider = { null }
             ),
             durationProvider = durationProvider,
-            cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID)
+            cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID, publishableKey = "pk_test_123")
         )
 
         testBlock(eventsReporter, analyticsRequestExecutor)


### PR DESCRIPTION
# Summary
Passes `ApiConfiguration.State` through card-scan launchers, configuration, activities, and DI instead of reading global `PaymentConfiguration` inside the flow.

This is PR 4 of 8. Base: `tyler/api-config-stack-03-paymentsheet`.

# Motivation
Card scanning must use the same credentials selected by its parent payment flow. Explicit propagation prevents a future per-instance configuration from being replaced by the global singleton.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Covered by the passing final-stack PaymentSheet unit suite.

# Screenshots
Not applicable; no UI changes.

# Changelog
None; no public behavior changes.
