### PR TITLE
Fix external payment method cancel flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -781,7 +781,7 @@ internal class PlaygroundTestDriver(
             selectors.externalPaymentMethodCancelButton,
         )
 
-        isSelectPaymentMethodScreen()
+        waitForPaymentSheetActivity()
         selectors.buyButton.waitProcessingComplete()
         selectors.buyButton.isEnabled()
 


### PR DESCRIPTION
# Summary

Wait for `PaymentSheetActivity` after canceling an external payment method before asserting the buy button is ready.

# Motivation

`TestExternalPaymentMethod_Cancel` could query Compose while the external `FawryActivity` return transition temporarily had no Compose hierarchy, causing `IllegalStateException: No compose hierarchies found in the app`.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Focused managed-device instrumentation test:

`CI=true ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestExternalPaymentMethod#testExternalPaymentMethod_Cancel' :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle`

- Passed a 2-iteration Shampoo diagnostic run.
- Passed a 50-iteration Shampoo diagnostic soak (iterations 0–49).
- Passed once in normal retry configuration.

# Screenshots

Not applicable: this is an instrumentation synchronization change with no visual UI change.

# Changelog

Not applicable: this is internal test-only synchronization and does not affect the SDK's user-facing behavior.
