### PR TITLE
[ApiConfiguration 5/8] Migrate Financial Connections

### DIFF
--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepository.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepository.kt
@@ -24,8 +24,8 @@ internal class FinancialConnectionsLiteRepositoryImpl(
 ) : FinancialConnectionsLiteRepository {
 
     fun FinancialConnectionsSheetConfiguration.apiRequestOptions() = ApiRequest.Options(
-        publishableKeyProvider = { publishableKey },
-        stripeAccountIdProvider = { stripeAccountId },
+        apiKey = publishableKey,
+        stripeAccount = stripeAccountId,
     )
 
     override suspend fun synchronize(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.financialconnections.di
 
 import android.app.Application
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.financialconnections.BuildConfig
 import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import dagger.Module
@@ -14,18 +14,13 @@ import javax.inject.Named
 internal object FinancialConnectionsSheetConfigurationModule {
 
     @Provides
-    @Named(PUBLISHABLE_KEY)
     @ActivityRetainedScope
-    fun providesPublishableKey(
+    fun providesApiConfigurationState(
         configuration: FinancialConnectionsSheetConfiguration
-    ): String = configuration.publishableKey
-
-    @Provides
-    @Named(STRIPE_ACCOUNT_ID)
-    @ActivityRetainedScope
-    fun providesStripeAccountId(
-        configuration: FinancialConnectionsSheetConfiguration
-    ): String? = configuration.stripeAccountId
+    ): ApiConfiguration.State = ApiConfiguration.State(
+        publishableKey = configuration.publishableKey,
+        stripeAccountId = configuration.stripeAccountId,
+    )
 
     @Provides
     @Named(ENABLE_LOGGING)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -3,12 +3,12 @@ package com.stripe.android.financialconnections.di
 import android.app.Application
 import android.content.Context
 import androidx.core.os.LocaleListCompat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -119,11 +119,10 @@ internal interface FinancialConnectionsSheetSharedModule {
         @Provides
         @ActivityRetainedScope
         internal fun providesApiOptions(
-            @Named(PUBLISHABLE_KEY) publishableKey: String,
-            @Named(STRIPE_ACCOUNT_ID) stripeAccountId: String?
+            apiConfiguration: ApiConfiguration.State
         ): ApiRequest.Options = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId
         )
 
         @Provides
@@ -181,12 +180,12 @@ internal interface FinancialConnectionsSheetSharedModule {
         @ActivityRetainedScope
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            @Named(PUBLISHABLE_KEY) publishableKey: String
+            apiConfiguration: ApiConfiguration.State
         ): AnalyticsRequestFactory = AnalyticsRequestFactory(
             packageManager = application.packageManager,
             packageName = application.packageName.orEmpty(),
             packageInfo = application.packageInfo,
-            publishableKeyProvider = { publishableKey },
+            publishableKeyProvider = { apiConfiguration.publishableKey },
             networkTypeProvider = NetworkTypeDetector(application)::invoke,
         )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/NamedConstants.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/NamedConstants.kt
@@ -1,11 +1,6 @@
 package com.stripe.android.financialconnections.di
 
 /**
- * Name for user's publishable key.
- */
-internal const val PUBLISHABLE_KEY = "publishableKey"
-
-/**
  * Host's applicationId.
  */
 internal const val APPLICATION_ID = "applicationId"


### PR DESCRIPTION
# Summary
Migrates Financial Connections and Financial Connections Lite configuration bindings to `ApiConfiguration.State`.

This is PR 5 of 8. Base: `tyler/api-config-stack-04-card-scan`.

# Motivation
Financial Connections requests should consume the same typed key/account pair as the rest of the SDK, avoiding separate named bindings and preparing the flow for explicit configuration.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Covered by downstream stack compilation and the passing final-stack PaymentSheet unit suite.

# Screenshots
Not applicable; internal DI refactor only.

# Changelog
None; no public behavior changes.
