### PR TITLE
Add guidance about opening PRs to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
 
 **GitHub Issues** — use `gh` CLI with `GH_HOST=github.com` prefix (`export` for reads, inline for writes). Always use `--state all` when searching. Check existing issues before investigating user reports.
 
+**Pull requests** — always open pull requests as drafts. When an agent opens a pull request, include `Committed and created by <agent>.` in the PR description, where agent is the type of agent (e.g., Claude or Codex).
+
 **Internal Tools** — Jira: MOBILESDK, RUN_MOBILESDK | Trailhead space: mobile-sdk
 
 ## Architecture


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add guidance about opening PRs to AGENTS

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- open PRs as drafts so I can review before I open up for review from my coworkers
- attribution just bc it's kinda nice, though tbh it's usually obvious when a pr description is agent generated
