### PR TITLE
Assert all LPM billing-address form params

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitLpmBillingAddressTestCases.kt
@@ -104,20 +104,32 @@ internal val auBecsDebitTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.AuBecsDebit,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = auBecsDebitFullRawValues,
-        expectedPaymentMethodParams = auBecsDebitBankDetailsExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = auBecsDebitBankDetailsExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "AU BECS Debit Automatic without tax",
         paymentMethodType = PaymentMethod.Type.AuBecsDebit,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = auBecsDebitFullRawValues,
-        expectedPaymentMethodParams = auBecsDebitWithContactDetailsExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = auBecsDebitWithContactDetailsExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "AU BECS Debit Full",
         paymentMethodType = PaymentMethod.Type.AuBecsDebit,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = auBecsDebitFullRawValues,
-        expectedPaymentMethodParams = auBecsDebitWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = auBecsDebitWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitLpmBillingAddressTestCases.kt
@@ -4,6 +4,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.uicore.elements.IdentifierSpec
 
 private val bacsDebitFullRawValues = mapOf(
@@ -78,20 +79,32 @@ internal val bacsDebitTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.BacsDebit,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = bacsDebitFullRawValues,
-        expectedPaymentMethodParams = bacsDebitBankDetailsExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = bacsDebitBankDetailsExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.BacsDebit(confirmed = true),
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Bacs Debit Automatic without tax",
         paymentMethodType = PaymentMethod.Type.BacsDebit,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = bacsDebitFullRawValues,
-        expectedPaymentMethodParams = bacsDebitWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = bacsDebitWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.BacsDebit(confirmed = true),
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Bacs Debit Full",
         paymentMethodType = PaymentMethod.Type.BacsDebit,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = bacsDebitFullRawValues,
-        expectedPaymentMethodParams = bacsDebitWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = bacsDebitWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.BacsDebit(confirmed = true),
+        ),
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoLpmBillingAddressTestCases.kt
@@ -76,20 +76,32 @@ internal val boletoTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.Boleto,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = boletoNoBillingAddressRawValues,
-        expectedPaymentMethodParams = boletoNoBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = boletoNoBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Boleto Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Boleto,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = boletoWithBillingAddressRawValues,
-        expectedPaymentMethodParams = boletoWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = boletoWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Boleto Full",
         paymentMethodType = PaymentMethod.Type.Boleto,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = boletoWithBillingAddressRawValues,
-        expectedPaymentMethodParams = boletoWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = boletoWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaLpmBillingAddressTestCases.kt
@@ -90,20 +90,32 @@ internal val klarnaTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.Klarna,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = klarnaFullRawValues,
-        expectedPaymentMethodParams = klarnaCountryOnlyExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = klarnaCountryOnlyExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Klarna Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Klarna,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = klarnaFullRawValues,
-        expectedPaymentMethodParams = klarnaWithEmailAndCountryExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = klarnaWithEmailAndCountryExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Klarna Full",
         paymentMethodType = PaymentMethod.Type.Klarna,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = klarnaFullRawValues,
-        expectedPaymentMethodParams = klarnaWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = klarnaWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -10,9 +10,12 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormViewModel
-import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.ui.core.elements.BsbElement
 import com.stripe.android.uicore.elements.AddressFieldsElement
