### PR TITLE
Fix address autocomplete instrumentation flake

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -107,6 +107,9 @@ class PaymentSheetAddressAutocompleteTest {
 
         clickAndFillOutCard()
 
+        paymentSheetPage.waitForContentDescription(description = "Search")
+        paymentSheetPage.clickViewWithContentDescription(description = "Search")
+
         fillOutAutocompletePage()
 
         enqueueConfirm()


### PR DESCRIPTION
# Summary

Restores explicit activation of the inline address-autocomplete search control before the prefilled-address test edits the field.

# Motivation

The prefilled-address instrumentation test intermittently timed out waiting for autocomplete predictions after inline autocomplete became the default. Activating Search establishes the expected state-machine transition before entering the new address query.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused managed-device test:

- 2 Shampoo diagnostic iterations: passed
- 50 Shampoo diagnostic iterations: passed (iterations 0–49, zero failures)
- Normal configuration focused test: passed

No tests were ignored.

# Screenshots

Not applicable: instrumentation-test synchronization change with no user-visible UI change.

# Changelog

Not applicable: test-only flake fix; no customer-facing behavior changes.
