### PR TITLE
Add card funding configuration to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CardFundingTypeMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CardFundingTypeMapper.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview as PaymentSheetCardFundingFilteringPrivatePreview
+
+@OptIn(
+    CheckoutSessionPreview::class,
+    CardFundingFilteringPrivatePreview::class,
+    PaymentSheetCardFundingFilteringPrivatePreview::class,
+)
+internal fun List<PaymentElement.Configuration.CardFundingType>.asPaymentSheet(): List<PaymentSheet.CardFundingType> =
+    map { cardFundingType ->
+        when (cardFundingType) {
+            PaymentElement.Configuration.CardFundingType.Debit -> PaymentSheet.CardFundingType.Debit
+            PaymentElement.Configuration.CardFundingType.Credit -> PaymentSheet.CardFundingType.Credit
+            PaymentElement.Configuration.CardFundingType.Prepaid -> PaymentSheet.CardFundingType.Prepaid
+            PaymentElement.Configuration.CardFundingType.Unknown -> PaymentSheet.CardFundingType.Unknown
+        }
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -3,11 +3,12 @@ package com.stripe.android.checkout
 import com.stripe.android.checkout.injection.AppName
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
-@OptIn(CheckoutSessionPreview::class)
+@OptIn(CheckoutSessionPreview::class, CardFundingFilteringPrivatePreview::class)
 internal class CheckoutCommonConfigurationFactory @Inject constructor(
     @AppName private val appName: String,
 ) {
@@ -32,7 +33,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         paymentMethodOrder = configuration.paymentElementConfiguration.paymentMethodOrder,
         externalPaymentMethods = ConfigurationDefaults.externalPaymentMethods,
         cardBrandAcceptance = ConfigurationDefaults.cardBrandAcceptance,
-        allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,
+        allowedCardFundingTypes = configuration.paymentElementConfiguration.allowedCardFundingTypes.asPaymentSheet(),
         customPaymentMethods = ConfigurationDefaults.customPaymentMethods,
         googlePlacesApiKey = null,
         termsDisplay = configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet(),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -1,12 +1,18 @@
 package com.stripe.android.checkout
 
 import com.stripe.android.checkout.injection.AppName
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
+import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview as PaymentSheetCardFundingFilteringPrivatePreview
 
-@OptIn(CheckoutSessionPreview::class)
+@OptIn(
+    CheckoutSessionPreview::class,
+    CardFundingFilteringPrivatePreview::class,
+    PaymentSheetCardFundingFilteringPrivatePreview::class,
+)
 internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
     @AppName private val appName: String,
 ) {
@@ -25,6 +31,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             )
             .preferredNetworks(configuration.paymentElementConfiguration.preferredNetworks)
             .paymentMethodOrder(configuration.paymentElementConfiguration.paymentMethodOrder)
+            .allowedCardFundingTypes(configuration.paymentElementConfiguration.allowedCardFundingTypes.asPaymentSheet())
             .opensCardScannerAutomatically(
                 configuration.paymentElementConfiguration.opensCardScannerAutomatically
             )

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -12,6 +12,7 @@ import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.uicore.StripeThemeDefaults
@@ -45,6 +46,7 @@ class PaymentElement @Inject internal constructor(
 
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @OptIn(CardFundingFilteringPrivatePreview::class)
     class Configuration {
         private var embeddedViewDisplaysMandateText: Boolean = true
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
@@ -53,6 +55,7 @@ class PaymentElement @Inject internal constructor(
         private var opensCardScannerAutomatically: Boolean = false
         private var preferredNetworks: List<CardBrand> = emptyList()
         private var paymentMethodOrder: List<String> = emptyList()
+        private var allowedCardFundingTypes: List<CardFundingType> = CardFundingType.entries
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
         private var appearance: Appearance = Appearance()
 
@@ -122,6 +125,19 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
+         * Specifies the card funding types accepted by the payment element.
+         *
+         * By default, all card funding types are accepted. This is a client-side setting and is
+         * not currently supported in Link.
+         */
+        @CardFundingFilteringPrivatePreview
+        fun allowedCardFundingTypes(
+            allowedCardFundingTypes: List<CardFundingType>
+        ): Configuration = apply {
+            this.allowedCardFundingTypes = allowedCardFundingTypes
+        }
+
+        /**
          * A map for specifying when legal agreements are displayed for each payment method type.
          * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
          */
@@ -135,6 +151,7 @@ class PaymentElement @Inject internal constructor(
         }
 
         @Parcelize
+        @OptIn(CardFundingFilteringPrivatePreview::class)
         internal data class State(
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
@@ -142,10 +159,12 @@ class PaymentElement @Inject internal constructor(
             val opensCardScannerAutomatically: Boolean,
             val preferredNetworks: List<CardBrand>,
             val paymentMethodOrder: List<String>,
+            val allowedCardFundingTypes: List<CardFundingType>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
             val appearance: Appearance.State,
         ) : Parcelable
 
+        @OptIn(CardFundingFilteringPrivatePreview::class)
         internal fun build(): State = State(
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
@@ -153,9 +172,31 @@ class PaymentElement @Inject internal constructor(
             opensCardScannerAutomatically = opensCardScannerAutomatically,
             preferredNetworks = preferredNetworks,
             paymentMethodOrder = paymentMethodOrder,
+            allowedCardFundingTypes = allowedCardFundingTypes,
             termsDisplay = termsDisplay,
             appearance = appearance.build(),
         )
+
+        /**
+         * Card funding categories that can be filtered.
+         */
+        @CheckoutSessionPreview
+        @CardFundingFilteringPrivatePreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        enum class CardFundingType : Parcelable {
+            /** Debit cards. */
+            Debit,
+
+            /** Credit cards. */
+            Credit,
+
+            /** Prepaid cards. */
+            Prepaid,
+
+            /** Unknown funding type. */
+            Unknown,
+        }
 
         /** Appearance configuration for the Payment Element. */
         @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/CardFundingFilteringPrivatePreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/CardFundingFilteringPrivatePreview.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.paymentelement
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Marks card funding filtering API as being in private preview.
+ * This feature allows filtering which card funding types (credit, debit, prepaid) are accepted.
+ *
+ * Note: This is a client-side solution. Card funding filtering is not currently supported in Link.
+ * The backend performs the final validation.
+ */
+@RequiresOptIn(
+    message = "This card funding filtering API is in private preview and may change without notice.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS
+)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+annotation class CardFundingFilteringPrivatePreview

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCo
 import com.stripe.android.elements.PaymentElement.Configuration.TermsDisplay
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -21,6 +22,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 @OptIn(
     CheckoutSessionPreview::class,
     com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+    CardFundingFilteringPrivatePreview::class,
 )
 internal class CheckoutCommonConfigurationFactoryTest {
 
@@ -211,6 +213,26 @@ internal class CheckoutCommonConfigurationFactoryTest {
         )
 
         assertThat(result.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
+    fun `maps allowed card funding types to common configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().allowedCardFundingTypes(
+                    listOf(PaymentElement.Configuration.CardFundingType.Debit)
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.allowedCardFundingTypes)
+            .isEqualTo(listOf(PaymentSheet.CardFundingType.Debit))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.elements.PaymentElement.Configuration.BillingDetailsCo
 import com.stripe.android.elements.PaymentElement.Configuration.TermsDisplay
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -19,6 +20,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 @OptIn(
     CheckoutSessionPreview::class,
     com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+    CardFundingFilteringPrivatePreview::class,
 )
 internal class CheckoutEmbeddedConfigurationFactoryTest {
 
@@ -203,6 +205,26 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         )
 
         assertThat(result.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
+    fun `maps allowed card funding types to embedded configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().allowedCardFundingTypes(
+                    listOf(PaymentElement.Configuration.CardFundingType.Debit)
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.allowedCardFundingTypes)
+            .isEqualTo(listOf(PaymentSheet.CardFundingType.Debit))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
@@ -23,6 +24,7 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -53,7 +55,11 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
-@OptIn(CheckoutSessionPreview::class, com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class)
+@OptIn(
+    CheckoutSessionPreview::class,
+    com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview::class,
+    CardFundingFilteringPrivatePreview::class,
+)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutStateLoaderTest {
 
@@ -146,6 +152,23 @@ internal class CheckoutStateLoaderTest {
         )
 
         assertThat(stateHolder.state?.commonConfiguration?.opensCardScannerAutomatically).isTrue()
+    }
+
+    @Test
+    fun `loadInitial passes allowed card funding types to common configuration`() = runScenario {
+        loader.loadInitial(
+            configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().allowedCardFundingTypes(
+                        listOf(PaymentElement.Configuration.CardFundingType.Debit)
+                    )
+                )
+                .build(),
+            checkoutSessionResponse = response(),
+        )
+
+        assertThat(stateHolder.state?.commonConfiguration?.allowedCardFundingTypes)
+            .isEqualTo(listOf(PaymentSheet.CardFundingType.Debit))
     }
 
     @Test


### PR DESCRIPTION
# Summary

Adds `allowedCardFundingTypes` to the Checkout Session preview `PaymentElement.Configuration`, including the nested `PaymentElement.Configuration.CardFundingType` API, and propagates the setting to sheet and embedded payment-element flows. This layer depends on #14031.

# Motivation

Checkout Session integrations need to limit the card funding types accepted by the payment element, consistent with the existing PaymentSheet and Embedded Payment Element APIs.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest`

# Screenshots

Not applicable — this changes configuration plumbing and unit tests only.

# Changelog

Not applicable — this is a private-preview Checkout Session API change.
