### PR TITLE
[ApiConfiguration 6/8] Migrate Payment Method Messaging

### DIFF
--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingCoordinator.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingCoordinator.kt
@@ -2,7 +2,7 @@
 
 package com.stripe.android.paymentmethodmessaging.element
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethodMessage
@@ -15,7 +15,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
-import javax.inject.Provider
 
 internal interface PaymentMethodMessagingCoordinator {
     val messagingContent: StateFlow<PaymentMethodMessagingContent?>
@@ -26,7 +25,7 @@ internal interface PaymentMethodMessagingCoordinator {
 
 internal class DefaultPaymentMethodMessagingCoordinator @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     private val eventReporter: PaymentMethodMessagingEventReporter,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     private val errorReporter: ErrorReporter
@@ -46,8 +45,8 @@ internal class DefaultPaymentMethodMessagingCoordinator @Inject constructor(
             locale = configuration.locale,
             country = configuration.countryCode,
             requestOptions = ApiRequest.Options(
-                apiKey = paymentConfiguration.get().publishableKey,
-                stripeAccount = paymentConfiguration.get().stripeAccountId
+                apiKey = apiConfigProvider().publishableKey,
+                stripeAccount = apiConfigProvider().stripeAccountId
             )
         ).fold(
             onSuccess = { paymentMethodMessage ->

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
@@ -13,8 +13,8 @@ import com.stripe.android.paymentmethodmessaging.element.analytics.DefaultPaymen
 import com.stripe.android.paymentmethodmessaging.element.analytics.PaymentMethodMessagingEventReporter
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.isSystemDarkTheme
@@ -26,7 +26,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 
-@Module(includes = [PaymentConfigurationModule::class])
+@Module(includes = [ApiConfigurationFromPaymentConfigurationModule::class])
 internal interface PaymentMethodMessagingModule {
 
     @Binds

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/DefaultPaymentMethodMessagingCoordinatorTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/DefaultPaymentMethodMessagingCoordinatorTest.kt
@@ -4,7 +4,7 @@ package com.stripe.android.paymentmethodmessaging.element
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentmethodmessaging.element.analytics.FakeEventReporter
@@ -133,11 +133,10 @@ internal class DefaultPaymentMethodMessagingCoordinatorTest {
         testBlock: suspend Scenario.() -> Unit
     ) = runTest {
         val repository: StripeRepository = FakeStripeRepository()
-        val paymentConfig = { PaymentConfiguration(publishableKey = "key") }
         val errorReporter = FakeErrorReporter()
         val coordinator = DefaultPaymentMethodMessagingCoordinator(
             stripeRepository = repository,
-            paymentConfiguration = paymentConfig,
+            apiConfigProvider = { ApiConfiguration.State(publishableKey = "key", stripeAccountId = null) },
             eventReporter = FakeEventReporter(),
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = errorReporter

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
@@ -12,7 +12,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElement.Appearance.Theme
 import com.stripe.android.paymentmethodmessaging.element.analytics.FakeEventReporter
@@ -100,7 +100,7 @@ internal class PaymentMethodMessagingContentTest {
     ) = runTest {
         val coordinator = DefaultPaymentMethodMessagingCoordinator(
             stripeRepository = FakeStripeRepository(),
-            paymentConfiguration = { PaymentConfiguration("key") },
+            apiConfigProvider = { ApiConfiguration.State(publishableKey = "key", stripeAccountId = null) },
             eventReporter = FakeEventReporter(),
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = FakeErrorReporter()

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessageAnalyticsTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessageAnalyticsTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentmethodmessaging.element.DefaultPaymentMethodMessagingCoordinator
 import com.stripe.android.paymentmethodmessaging.element.FakeStripeRepository
@@ -192,7 +192,7 @@ internal class PaymentMethodMessageAnalyticsTest {
         val errorReporter = FakeErrorReporter()
         val coordinator = DefaultPaymentMethodMessagingCoordinator(
             stripeRepository = FakeStripeRepository(),
-            paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_123_test") },
+            apiConfigProvider = { ApiConfiguration.State(publishableKey = "pk_123_test", stripeAccountId = null) },
             eventReporter = eventReporter,
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = errorReporter


### PR DESCRIPTION
# Summary
Migrates Payment Method Messaging coordination, analytics, and DI to consume `ApiConfiguration.State`.

This is PR 6 of 8. Base: `tyler/api-config-stack-05-financial-connections`.

# Motivation
Promotions and their analytics must use the configuration selected by the owning payment flow rather than independently resolving global credentials.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Covered by the passing final-stack PaymentSheet unit suite.

# Screenshots
Not applicable; no UI changes.

# Changelog
None; no public behavior changes.
