### PR TITLE
Add CheckoutSession row selection behavior

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenter.kt
@@ -14,6 +14,7 @@ import javax.inject.Provider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CheckoutPresenter @Inject internal constructor(
     private val paymentElementProvider: Lazy<PaymentElement>,
+    private val rowSelectionBehaviorHolder: CheckoutRowSelectionBehaviorHolder,
     private val currencySelectorElementProvider: Lazy<CurrencySelectorElement>,
     private val shippingAddressElementProvider: Lazy<ShippingAddressElement>,
     private val expressCheckoutElementProvider: Lazy<ExpressCheckoutElement>,
@@ -23,7 +24,15 @@ class CheckoutPresenter @Inject internal constructor(
     /**
      * Returns the [PaymentElement], which displays and collects the customer's payment method.
      */
-    fun paymentElement(): PaymentElement {
+    fun paymentElement(): PaymentElement = paymentElement(PaymentElement.RowSelectionBehavior.default())
+
+    /**
+     * Returns the [PaymentElement], which displays and collects the customer's payment method.
+     *
+     * Call this once when creating the presenter. [rowSelectionBehavior] only applies to [PaymentElement.Content].
+     */
+    fun paymentElement(rowSelectionBehavior: PaymentElement.RowSelectionBehavior): PaymentElement {
+        rowSelectionBehaviorHolder.behavior = rowSelectionBehavior
         return paymentElementProvider.get()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutRowSelectionBehaviorHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutRowSelectionBehaviorHolder.kt
@@ -1,0 +1,17 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout
+
+import com.stripe.android.elements.PaymentElement
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds row-selection behavior for the lifetime of a checkout controller component.
+ *
+ * This is intentionally not persisted: the host supplies it again when recreating its presenter.
+ */
+@Singleton
+internal class CheckoutRowSelectionBehaviorHolder @Inject constructor() {
+    var behavior: PaymentElement.RowSelectionBehavior = PaymentElement.RowSelectionBehavior.default()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
@@ -35,6 +36,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
 ) : EmbeddedSheetLauncher {
 
     init {
@@ -63,7 +65,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
+            is EmbeddedActivityResult.Complete -> {
+                applyCompleteResult(result)
+                result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+            }
             is EmbeddedActivityResult.Cancelled -> applyCustomerState(result.customerState)
             is EmbeddedActivityResult.Error -> Unit
         }
@@ -71,7 +76,12 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleManageResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
+            is EmbeddedActivityResult.Complete -> {
+                applyCompleteResult(result)
+                if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
+                    rowSelectionImmediateActionHandler.invoke()
+                }
+            }
             is EmbeddedActivityResult.Cancelled -> Unit
             is EmbeddedActivityResult.Error -> Unit
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Bundle
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -10,6 +11,7 @@ import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
+import javax.inject.Provider
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
@@ -20,6 +22,7 @@ internal class CheckoutStateLoader @Inject constructor(
     private val selectionChooser: EmbeddedSelectionChooser,
     private val stateHolder: CheckoutControllerStateHolder,
     private val customerStateHolder: CustomerStateHolder,
+    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
 ) {
     suspend fun loadInitial(
         configuration: CheckoutController.Configuration.State,
@@ -76,7 +79,8 @@ internal class CheckoutStateLoader @Inject constructor(
                 checkoutSessionResponse = response,
             ),
             integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
-                isRowSelectionImmediateAction = false,
+                // This reports the default when configure() runs before paymentElement().
+                isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
                 configuration = embeddedConfig,
                 paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet(),
             ),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -12,6 +12,7 @@ import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerSavedState
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutPaymentOptionDisplayDataFactory
+import com.stripe.android.checkout.CheckoutRowSelectionBehaviorHolder
 import com.stripe.android.checkout.CheckoutSessionRefresher
 import com.stripe.android.checkout.DefaultCheckoutPaymentOptionDisplayDataFactory
 import com.stripe.android.checkout.DefaultCheckoutSessionRefresher
@@ -253,9 +254,9 @@ internal interface CheckoutControllerModule {
 
         @Provides
         fun providesInternalRowSelectionCallback(
-            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
+            holder: CheckoutRowSelectionBehaviorHolder,
         ): InternalRowSelectionCallback? {
-            return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]?.rowSelectionCallback
+            return holder.behavior.immediateActionCallbackOrNull()
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -42,6 +42,40 @@ class PaymentElement @Inject internal constructor(
         contentHelper.presentPaymentOptions()
     }
 
+    /**
+     * Describes how [Content] handles payment option row selections.
+     *
+     * Note: Only used if you call [Content].
+     */
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract class RowSelectionBehavior internal constructor() {
+        private object Default : RowSelectionBehavior()
+
+        private class ImmediateAction(
+            val didSelectPaymentOption: () -> Unit,
+        ) : RowSelectionBehavior()
+
+        internal fun immediateActionCallbackOrNull(): (() -> Unit)? {
+            return (this as? ImmediateAction)?.didSelectPaymentOption
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+            /** The default behavior, which only updates the selected payment option. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun default(): RowSelectionBehavior = Default
+
+            /** Invokes [didSelectPaymentOption] after the customer selects a payment option. */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun immediateAction(didSelectPaymentOption: () -> Unit): RowSelectionBehavior {
+                return ImmediateAction(didSelectPaymentOption)
+            }
+        }
+    }
+
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterTest.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
+import dagger.Lazy
+import javax.inject.Provider
+import kotlin.test.Test
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutPresenterTest {
+
+    @Test
+    fun `paymentElement with immediate action stores behavior before retrieving element`() {
+        val holder = CheckoutRowSelectionBehaviorHolder()
+        val callback = {}
+        val presenter = createPresenter(holder)
+
+        presenter.paymentElement(PaymentElement.RowSelectionBehavior.immediateAction(callback))
+
+        assertThat(holder.behavior.immediateActionCallbackOrNull()).isSameInstanceAs(callback)
+    }
+
+    @Test
+    fun `paymentElement without behavior stores default behavior`() {
+        val holder = CheckoutRowSelectionBehaviorHolder().apply {
+            behavior = PaymentElement.RowSelectionBehavior.immediateAction {}
+        }
+        val presenter = createPresenter(holder)
+
+        presenter.paymentElement()
+
+        assertThat(holder.behavior.immediateActionCallbackOrNull()).isNull()
+    }
+
+    private fun createPresenter(holder: CheckoutRowSelectionBehaviorHolder): CheckoutPresenter {
+        val paymentElement = PaymentElement(FakeEmbeddedContentHelper())
+        return CheckoutPresenter(
+            paymentElementProvider = Lazy { paymentElement },
+            rowSelectionBehaviorHolder = holder,
+            currencySelectorElementProvider = Lazy { error("unused") },
+            shippingAddressElementProvider = Lazy { error("unused") },
+            expressCheckoutElementProvider = Lazy { error("unused") },
+            checkoutConfirmationPerformerProvider = Provider { error("unused") },
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -209,6 +209,23 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `formActivityLauncher invokes immediate action when complete result has selection`() = testScenario {
+        launchForm("cashapp")
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            hasBeenConfirmed = false,
+            customerState = null,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "cashapp"),
+        )
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+        assertThat(immediateActionWasInvoked()).isTrue()
+    }
+
+    @Test
     fun `formActivityLauncher sets customer state but keeps selection on cancelled result`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         launchForm("card")
@@ -342,6 +359,23 @@ internal class CheckoutSheetLauncherTest {
         assertThat(customerStateHolder.customer.value).isEqualTo(customerState)
         assertThat(selectionHolder.selection.value).isEqualTo(selection)
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(immediateActionWasInvoked()).isFalse()
+    }
+
+    @Test
+    fun `manageSheetLauncher invokes immediate action for saved selection when flagged`() = testScenario {
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            customerState = null,
+            selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            hasBeenConfirmed = false,
+            shouldInvokeSelectionCallback = true,
+            launchMode = EmbeddedLaunchMode.Manage,
+        )
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+        assertThat(immediateActionWasInvoked()).isTrue()
     }
 
     @Test
@@ -575,6 +609,7 @@ internal class CheckoutSheetLauncherTest {
     private fun testScenario(
         block: suspend Scenario.() -> Unit
     ) = runTest {
+        var immediateActionInvoked = false
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
@@ -598,6 +633,7 @@ internal class CheckoutSheetLauncherTest {
                 errorReporter = errorReporter,
                 statusBarColor = null,
                 paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+                rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
             )
             val registerCall = awaitRegisterCall()
             val launcher = awaitNextRegisteredLauncher()
@@ -615,6 +651,7 @@ internal class CheckoutSheetLauncherTest {
                 sheetLauncher = sheetLauncher,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
+                immediateActionWasInvoked = { immediateActionInvoked },
             ).block()
         }
     }
@@ -629,6 +666,7 @@ internal class CheckoutSheetLauncherTest {
         val sheetLauncher: EmbeddedSheetLauncher,
         val sheetStateHolder: SheetStateHolder,
         val errorReporter: FakeErrorReporter,
+        val immediateActionWasInvoked: () -> Boolean,
     ) {
         suspend fun launchForm(code: String) {
             sheetLauncher.launchForm(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
@@ -64,6 +65,17 @@ internal class CheckoutStateLoaderTest {
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
 
         assertThat(stateHolder.state?.paymentMethodMetadata).isNotNull()
+    }
+
+    @Test
+    fun `loadInitial reports immediate row selection action to payment element loader`() = runScenario(
+        internalRowSelectionCallback = {},
+    ) {
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        val integrationConfiguration = paymentElementLoader.lastIntegrationConfiguration
+            as PaymentElementLoader.Configuration.Embedded
+        assertThat(integrationConfiguration.isRowSelectionImmediateAction).isTrue()
     }
 
     @Test
@@ -386,6 +398,7 @@ internal class CheckoutStateLoaderTest {
         shouldFail: Boolean = false,
         isGooglePayAvailable: Boolean = false,
         customer: CustomerState? = null,
+        internalRowSelectionCallback: (() -> Unit)? = null,
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
@@ -427,6 +440,7 @@ internal class CheckoutStateLoaderTest {
             selectionChooser = chooser,
             stateHolder = stateHolder,
             customerStateHolder = customerStateHolder,
+            internalRowSelectionCallback = { internalRowSelectionCallback },
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.elements
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContent
@@ -37,6 +38,21 @@ internal class PaymentElementTest {
 
         contentHelper.presentPaymentOptionsCalls.awaitItem()
         contentHelper.presentPaymentOptionsCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `default row selection behavior has no immediate action callback`() {
+        assertThat(PaymentElement.RowSelectionBehavior.default().immediateActionCallbackOrNull()).isNull()
+    }
+
+    @Test
+    fun `immediate action row selection behavior returns its callback`() {
+        var wasInvoked = false
+        val behavior = PaymentElement.RowSelectionBehavior.immediateAction { wasInvoked = true }
+
+        behavior.immediateActionCallbackOrNull()?.invoke()
+
+        assertThat(wasInvoked).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -39,6 +39,9 @@ internal class FakePaymentElementLoader(
     private val integrationMetadata: IntegrationMetadata? = null,
 ) : PaymentElementLoader {
 
+    var lastIntegrationConfiguration: PaymentElementLoader.Configuration? = null
+        private set
+
     fun updateStripeIntent(intent: StripeIntent) {
         this.stripeIntent = intent
     }
@@ -89,6 +92,7 @@ internal class FakePaymentElementLoader(
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
     ): Result<PaymentElementLoader.State> {
+        lastIntegrationConfiguration = integrationConfiguration
         delay(delay)
         return if (shouldFail) {
             Result.failure(IllegalStateException("oh no"))


### PR DESCRIPTION
# Summary

- Add configurable row-selection behavior for CheckoutSession payment options.
- Support an immediate-action callback after a payment option is selected.

# Motivation

CheckoutSession hosts need to control whether selecting a payment option triggers an immediate follow-up action while retaining the existing default selection behavior.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Tests were added but not run (not requested).

# Screenshots

Not applicable: this is an internal, non-visual behavior change.

# Changelog

Not applicable: this changes an internal `LIBRARY_GROUP` CheckoutSession preview API and does not add a public SDK surface.
