### PR TITLE
Add card scanner configuration to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -37,7 +37,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         googlePlacesApiKey = null,
         termsDisplay = configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet(),
         walletButtons = null,
-        opensCardScannerAutomatically = ConfigurationDefaults.opensCardScannerAutomatically,
+        opensCardScannerAutomatically = configuration.paymentElementConfiguration.opensCardScannerAutomatically,
         userOverrideCountry = ConfigurationDefaults.userOverrideCountry,
         appearance = configuration.paymentElementConfiguration.appearance.asPaymentSheet(),
     )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -25,6 +25,9 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             )
             .preferredNetworks(configuration.paymentElementConfiguration.preferredNetworks)
             .paymentMethodOrder(configuration.paymentElementConfiguration.paymentMethodOrder)
+            .opensCardScannerAutomatically(
+                configuration.paymentElementConfiguration.opensCardScannerAutomatically
+            )
             .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
             .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())
             .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -50,6 +50,7 @@ class PaymentElement @Inject internal constructor(
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
+        private var opensCardScannerAutomatically: Boolean = false
         private var preferredNetworks: List<CardBrand> = emptyList()
         private var paymentMethodOrder: List<String> = emptyList()
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
@@ -92,6 +93,14 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
+         * Controls whether the card scanner opens automatically when the card entry form is shown.
+         * Defaults to `false`.
+         */
+        fun opensCardScannerAutomatically(opensCardScannerAutomatically: Boolean): Configuration = apply {
+            this.opensCardScannerAutomatically = opensCardScannerAutomatically
+        }
+
+        /**
          * A list of preferred networks that should be used to process payments made with a
          * co-branded card if your user hasn't selected a network themselves.
          *
@@ -130,6 +139,7 @@ class PaymentElement @Inject internal constructor(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
             val paymentMethodLayout: PaymentMethodLayout,
+            val opensCardScannerAutomatically: Boolean,
             val preferredNetworks: List<CardBrand>,
             val paymentMethodOrder: List<String>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
@@ -140,6 +150,7 @@ class PaymentElement @Inject internal constructor(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
             paymentMethodLayout = paymentMethodLayout,
+            opensCardScannerAutomatically = opensCardScannerAutomatically,
             preferredNetworks = preferredNetworks,
             paymentMethodOrder = paymentMethodOrder,
             termsDisplay = termsDisplay,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -199,6 +199,21 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps opens card scanner automatically to common configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(PaymentElement.Configuration().opensCardScannerAutomatically(true))
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
     fun `sources the billing email from the checkout session customer email`() {
         val result = factory().create(
             configuration = controllerConfiguration(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -191,6 +191,21 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps opens card scanner automatically to embedded configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(PaymentElement.Configuration().opensCardScannerAutomatically(true))
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
     fun `leaves googlePay null when the merchant supplied no googlePayConfiguration`() {
         val result = factory().create(
             configuration = controllerConfiguration(googlePayConfiguration = null),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -137,6 +137,18 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `loadInitial passes opens card scanner automatically to common configuration`() = runScenario {
+        loader.loadInitial(
+            configuration = CheckoutController.Configuration()
+                .paymentElement(PaymentElement.Configuration().opensCardScannerAutomatically(true))
+                .build(),
+            checkoutSessionResponse = response(),
+        )
+
+        assertThat(stateHolder.state?.commonConfiguration?.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
     fun `loadInitial seeds collected details with the defaults billing address`() = runScenario {
         val address = CheckoutController.Address()
             .city(" San Francisco ")


### PR DESCRIPTION
# Summary

Adds `opensCardScannerAutomatically` to the Checkout Session preview `PaymentElement.Configuration` and propagates it to sheet and embedded payment-element flows. This is the final layer, dependent on #14028.

# Motivation

Checkout Session integrations need to opt into opening the card scanner as soon as the card-entry form is displayed, consistent with the existing PaymentSheet and Embedded Payment Element APIs.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:compileDebugKotlin` passed.

`./gradlew :paymentsheet:testDebugUnitTest` was started but did not yield usable output. The previously attempted clean run is blocked at test compilation by a pre-existing generated Dagger mismatch: generated confirmation components omit the `CheckoutSessionTaxRegionUpdater` provider required by `CheckoutSessionConfirmationInterceptor_Factory`.

# Screenshots

Not applicable — this changes configuration plumbing and unit tests only.

# Changelog

Not applicable — this is an internal Checkout Session preview API change.
