### PR TITLE
Focus on CVC field after a successful NFC scan

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -141,6 +141,9 @@ internal class CardDetailsController(
                     scannedCardDetails.expirationYear,
                 )
             )
+            cvcElement.controller.onRawValueChange("")
+            cvcElement.controller.requestFocus()
+            return
         } else {
             numberElement.controller.onRawValueChange(scannedCardDetails.cardNumber)
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -1,7 +1,17 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.LayoutDirection
@@ -9,6 +19,9 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.FieldValidationMessage
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionFieldElement
+import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
@@ -20,6 +33,7 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import com.stripe.android.R as StripeR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -78,6 +92,8 @@ class CvcController constructor(
     private val _isValidating = MutableStateFlow(false)
     private val _hasFocus = MutableStateFlow(false)
 
+    private val focusAsk = MutableStateFlow(false)
+
     override val visibleValidationMessage: StateFlow<Boolean> =
         combineAsStateFlow(_fieldState, _hasFocus, _isValidating) { fieldState, hasFocus, isValidating ->
             fieldState.shouldShowValidationMessage(hasFocus, isValidating)
@@ -130,5 +146,47 @@ class CvcController constructor(
 
     override fun onValidationStateChanged(isValidating: Boolean) {
         _isValidating.value = isValidating
+    }
+
+    fun requestFocus() {
+        focusAsk.value = true
+    }
+
+    @Composable
+    override fun ComposeUI(
+        enabled: Boolean,
+        field: SectionFieldElement,
+        modifier: Modifier,
+        hiddenIdentifiers: Set<IdentifierSpec>,
+        lastTextFieldIdentifier: IdentifierSpec?,
+    ) {
+        val isInspectionMode = LocalInspectionMode.current
+        val focusRequester = remember { FocusRequester() }
+        val windowInfo = LocalWindowInfo.current
+
+        LaunchedEffect(isInspectionMode) {
+            if (!isInspectionMode) {
+                focusAsk.collect { shouldFocus ->
+                    if (shouldFocus) {
+                        snapshotFlow { windowInfo.isWindowFocused }.first { it }
+                        withFrameNanos {}
+                        focusRequester.requestFocus()
+                        focusAsk.value = false
+                    }
+                }
+            }
+        }
+
+        TextField(
+            textFieldController = this,
+            enabled = enabled,
+            imeAction = if (lastTextFieldIdentifier == field.identifier) {
+                ImeAction.Done
+            } else {
+                ImeAction.Next
+            },
+            modifier = modifier,
+            focusRequester = focusRequester,
+        )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -170,7 +170,9 @@ class CvcController constructor(
                     if (shouldFocus) {
                         snapshotFlow { windowInfo.isWindowFocused }.first { it }
                         withFrameNanos {}
-                        focusRequester.requestFocus()
+                        while (!focusRequester.requestFocus()) {
+                            withFrameNanos {}
+                        }
                         focusAsk.value = false
                     }
                 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -1,6 +1,12 @@
 package com.stripe.android.ui.core.elements
 
 import android.content.Context
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -10,6 +16,7 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.FieldValidationMessage
@@ -32,6 +39,12 @@ class CardDetailsControllerTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
@@ -363,6 +376,54 @@ class CardDetailsControllerTest {
             .isEqualTo("")
     }
 
+    @Test
+    fun `When validated card scanned, CVC field gains focus`() = scannedCardTest(
+        scannedCardDetails = ScannedCardDetails.Validated(
+            cardNumber = "4242424242424242",
+            expirationYear = 2030,
+            expirationMonth = 6,
+        ),
+    ) {
+        composeTestRule.onNodeWithTag(TEST_TAG).assert(isFocused())
+    }
+
+    @Test
+    fun `When card scanned via camera, CVC field does not gain focus`() = scannedCardTest(
+        scannedCardDetails = ScannedCardDetails.Unvalidated(
+            cardNumber = "5555555555554444",
+            expirationYear = 2044,
+            expirationMonth = 4,
+        )
+    ) {
+        composeTestRule.onNodeWithTag(TEST_TAG).assert(!isFocused())
+    }
+
+    private fun scannedCardTest(
+        scannedCardDetails: ScannedCardDetails,
+        block: suspend () -> Unit,
+    ) = runTest {
+        val cardController = cardDetailsController()
+
+        composeTestRule.setContent {
+            cardController.cvcElement.controller.ComposeUI(
+                enabled = true,
+                field = cardController.cvcElement,
+                modifier = Modifier.testTag(TEST_TAG),
+                hiddenIdentifiers = emptySet(),
+                lastTextFieldIdentifier = null,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(TEST_TAG).assert(!isFocused())
+
+        cardController.onScannedCard(scannedCardDetails)
+
+        composeTestRule.waitForIdle()
+
+        block()
+    }
+
     private fun cardDetailsController(
         initialValues: Map<IdentifierSpec, String?> = emptyMap(),
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
@@ -433,5 +494,9 @@ class CardDetailsControllerTest {
         override fun determineState(input: String): TextFieldState {
             return textFieldState
         }
+    }
+
+    private companion object {
+        const val TEST_TAG = "CVC_FIELD"
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningCardFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningCardFormPage.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.nfcscan
 
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -51,7 +50,8 @@ internal class NfcScanningCardFormPage(
 
     fun assertCvcIsFocused() {
         composeTestRule.waitUntil(UI_TIMEOUT_MS) {
-            composeTestRule.onAllNodes(hasText("CVC"))
+            composeTestRule.waitForIdle()
+            composeTestRule.onAllNodes(hasText("CVC").and(isFocused()))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningCardFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningCardFormPage.kt
@@ -2,9 +2,9 @@ package com.stripe.android.paymentelement.nfcscan
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -47,6 +47,14 @@ internal class NfcScanningCardFormPage(
 
         composeTestRule.onNodeWithText("•••• $lastFourDigits").assertExists()
         composeTestRule.onNodeWithContentDescription(CLEAR_SCANNED_CARD_CONTENT_DESCRIPTION).assertExists()
+    }
+
+    fun assertCvcIsFocused() {
+        composeTestRule.waitUntil(UI_TIMEOUT_MS) {
+            composeTestRule.onAllNodes(hasText("CVC"))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
     }
 
     private companion object {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningTest.kt
@@ -65,6 +65,8 @@ internal class NfcScanningTest {
             lastFourDigits = SCANNED_CARD_LAST_FOUR,
         )
 
+        nfcScanningCardFormPage.assertCvcIsFocused()
+
         nfcScanningCardFormPage.fillRemainingCardDetails()
 
         enqueueConfirmRequests()


### PR DESCRIPTION
# Summary
Focus on CVC field after a successful NFC scan by requesting focus through `CvcController` in `CardDetailsController` after `onScannedCard` is called with a validated scan (in this case the NFC scan)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates -->
Better UX experience for NFC scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/9085f808-f3cf-48de-8e48-71199c4ff69c