### PR TITLE
Fix Boleto and Card address E2E test variants

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBoleto.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBoleto.kt
@@ -15,8 +15,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.FieldPopulator
+import com.stripe.android.test.core.FieldPopulator.AddressEntryMode
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -37,9 +37,9 @@ internal class TestBoleto : BasePlaygroundTest() {
     private val boletoValues = FieldPopulator.Values().copy(
         zip = "76600-000",
         state = "Goiás",
+        addressEntryMode = AddressEntryMode.InlineAutocomplete,
     )
 
-    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testBoleto() {
         testDriver.confirmNewOrGuestComplete(
@@ -54,7 +54,6 @@ internal class TestBoleto : BasePlaygroundTest() {
         )
     }
 
-    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testBoletoSfu() {
         testDriver.confirmNewOrGuestComplete(
@@ -71,7 +70,6 @@ internal class TestBoleto : BasePlaygroundTest() {
         )
     }
 
-    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testBoletoSetup() {
         testDriver.confirmNewOrGuestComplete(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -33,8 +33,8 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.FieldPopulator
+import com.stripe.android.test.core.FieldPopulator.AddressEntryMode
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -57,7 +57,6 @@ internal class TestCard : BasePlaygroundTest() {
         )
     }
 
-    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testCardWithCustomBillingDetailsCollection() {
         testDriver.confirmNewOrGuestComplete(
@@ -72,6 +71,9 @@ internal class TestCard : BasePlaygroundTest() {
                 settings[CollectAddressSettingsDefinition] =
                     PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
             },
+            values = FieldPopulator.Values(
+                addressEntryMode = AddressEntryMode.InlineAutocomplete,
+            ),
             populateCustomLpmFields = {
                 populateCardDetails()
                 populateEmail()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
@@ -7,11 +7,14 @@ import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsToggleable
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.settings.CollectAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
@@ -21,6 +24,7 @@ import com.stripe.android.ui.core.elements.TranslationId
 import com.stripe.android.ui.core.elements.formatExpirationDateForAccessibility
 import com.stripe.android.uicore.utils.asIndividualDigits
 import com.stripe.android.core.R as CoreR
+import com.stripe.android.uicore.R as UiCoreR
 
 internal class FieldPopulator(
     private val selectors: Selectors,
@@ -86,6 +90,20 @@ internal class FieldPopulator(
         }
     }
 
+    enum class AddressEntryMode(
+        val lineOneLabelResourceId: Int,
+        val requiresManualEntry: Boolean,
+    ) {
+        Regular(
+            lineOneLabelResourceId = CoreR.string.stripe_address_label_address_line1,
+            requiresManualEntry = false,
+        ),
+        InlineAutocomplete(
+            lineOneLabelResourceId = UiCoreR.string.stripe_address_label_address,
+            requiresManualEntry = true,
+        ),
+    }
+
     data class Values(
         val name: String = "Jenny Rosen",
         val email: String = "jrosen@email.com",
@@ -103,6 +121,7 @@ internal class FieldPopulator(
         val bacsSortCode: String = "108800",
         val bacsAccountNumber: String = "00012345",
         val boletoTaxId: String = "00000000000",
+        val addressEntryMode: AddressEntryMode = AddressEntryMode.Regular,
     )
 
     private fun verifyPlatformLpmFields() {
@@ -113,7 +132,9 @@ internal class FieldPopulator(
             selectors.getName(selectors.getResourceString(TranslationId.AddressName.resourceId))
                 .ifExistsAssertContentDescriptionEquals(values.name)
 
-            selectors.getLine1()
+            selectors.composeTestRule.onNodeWithText(
+                selectors.getResourceString(values.addressEntryMode.lineOneLabelResourceId)
+            )
                 .ifExistsAssertContentDescriptionEquals(values.line1)
             selectors.getCity()
                 .ifExistsAssertContentDescriptionEquals(values.city)
@@ -158,6 +179,10 @@ internal class FieldPopulator(
     private val merchantCountryCode: String
         get() = testParameters.playgroundSettingsSnapshot[MerchantSettingsDefinition].countryCode
 
+    private val collectsFullAddress: Boolean
+        get() = testParameters.playgroundSettingsSnapshot[CollectAddressSettingsDefinition] ==
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+
     private fun usesStateDropdown(): Boolean {
         return merchantCountryCode in setOf("BR", "US", "GB")
     }
@@ -175,7 +200,7 @@ internal class FieldPopulator(
             performTextInput(values.cardCvc)
         }
 
-        if (!defaultBillingAddress) {
+        if (!defaultBillingAddress && !collectsFullAddress) {
             populateZip()
         }
     }
@@ -221,11 +246,20 @@ internal class FieldPopulator(
 
     fun populateAddress() {
         selectors
-            .getLine1()
+            .composeTestRule
+            .onNodeWithText(selectors.getResourceString(values.addressEntryMode.lineOneLabelResourceId))
             .performScrollTo()
             .performClick()
             .performTextInput(values.line1)
 
+        if (values.addressEntryMode.requiresManualEntry) {
+            selectors.enterAddressManually()
+        }
+
+        populateAddressDetails()
+    }
+
+    private fun populateAddressDetails() {
         selectors
             .getCity()
             .performScrollTo()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -366,9 +366,14 @@ internal class Selectors(
 
     fun getName(labelText: String) = composeTestRule.onNodeWithText(labelText)
 
-    fun getLine1() = composeTestRule.onNodeWithText(
-        getResourceString(CoreR.string.stripe_address_label_address_line1)
-    )
+    fun enterAddressManually() {
+        composeTestRule.onNodeWithTextAfterWaiting(
+            getResourceString(UiCoreR.string.stripe_address_enter_manually)
+        ).performClick()
+        composeTestRule.onNodeWithTextAfterWaiting(
+            getResourceString(CoreR.string.stripe_address_label_city)
+        )
+    }
 
     fun getCity() = composeTestRule.onNodeWithText(
         getResourceString(CoreR.string.stripe_address_label_city)


### PR DESCRIPTION
# Summary

Re-enable the four address E2E tests quarantined during the autocomplete-endpoint rollout:

- TestBoleto.testBoleto
- TestBoleto.testBoletoSfu
- TestBoleto.testBoletoSetup
- TestCard.testCardWithCustomBillingDetailsCollection

# Root cause

Boleto does not use BillingAddressElement. It requests its required BR billing address through the direct LPM FormElementsBuilder path, which creates AddressSpec and passes it the PaymentSheet autocomplete factory. After the Stripe-hosted autocomplete endpoint rollout, that factory creates the inline address experience, whose initial field is Address rather than Address line 1.

The Card test is different: its explicit full billing-address configuration uses BillingAddressElement, which enables autocomplete in Full mode. That address form owns ZIP, so the card-details helper must not also enter ZIP.

# What changed

- Remove the four temporary #ir-fishery-zigzag ignores.
- Declare addressEntryMode in FieldPopulator.Values, defaulting to Regular. Each mode owns its first-field label and whether to select Enter address manually.
- Configure InlineAutocomplete only in Boleto shared values and the full-address Card test values. All other callers retain Regular.
- Keep card-level ZIP input disabled when the full billing-address form owns ZIP.

# Scope

This is test-only. It does not change PaymentSheet address collection or experiment behavior.

# Testing

- Kotlin compilation passed with ./gradlew :paymentsheet-example:compileBaseDebugAndroidTestKotlin --rerun-tasks --no-build-cache. 293 tasks executed.
- The pre-push :paymentsheet-example:detekt check passed.
- On pixel2api33chrome with one shard and one device, Boleto SFU passed ShampooRule(2) iterations 0 and 1 in 1m29s, then passed ShampooRule(50) iterations 0 through 49 in 18m56s with zero failed iterations.
- The custom-billing Card test passed ShampooRule(2) iterations 0 and 1 in 1m07s, then passed ShampooRule(50) iterations 0 through 49 in 9m12s with zero failed iterations.
- An earlier Boleto SFU ShampooRule(50) attempt timed out at iteration 20 while PlaygroundTestDriver.doAuthorization clicked CLOSE. The log showed UI contention and skipped frames, with no address-field failure. A clean two-iteration rerun passed before the successful 50-iteration soak.
- With RetryRule(3) restored, each target passed once normally: Boleto 59s, Boleto SFU 58s, Boleto setup 43s, and custom-billing Card 44s.
- ShampooRule was diagnostic-only. TestRules.kt was restored to RetryRule(3) and is absent from the PR diff.

# Screenshots

Not applicable: instrumentation-test helper behavior only.

# Changelog

Not applicable: test-only change with no customer-facing behavior change.
