### PR TITLE
Add LinkConfiguration.Display.WalletButtonHidden case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ NEXT_VERSION_BUMP: MINOR
 ## XX.XX.XX - 20XX-XX-XX
 
 ### PaymentSheet
+* [ADDED] Added `PaymentSheet.LinkConfiguration.Display.WalletButtonHidden`, which keeps Link enabled but hides its button from the payment element UI.
 * [CHANGED] Inline address autocomplete is now enabled by default in PaymentSheet and FlowController.
 
 ### AddressElement

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/latency/TestLatency.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePayMode
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkDisplaySetting
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
@@ -110,7 +111,7 @@ internal class TestLatency(
 
         private fun PlaygroundSettings.latencyTestDefaults() {
             this[MerchantSettingsDefinition] = Merchant.US
-            this[LinkSettingsDefinition] = false
+            this[LinkSettingsDefinition] = LinkDisplaySetting.Never
             this[CustomerSettingsDefinition] = CustomerType.GUEST
             this[GooglePaySettingsDefinition] = GooglePayMode.Off
             this[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.Off
@@ -153,13 +154,13 @@ internal class TestLatency(
                     testName = "test_link_on_with_no_customer",
                     isReturningCustomer = false,
                 ) { settings: PlaygroundSettings ->
-                    settings[LinkSettingsDefinition] = true
+                    settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
                 },
                 testConfig(
                     testName = "test_link_on_with_ek",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[LinkSettingsDefinition] = true
+                    settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = false
                 },
@@ -167,7 +168,7 @@ internal class TestLatency(
                     testName = "test_link_on_with_cs",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[LinkSettingsDefinition] = true
+                    settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
                 },
@@ -175,7 +176,7 @@ internal class TestLatency(
                     testName = "test_link_on_with_ek_default_email",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[LinkSettingsDefinition] = true
+                    settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = false
                     settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
@@ -184,7 +185,7 @@ internal class TestLatency(
                     testName = "test_link_on_with_cs_default_email",
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
-                    settings[LinkSettingsDefinition] = true
+                    settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
                     settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On
@@ -216,7 +217,7 @@ internal class TestLatency(
                     isReturningCustomer = true,
                 ) { settings: PlaygroundSettings ->
                     settings[GooglePaySettingsDefinition] = GooglePayMode.Test
-                    settings[LinkSettingsDefinition] = true
+                    settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
                     settings[CustomerSettingsDefinition] = CustomerType.RETURNING
                     settings[CustomerSessionSettingsDefinition] = true
                 },

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkDisplaySetting
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_ACCOUNT_DETAILS
@@ -78,7 +79,7 @@ internal class TestInstantDebits : BasePlaygroundTest() {
             settings[CurrencySettingsDefinition] = Currency.USD
             settings[AutomaticPaymentMethodsSettingsDefinition] = false
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
-            settings[LinkSettingsDefinition] = true
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
             settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
                 PaymentMethod.Type.Card,
                 PaymentMethod.Type.Link
@@ -94,7 +95,7 @@ internal class TestInstantDebits : BasePlaygroundTest() {
             settings[CurrencySettingsDefinition] = Currency.USD
             settings[AutomaticPaymentMethodsSettingsDefinition] = false
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
-            settings[LinkSettingsDefinition] = true
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
             settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
                 PaymentMethod.Type.Card,
                 PaymentMethod.Type.Link

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkDisplaySetting
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.LinkType
 import com.stripe.android.paymentsheet.example.playground.settings.LinkTypeSettingsDefinition
@@ -48,7 +49,7 @@ internal class TestLink : BasePlaygroundTest() {
         ) { settings ->
             settings[SupportedPaymentMethodsSettingsDefinition] = if (passthroughMode) "card" else "card,link"
             settings[MerchantSettingsDefinition] = Merchant.US
-            settings[LinkSettingsDefinition] = true
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
         }
     }
@@ -60,7 +61,7 @@ internal class TestLink : BasePlaygroundTest() {
         ) { settings ->
             settings[SupportedPaymentMethodsSettingsDefinition] = if (passthroughMode) "card" else "card,link"
             settings[MerchantSettingsDefinition] = Merchant.US
-            settings[LinkSettingsDefinition] = true
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
             settings[LinkTypeSettingsDefinition] = LinkType.Native
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkDisplaySetting
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_ACCOUNT_DETAILS
@@ -77,7 +78,7 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
             settings[CurrencySettingsDefinition] = Currency.USD
             settings[AutomaticPaymentMethodsSettingsDefinition] = false
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
-            settings[LinkSettingsDefinition] = true
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
             settings[SupportedPaymentMethodsSettingsDefinition] = "card"
         }
     }
@@ -90,7 +91,7 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
             settings[CurrencySettingsDefinition] = Currency.USD
             settings[AutomaticPaymentMethodsSettingsDefinition] = false
             settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.WithEmail(email)
-            settings[LinkSettingsDefinition] = true
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Automatic
             settings[SupportedPaymentMethodsSettingsDefinition] = "card"
         }
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultShippi
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Layout
 import com.stripe.android.paymentsheet.example.playground.settings.LayoutSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.LinkDisplaySetting
 import com.stripe.android.paymentsheet.example.playground.settings.LinkSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 
@@ -60,7 +61,7 @@ internal data class TestParameters(
             val settings = PlaygroundSettings.createFromDefaults()
             settings[CustomerSettingsDefinition] = CustomerType.NEW
             settings[CustomerSessionSettingsDefinition] = false
-            settings[LinkSettingsDefinition] = false
+            settings[LinkSettingsDefinition] = LinkDisplaySetting.Never
             settings[MerchantSettingsDefinition] = Merchant.GB
             settings[CurrencySettingsDefinition] = Currency.EUR
             settings[DefaultShippingAddressSettingsDefinition] = false

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
@@ -1,15 +1,29 @@
+@file:OptIn(LinkHiddenWalletButtonPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
-internal object LinkSettingsDefinition : BooleanSettingsDefinition(
-    key = "link",
-    displayName = "Link",
-    defaultValue = true,
-) {
+internal object LinkSettingsDefinition :
+    PlaygroundSettingDefinition<LinkDisplaySetting>,
+    PlaygroundSettingDefinition.Saveable<LinkDisplaySetting> by EnumSaveable(
+        key = "link",
+        values = LinkDisplaySetting.entries.toTypedArray(),
+        defaultValue = LinkDisplaySetting.Automatic,
+    ),
+    PlaygroundSettingDefinition.Displayable<LinkDisplaySetting> {
+    override val displayName: String = "Link"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ): List<PlaygroundSettingDefinition.Displayable.Option<LinkDisplaySetting>> {
+        return LinkDisplaySetting.entries.map { setting -> option(setting.value, setting) }
+    }
+
     override fun applicable(
         configurationData: PlaygroundConfigurationData,
         settings: Map<PlaygroundSettingDefinition<*>, Any?>,
@@ -18,14 +32,14 @@ internal object LinkSettingsDefinition : BooleanSettingsDefinition(
     }
 
     override fun configure(
-        value: Boolean,
+        value: LinkDisplaySetting,
         checkoutRequestBuilder: CheckoutRequest.Builder,
     ) {
-        checkoutRequestBuilder.useLink(value)
+        checkoutRequestBuilder.useLink(value.useLink)
     }
 
     override fun configure(
-        value: Boolean,
+        value: LinkDisplaySetting,
         configurationBuilder: PaymentSheet.Configuration.Builder,
         playgroundState: PlaygroundState.Payment,
         configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
@@ -36,7 +50,7 @@ internal object LinkSettingsDefinition : BooleanSettingsDefinition(
     }
 
     override fun configure(
-        value: Boolean,
+        value: LinkDisplaySetting,
         configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
         playgroundState: PlaygroundState.Payment,
         configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
@@ -46,13 +60,20 @@ internal object LinkSettingsDefinition : BooleanSettingsDefinition(
         )
     }
 
-    private fun makeLinkConfiguration(value: Boolean): PaymentSheet.LinkConfiguration {
+    private fun makeLinkConfiguration(value: LinkDisplaySetting): PaymentSheet.LinkConfiguration {
         return PaymentSheet.LinkConfiguration(
-            display = if (value) {
-                PaymentSheet.LinkConfiguration.Display.Automatic
-            } else {
-                PaymentSheet.LinkConfiguration.Display.Never
-            }
+            display = value.display,
         )
     }
+}
+
+@OptIn(LinkHiddenWalletButtonPreview::class)
+internal enum class LinkDisplaySetting(
+    override val value: String,
+    val useLink: Boolean,
+    val display: PaymentSheet.LinkConfiguration.Display,
+) : ValueEnum {
+    Automatic("automatic", true, PaymentSheet.LinkConfiguration.Display.Automatic),
+    Never("never", false, PaymentSheet.LinkConfiguration.Display.Never),
+    Hidden("hidden", true, PaymentSheet.LinkConfiguration.Display.Hidden),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkSettingsDefinition.kt
@@ -1,9 +1,6 @@
-@file:OptIn(LinkHiddenWalletButtonPreview::class)
-
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
@@ -67,7 +64,6 @@ internal object LinkSettingsDefinition :
     }
 }
 
-@OptIn(LinkHiddenWalletButtonPreview::class)
 internal enum class LinkDisplaySetting(
     override val value: String,
     val useLink: Boolean,
@@ -75,5 +71,5 @@ internal enum class LinkDisplaySetting(
 ) : ValueEnum {
     Automatic("automatic", true, PaymentSheet.LinkConfiguration.Display.Automatic),
     Never("never", false, PaymentSheet.LinkConfiguration.Display.Never),
-    Hidden("hidden", true, PaymentSheet.LinkConfiguration.Display.Hidden),
+    WalletButtonHidden("wallet_button_hidden", true, PaymentSheet.LinkConfiguration.Display.WalletButtonHidden),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
@@ -22,7 +22,7 @@ internal object LinkTypeSettingsDefinition :
 
         return (
             LinkSettingsDefinition.applicable(configurationData, settings) &&
-                settings[LinkSettingsDefinition] == true
+                settings[LinkSettingsDefinition] != LinkDisplaySetting.Never
             )
     }
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -810,9 +810,6 @@ public abstract interface annotation class com/stripe/android/paymentelement/Exp
 public abstract interface annotation class com/stripe/android/paymentelement/ExtendedLabelsInPaymentOptionPreview : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class com/stripe/android/paymentelement/LinkHiddenWalletButtonPreview : java/lang/annotation/Annotation {
-}
-
 public abstract interface annotation class com/stripe/android/paymentelement/PaymentMethodOptionsSetupFutureUsagePreview : java/lang/annotation/Annotation {
 }
 
@@ -1747,8 +1744,8 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$LinkConfiguratio
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display : java/lang/Enum {
 	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
-	public static final field Hidden Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 	public static final field Never Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
+	public static final field WalletButtonHidden Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -810,6 +810,9 @@ public abstract interface annotation class com/stripe/android/paymentelement/Exp
 public abstract interface annotation class com/stripe/android/paymentelement/ExtendedLabelsInPaymentOptionPreview : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/stripe/android/paymentelement/LinkHiddenWalletButtonPreview : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/stripe/android/paymentelement/PaymentMethodOptionsSetupFutureUsagePreview : java/lang/annotation/Annotation {
 }
 
@@ -1744,6 +1747,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$LinkConfiguratio
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display : java/lang/Enum {
 	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
+	public static final field Hidden Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 	public static final field Never Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/CommonElementsDimensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/CommonElementsDimensions.kt
@@ -12,7 +12,7 @@ internal object CommonElementsDimensions {
     ): Map<String, String> {
         val paymentMethodTypes = paymentMethodMetadata.sortedSupportedPaymentMethods().map { it.code }
         val isGooglePayAvailable = paymentMethodMetadata.isGooglePayReady
-        val isLinkDisplayed = paymentMethodMetadata.linkState != null
+        val isLinkDisplayed = paymentMethodMetadata.shouldShowLinkButton
         val integrationType = when (mode) {
             EventReporter.Mode.Complete -> "paymentsheet"
             EventReporter.Mode.Custom -> "flowcontroller"

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -128,7 +128,7 @@ internal data class PaymentMethodMetadata(
     /**
      * Canonical source of truth for whether the Link button/row should be rendered in the
      * payment element UI. Link may remain functionally enabled ([linkState] non-null) even when
-     * its button is hidden via [PaymentSheet.LinkConfiguration.Display.Hidden].
+     * its button is hidden via [PaymentSheet.LinkConfiguration.Display.WalletButtonHidden].
      */
     val shouldShowLinkButton: Boolean
         get() = linkState != null && linkConfiguration.shouldShowButton

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -126,6 +126,14 @@ internal data class PaymentMethodMetadata(
         }
 
     /**
+     * Canonical source of truth for whether the Link button/row should be rendered in the
+     * payment element UI. Link may remain functionally enabled ([linkState] non-null) even when
+     * its button is hidden via [PaymentSheet.LinkConfiguration.Display.Hidden].
+     */
+    val shouldShowLinkButton: Boolean
+        get() = linkState != null && linkConfiguration.shouldShowButton
+
+    /**
      * Returns the consumer's LinkBrand if logged in, otherwise falls back to the metadata's brand.
      */
     internal fun effectiveLinkBrand(account: LinkAccount?): LinkBrand {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/LinkHiddenWalletButtonPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/LinkHiddenWalletButtonPreview.kt
@@ -1,8 +1,0 @@
-package com.stripe.android.paymentelement
-
-@RequiresOptIn(
-    level = RequiresOptIn.Level.ERROR,
-    message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."
-)
-@Retention(AnnotationRetention.BINARY)
-annotation class LinkHiddenWalletButtonPreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/LinkHiddenWalletButtonPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/LinkHiddenWalletButtonPreview.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.paymentelement
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class LinkHiddenWalletButtonPreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedWalletsHelper.kt
@@ -25,7 +25,7 @@ internal class DefaultEmbeddedWalletsHelper @Inject constructor(
             linkHandler.linkConfigurationCoordinator.accountFlow,
         ) { isLinkAvailable, linkEmail, linkAccount ->
             WalletsState.create(
-                isLinkAvailable = isLinkAvailable,
+                isLinkAvailable = isLinkAvailable == true && paymentMethodMetadata.shouldShowLinkButton,
                 linkEmail = linkEmail,
                 isGooglePayReady = paymentMethodMetadata.isGooglePayReady == true,
                 buttonsEnabled = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -227,7 +227,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private fun walletsState(): WalletsState? {
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
         return WalletsState.create(
-            isLinkAvailable = paymentMethodMetadata.linkState != null,
+            isLinkAvailable = paymentMethodMetadata.shouldShowLinkButton,
             linkEmail = null,
             isGooglePayReady = paymentMethodMetadata.isGooglePayReady,
             buttonsEnabled = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -177,7 +177,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
         val linkConfiguration = paymentMethodMetadata.linkState?.configuration
         val hasLinkWithSelectedPayment = currentSelection is Link && currentSelection.selectedPayment != null
         WalletsState.create(
-            isLinkAvailable = isLinkAvailable == true && visibleWallets.contains(WalletType.Link),
+            isLinkAvailable = isLinkAvailable == true &&
+                visibleWallets.contains(WalletType.Link) &&
+                paymentMethodMetadata.shouldShowLinkButton,
             linkEmail = linkEmail,
             isGooglePayReady = paymentMethodMetadata.isGooglePayReady && visibleWallets.contains(WalletType.GooglePay),
             buttonsEnabled = buttonsEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -38,7 +38,6 @@ import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -3710,12 +3709,11 @@ class PaymentSheet internal constructor(
             disallowFundingSourceCreation = emptySet(),
         )
 
-        @OptIn(LinkHiddenWalletButtonPreview::class)
         internal val shouldDisplay: Boolean
             get() = when (display) {
                 Display.Automatic -> true
                 Display.Never -> false
-                Display.Hidden -> true
+                Display.WalletButtonHidden -> true
             }
 
         /**
@@ -3724,11 +3722,10 @@ class PaymentSheet internal constructor(
          * when its button is hidden, e.g. to support the returning-user flow and inline sign-up
          * without a visible entry point.
          */
-        @OptIn(LinkHiddenWalletButtonPreview::class)
         internal val shouldShowButton: Boolean
             get() = when (display) {
                 Display.Automatic -> true
-                Display.Never, Display.Hidden -> false
+                Display.Never, Display.WalletButtonHidden -> false
             }
 
         class Builder {
@@ -3782,15 +3779,13 @@ class PaymentSheet internal constructor(
              * otherwise enabled: the returning-user flow and the inline sign-up checkbox are
              * still shown.
              */
-            @LinkHiddenWalletButtonPreview
-            Hidden;
+            WalletButtonHidden;
 
-            @OptIn(LinkHiddenWalletButtonPreview::class)
             internal val analyticsValue: String
                 get() = when (this) {
                     Automatic -> "automatic"
                     Never -> "never"
-                    Hidden -> "hidden"
+                    WalletButtonHidden -> "wallet_button_hidden"
                 }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -38,6 +38,7 @@ import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -3709,10 +3710,25 @@ class PaymentSheet internal constructor(
             disallowFundingSourceCreation = emptySet(),
         )
 
+        @OptIn(LinkHiddenWalletButtonPreview::class)
         internal val shouldDisplay: Boolean
             get() = when (display) {
                 Display.Automatic -> true
                 Display.Never -> false
+                Display.Hidden -> true
+            }
+
+        /**
+         * Canonical source of truth for whether the Link button/row should be rendered in the
+         * payment element UI. Link may remain functionally enabled (see [shouldDisplay]) even
+         * when its button is hidden, e.g. to support the returning-user flow and inline sign-up
+         * without a visible entry point.
+         */
+        @OptIn(LinkHiddenWalletButtonPreview::class)
+        internal val shouldShowButton: Boolean
+            get() = when (display) {
+                Display.Automatic -> true
+                Display.Never, Display.Hidden -> false
             }
 
         class Builder {
@@ -3759,12 +3775,22 @@ class PaymentSheet internal constructor(
             /**
              * Link will never be displayed.
              */
-            Never;
+            Never,
 
+            /**
+             * Link's button/row is hidden from the payment element UI, but Link remains
+             * otherwise enabled: the returning-user flow and the inline sign-up checkbox are
+             * still shown.
+             */
+            @LinkHiddenWalletButtonPreview
+            Hidden;
+
+            @OptIn(LinkHiddenWalletButtonPreview::class)
             internal val analyticsValue: String
                 get() = when (this) {
                     Automatic -> "automatic"
                     Never -> "never"
+                    Hidden -> "hidden"
                 }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -223,7 +223,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     ) { isLinkAvailable, linkEmail, account, buttonsEnabled, paymentMethodMetadata ->
         val linkBrand = paymentMethodMetadata?.effectiveLinkBrand(account) ?: LinkBrand.Link
         WalletsState.create(
-            isLinkAvailable = isLinkAvailable,
+            isLinkAvailable = isLinkAvailable == true && paymentMethodMetadata?.shouldShowLinkButton == true,
             linkEmail = linkEmail,
             isGooglePayReady = paymentMethodMetadata?.isGooglePayReady == true,
             buttonsEnabled = buttonsEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -76,11 +76,17 @@ internal class SavedPaymentMethodMutator(
         ) { paymentMethodMetadata, linkAccount ->
             paymentMethodMetadata?.effectiveLinkBrand(linkAccount)
         }
+        val shouldShowLinkInList = combineAsStateFlow(
+            isLinkEnabled,
+            paymentMethodMetadataFlow,
+        ) { isLinkEnabled, paymentMethodMetadata ->
+            isLinkEnabled == true && paymentMethodMetadata?.shouldShowLinkButton == true
+        }
         PaymentOptionsItemsMapper(
             customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow { it?.customerMetadata },
             customerState = customerStateHolder.customer,
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
-            isLinkEnabled = isLinkEnabled,
+            isLinkEnabled = shouldShowLinkInList,
             linkBrand = effectiveLinkBrand,
             isNotPaymentFlow = isNotPaymentFlow,
             nameProvider = { paymentMethodMetadataFlow.value?.displayNameForCode(it).orEmpty() },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -204,7 +204,8 @@ internal class DefaultWalletButtonsInteractor constructor(
                         ).takeIf {
                             // Only show Link button if the Link verification state is resolved.
                             linkEmbeddedState.verificationState is VerificationState.RenderButton &&
-                                walletsAllowedByMerchant.contains(WalletType.Link)
+                                walletsAllowedByMerchant.contains(WalletType.Link) &&
+                                arguments.paymentMethodMetadata.shouldShowLinkButton
                         }
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
@@ -38,7 +39,9 @@ internal object VerticalModeInitialScreenFactory {
                         bankFormInteractor = bankFormInteractor,
                         paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
                     ),
-                    showsWalletHeader = paymentMethodMetadata.availableWallets.isNotEmpty(),
+                    showsWalletHeader = paymentMethodMetadata.availableWallets.any {
+                        it != WalletType.Link || paymentMethodMetadata.shouldShowLinkButton
+                    },
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -1858,9 +1857,8 @@ internal class PaymentMethodMetadataTest {
         assertThat(metadata.shouldShowLinkButton).isFalse()
     }
 
-    @OptIn(LinkHiddenWalletButtonPreview::class)
     @Test
-    fun `shouldShowLinkButton returns false when linkState is present and display is Hidden`() {
+    fun `shouldShowLinkButton returns false when linkState is present and display is WalletButtonHidden`() {
         val metadata = PaymentMethodMetadataFactory.create(
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
@@ -1868,7 +1866,7 @@ internal class PaymentMethodMetadataTest {
                 signupMode = null,
             ),
             linkConfiguration = PaymentSheet.LinkConfiguration(
-                display = PaymentSheet.LinkConfiguration.Display.Hidden,
+                display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -1811,6 +1812,67 @@ internal class PaymentMethodMetadataTest {
 
         val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes()
         assertThat(displayedPaymentMethodTypes).containsExactly("card")
+    }
+
+    @Test
+    fun `shouldShowLinkButton returns false when linkState is null`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = null,
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Automatic,
+            ),
+        )
+
+        assertThat(metadata.shouldShowLinkButton).isFalse()
+    }
+
+    @Test
+    fun `shouldShowLinkButton returns true when linkState is present and display is Automatic`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Automatic,
+            ),
+        )
+
+        assertThat(metadata.shouldShowLinkButton).isTrue()
+    }
+
+    @Test
+    fun `shouldShowLinkButton returns false when linkState is present and display is Never`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Never,
+            ),
+        )
+
+        assertThat(metadata.shouldShowLinkButton).isFalse()
+    }
+
+    @OptIn(LinkHiddenWalletButtonPreview::class)
+    @Test
+    fun `shouldShowLinkButton returns false when linkState is present and display is Hidden`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Hidden,
+            ),
+        )
+
+        assertThat(metadata.shouldShowLinkButton).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
-import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -66,13 +65,12 @@ class SavedPaymentMethodMutatorTest {
             .contains(PaymentOptionsItem.Link(LinkBrand.Onelink))
     }
 
-    @OptIn(LinkHiddenWalletButtonPreview::class)
     @Test
-    fun `paymentOptionsItems does not include Link when Display is Hidden`() = runScenario(
+    fun `paymentOptionsItems does not include Link when Display is WalletButtonHidden`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             linkBrand = LinkBrand.Link,
             linkConfiguration = PaymentSheet.LinkConfiguration(
-                display = PaymentSheet.LinkConfiguration.Display.Hidden,
+                display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
             ),
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -18,10 +18,12 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
+import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -49,6 +51,11 @@ class SavedPaymentMethodMutatorTest {
     fun `paymentOptionsItems uses the Link account brand`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             linkBrand = LinkBrand.Link,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         ),
         isLinkEnabled = stateFlowOf(true),
         linkAccount = stateFlowOf(
@@ -57,6 +64,29 @@ class SavedPaymentMethodMutatorTest {
     ) {
         assertThat(savedPaymentMethodMutator.paymentOptionsItems.value)
             .contains(PaymentOptionsItem.Link(LinkBrand.Onelink))
+    }
+
+    @OptIn(LinkHiddenWalletButtonPreview::class)
+    @Test
+    fun `paymentOptionsItems does not include Link when Display is Hidden`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkBrand = LinkBrand.Link,
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Hidden,
+            ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        ),
+        isLinkEnabled = stateFlowOf(true),
+        linkAccount = stateFlowOf(
+            LinkAccount(TestFactory.CONSUMER_SESSION.copy(linkBrand = LinkBrand.Onelink))
+        ),
+    ) {
+        assertThat(savedPaymentMethodMutator.paymentOptionsItems.value)
+            .doesNotContain(PaymentOptionsItem.Link(LinkBrand.Onelink))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.AnalyticEvent
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -121,15 +120,14 @@ class DefaultWalletButtonsInteractorTest {
         }
     }
 
-    @OptIn(LinkHiddenWalletButtonPreview::class)
     @Test
-    fun `on init with Link Display Hidden, state should have no Link button`() = runTest {
+    fun `on init with Link Display WalletButtonHidden, state should have no Link button`() = runTest {
         val interactor = createInteractor(
             arguments = createArguments(
                 availableWallets = listOf(WalletType.Link),
                 linkEmail = null,
                 linkConfiguration = PaymentSheet.LinkConfiguration(
-                    display = PaymentSheet.LinkConfiguration.Display.Hidden,
+                    display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.AnalyticEvent
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.WalletButtonsViewClickHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -117,6 +118,26 @@ class DefaultWalletButtonsInteractorTest {
             assertThat(state.walletButtons.firstOrNull()).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
 
             assertThat(state.buttonsEnabled).isTrue()
+        }
+    }
+
+    @OptIn(LinkHiddenWalletButtonPreview::class)
+    @Test
+    fun `on init with Link Display Hidden, state should have no Link button`() = runTest {
+        val interactor = createInteractor(
+            arguments = createArguments(
+                availableWallets = listOf(WalletType.Link),
+                linkEmail = null,
+                linkConfiguration = PaymentSheet.LinkConfiguration(
+                    display = PaymentSheet.LinkConfiguration.Display.Hidden,
+                ),
+            )
+        )
+
+        interactor.state.test {
+            val state = awaitItem()
+
+            assertThat(state.walletButtons).isEmpty()
         }
     }
 
@@ -906,7 +927,11 @@ class DefaultWalletButtonsInteractorTest {
         linkEmail: String? = null,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
         googlePay: PaymentSheet.GooglePayConfiguration? = null,
-        linkState: LinkState? = null,
+        linkState: LinkState? = LinkState(
+            configuration = TestFactory.LINK_CONFIGURATION,
+            loginState = LinkState.LoginState.LoggedOut,
+            signupMode = null,
+        ),
         cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = PaymentSheet.CardBrandAcceptance.all(),
         walletButtonsViewVisibility: Map<
             PaymentSheet.WalletButtonsConfiguration.Wallet,
@@ -914,13 +939,15 @@ class DefaultWalletButtonsInteractorTest {
             > = emptyMap(),
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
             PaymentSheet.BillingDetailsCollectionConfiguration(),
-        attestOnIntentConfirmation: Boolean = false
+        attestOnIntentConfirmation: Boolean = false,
+        linkConfiguration: PaymentSheet.LinkConfiguration = PaymentSheet.LinkConfiguration(),
     ): DefaultWalletButtonsInteractor.Arguments {
         return DefaultWalletButtonsInteractor.Arguments(
             linkEmail = linkEmail,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 availableWallets = availableWallets,
                 linkState = linkState,
+                linkConfiguration = linkConfiguration,
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 attestOnIntentConfirmation = attestOnIntentConfirmation,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -9,7 +9,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
@@ -59,12 +61,40 @@ class VerticalModeInitialScreenFactoryTest {
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("cashapp"),
             ),
-            availableWallets = listOf(WalletType.Link)
+            availableWallets = listOf(WalletType.Link),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         )
     ) {
         assertThat(screens).hasSize(1)
         assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
         assertThat(screens[0].showsWalletsHeader(false).value).isTrue()
+    }
+
+    @OptIn(LinkHiddenWalletButtonPreview::class)
+    @Test
+    fun `showsWalletHeader is false for VerticalModeForm if only wallet is Link with Display Hidden`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("cashapp"),
+            ),
+            availableWallets = listOf(WalletType.Link),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Hidden,
+            ),
+        )
+    ) {
+        assertThat(screens).hasSize(1)
+        assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
+        assertThat(screens[0].showsWalletsHeader(false).value).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.paymentelement.LinkHiddenWalletButtonPreview
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -74,9 +73,8 @@ class VerticalModeInitialScreenFactoryTest {
         assertThat(screens[0].showsWalletsHeader(false).value).isTrue()
     }
 
-    @OptIn(LinkHiddenWalletButtonPreview::class)
     @Test
-    fun `showsWalletHeader is false for VerticalModeForm if only wallet is Link with Display Hidden`() = runScenario(
+    fun `showsWalletHeader is false for VerticalModeForm if only wallet is Link and WalletButtonHidden`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = listOf("cashapp"),
@@ -88,7 +86,7 @@ class VerticalModeInitialScreenFactoryTest {
                 signupMode = null,
             ),
             linkConfiguration = PaymentSheet.LinkConfiguration(
-                display = PaymentSheet.LinkConfiguration.Display.Hidden,
+                display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
             ),
         )
     ) {


### PR DESCRIPTION
# Summary

Adds a new `WalletButtonHidden` case to the `LinkConfiguration.Display` enum that hides the Link wallet button from MPE, but keeps Link otherwise enabled.

# Motivation

https://docs.google.com/document/d/1NxBuePHYBRJcDv4uMJV3pPTzXa_yO3tuj3eZEN5Jw3w/edit?usp=sharing

# Testing


https://github.com/user-attachments/assets/e9a3a418-0724-4209-a6db-6f09de414e3d


# Changelog

```md
### PaymentSheet
* [ADDED] Added `PaymentSheet.LinkConfiguration.Display.WalletButtonHidden`, which keeps Link enabled but hides its button from the payment element UI.
```