@@ -32,24 +35,24 @@ internal class LpmBillingAddressFormValuesToParamsTest {
     val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
-    fun `creates the expected payment method params`(
+    fun `creates the expected form params`(
         @TestParameter(valuesProvider = TestCaseProvider::class)
         testCase: LpmBillingAddressFormValuesToParamsTestCase,
     ) = runTest {
         assertThat(
-            createPaymentMethodCreateParamsFromFormValues(
+            createFormParamsFromFormValues(
                 paymentMethodType = testCase.paymentMethodType,
                 mode = testCase.mode,
                 rawValues = testCase.rawValues,
             ),
-        ).isEqualTo(testCase.expectedPaymentMethodParams)
+        ).isEqualTo(testCase.expectedParams)
     }
 
-    private suspend fun createPaymentMethodCreateParamsFromFormValues(
+    private suspend fun createFormParamsFromFormValues(
         paymentMethodType: PaymentMethod.Type,
         mode: LpmBillingAddressBaselineMode,
         rawValues: Map<IdentifierSpec, String?>,
-    ): PaymentMethodCreateParams {
+    ): LpmBillingAddressFormParams {
         val metadata = createMetadata(paymentMethodType, mode)
         val formViewModel = createFormViewModel(
             paymentMethodType = paymentMethodType,
@@ -76,7 +79,7 @@ internal class LpmBillingAddressFormValuesToParamsTest {
                 rawValues[element.identifier]?.let { element.controller.onValueChange(it.toBoolean()) }
             }
 
-        return formViewModel.createPaymentMethodCreateParams(paymentMethodType, metadata)
+        return formViewModel.createFormParams(paymentMethodType, metadata)
     }
 
     private fun createMetadata(
@@ -112,15 +115,23 @@ internal class LpmBillingAddressFormValuesToParamsTest {
         )
     }
 
-    private suspend fun FormViewModel.createPaymentMethodCreateParams(
+    private suspend fun FormViewModel.createFormParams(
         paymentMethodType: PaymentMethod.Type,
         metadata: PaymentMethodMetadata,
-    ): PaymentMethodCreateParams {
-        return requireNotNull(completeFormValues.first())
-            .transformToPaymentMethodCreateParams(
-                paymentMethodCode = paymentMethodType.code,
-                paymentMethodMetadata = metadata,
-            )
+    ): LpmBillingAddressFormParams {
+        val supportedPaymentMethod = requireNotNull(
+            metadata.supportedPaymentMethodForCode(paymentMethodType.code),
+        )
+        val paymentSelection = requireNotNull(completeFormValues.first())
+            .transformToPaymentSelection(supportedPaymentMethod, metadata)
+
+        require(paymentSelection is PaymentSelection.New)
+
+        return LpmBillingAddressFormParams(
+            createParams = paymentSelection.paymentMethodCreateParams,
+            optionsParams = paymentSelection.paymentMethodOptionsParams,
+            extraParams = paymentSelection.paymentMethodExtraParams,
+        )
     }
 
     private companion object {
@@ -145,7 +156,13 @@ internal data class LpmBillingAddressFormValuesToParamsTestCase(
     val paymentMethodType: PaymentMethod.Type,
     val mode: LpmBillingAddressBaselineMode,
     val rawValues: Map<IdentifierSpec, String?>,
-    val expectedPaymentMethodParams: PaymentMethodCreateParams,
+    val expectedParams: LpmBillingAddressFormParams,
 ) {
     override fun toString(): String = name
 }
+
+internal data class LpmBillingAddressFormParams(
+    val createParams: PaymentMethodCreateParams,
+    val optionsParams: PaymentMethodOptionsParams?,
+    val extraParams: PaymentMethodExtraParams?,
+)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoLpmBillingAddressTestCases.kt
@@ -90,20 +90,32 @@ internal val oxxoTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.Oxxo,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = oxxoFullRawValues,
-        expectedPaymentMethodParams = oxxoNoBillingDetailsExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = oxxoNoBillingDetailsExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "OXXO Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Oxxo,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = oxxoFullRawValues,
-        expectedPaymentMethodParams = oxxoWithContactDetailsExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = oxxoWithContactDetailsExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "OXXO Full",
         paymentMethodType = PaymentMethod.Type.Oxxo,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = oxxoFullRawValues,
-        expectedPaymentMethodParams = oxxoWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = oxxoWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitLpmBillingAddressTestCases.kt
@@ -4,6 +4,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.uicore.elements.IdentifierSpec
 
 private val sepaDebitNoBillingAddressRawValues = mapOf(
@@ -74,20 +76,32 @@ internal val sepaDebitTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.SepaDebit,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = sepaDebitNoBillingAddressRawValues,
-        expectedPaymentMethodParams = sepaDebitNoBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = sepaDebitNoBillingAddressExpectedPaymentMethodParams,
+            optionsParams = PaymentMethodOptionsParams.SepaDebit(null),
+            extraParams = PaymentMethodExtraParams.SepaDebit(null),
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "SEPA Debit Automatic without tax",
         paymentMethodType = PaymentMethod.Type.SepaDebit,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = sepaDebitWithBillingAddressRawValues,
-        expectedPaymentMethodParams = sepaDebitWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = sepaDebitWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = PaymentMethodOptionsParams.SepaDebit(null),
+            extraParams = PaymentMethodExtraParams.SepaDebit(null),
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "SEPA Debit Full",
         paymentMethodType = PaymentMethod.Type.SepaDebit,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = sepaDebitWithBillingAddressRawValues,
-        expectedPaymentMethodParams = sepaDebitWithBillingAddressExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = sepaDebitWithBillingAddressExpectedPaymentMethodParams,
+            optionsParams = PaymentMethodOptionsParams.SepaDebit(null),
+            extraParams = PaymentMethodExtraParams.SepaDebit(null),
+        ),
     ),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroLpmBillingAddressTestCases.kt
@@ -69,20 +69,32 @@ internal val weroTestCases = listOf(
         paymentMethodType = PaymentMethod.Type.Wero,
         mode = LpmBillingAddressBaselineMode.Never,
         rawValues = weroCountryOnlyRawValues,
-        expectedPaymentMethodParams = weroCountryOnlyExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = weroCountryOnlyExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Wero Automatic without tax",
         paymentMethodType = PaymentMethod.Type.Wero,
         mode = LpmBillingAddressBaselineMode.AutomaticWithoutTax,
         rawValues = weroCountryOnlyRawValues,
-        expectedPaymentMethodParams = weroCountryOnlyExpectedPaymentMethodParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = weroCountryOnlyExpectedPaymentMethodParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
     LpmBillingAddressFormValuesToParamsTestCase(
         name = "Wero Full",
         paymentMethodType = PaymentMethod.Type.Wero,
         mode = LpmBillingAddressBaselineMode.Full,
         rawValues = weroWithBillingAddressRawValues,
-        expectedPaymentMethodParams = weroWithBillingAddressExpectedPaymentParams,
+        expectedParams = LpmBillingAddressFormParams(
+            createParams = weroWithBillingAddressExpectedPaymentParams,
+            optionsParams = null,
+            extraParams = null,
+        ),
     ),
 )


### PR DESCRIPTION
# Summary

This test-only change expands the 21 existing LPM billing-address completed-form cases to assert all three parameter fields carried by `PaymentSelection.New`.

Each parameterized case now passes completed form values through the production `transformToPaymentSelection` handoff, requires `PaymentSelection.New`, and compares the exact create, options, and extra params. The existing create-param expectations remain unchanged.

This covers the route-neutral completed-form handoff. It does not cover Compose user entry or confirm-request construction.

# Motivation

The existing harness asserted only payment method create params. This change also verifies options and extra params, including the Bacs confirmation value and SEPA's typed parameter objects.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- Focused `LpmBillingAddressFormValuesToParamsTest`: passed exactly 21 cases
- `./gradlew :paymentsheet:detekt :paymentsheet:apiCheck`: passed
- `git diff --check`: passed

# Screenshots

Unchanged. No screenshot or snapshot files are modified.

# Changelog

Unchanged. `CHANGELOG.md` is not modified because this is a test-only change.
