### PR TITLE
Add preferred networks to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -27,7 +27,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
             ConfigurationDefaults.allowsPaymentMethodsRequiringShippingAddress,
         billingDetailsCollectionConfiguration =
             configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse),
-        preferredNetworks = ConfigurationDefaults.preferredNetworks,
+        preferredNetworks = configuration.paymentElementConfiguration.preferredNetworks,
         allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
         paymentMethodOrder = configuration.paymentElementConfiguration.paymentMethodOrder,
         externalPaymentMethods = ConfigurationDefaults.externalPaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -23,6 +23,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .billingDetailsCollectionConfiguration(
                 configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse)
             )
+            .preferredNetworks(configuration.paymentElementConfiguration.preferredNetworks)
             .paymentMethodOrder(configuration.paymentElementConfiguration.paymentMethodOrder)
             .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
             .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -49,6 +50,7 @@ class PaymentElement @Inject internal constructor(
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
+        private var preferredNetworks: List<CardBrand> = emptyList()
         private var paymentMethodOrder: List<String> = emptyList()
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
         private var appearance: Appearance = Appearance()
@@ -90,6 +92,17 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
+         * A list of preferred networks that should be used to process payments made with a
+         * co-branded card if your user hasn't selected a network themselves.
+         *
+         * The first preferred network that matches any available network will be used. If no
+         * preferred network is applicable, Stripe will select the network.
+         */
+        fun preferredNetworks(preferredNetworks: List<CardBrand>): Configuration = apply {
+            this.preferredNetworks = preferredNetworks
+        }
+
+        /**
          * Overrides the default order in which payment methods are displayed.
          *
          * Payment methods omitted from this list are automatically ordered by Stripe after the
@@ -117,6 +130,7 @@ class PaymentElement @Inject internal constructor(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
             val paymentMethodLayout: PaymentMethodLayout,
+            val preferredNetworks: List<CardBrand>,
             val paymentMethodOrder: List<String>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
             val appearance: Appearance.State,
@@ -126,6 +140,7 @@ class PaymentElement @Inject internal constructor(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
             paymentMethodLayout = paymentMethodLayout,
+            preferredNetworks = preferredNetworks,
             paymentMethodOrder = paymentMethodOrder,
             termsDisplay = termsDisplay,
             appearance = appearance.build(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCo
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
 import com.stripe.android.elements.PaymentElement.Configuration.TermsDisplay
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -159,6 +160,26 @@ internal class CheckoutCommonConfigurationFactoryTest {
         )
 
         assertThat(result.paymentMethodOrder).isEqualTo(listOf("card", "klarna"))
+    }
+
+    @Test
+    fun `maps preferred networks to common configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().preferredNetworks(
+                    listOf(CardBrand.CartesBancaires, CardBrand.Visa)
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.preferredNetworks)
+            .isEqualTo(listOf(CardBrand.CartesBancaires, CardBrand.Visa))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCo
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
 import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
 import com.stripe.android.elements.PaymentElement.Configuration.TermsDisplay
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -167,6 +168,26 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         )
 
         assertThat(result.googlePay).isNull()
+    }
+
+    @Test
+    fun `maps preferred networks to embedded configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().preferredNetworks(
+                    listOf(CardBrand.CartesBancaires, CardBrand.Visa)
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.preferredNetworks)
+            .isEqualTo(listOf(CardBrand.CartesBancaires, CardBrand.Visa))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.elements.PaymentElement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -116,6 +117,23 @@ internal class CheckoutStateLoaderTest {
 
         assertThat(stateHolder.state?.paymentMethodMetadata?.paymentMethodOrder)
             .isEqualTo(listOf("klarna", "card"))
+    }
+
+    @Test
+    fun `loadInitial passes preferred networks to common configuration`() = runScenario {
+        loader.loadInitial(
+            configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().preferredNetworks(
+                        listOf(CardBrand.CartesBancaires, CardBrand.Visa)
+                    )
+                )
+                .build(),
+            checkoutSessionResponse = response(),
+        )
+
+        assertThat(stateHolder.state?.commonConfiguration?.preferredNetworks)
+            .isEqualTo(listOf(CardBrand.CartesBancaires, CardBrand.Visa))
     }
 
     @Test


### PR DESCRIPTION
# Summary

Adds preferred-network configuration to the Checkout Session preview `PaymentElement.Configuration` and passes it to both sheet and embedded payment-element flows. This is the second layer, dependent on #14026.

# Motivation

Checkout Session integrations need to choose a processing network for eligible co-branded cards, consistent with the existing PaymentSheet and Embedded Payment Element configuration.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:compileDebugKotlin` passed.

`./gradlew :paymentsheet:testDebugUnitTest` was attempted after a clean module build, but test compilation is blocked by a pre-existing generated Dagger mismatch: generated confirmation components omit the `CheckoutSessionTaxRegionUpdater` provider required by `CheckoutSessionConfirmationInterceptor_Factory`.

# Screenshots

Not applicable — this changes configuration plumbing and unit tests only.

# Changelog

Not applicable — this is an internal Checkout Session preview API change.
