### PR TITLE
Add terms display configuration to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -35,7 +35,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,
         customPaymentMethods = ConfigurationDefaults.customPaymentMethods,
         googlePlacesApiKey = null,
-        termsDisplay = emptyMap(),
+        termsDisplay = configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet(),
         walletButtons = null,
         opensCardScannerAutomatically = ConfigurationDefaults.opensCardScannerAutomatically,
         userOverrideCountry = ConfigurationDefaults.userOverrideCountry,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -23,6 +23,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .billingDetailsCollectionConfiguration(
                 configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse)
             )
+            .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
             .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))
             .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
             .shippingDetails(collectedDetails.toShippingDetails())

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/TermsDisplayMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/TermsDisplayMapper.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun Map<PaymentMethod.Type, PaymentElement.Configuration.TermsDisplay>.asPaymentSheet():
+    Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> =
+    mapValues { (_, termsDisplay) -> termsDisplay.asPaymentSheet() }
+
+@OptIn(CheckoutSessionPreview::class)
+private fun PaymentElement.Configuration.TermsDisplay.asPaymentSheet(): PaymentSheet.TermsDisplay = when (this) {
+    PaymentElement.Configuration.TermsDisplay.AUTOMATIC -> PaymentSheet.TermsDisplay.AUTOMATIC
+    PaymentElement.Configuration.TermsDisplay.NEVER -> PaymentSheet.TermsDisplay.NEVER
+}

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.uicore.utils.collectAsState
@@ -42,6 +43,7 @@ class PaymentElement @Inject internal constructor(
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
+        private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
 
         /**
          * Controls whether [Content] displays mandate text below the payment methods.
@@ -79,18 +81,44 @@ class PaymentElement @Inject internal constructor(
             this.paymentMethodLayout = paymentMethodLayout
         }
 
+        /**
+         * A map for specifying when legal agreements are displayed for each payment method type.
+         * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
+         */
+        fun termsDisplay(termsDisplay: Map<PaymentMethod.Type, TermsDisplay>): Configuration = apply {
+            this.termsDisplay = termsDisplay
+        }
+
         @Parcelize
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
             val paymentMethodLayout: PaymentMethodLayout,
+            val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
         ) : Parcelable
 
         internal fun build(): State = State(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
             paymentMethodLayout = paymentMethodLayout,
+            termsDisplay = termsDisplay,
         )
+
+        /**
+         * [TermsDisplay] controls how mandates and legal agreements are displayed.
+         * Use [TermsDisplay.NEVER] to never display legal agreements.
+         * The default setting is [TermsDisplay.AUTOMATIC], which causes legal agreements to be shown only when
+         * necessary.
+         */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        enum class TermsDisplay {
+            /** Show legal agreements only when necessary */
+            AUTOMATIC,
+
+            /** Never show legal agreements */
+            NEVER,
+        }
 
         /**
          * Configuration for how billing details are collected during checkout.

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -8,6 +8,8 @@ import com.stripe.android.elements.PaymentElement
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+import com.stripe.android.elements.PaymentElement.Configuration.TermsDisplay
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -119,6 +121,26 @@ internal class CheckoutCommonConfigurationFactoryTest {
         )
 
         assertThat(result.googlePay).isNull()
+    }
+
+    @Test
+    fun `maps terms display to common configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().termsDisplay(
+                    mapOf(PaymentMethod.Type.Card to TermsDisplay.NEVER)
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.termsDisplay)
+            .isEqualTo(mapOf(PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -6,6 +6,8 @@ import com.stripe.android.elements.PaymentElement
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+import com.stripe.android.elements.PaymentElement.Configuration.TermsDisplay
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -157,6 +159,26 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         )
 
         assertThat(result.googlePay).isNull()
+    }
+
+    @Test
+    fun `maps terms display to embedded payment element configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().termsDisplay(
+                    mapOf(PaymentMethod.Type.Card to TermsDisplay.NEVER)
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.termsDisplay)
+            .isEqualTo(mapOf(PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER))
     }
 
     @Test


### PR DESCRIPTION
# Summary

Adds `PaymentElement.Configuration.TermsDisplay` and forwards its per-payment-method settings to the existing PaymentSheet and embedded-payment-element configurations.

# Motivation

Checkout Session integrations need to control legal-agreement display using the same semantics as PaymentSheet without depending directly on PaymentSheet configuration types.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran:
`./gradlew :paymentsheet:testDebugUnitTest --rerun-tasks --tests com.stripe.android.checkout.CheckoutEmbeddedConfigurationFactoryTest --tests com.stripe.android.checkout.CheckoutCommonConfigurationFactoryTest`

# Screenshots

| Before | After |
| ------------- | ------------- |
| Not applicable — configuration-only change | Not applicable — configuration-only change |

# Changelog

Not applicable — this is a Checkout Session private-preview configuration addition.
