### PR TITLE
Add PaymentElement appearance configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/AppearanceMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/AppearanceMapper.kt
@@ -1,0 +1,77 @@
+@file:OptIn(
+    com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+    com.stripe.android.paymentelement.CheckoutSessionPreview::class,
+)
+
+package com.stripe.android.checkout
+
+import com.stripe.android.elements.PaymentElement.Configuration.Appearance
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal fun Appearance.State.asPaymentSheet(): PaymentSheet.Appearance {
+    return PaymentSheet.Appearance.Builder()
+        .colorsLight(colorsLight.asPaymentSheet())
+        .colorsDark(colorsDark.asPaymentSheet())
+        .themeMode(themeMode.asPaymentSheet())
+        .shapes(shapes.asPaymentSheet())
+        .typography(typography.asPaymentSheet())
+        .primaryButton(primaryButton.asPaymentSheet())
+        .formInsetValues(formInsetValues.asPaymentSheet())
+        .sectionSpacing(sectionSpacing.asPaymentSheet())
+        .textFieldInsets(textFieldInsets.asPaymentSheet())
+        .iconStyle(iconStyle.asPaymentSheet())
+        .verticalModeRowPadding(verticalModeRowPadding)
+        .build()
+}
+
+private fun Appearance.Colors.State.asPaymentSheet(): PaymentSheet.Colors = PaymentSheet.Colors(
+    primary = primary, surface = surface, component = component, componentBorder = componentBorder,
+    componentDivider = componentDivider, onComponent = onComponent, onSurface = onSurface,
+    subtitle = subtitle, placeholderText = placeholderText, appBarIcon = appBarIcon, error = error,
+)
+
+private fun Appearance.Shapes.State.asPaymentSheet(): PaymentSheet.Shapes = PaymentSheet.Shapes(
+    cornerRadiusDp = cornerRadiusDp,
+    borderStrokeWidthDp = borderStrokeWidthDp,
+    bottomSheetCornerRadiusDp = bottomSheetCornerRadiusDp,
+)
+
+private fun Appearance.Typography.State.asPaymentSheet(): PaymentSheet.Typography = PaymentSheet.Typography(
+    sizeScaleFactor = sizeScaleFactor,
+    fontResId = fontResId,
+    custom = PaymentSheet.Typography.Custom(
+        h1 = custom.h1?.let {
+            PaymentSheet.Typography.Font(it.fontFamily, it.fontSizeSp, it.fontWeight, it.letterSpacingSp)
+        },
+    ),
+)
+
+private fun Appearance.PrimaryButton.State.asPaymentSheet(): PaymentSheet.PrimaryButton = PaymentSheet.PrimaryButton(
+    colorsLight = colorsLight.asPaymentSheet(), colorsDark = colorsDark.asPaymentSheet(),
+    shape = PaymentSheet.PrimaryButtonShape(shape.cornerRadiusDp, shape.borderStrokeWidthDp, shape.heightDp),
+    typography = PaymentSheet.PrimaryButtonTypography(typography.fontResId, typography.fontSizeSp),
+)
+
+private fun Appearance.PrimaryButton.Colors.State.asPaymentSheet(): PaymentSheet.PrimaryButtonColors =
+    PaymentSheet.PrimaryButtonColors(
+        background = background,
+        onBackground = onBackground,
+        border = border,
+        successBackgroundColor = successBackgroundColor,
+        onSuccessBackgroundColor = onSuccessBackgroundColor,
+    )
+
+private fun Appearance.Insets.State.asPaymentSheet(): PaymentSheet.Insets =
+    PaymentSheet.Insets(startDp, topDp, endDp, bottomDp)
+
+private fun Appearance.Spacing.State.asPaymentSheet(): PaymentSheet.Spacing = PaymentSheet.Spacing(spacingDp)
+private fun Appearance.ThemeMode.asPaymentSheet(): PaymentSheet.ThemeMode = when (this) {
+    Appearance.ThemeMode.Automatic -> PaymentSheet.ThemeMode.Automatic
+    Appearance.ThemeMode.AlwaysLight -> PaymentSheet.ThemeMode.AlwaysLight
+    Appearance.ThemeMode.AlwaysDark -> PaymentSheet.ThemeMode.AlwaysDark
+}
+
+private fun Appearance.IconStyle.asPaymentSheet(): PaymentSheet.IconStyle = when (this) {
+    Appearance.IconStyle.Filled -> PaymentSheet.IconStyle.Filled
+    Appearance.IconStyle.Outlined -> PaymentSheet.IconStyle.Outlined
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -39,6 +39,6 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         walletButtons = null,
         opensCardScannerAutomatically = ConfigurationDefaults.opensCardScannerAutomatically,
         userOverrideCountry = ConfigurationDefaults.userOverrideCountry,
-        appearance = ConfigurationDefaults.appearance,
+        appearance = configuration.paymentElementConfiguration.appearance.asPaymentSheet(),
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -24,6 +24,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
                 configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse)
             )
             .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
