### PR TITLE
[ApiConfiguration 8/8] Remove legacy configuration bindings

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentConfigurationModule.kt
@@ -3,12 +3,8 @@ package com.stripe.android.payments.core.injection
 import android.content.Context
 import androidx.annotation.RestrictTo
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import dagger.Module
 import dagger.Provides
-import javax.inject.Named
-import javax.inject.Provider
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Module
@@ -17,16 +13,4 @@ class PaymentConfigurationModule {
     fun providePaymentConfiguration(context: Context): PaymentConfiguration {
         return PaymentConfiguration.getInstance(context)
     }
-
-    @Provides
-    @Named(PUBLISHABLE_KEY)
-    fun providePublishableKey(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): () -> String = { paymentConfiguration.get().publishableKey }
-
-    @Provides
-    @Named(STRIPE_ACCOUNT_ID)
-    fun provideStripeAccountId(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): () -> String? = { paymentConfiguration.get().stripeAccountId }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
@@ -9,18 +9,6 @@ import androidx.annotation.RestrictTo
 const val ENABLE_LOGGING = "enableLogging"
 
 /**
- * Name for user's publishable key
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val PUBLISHABLE_KEY = "publishableKey"
-
-/**
- * Name for user's account id
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val STRIPE_ACCOUNT_ID = "stripeAccountId"
-
-/**
  * Name for form initial values
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -6,15 +6,10 @@ import com.stripe.android.core.ApiKeyValidator
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.AppInfo
 import com.stripe.android.core.exception.InvalidRequestException
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.version.StripeSdkVersion
 import kotlinx.parcelize.Parcelize
 import java.io.OutputStream
 import java.io.UnsupportedEncodingException
-import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Provider
 
 /**
  * A class representing a Stripe API or Analytics request.
@@ -114,22 +109,6 @@ data class ApiRequest internal constructor(
 
         val apiKeyIsLiveMode: Boolean
             get() = !apiKey.contains("test")
-
-        /**
-         * Dedicated constructor for injection.
-         *
-         * Because [PUBLISHABLE_KEY] and [STRIPE_ACCOUNT_ID] might change, whenever required, a new
-         * [ApiRequest.Options] instance is created with the latest values.
-         * Should always be used with [Provider] or [Lazy].
-         */
-        @Inject
-        constructor(
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-            @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?
-        ) : this(
-            apiKey = publishableKeyProvider(),
-            stripeAccount = stripeAccountIdProvider()
-        )
 
         init {
             ApiKeyValidator().requireValid(apiKey)


### PR DESCRIPTION
# Summary
Removes the legacy named publishable-key and Stripe-account DI bindings and the obsolete injectable `ApiRequest.Options` constructor after all consumers have migrated.

This is PR 8 of 8. Base: `tyler/api-config-stack-07-crypto-onramp`.

# Motivation
With every consumer using `ApiConfiguration.State`, retaining the parallel named-provider path would create two credential sources and make future explicit configuration error-prone. Cleanup is intentionally last so every earlier PR remains functional and reviewable on its own.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :payments-core:testDebugUnitTest` — passed (1,838 tests)
- `./gradlew :paymentsheet:testDebugUnitTest` — passed (6,260 tests)

# Screenshots
Not applicable; internal configuration cleanup only.

# Changelog
None; no public behavior changes.
