### PR TITLE
Build Google Pay display items during confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -3,7 +3,6 @@ package com.stripe.android.checkout
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import kotlinx.coroutines.CancellationException
@@ -39,7 +38,6 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
             configuration = configuration,
             linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
-            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(state.paymentMethodMetadata),
             googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = configuration,
                 paymentMethodMetadata = state.paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -7,7 +7,6 @@ import com.stripe.android.checkout.CheckoutOperationCoordinator
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
@@ -85,7 +84,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             configuration = configuration,
             linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
-            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(state.paymentMethodMetadata),
             googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = configuration,
                 paymentMethodMetadata = state.paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOptio
 import com.stripe.android.paymentelement.confirmation.cpms.CustomPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.epms.ExternalPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItem
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationOption
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -20,7 +19,6 @@ internal fun PaymentSelection.toConfirmationOption(
     configuration: CommonConfiguration,
     linkConfiguration: LinkConfiguration?,
     cardFundingFilter: CardFundingFilter,
-    googlePayDisplayItems: List<GooglePayDisplayItem> = emptyList(),
     googlePayIsEmailRequired: Boolean = configuration.billingDetailsCollectionConfiguration.collectsEmail,
     googlePayBillingEmailOverride: String? = null,
     googlePayShippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters? = null,
@@ -35,7 +33,6 @@ internal fun PaymentSelection.toConfirmationOption(
         is PaymentSelection.GooglePay -> toConfirmationOption(
             configuration,
             cardFundingFilter,
-            googlePayDisplayItems,
             isEmailRequired = googlePayIsEmailRequired,
             billingEmailOverride = googlePayBillingEmailOverride,
             shippingAddressParameters = googlePayShippingAddressParameters,
@@ -132,7 +129,6 @@ private fun PaymentSelection.New.toConfirmationOption(): ConfirmationHandler.Opt
 private fun PaymentSelection.GooglePay.toConfirmationOption(
     configuration: CommonConfiguration,
     cardFundingFilter: CardFundingFilter,
-    displayItems: List<GooglePayDisplayItem>,
     isEmailRequired: Boolean,
     billingEmailOverride: String?,
     shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,
@@ -150,7 +146,6 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
                 additionalEnabledNetworks = googlePay.additionalEnabledNetworks,
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
                 cardFundingFilter = cardFundingFilter,
-                displayItems = displayItems,
                 isEmailRequired = isEmailRequired,
                 billingEmailOverride = billingEmailOverride,
                 shippingAddressParameters = shippingAddressParameters,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -104,7 +104,9 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             label = config.customLabel,
             isElements = true,
             publishableKey = null,
-            displayItems = config.displayItems.map { it.resolve(context) },
+            displayItems = GooglePayDisplayItemsFactory.create(confirmationArgs.paymentMethodMetadata).map {
+                it.resolve(context)
+            },
             billingEmailOverride = config.billingEmailOverride,
             shippingAddressParameters = config.shippingAddressParameters,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -24,7 +24,6 @@ internal data class GooglePayConfirmationOption(
         val cardBrandFilter: CardBrandFilter,
         val cardFundingFilter: CardFundingFilter,
         val additionalEnabledNetworks: List<String> = emptyList(),
-        val displayItems: List<GooglePayDisplayItem> = emptyList(),
         val isEmailRequired: Boolean = billingDetailsCollectionConfiguration.collectsEmail,
         val billingEmailOverride: String? = null,
         val shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayDisplayItem.kt
@@ -1,17 +1,14 @@
 package com.stripe.android.paymentelement.confirmation.gpay
 
 import android.content.Context
-import android.os.Parcelable
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.core.strings.ResolvableString
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 internal data class GooglePayDisplayItem(
     val label: ResolvableString,
     val type: GooglePayJsonFactory.DisplayItem.Type,
     val price: Long,
-) : Parcelable {
+) {
     fun resolve(context: Context): GooglePayJsonFactory.DisplayItem {
         return GooglePayJsonFactory.DisplayItem(
             label = label.resolve(context),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -7,7 +7,6 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -58,7 +57,6 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
             configuration = confirmationState.configuration.asCommonConfiguration(),
             linkConfiguration = confirmationState.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = confirmationState.paymentMethodMetadata.cardFundingFilter,
-            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(confirmationState.paymentMethodMetadata),
             googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = confirmationState.configuration.asCommonConfiguration(),
                 paymentMethodMetadata = confirmationState.paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -6,7 +6,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
@@ -75,7 +74,6 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
             configuration = configuration.asCommonConfiguration(),
             linkConfiguration = paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
-            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(paymentMethodMetadata),
             googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = configuration.asCommonConfiguration(),
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -38,7 +38,6 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
@@ -589,7 +588,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                         configuration = config.asCommonConfiguration(),
                         linkConfiguration = linkHandler.linkConfiguration.value,
                         cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
-                        googlePayDisplayItems = GooglePayDisplayItemsFactory.create(paymentMethodMetadata),
                         googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                             configuration = config.asCommonConfiguration(),
                             paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -41,7 +41,6 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
@@ -561,7 +560,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 configuration = state.config,
                 linkConfiguration = state.linkConfiguration,
                 cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
-                googlePayDisplayItems = GooglePayDisplayItemsFactory.create(state.paymentMethodMetadata),
                 googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                     configuration = state.config,
                     paymentMethodMetadata = state.paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayIsEmailRequiredProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
@@ -329,7 +328,6 @@ internal class DefaultWalletButtonsInteractor constructor(
             configuration = arguments.configuration,
             linkConfiguration = arguments.paymentMethodMetadata.linkState?.configuration,
             cardFundingFilter = arguments.paymentMethodMetadata.cardFundingFilter,
-            googlePayDisplayItems = GooglePayDisplayItemsFactory.create(arguments.paymentMethodMetadata),
             googlePayIsEmailRequired = GooglePayIsEmailRequiredProvider.get(
                 configuration = arguments.configuration,
                 paymentMethodMetadata = arguments.paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOptio
 import com.stripe.android.paymentelement.confirmation.cpms.CustomPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.epms.ExternalPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItem
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationOption
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
@@ -332,64 +331,6 @@ class ConfirmationHandlerOptionKtxTest {
         assertThat(
             confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.additionalEnabledNetworks
         ).isEqualTo(additionalNetworks)
-    }
-
-    @Test
-    fun `On Google Pay selection with displayItems, should return expected option with displayItems`() {
-        val displayItems = listOf(
-            GooglePayDisplayItem(
-                label = "Widget".resolvableString,
-                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 2000L,
-            ),
-            GooglePayDisplayItem(
-                label = "Tax".resolvableString,
-                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.TAX,
-                price = 500L,
-            ),
-        )
-
-        val confirmationOption = PaymentSelection.GooglePay.toConfirmationOption(
-            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
-                        countryCode = "US",
-                        currencyCode = "USD",
-                    )
-                )
-                .build()
-                .asCommonConfiguration(),
-            linkConfiguration = null,
-            cardFundingFilter = DefaultCardFundingFilter,
-            googlePayDisplayItems = displayItems,
-        )
-
-        assertThat(
-            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.displayItems
-        ).isEqualTo(displayItems)
-    }
-
-    @Test
-    fun `On Google Pay selection without displayItems, should return empty displayItems`() {
-        val confirmationOption = PaymentSelection.GooglePay.toConfirmationOption(
-            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
-                        countryCode = "US",
-                        currencyCode = "USD",
-                    )
-                )
-                .build()
-                .asCommonConfiguration(),
-            linkConfiguration = null,
-            cardFundingFilter = DefaultCardFundingFilter,
-        )
-
-        assertThat(
-            confirmationOption?.asOption<GooglePayConfirmationOption>()?.config?.displayItems
-        ).isEmpty()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.injection.InternalGooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -41,6 +42,8 @@ import com.stripe.android.paymentelement.confirmation.asSaved
 import com.stripe.android.paymentelement.confirmation.fakeLifecycleOwner
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.paymentsheet.utils.RecordingInternalGooglePayPaymentMethodLauncherFactory
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -512,37 +515,36 @@ class GooglePayConfirmationDefinitionTest {
     }
 
     @Test
-    fun `On 'launch', should pass display items to present`() = runTest {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val displayItems = listOf(
-            GooglePayDisplayItem(
-                label = "Widget".resolvableString,
-                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
-                price = 2000L,
-            ),
-            GooglePayDisplayItem(
-                label = "Tax".resolvableString,
-                type = com.stripe.android.GooglePayJsonFactory.DisplayItem.Type.TAX,
-                price = 500L,
+    fun `On 'launch', should create display items from payment method metadata`() = runTest {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            lineItems = listOf(
+                CheckoutSessionResponse.LineItem(
+                    id = "li_1",
+                    name = "Widget",
+                    quantity = 2,
+                    unitAmount = 1000L,
+                    subtotal = 2000L,
+                    total = 2000L,
+                ),
             ),
         )
-        val resolvedDisplayItems = displayItems.map { displayItem ->
-            displayItem.resolve(context)
-        }
-
         val launcher = mock<InternalGooglePayPaymentMethodLauncher>()
-        val definition = createGooglePayConfirmationDefinition(context = context)
+        val definition = createGooglePayConfirmationDefinition()
 
         definition.launch(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
                 config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
                     merchantCurrencyCode = "USD",
-                    displayItems = displayItems,
                 ),
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS.copy(
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                    stripeIntent = PAYMENT_INTENT.copy(currency = "USD")
+                    stripeIntent = PAYMENT_INTENT.copy(currency = "USD"),
+                    integrationMetadata = IntegrationMetadata.CheckoutSession(
+                        id = checkoutSessionResponse.id,
+                        instancesKey = "GooglePayConfirmationDefinitionTest",
+                        checkoutSessionResponse = checkoutSessionResponse,
+                    ),
                 ),
             ),
             arguments = EmptyConfirmationLauncherArgs,
@@ -560,7 +562,13 @@ class GooglePayConfirmationDefinitionTest {
             label = null,
             isElements = true,
             publishableKey = null,
-            displayItems = resolvedDisplayItems,
+            displayItems = listOf(
+                GooglePayJsonFactory.DisplayItem(
+                    label = "Widget x2",
+                    type = GooglePayJsonFactory.DisplayItem.Type.LINE_ITEM,
+                    price = 1000L,
+                ),
+            ),
             billingEmailOverride = null,
             shippingAddressParameters = null,
         )


### PR DESCRIPTION
committed and created by codex 

# Summary
Build Google Pay display items inside `GooglePayConfirmationDefinition` from `ConfirmationHandler.Args.paymentMethodMetadata`.

Remove display items from `GooglePayConfirmationOption.Config` and stop threading them through `PaymentSelection.toConfirmationOption` and its callers.

# Motivation
Display items are derived from payment method metadata, which is already available to the confirmation definition. Keeping them in the confirmation option duplicated data flow and made every confirmation entry point responsible for constructing them.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationDefinitionTest' --tests 'com.stripe.android.paymentelement.confirmation.ConfirmationHandlerOptionKtxTest'`
- `./gradlew :paymentsheet:detekt`

# Screenshots
Not applicable; no UI changes.

# Changelog
Not applicable; internal refactor with no user-facing behavior change.