### PR TITLE
Ignore address E2E tests to unblock CI

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBoleto.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestBoleto.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymen
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -38,6 +39,7 @@ internal class TestBoleto : BasePlaygroundTest() {
         state = "Goiás",
     )
 
+    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testBoleto() {
         testDriver.confirmNewOrGuestComplete(
@@ -52,6 +54,7 @@ internal class TestBoleto : BasePlaygroundTest() {
         )
     }
 
+    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testBoletoSfu() {
         testDriver.confirmNewOrGuestComplete(
@@ -68,6 +71,7 @@ internal class TestBoleto : BasePlaygroundTest() {
         )
     }
 
+    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testBoletoSetup() {
         testDriver.confirmNewOrGuestComplete(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -56,6 +57,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
     }
 
+    @Ignore("#ir-fishery-zigzag")
     @Test
     fun testCardWithCustomBillingDetailsCollection() {
         testDriver.confirmNewOrGuestComplete(


### PR DESCRIPTION
# Summary

Temporarily quarantines four PaymentSheet E2E tests blocked by the server-selected address-autocomplete rollout.

# Scope

- `TestBoleto.testBoleto`
- `TestBoleto.testBoletoSetup`
- `TestBoleto.testBoletoSfu`
- `TestCard.testCardWithCustomBillingDetailsCollection`

Each uses `@Ignore("#ir-fishery-zigzag")`. No production code or test behavior is changed.

# Testing

- `git diff --check`
- Tests intentionally not run because this PR quarantines the failing E2E methods.

# Changelog

Not applicable: test-only temporary CI quarantine.