+            .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())
             .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))
             .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
             .shippingDetails(collectedDetails.toShippingDetails())

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterInitializer.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.parseAppearance
 import javax.inject.Inject
 
 internal class CheckoutPresenterInitializer @Inject constructor(
@@ -14,11 +15,13 @@ internal class CheckoutPresenterInitializer @Inject constructor(
     private val lifecycleOwner: LifecycleOwner,
     private val sheetLauncher: EmbeddedSheetLauncher,
     private val sheetStateHolder: SheetStateHolder,
+    private val stateHolder: CheckoutControllerStateHolder,
 ) {
     fun initialize() {
         confirmationHandler.register(activityResultCaller, lifecycleOwner)
 
         sheetStateHolder.sheetLauncher = sheetLauncher
+        stateHolder.state?.embeddedConfiguration?.appearance?.parseAppearance()
 
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
@@ -61,6 +62,7 @@ internal class CheckoutStateLoader @Inject constructor(
             checkoutSessionResponse = response,
             collectedDetails = collectedDetails,
         )
+        embeddedConfig.appearance.parseAppearance()
 
         val commonConfiguration = commonConfigurationFactory.create(
             configuration = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -1,13 +1,19 @@
 package com.stripe.android.elements
 
 import android.os.Parcelable
+import androidx.annotation.ColorInt
+import androidx.annotation.FontRes
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -44,6 +50,7 @@ class PaymentElement @Inject internal constructor(
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
+        private var appearance: Appearance = Appearance()
 
         /**
          * Controls whether [Content] displays mandate text below the payment methods.
@@ -89,12 +96,18 @@ class PaymentElement @Inject internal constructor(
             this.termsDisplay = termsDisplay
         }
 
+        /** Sets the visual appearance of the payment element. */
+        fun appearance(appearance: Appearance): Configuration = apply {
+            this.appearance = appearance
+        }
+
         @Parcelize
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
             val paymentMethodLayout: PaymentMethodLayout,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
+            val appearance: Appearance.State,
         ) : Parcelable
 
         internal fun build(): State = State(
@@ -102,7 +115,579 @@ class PaymentElement @Inject internal constructor(
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
             paymentMethodLayout = paymentMethodLayout,
             termsDisplay = termsDisplay,
+            appearance = appearance.build(),
         )
+
+        /** Appearance configuration for the Payment Element. */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Suppress("TooManyFunctions")
+        @OptIn(AppearanceAPIAdditionsPreview::class)
+        class Appearance {
+            private var colorsLight = Colors.light()
+            private var colorsDark = Colors.dark()
+            private var themeMode = ThemeMode.Automatic
+            private var shapes = Shapes()
+            private var typography = Typography()
+            private var primaryButton = PrimaryButton()
+            private var formInsetValues = Insets.defaultFormInsetValues
+            private var sectionSpacing = Spacing(-1f)
+            private var textFieldInsets = Insets.defaultTextFieldInsets
+            private var iconStyle = IconStyle.Filled
+            private var verticalModeRowPadding = StripeThemeDefaults.verticalModeRowPadding
+
+            /** Sets the colors used in light mode. */
+            fun colorsLight(colors: Colors): Appearance = apply { colorsLight = colors }
+
+            /** Sets the colors used in dark mode. */
+            fun colorsDark(colors: Colors): Appearance = apply { colorsDark = colors }
+
+            /** Sets the color mode used by the Payment Element. */
+            fun themeMode(themeMode: ThemeMode): Appearance = apply { this.themeMode = themeMode }
+
+            /** Sets the appearance of shapes. */
+            fun shapes(shapes: Shapes): Appearance = apply { this.shapes = shapes }
+
+            /** Sets the typography used by the Payment Element. */
+            fun typography(typography: Typography): Appearance = apply { this.typography = typography }
+
+            /** Sets the appearance of the primary button. */
+            fun primaryButton(primaryButton: PrimaryButton): Appearance = apply { this.primaryButton = primaryButton }
+
+            /** Sets the insets used by forms. */
+            fun formInsetValues(insets: Insets): Appearance = apply { formInsetValues = insets }
+
+            /** Sets the spacing between form sections. */
+            @AppearanceAPIAdditionsPreview
+            fun sectionSpacing(spacing: Spacing): Appearance = apply { sectionSpacing = spacing }
+
+            /** Sets the insets inside form fields. */
+            @AppearanceAPIAdditionsPreview
+            fun textFieldInsets(insets: Insets): Appearance = apply { textFieldInsets = insets }
+
+            /** Sets the visual style of Payment Element icons. */
+            @AppearanceAPIAdditionsPreview
+            fun iconStyle(iconStyle: IconStyle): Appearance = apply { this.iconStyle = iconStyle }
+
+            /** Sets the vertical padding of payment-method rows, in dp. */
+            @AppearanceAPIAdditionsPreview
+            fun verticalModeRowPadding(value: Float): Appearance = apply { verticalModeRowPadding = value }
+
+            @Parcelize
+            internal data class State(
+                val colorsLight: Colors.State,
+                val colorsDark: Colors.State,
+                val themeMode: ThemeMode,
+                val shapes: Shapes.State,
+                val typography: Typography.State,
+                val primaryButton: PrimaryButton.State,
+                val formInsetValues: Insets.State,
+                val sectionSpacing: Spacing.State,
+                val textFieldInsets: Insets.State,
+                val iconStyle: IconStyle,
+                val verticalModeRowPadding: Float,
+            ) : Parcelable
+
+            internal fun build(): State = State(
+                colorsLight = colorsLight.build(),
+                colorsDark = colorsDark.build(),
+                themeMode = themeMode,
+                shapes = shapes.build(),
+                typography = typography.build(),
+                primaryButton = primaryButton.build(),
+                formInsetValues = formInsetValues.build(),
+                sectionSpacing = sectionSpacing.build(),
+                textFieldInsets = textFieldInsets.build(),
+                iconStyle = iconStyle,
+                verticalModeRowPadding = verticalModeRowPadding,
+            )
+
+            /** Colors used to render the Payment Element. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @Suppress("TooManyFunctions")
+            class Colors private constructor(
+                @ColorInt private var primary: Int,
+                @ColorInt private var surface: Int,
+                @ColorInt private var component: Int,
+                @ColorInt private var componentBorder: Int,
+                @ColorInt private var componentDivider: Int,
+                @ColorInt private var onComponent: Int,
+                @ColorInt private var subtitle: Int,
+                @ColorInt private var placeholderText: Int,
+                @ColorInt private var onSurface: Int,
+                @ColorInt private var appBarIcon: Int,
+                @ColorInt private var error: Int,
+            ) {
+                /** Sets the primary color. */
+                fun primary(@ColorInt c: Int): Colors = apply { primary = c }
+
+                /** Sets the primary color. */
+                fun primary(c: Color): Colors = apply { primary = c.toArgb() }
+
+                /** Sets the surface background color. */
+                fun surface(@ColorInt c: Int): Colors = apply { surface = c }
+
+                /** Sets the surface background color. */
+                fun surface(c: Color): Colors = apply { surface = c.toArgb() }
+
+                /** Sets the component background color. */
+                fun component(@ColorInt c: Int): Colors = apply { component = c }
+
+                /** Sets the component background color. */
+                fun component(c: Color): Colors = apply { component = c.toArgb() }
+
+                /** Sets the component border color. */
+                fun componentBorder(@ColorInt c: Int): Colors = apply { componentBorder = c }
+
+                /** Sets the component border color. */
+                fun componentBorder(c: Color): Colors = apply { componentBorder = c.toArgb() }
+
+                /** Sets the component divider color. */
+                fun componentDivider(@ColorInt c: Int): Colors = apply { componentDivider = c }
+
+                /** Sets the component divider color. */
+                fun componentDivider(c: Color): Colors = apply { componentDivider = c.toArgb() }
+
+                /** Sets the color of content displayed on components. */
+                fun onComponent(@ColorInt c: Int): Colors = apply { onComponent = c }
+
+                /** Sets the color of content displayed on components. */
+                fun onComponent(c: Color): Colors = apply { onComponent = c.toArgb() }
+
+                /** Sets the secondary text color. */
+                fun subtitle(@ColorInt c: Int): Colors = apply { subtitle = c }
+
+                /** Sets the secondary text color. */
+                fun subtitle(c: Color): Colors = apply { subtitle = c.toArgb() }
+
+                /** Sets the placeholder-text color. */
+                fun placeholderText(@ColorInt c: Int): Colors = apply { placeholderText = c }
+
+                /** Sets the placeholder-text color. */
+                fun placeholderText(c: Color): Colors = apply { placeholderText = c.toArgb() }
+
+                /** Sets the color of content displayed on surfaces. */
+                fun onSurface(@ColorInt c: Int): Colors = apply { onSurface = c }
+
+                /** Sets the color of content displayed on surfaces. */
+                fun onSurface(c: Color): Colors = apply { onSurface = c.toArgb() }
+
+                /** Sets the app-bar icon color. */
+                fun appBarIcon(@ColorInt c: Int): Colors = apply { appBarIcon = c }
+
+                /** Sets the app-bar icon color. */
+                fun appBarIcon(c: Color): Colors = apply { appBarIcon = c.toArgb() }
+
+                /** Sets the error color. */
+                fun error(@ColorInt c: Int): Colors = apply { error = c }
+
+                /** Sets the error color. */
+                fun error(c: Color): Colors = apply { error = c.toArgb() }
+
+                @Parcelize
+                internal data class State(
+                    @ColorInt val primary: Int,
+                    @ColorInt val surface: Int,
+                    @ColorInt val component: Int,
+                    @ColorInt val componentBorder: Int,
+                    @ColorInt val componentDivider: Int,
+                    @ColorInt val onComponent: Int,
+                    @ColorInt val subtitle: Int,
+                    @ColorInt val placeholderText: Int,
+                    @ColorInt val onSurface: Int,
+                    @ColorInt val appBarIcon: Int,
+                    @ColorInt val error: Int,
+                ) : Parcelable
+
+                internal fun build(): State = State(
+                    primary = primary,
+                    surface = surface,
+                    component = component,
+                    componentBorder = componentBorder,
+                    componentDivider = componentDivider,
+                    onComponent = onComponent,
+                    subtitle = subtitle,
+                    placeholderText = placeholderText,
+                    onSurface = onSurface,
+                    appBarIcon = appBarIcon,
+                    error = error,
+                )
+
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                companion object {
+                    /** Creates colors initialized with the default light-mode values. */
+                    fun light(): Colors = defaults(StripeThemeDefaults.colorsLight)
+
+                    /** Creates colors initialized with the default dark-mode values. */
+                    fun dark(): Colors = defaults(StripeThemeDefaults.colorsDark)
+                    private fun defaults(colors: com.stripe.android.uicore.StripeColors): Colors = Colors(
+                        primary = colors.materialColors.primary.toArgb(),
+                        surface = colors.materialColors.surface.toArgb(),
+                        component = colors.component.toArgb(),
+                        componentBorder = colors.componentBorder.toArgb(),
+                        componentDivider = colors.componentDivider.toArgb(),
+                        onComponent = colors.onComponent.toArgb(),
+                        subtitle = colors.subtitle.toArgb(),
+                        placeholderText = colors.placeholderText.toArgb(),
+                        onSurface = colors.materialColors.onSurface.toArgb(),
+                        appBarIcon = colors.appBarIcon.toArgb(),
+                        error = colors.materialColors.error.toArgb(),
+                    )
+                }
+            }
+
+            /** Configures the shapes used by the Payment Element. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @AppearanceAPIAdditionsPreview
+            class Shapes {
+                private var cornerRadiusDp = StripeThemeDefaults.shapes.cornerRadius
+                private var borderStrokeWidthDp = StripeThemeDefaults.shapes.borderStrokeWidth
+                private var bottomSheetCornerRadiusDp: Float? = null
+
+                /** Sets the corner radius, in dp. */
+                fun cornerRadiusDp(value: Float): Shapes = apply { cornerRadiusDp = value }
+
+                /** Sets the border stroke width, in dp. */
+                fun borderStrokeWidthDp(value: Float): Shapes = apply { borderStrokeWidthDp = value }
+
+                /** Sets the bottom-sheet corner radius, in dp. */
+                fun bottomSheetCornerRadiusDp(value: Float): Shapes = apply { bottomSheetCornerRadiusDp = value }
+
+                @Parcelize
+                internal data class State(
+                    val cornerRadiusDp: Float,
+                    val borderStrokeWidthDp: Float,
+                    val bottomSheetCornerRadiusDp: Float,
+                ) : Parcelable
+
+                internal fun build(): State = State(
+                    cornerRadiusDp = cornerRadiusDp,
+                    borderStrokeWidthDp = borderStrokeWidthDp,
+                    bottomSheetCornerRadiusDp = bottomSheetCornerRadiusDp ?: cornerRadiusDp,
+                )
+            }
+
+            /** Configures typography used by the Payment Element. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @AppearanceAPIAdditionsPreview
+            class Typography {
+                private var sizeScaleFactor = StripeThemeDefaults.typography.fontSizeMultiplier
+
+                @FontRes
+                private var fontResId: Int? = StripeThemeDefaults.typography.fontFamily
+                private var custom = Custom()
+
+                /** Sets the scale factor applied to text sizes. */
+                fun sizeScaleFactor(value: Float): Typography = apply { sizeScaleFactor = value }
+
+                /** Sets the font resource used by the Payment Element. */
+                fun fontResId(@FontRes value: Int?): Typography = apply { fontResId = value }
+
+                /** Sets custom typography for individual text styles. */
+                fun custom(value: Custom): Typography = apply { custom = value }
+
+                @Parcelize
+                internal data class State(
+                    val sizeScaleFactor: Float,
+                    @FontRes val fontResId: Int?,
+                    val custom: Custom.State,
+                ) : Parcelable
+
+                internal fun build(): State = State(sizeScaleFactor, fontResId, custom.build())
+
+                /** Configures custom typography for individual Payment Element text styles. */
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                @AppearanceAPIAdditionsPreview
+                class Custom {
+                    private var h1: Font? = null
+
+                    /** Sets the typography for first-level headings. */
+                    fun h1(value: Font?): Custom = apply { h1 = value }
+
+                    @Parcelize
+                    internal data class State(val h1: Font.State?) : Parcelable
+
+                    internal fun build(): State = State(h1?.build())
+                }
+
+                /** Describes the typography of a text style. */
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                @AppearanceAPIAdditionsPreview
+                class Font {
+                    @FontRes
+                    private var fontFamily: Int? = null
+                    private var fontSizeSp: Float? = null
+                    private var fontWeight: Int? = null
+                    private var letterSpacingSp: Float? = null
+
+                    /** Sets the font resource. */
+                    fun fontFamily(@FontRes value: Int?): Font = apply { fontFamily = value }
+
+                    /** Sets the font size, in sp. */
+                    fun fontSizeSp(value: Float?): Font = apply { fontSizeSp = value }
+
+                    /** Sets the font weight. */
+                    fun fontWeight(value: Int?): Font = apply { fontWeight = value }
+
+                    /** Sets the letter spacing, in sp. */
+                    fun letterSpacingSp(value: Float?): Font = apply { letterSpacingSp = value }
+
+                    @Parcelize
+                    internal data class State(
+                        @FontRes val fontFamily: Int?,
+                        val fontSizeSp: Float?,
+                        val fontWeight: Int?,
+                        val letterSpacingSp: Float?,
+                    ) : Parcelable
+
+                    internal fun build(): State = State(fontFamily, fontSizeSp, fontWeight, letterSpacingSp)
+                }
+            }
+
+            /** Defines spacing between form sections. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @AppearanceAPIAdditionsPreview
+            class Spacing(private val spacingDp: Float) {
+                @Parcelize
+                internal data class State(val spacingDp: Float) : Parcelable
+
+                internal fun build(): State = State(spacingDp)
+            }
+
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @AppearanceAPIAdditionsPreview
+            /** Visual styles available for Payment Element icons. */
+            enum class IconStyle {
+                /** Use filled icons. */
+                Filled,
+
+                /** Use outlined icons. */
+                Outlined,
+            }
+
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            /** Color modes available for the Payment Element. */
+            enum class ThemeMode {
+                /** Follow the system's light or dark mode. */
+                Automatic,
+
+                /** Always use light-mode colors. */
+                AlwaysLight,
+
+                /** Always use dark-mode colors. */
+                AlwaysDark,
+            }
+
+            /** Insets used to position Payment Element content, in dp. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class Insets(
+                private val startDp: Float,
+                private val topDp: Float,
+                private val endDp: Float,
+                private val bottomDp: Float,
+            ) {
+                /** Creates equal start/end and top/bottom insets, in dp. */
+                constructor(horizontalDp: Float, verticalDp: Float) : this(
+                    horizontalDp,
+                    verticalDp,
+                    horizontalDp,
+                    verticalDp,
+                )
+
+                @Parcelize
+                internal data class State(
+                    val startDp: Float,
+                    val topDp: Float,
+                    val endDp: Float,
+                    val bottomDp: Float,
+                ) : Parcelable
+
+                internal fun build(): State = State(startDp, topDp, endDp, bottomDp)
+
+                internal companion object {
+                    val defaultFormInsetValues = Insets(20f, 0f, 20f, 40f)
+                    val defaultTextFieldInsets = Insets(
+                        StripeThemeDefaults.textFieldInsets.start,
+                        StripeThemeDefaults.textFieldInsets.top,
+                        StripeThemeDefaults.textFieldInsets.end,
+                        StripeThemeDefaults.textFieldInsets.bottom,
+                    )
+                }
+            }
+
+            /** Configures the appearance of the primary button. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class PrimaryButton {
+                private var colorsLight = Colors.light()
+                private var colorsDark = Colors.dark()
+                private var shape = Shape()
+                private var typography = Typography()
+
+                /** Sets the primary-button colors used in light mode. */
+                fun colorsLight(value: Colors): PrimaryButton = apply { colorsLight = value }
+
+                /** Sets the primary-button colors used in dark mode. */
+                fun colorsDark(value: Colors): PrimaryButton = apply { colorsDark = value }
+
+                /** Sets the primary-button shape. */
+                fun shape(value: Shape): PrimaryButton = apply { shape = value }
+
+                /** Sets the primary-button typography. */
+                fun typography(value: Typography): PrimaryButton = apply { typography = value }
+
+                @Parcelize
+                internal data class State(
+                    val colorsLight: Colors.State,
+                    val colorsDark: Colors.State,
+                    val shape: Shape.State,
+                    val typography: Typography.State,
+                ) : Parcelable
+
+                internal fun build(): State = State(
+                    colorsLight.build(),
+                    colorsDark.build(),
+                    shape.build(),
+                    typography.build(),
+                )
+
+                /** Colors used to render the primary button. */
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                @Suppress("TooManyFunctions")
+                class Colors private constructor(
+                    @ColorInt private var background: Int?,
+                    @ColorInt private var onBackground: Int,
+                    @ColorInt private var border: Int,
+                    @ColorInt private var successBackgroundColor: Int,
+                    @ColorInt private var onSuccessBackgroundColor: Int,
+                ) {
+                    /** Sets the primary-button background color. */
+                    fun background(@ColorInt value: Int?): Colors = apply { background = value }
+
+                    /** Sets the primary-button background color. */
+                    fun background(value: Color?): Colors = apply { background = value?.toArgb() }
+
+                    /** Sets the content color used on the primary button. */
+                    fun onBackground(@ColorInt value: Int): Colors = apply {
+                        onBackground = value
+                        onSuccessBackgroundColor = value
+                    }
+
+                    /** Sets the content color used on the primary button. */
+                    fun onBackground(value: Color): Colors = onBackground(value.toArgb())
+
+                    /** Sets the primary-button border color. */
+                    fun border(@ColorInt value: Int): Colors = apply { border = value }
+
+                    /** Sets the primary-button border color. */
+                    fun border(value: Color): Colors = border(value.toArgb())
+
+                    /** Sets the primary-button success background color. */
+                    fun successBackgroundColor(@ColorInt value: Int): Colors = apply { successBackgroundColor = value }
+
+                    /** Sets the primary-button success background color. */
+                    fun successBackgroundColor(value: Color): Colors = successBackgroundColor(value.toArgb())
+
+                    /** Sets the content color used on the success background. */
+                    fun onSuccessBackgroundColor(@ColorInt value: Int): Colors = apply {
+                        onSuccessBackgroundColor = value
+                    }
+
+                    /** Sets the content color used on the success background. */
+                    fun onSuccessBackgroundColor(value: Color): Colors = onSuccessBackgroundColor(value.toArgb())
+
+                    @Parcelize
+                    internal data class State(
+                        @ColorInt val background: Int?,
+                        @ColorInt val onBackground: Int,
+                        @ColorInt val border: Int,
+                        @ColorInt val successBackgroundColor: Int,
+                        @ColorInt val onSuccessBackgroundColor: Int,
+                    ) : Parcelable
+
+                    internal fun build(): State = State(
+                        background,
+                        onBackground,
+                        border,
+                        successBackgroundColor,
+                        onSuccessBackgroundColor,
+                    )
+
+                    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                    companion object {
+                        fun light(): Colors = defaults(StripeThemeDefaults.primaryButtonStyle.colorsLight)
+                        fun dark(): Colors = defaults(StripeThemeDefaults.primaryButtonStyle.colorsDark)
+                        private fun defaults(colors: com.stripe.android.uicore.PrimaryButtonColors): Colors = Colors(
+                            background = null,
+                            onBackground = colors.onBackground.toArgb(),
+                            border = colors.border.toArgb(),
+                            successBackgroundColor = colors.successBackground.toArgb(),
+                            onSuccessBackgroundColor = colors.onSuccessBackground.toArgb(),
+                        )
+                    }
+                }
+
+                /** Configures the shape of the primary button. */
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                class Shape {
+                    private var cornerRadiusDp: Float? = null
+                    private var borderStrokeWidthDp: Float? = null
+                    private var heightDp: Float? = null
+
+                    /** Sets the corner radius, in dp. */
+                    fun cornerRadiusDp(value: Float?): Shape = apply { cornerRadiusDp = value }
+
+                    /** Sets the border stroke width, in dp. */
+                    fun borderStrokeWidthDp(value: Float?): Shape = apply { borderStrokeWidthDp = value }
+
+                    /** Sets the button height, in dp. */
+                    fun heightDp(value: Float?): Shape = apply { heightDp = value }
+
+                    @Parcelize
+                    internal data class State(
+                        val cornerRadiusDp: Float?,
+                        val borderStrokeWidthDp: Float?,
+                        val heightDp: Float?,
+                    ) : Parcelable
+
+                    internal fun build(): State = State(cornerRadiusDp, borderStrokeWidthDp, heightDp)
+                }
+
+                /** Configures the typography of the primary button. */
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                class Typography {
+                    @FontRes
+                    private var fontResId: Int? = null
+                    private var fontSizeSp: Float? = null
+
+                    /** Sets the font resource. */
+                    fun fontResId(@FontRes value: Int?): Typography = apply { fontResId = value }
+
+                    /** Sets the font size, in sp. */
+                    fun fontSizeSp(value: Float?): Typography = apply { fontSizeSp = value }
+
+                    @Parcelize
+                    internal data class State(
+                        @FontRes val fontResId: Int?,
+                        val fontSizeSp: Float?,
+                    ) : Parcelable
+
+                    internal fun build(): State = State(fontResId, fontSizeSp)
+                }
+            }
+        }
 
         /**
          * [TermsDisplay] controls how mandates and legal agreements are displayed.

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/AppearanceMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/AppearanceMapperTest.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.checkout
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Test
+
+@OptIn(
+    com.stripe.android.paymentelement.CheckoutSessionPreview::class,
+    com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+)
+class AppearanceMapperTest {
+    @Test
+    fun `default appearance maps to PaymentSheet defaults`() {
+        val appearance = PaymentElement.Configuration.Appearance()
+
+        assertThat(appearance.build().asPaymentSheet()).isEqualTo(PaymentSheet.Appearance())
+    }
+
+    @Test
+    fun `configured appearance maps colors shapes and primary button`() {
+        val appearance = PaymentElement.Configuration.Appearance()
+            .colorsLight(
+                PaymentElement.Configuration.Appearance.Colors.light()
+                    .primary(Color.Red)
+            )
+            .shapes(
+                PaymentElement.Configuration.Appearance.Shapes()
+                    .cornerRadiusDp(0f)
+            )
+            .primaryButton(
+                PaymentElement.Configuration.Appearance.PrimaryButton()
+                    .colorsLight(
+                        PaymentElement.Configuration.Appearance.PrimaryButton.Colors.light()
+                            .background(Color.Green)
+                    )
+            )
+
+        val mapped = appearance.build().asPaymentSheet()
+
+        assertThat(mapped.colorsLight.primary).isEqualTo(Color.Red.toArgb())
+        assertThat(mapped.shapes.cornerRadiusDp).isEqualTo(0f)
+        assertThat(mapped.primaryButton.colorsLight.background).isEqualTo(Color.Green.toArgb())
+    }
+
+    @Test
+    fun `integer color setters are preserved`() {
+        val appearance = PaymentElement.Configuration.Appearance()
+            .colorsDark(
+                PaymentElement.Configuration.Appearance.Colors.dark()
+                    .primary(0xFF654321.toInt())
+            )
+
+        assertThat(appearance.build().asPaymentSheet().colorsDark.primary)
+            .isEqualTo(0xFF654321.toInt())
+    }
+
+    @Test
+    fun `configuration stores its supplied appearance`() {
+        val appearance = PaymentElement.Configuration.Appearance()
+            .shapes(PaymentElement.Configuration.Appearance.Shapes().cornerRadiusDp(12f))
+
+        val state = PaymentElement.Configuration().appearance(appearance).build()
+
+        assertThat(state.appearance).isEqualTo(appearance.build())
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -17,7 +17,10 @@ import org.junit.Test
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
-@OptIn(CheckoutSessionPreview::class)
+@OptIn(
+    CheckoutSessionPreview::class,
+    com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+)
 internal class CheckoutCommonConfigurationFactoryTest {
 
     @Test
@@ -191,15 +194,31 @@ internal class CheckoutCommonConfigurationFactoryTest {
         assertThat(result.googlePlacesApiKey).isNull()
     }
 
+    @Test
+    fun `propagates payment element appearance`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(
+                appearance = PaymentElement.Configuration.Appearance()
+                    .shapes(PaymentElement.Configuration.Appearance.Shapes().cornerRadiusDp(3f))
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.appearance.shapes.cornerRadiusDp).isEqualTo(3f)
+    }
+
     private fun factory(appName: String = "Test App") = CheckoutCommonConfigurationFactory(appName)
 
     private fun controllerConfiguration(
         billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
+        appearance: PaymentElement.Configuration.Appearance = PaymentElement.Configuration.Appearance(),
         googlePayConfiguration: GooglePayConfiguration? = null,
     ): CheckoutController.Configuration.State {
         val builder = CheckoutController.Configuration()
             .paymentElement(
                 PaymentElement.Configuration()
+                    .appearance(appearance)
                     .billingDetailsCollectionConfiguration(
                         BillingDetailsCollectionConfiguration().address(billingDetailsAddress)
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -15,7 +15,10 @@ import org.junit.Test
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
-@OptIn(CheckoutSessionPreview::class)
+@OptIn(
+    CheckoutSessionPreview::class,
+    com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+)
 internal class CheckoutEmbeddedConfigurationFactoryTest {
 
     @Test
@@ -75,6 +78,22 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         )
 
         assertThat(result.embeddedViewDisplaysMandateText).isFalse()
+    }
+
+    @Test
+    fun `propagates payment element appearance`() {
+        val result = factory().create(
+            configuration = controllerConfiguration(
+                appearance = PaymentElement.Configuration.Appearance()
+                    .colorsLight(
+                        PaymentElement.Configuration.Appearance.Colors.light().primary(0xFF123456.toInt())
+                    )
+            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.appearance.colorsLight.primary).isEqualTo(0xFF123456.toInt())
     }
 
     @Test
@@ -264,6 +283,7 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
 
     private fun controllerConfiguration(
         embeddedViewDisplaysMandateText: Boolean = true,
+        appearance: PaymentElement.Configuration.Appearance = PaymentElement.Configuration.Appearance(),
         billingDetailsAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = Automatic,
         googlePayConfiguration: GooglePayConfiguration? = null,
     ): CheckoutController.Configuration.State {
@@ -271,6 +291,7 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
             .paymentElement(
                 PaymentElement.Configuration()
                     .embeddedViewDisplaysMandateText(embeddedViewDisplaysMandateText)
+                    .appearance(appearance)
                     .billingDetailsCollectionConfiguration(
                         BillingDetailsCollectionConfiguration().address(billingDetailsAddress)
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterInitializerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import androidx.activity.result.ActivityResultCaller
+import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
@@ -9,12 +10,18 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.FakeEmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.uicore.StripeTheme
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 
+@OptIn(
+    com.stripe.android.paymentelement.CheckoutSessionPreview::class,
+    com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+)
 internal class CheckoutPresenterInitializerTest {
 
     @get:Rule
@@ -50,6 +57,39 @@ internal class CheckoutPresenterInitializerTest {
         confirmationHandler.registerTurbine.awaitItem()
     }
 
+    @Test
+    fun `initialize applies the restored embedded appearance`() = runTest {
+        val appearance = PaymentSheet.Appearance.Builder()
+            .colorsLight(PaymentSheet.Colors.Builder.light().primary(0xFF123456.toInt()).build())
+            .build()
+        val restoredState = CheckoutControllerStateFactory.create(
+            embeddedConfiguration = com.stripe.android.paymentelement.EmbeddedPaymentElement.Configuration
+                .Builder("Example, Inc.")
+                .appearance(appearance)
+                .build(),
+        )
+        val previousTheme = StripeThemeSnapshot()
+        try {
+            val initializer = CheckoutPresenterInitializer(
+                confirmationHandler = FakeConfirmationHandler(),
+                activityResultCaller = mock(),
+                lifecycleOwner = TestLifecycleOwner(),
+                sheetLauncher = FakeEmbeddedSheetLauncher(),
+                sheetStateHolder = SheetStateHolder(SavedStateHandle()),
+                stateHolder = CheckoutControllerStateFactory.createStateHolder(
+                    SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restoredState))
+                ),
+            )
+
+            initializer.initialize()
+
+            assertThat(StripeTheme.colorsLightMutable.materialColors.primary.toArgb())
+                .isEqualTo(0xFF123456.toInt())
+        } finally {
+            previousTheme.restore()
+        }
+    }
+
     private fun runScenario(
         lifecycleOwner: TestLifecycleOwner = TestLifecycleOwner(),
         block: suspend Scenario.() -> Unit,
@@ -58,12 +98,14 @@ internal class CheckoutPresenterInitializerTest {
         val activityResultCaller = mock<ActivityResultCaller>()
         val sheetLauncher = FakeEmbeddedSheetLauncher()
         val sheetStateHolder = SheetStateHolder(SavedStateHandle())
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         val initializer = CheckoutPresenterInitializer(
             confirmationHandler = confirmationHandler,
             activityResultCaller = activityResultCaller,
             lifecycleOwner = lifecycleOwner,
             sheetLauncher = sheetLauncher,
             sheetStateHolder = sheetStateHolder,
+            stateHolder = stateHolder,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -3,11 +3,13 @@ package com.stripe.android.checkout
 import android.app.Application
 import android.graphics.Bitmap
 import android.os.Bundle
+import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.elements.PaymentElement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
@@ -28,6 +30,13 @@ import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
+import com.stripe.android.uicore.FormInsets
+import com.stripe.android.uicore.IconStyle
+import com.stripe.android.uicore.PrimaryButtonStyle
+import com.stripe.android.uicore.StripeColors
+import com.stripe.android.uicore.StripeShapes
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.StripeTypography
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -43,7 +52,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
-@OptIn(CheckoutSessionPreview::class)
+@OptIn(CheckoutSessionPreview::class, com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutStateLoaderTest {
 
@@ -67,6 +76,31 @@ internal class CheckoutStateLoaderTest {
         )
 
         assertThat(stateHolder.state?.commonConfiguration?.googlePay?.countryCode).isEqualTo("US")
+    }
+
+    @Test
+    fun `loadInitial applies payment element appearance to the global theme`() = runScenario {
+        val previousTheme = StripeThemeSnapshot()
+        try {
+            loader.loadInitial(
+                configuration = CheckoutController.Configuration()
+                    .paymentElement(
+                        PaymentElement.Configuration().appearance(
+                            PaymentElement.Configuration.Appearance().colorsLight(
+                                PaymentElement.Configuration.Appearance.Colors.light()
+                                    .primary(0xFF123456.toInt())
+                            )
+                        )
+                    )
+                    .build(),
+                checkoutSessionResponse = response(),
+            )
+
+            assertThat(StripeTheme.colorsLightMutable.materialColors.primary.toArgb())
+                .isEqualTo(0xFF123456.toInt())
+        } finally {
+            previousTheme.restore()
+        }
     }
 
     @Test
@@ -440,5 +474,31 @@ internal class CheckoutStateLoaderTest {
             val previousSelection: PaymentSelection?,
             val newSelection: PaymentSelection?,
         )
+    }
+}
+
+internal class StripeThemeSnapshot(
+    private val colorsLight: StripeColors = StripeTheme.colorsLightMutable,
+    private val colorsDark: StripeColors = StripeTheme.colorsDarkMutable,
+    private val shapes: StripeShapes = StripeTheme.shapesMutable,
+    private val typography: StripeTypography = StripeTheme.typographyMutable,
+    private val primaryButtonStyle: PrimaryButtonStyle = StripeTheme.primaryButtonStyle,
+    private val formInsets: FormInsets = StripeTheme.formInsets,
+    private val sectionSpacing: Float? = StripeTheme.customSectionSpacing,
+    private val textFieldInsets: FormInsets = StripeTheme.textFieldInsets,
+    private val iconStyle: IconStyle = StripeTheme.iconStyle,
+    private val verticalModeRowPadding: Float = StripeTheme.verticalModeRowPadding,
+) {
+    fun restore() {
+        StripeTheme.colorsLightMutable = colorsLight
+        StripeTheme.colorsDarkMutable = colorsDark
+        StripeTheme.shapesMutable = shapes
+        StripeTheme.typographyMutable = typography
+        StripeTheme.primaryButtonStyle = primaryButtonStyle
+        StripeTheme.formInsets = formInsets
+        StripeTheme.customSectionSpacing = sectionSpacing
+        StripeTheme.textFieldInsets = textFieldInsets
+        StripeTheme.iconStyle = iconStyle
+        StripeTheme.verticalModeRowPadding = verticalModeRowPadding
     }
 }


### PR DESCRIPTION
# Summary

Adds a CheckoutSession-restricted `PaymentElement.Configuration.Appearance` API and maps it to the existing PaymentSheet appearance renderer.

# Motivation

CheckoutSession Payment Element integrations could not customize colors, typography, shapes, or primary-button styling. This passes the supplied appearance through both checkout configuration paths and reapplies it when loading or restoring state.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

`./gradlew :paymentsheet:testDebugUnitTest --tests '*AppearanceMapperTest' --tests '*CheckoutEmbeddedConfigurationFactoryTest' --tests '*CheckoutCommonConfigurationFactoryTest' --tests '*CheckoutStateLoaderTest' --tests '*CheckoutPresenterInitializerTest'`

No tests were newly ignored.

# Screenshots

Not applicable: this is restricted CheckoutSession configuration plumbing with no independently changed visual surface captured in this PR.

# Changelog

Not applicable: this adds a restricted CheckoutSession preview API and internal configuration propagation.
