### PR TITLE
Add payment method order to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -29,7 +29,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
             configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse),
         preferredNetworks = ConfigurationDefaults.preferredNetworks,
         allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
-        paymentMethodOrder = ConfigurationDefaults.paymentMethodOrder,
+        paymentMethodOrder = configuration.paymentElementConfiguration.paymentMethodOrder,
         externalPaymentMethods = ConfigurationDefaults.externalPaymentMethods,
         cardBrandAcceptance = ConfigurationDefaults.cardBrandAcceptance,
         allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -23,6 +23,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .billingDetailsCollectionConfiguration(
                 configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse)
             )
+            .paymentMethodOrder(configuration.paymentElementConfiguration.paymentMethodOrder)
             .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
             .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())
             .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -49,6 +49,7 @@ class PaymentElement @Inject internal constructor(
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
+        private var paymentMethodOrder: List<String> = emptyList()
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
         private var appearance: Appearance = Appearance()
 
@@ -89,6 +90,16 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
+         * Overrides the default order in which payment methods are displayed.
+         *
+         * Payment methods omitted from this list are automatically ordered by Stripe after the
+         * specified methods. Invalid payment method types are ignored.
+         */
+        fun paymentMethodOrder(paymentMethodOrder: List<String>): Configuration = apply {
+            this.paymentMethodOrder = paymentMethodOrder
+        }
+
+        /**
          * A map for specifying when legal agreements are displayed for each payment method type.
          * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
          */
@@ -106,6 +117,7 @@ class PaymentElement @Inject internal constructor(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
             val paymentMethodLayout: PaymentMethodLayout,
+            val paymentMethodOrder: List<String>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
             val appearance: Appearance.State,
         ) : Parcelable
@@ -114,6 +126,7 @@ class PaymentElement @Inject internal constructor(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
             paymentMethodLayout = paymentMethodLayout,
+            paymentMethodOrder = paymentMethodOrder,
             termsDisplay = termsDisplay,
             appearance = appearance.build(),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -147,6 +147,21 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps payment method order to common configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(PaymentElement.Configuration().paymentMethodOrder(listOf("card", "klarna")))
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.paymentMethodOrder).isEqualTo(listOf("card", "klarna"))
+    }
+
+    @Test
     fun `sources the billing email from the checkout session customer email`() {
         val result = factory().create(
             configuration = controllerConfiguration(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -104,6 +104,21 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `loadInitial passes payment method order to payment method metadata`() = runScenario {
+        loader.loadInitial(
+            configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().paymentMethodOrder(listOf("klarna", "card"))
+                )
+                .build(),
+            checkoutSessionResponse = response(),
+        )
+
+        assertThat(stateHolder.state?.paymentMethodMetadata?.paymentMethodOrder)
+            .isEqualTo(listOf("klarna", "card"))
+    }
+
+    @Test
     fun `loadInitial seeds collected details with the defaults billing address`() = runScenario {
         val address = CheckoutController.Address()
             .city(" San Francisco ")

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -64,6 +64,7 @@ internal class FakePaymentElementLoader(
             allowsDelayedPaymentMethods = configuration.allowsDelayedPaymentMethods,
             allowsPaymentMethodsRequiringShippingAddress = configuration
                 .allowsPaymentMethodsRequiringShippingAddress,
+            paymentMethodOrder = configuration.paymentMethodOrder,
             isGooglePayReady = isGooglePayAvailable,
             cbcEligibility = cbcEligibility,
             linkState = linkState,


### PR DESCRIPTION
# Summary

Adds `paymentMethodOrder` to the Checkout Session preview `PaymentElement.Configuration` and propagates it through the embedded loader into payment-method metadata.

# Motivation

Checkout Session integrations need to control the order in which supported payment methods are shown, matching the existing PaymentSheet and Embedded Payment Element configuration.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused unit tests were attempted but compilation is currently blocked by pre-existing stale generated Dagger/KSP sources: generated confirmation components omit the `CheckoutSessionTaxRegionUpdater` provider required by `CheckoutSessionConfirmationInterceptor_Factory`.

# Screenshots

Not applicable — this changes configuration plumbing and unit tests only.

# Changelog

Not applicable — this is an internal Checkout Session preview API change.
