### PR TITLE
Fix NFC error delay reset in Compose & use proper saved state testing in `ErrorBannerTest` & `NfcCoilAnimatedInteriorTest`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/ui/ErrorBanner.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/ui/ErrorBanner.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.Ref
@@ -68,7 +69,7 @@ internal fun ErrorBanner(
         return
     }
 
-    val savedState = remember {
+    val savedState = rememberSaveable {
         mutableStateOf<ErrorBannerState>(ErrorBannerState.Init)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/ui/ErrorBannerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/ui/ErrorBannerTest.kt
@@ -1,14 +1,12 @@
 package com.stripe.android.common.nfcscan.ui
 
 import android.os.Build
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -34,6 +32,8 @@ internal class ErrorBannerTest {
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
 
+    val stateRestorer = StateRestorationTester(composeRule)
+
     @Before
     fun setUp() {
         composeRule.mainClock.autoAdvance = false
@@ -41,7 +41,7 @@ internal class ErrorBannerTest {
 
     @Test
     fun `error message shows error banner`() {
-        composeRule.setContent {
+        stateRestorer.setContent {
             ErrorBanner(
                 error = ErrorBannerParams(
                     message = ERROR_MESSAGE,
@@ -60,7 +60,7 @@ internal class ErrorBannerTest {
     fun `error invokes onShown after delay`() {
         var errorShownCount by mutableIntStateOf(0)
 
-        composeRule.setContent {
+        stateRestorer.setContent {
             ErrorBanner(
                 error = ErrorBannerParams(
                     message = ERROR_MESSAGE,
@@ -79,10 +79,8 @@ internal class ErrorBannerTest {
     @Test
     fun `config change during error delay resumes remaining delay`() {
         var errorShownCount by mutableIntStateOf(0)
-        val visible = mutableStateOf(true)
 
-        composeRule.setErrorBannerContent(
-            visible = visible,
+        stateRestorer.setErrorBannerContent(
             error = ERROR_MESSAGE,
             onShown = { errorShownCount++ },
         )
@@ -93,7 +91,7 @@ internal class ErrorBannerTest {
         composeRule.advanceErrorDelayBy(elapsedDelayMs)
         assertThat(errorShownCount).isEqualTo(0)
 
-        composeRule.simulateConfigChange(visible)
+        stateRestorer.emulateSavedInstanceStateRestore()
         assertThat(errorShownCount).isEqualTo(0)
 
         val remainingDelayMs = ERROR_SHOWN_DELAY_MS - elapsedDelayMs
@@ -107,10 +105,8 @@ internal class ErrorBannerTest {
     @Test
     fun `config change after error shown does not invoke onShown again`() {
         var errorShownCount by mutableIntStateOf(0)
-        val visible = mutableStateOf(true)
 
-        composeRule.setErrorBannerContent(
-            visible = visible,
+        stateRestorer.setErrorBannerContent(
             error = ERROR_MESSAGE,
             onShown = { errorShownCount++ },
         )
@@ -119,7 +115,7 @@ internal class ErrorBannerTest {
         composeRule.advanceErrorDelayBy(ERROR_SHOWN_DELAY_MS + FRAME_BUFFER_MS)
         assertThat(errorShownCount).isEqualTo(1)
 
-        composeRule.simulateConfigChange(visible)
+        stateRestorer.emulateSavedInstanceStateRestore()
         composeRule.waitForIdle()
 
         assertThat(errorShownCount).isEqualTo(1)
@@ -132,36 +128,21 @@ internal class ErrorBannerTest {
         waitForIdle()
     }
 
-    private fun ComposeContentTestRule.setErrorBannerContent(
-        visible: MutableState<Boolean>,
+    private fun StateRestorationTester.setErrorBannerContent(
         error: ResolvableString,
         onShown: () -> Unit = {},
     ) {
         setContent {
-            val saveableStateHolder = rememberSaveableStateHolder()
-
-            if (visible.value) {
-                saveableStateHolder.SaveableStateProvider(ERROR_BANNER_SAVABLE_KEY) {
-                    ErrorBanner(
-                        error = ErrorBannerParams(
-                            message = error,
-                            onShown = onShown,
-                        ),
-                    )
-                }
-            }
+            ErrorBanner(
+                error = ErrorBannerParams(
+                    message = error,
+                    onShown = onShown,
+                ),
+            )
         }
     }
 
-    private fun ComposeContentTestRule.simulateConfigChange(visible: MutableState<Boolean>) {
-        runOnUiThread { visible.value = false }
-        waitForIdle()
-        runOnUiThread { visible.value = true }
-        waitForIdle()
-    }
-
     private companion object {
-        const val ERROR_BANNER_SAVABLE_KEY = "nfc_error_banner"
         const val FRAME_BUFFER_MS = 32L
         const val ERROR_SHOWN_DELAY_MS = 3_000L
         const val ERROR_MESSAGE_TEXT = "Card expired. Try another card."

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/ui/NfcCoilAnimatedInteriorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/ui/NfcCoilAnimatedInteriorTest.kt
@@ -1,17 +1,16 @@
 package com.stripe.android.common.nfcscan.ui
 
 import android.os.Build
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
@@ -29,10 +28,12 @@ import java.util.concurrent.TimeUnit
 @Config(sdk = [Build.VERSION_CODES.Q])
 internal class NfcCoilAnimatedInteriorTest {
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
+
+    val stateRestorer = StateRestorationTester(composeRule)
 
     @Before
     fun setUp() {
@@ -120,10 +121,7 @@ internal class NfcCoilAnimatedInteriorTest {
 
     @Test
     fun `config change during checkmark animation resumes from saved progress`() {
-        val visible = mutableStateOf(true)
-
-        composeRule.setNfcCoilContent(
-            visible = visible,
+        stateRestorer.setNfcCoilContent(
             status = NfcScanningStatus.Scanned,
         )
 
@@ -134,7 +132,7 @@ internal class NfcCoilAnimatedInteriorTest {
         assertThat(progressBeforeConfigChange).isGreaterThan(0.1f)
         assertThat(progressBeforeConfigChange).isLessThan(0.99f)
 
-        composeRule.simulateConfigChange(visible)
+        stateRestorer.emulateSavedInstanceStateRestore()
 
         val progressAfterConfigChange = composeRule.checkmarkProgress()
         assertThat(progressAfterConfigChange)
@@ -145,10 +143,7 @@ internal class NfcCoilAnimatedInteriorTest {
 
     @Test
     fun `config change after animation complete does not restart success animation`() {
-        val visible = mutableStateOf(true)
-
-        composeRule.setNfcCoilContent(
-            visible = visible,
+        stateRestorer.setNfcCoilContent(
             status = NfcScanningStatus.Scanned,
         )
 
@@ -156,7 +151,7 @@ internal class NfcCoilAnimatedInteriorTest {
         composeRule.advanceThroughSuccessAnimation()
         assertCheckmarkProgressComplete(composeRule.checkmarkProgress())
 
-        composeRule.simulateConfigChange(visible)
+        stateRestorer.emulateSavedInstanceStateRestore()
 
         assertCheckmarkProgressComplete(composeRule.checkmarkProgress())
     }
@@ -164,10 +159,8 @@ internal class NfcCoilAnimatedInteriorTest {
     @Test
     fun `config change after success shown does not invoke onSuccessShown again`() {
         var successShownCount by mutableIntStateOf(0)
-        val visible = mutableStateOf(true)
 
-        composeRule.setNfcCoilContent(
-            visible = visible,
+        stateRestorer.setNfcCoilContent(
             status = NfcScanningStatus.Scanned,
             onSuccessShown = { successShownCount++ },
         )
@@ -177,7 +170,7 @@ internal class NfcCoilAnimatedInteriorTest {
         composeRule.advanceSuccessDelayBy(SUCCESS_SHOWN_DELAY_MS + FRAME_BUFFER_MS)
         assertThat(successShownCount).isEqualTo(1)
 
-        composeRule.simulateConfigChange(visible)
+        stateRestorer.emulateSavedInstanceStateRestore()
         composeRule.waitForIdle()
 
         assertThat(successShownCount).isEqualTo(1)
@@ -187,10 +180,8 @@ internal class NfcCoilAnimatedInteriorTest {
     @Test
     fun `config change during success delay resumes remaining delay`() {
         var successShownCount by mutableIntStateOf(0)
-        val visible = mutableStateOf(true)
 
-        composeRule.setNfcCoilContent(
-            visible = visible,
+        stateRestorer.setNfcCoilContent(
             status = NfcScanningStatus.Scanned,
             onSuccessShown = { successShownCount++ },
         )
@@ -202,7 +193,7 @@ internal class NfcCoilAnimatedInteriorTest {
         composeRule.advanceSuccessDelayBy(elapsedDelayMs)
         assertThat(successShownCount).isEqualTo(0)
 
-        composeRule.simulateConfigChange(visible)
+        stateRestorer.emulateSavedInstanceStateRestore()
         assertThat(successShownCount).isEqualTo(0)
 
         val remainingDelayMs = SUCCESS_SHOWN_DELAY_MS - elapsedDelayMs
@@ -228,31 +219,17 @@ internal class NfcCoilAnimatedInteriorTest {
         waitForIdle()
     }
 
-    private fun ComposeContentTestRule.setNfcCoilContent(
-        visible: MutableState<Boolean>,
+    private fun StateRestorationTester.setNfcCoilContent(
         status: NfcScanningStatus,
         onSuccessShown: () -> Unit = {},
     ) {
         setContent {
-            val saveableStateHolder = rememberSaveableStateHolder()
-
-            if (visible.value) {
-                saveableStateHolder.SaveableStateProvider(NFC_COIL_SAVABLE_KEY) {
-                    NfcCoilAnimatedInterior(
-                        status = status,
-                        onSuccessShown = onSuccessShown,
-                        modifier = Modifier.size(CoilSize),
-                    )
-                }
-            }
+            NfcCoilAnimatedInterior(
+                status = status,
+                onSuccessShown = onSuccessShown,
+                modifier = Modifier.size(CoilSize),
+            )
         }
-    }
-
-    private fun ComposeContentTestRule.simulateConfigChange(visible: MutableState<Boolean>) {
-        runOnUiThread { visible.value = false }
-        waitForIdle()
-        runOnUiThread { visible.value = true }
-        waitForIdle()
     }
 
     private fun assertCheckmarkProgressComplete(progress: Float) {
@@ -266,7 +243,6 @@ internal class NfcCoilAnimatedInteriorTest {
     }
 
     private companion object {
-        const val NFC_COIL_SAVABLE_KEY = "nfc_coil_animated_interior"
         const val FRAME_BUFFER_MS = 32L
         val CoilSize = 200.dp
         const val PROGRESS_TOLERANCE = 0.02f


### PR DESCRIPTION
# Summary
Fix NFC error delay reset in Compose by using `rememberSaveable` in `ErrorBanner` & use proper saved state testing in `ErrorBannerTest` & `NfcCoilAnimatedInteriorTest` in `StateRestorationTester`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix UX experience issue

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>