### PR TITLE
Additional security updates for NFC scanning

### DIFF
--- a/paymentsheet/src/main/AndroidManifest.xml
+++ b/paymentsheet/src/main/AndroidManifest.xml
@@ -52,7 +52,8 @@
             android:theme="@style/StripePaymentSheetDefaultTheme" />
         <activity
             android:name="com.stripe.android.common.nfcscan.NfcScanningActivity"
-            android:theme="@style/StripePaymentSheetTapToAddTheme" />
+            android:theme="@style/StripePaymentSheetTapToAddTheme"
+            android:exported="false" />
         <activity
             android:name="com.stripe.android.common.taptoadd.TapToAddActivity"
             android:theme="@style/StripePaymentSheetTapToAddTheme" />

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommand.kt
@@ -90,7 +90,7 @@ internal abstract class ApduCommand<TResponseData> {
             onSuccess = { tlv ->
                 responseData(tlv)?.let { responseData ->
                     Result.success(responseData)
-                } ?: Result.failure(ApduResponseError.Invalid(rawData))
+                } ?: Result.failure(ApduResponseError.Invalid())
             },
             onFailure = { cause ->
                 Result.failure(ApduResponseError.Parsing(cause))

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduResponseError.kt
@@ -89,10 +89,8 @@ internal sealed class ApduResponseError(
         override val userMessage: ResolvableString = R.string.stripe_nfc_scan_internal_error_message.resolvableString
     }
 
-    class Invalid(
-        val data: ByteArray
-    ) : ApduResponseError(
-        message = "Invalid data in response: ${data.toHexString()}"
+    class Invalid : ApduResponseError(
+        message = "Invalid data in response!"
     ) {
         override val errorCode: String = "cardUnsupportedByNfc"
         override val userMessage: ResolvableString = R.string.stripe_nfc_scan_internal_error_message.resolvableString

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/scanner/apdu/ApduCommandTest.kt
@@ -100,7 +100,6 @@ internal class ApduCommandTest {
 
             val error = result.exceptionOrNull()
             assertThat(error).isInstanceOf<ApduResponseError.Invalid>()
-            assertThat((error as ApduResponseError.Invalid).data.contentEquals(responseData)).isTrue()
             assertThat(transceiver.transceiveCalls.awaitItem()).isNotNull()
         }
     }


### PR DESCRIPTION
# Summary
Additional security updates for NFC scanning
- Explicitly set `NfcScanningActivity` to not exported (is by default but wanted to be explicit here)
- Remove APDU data from `Invalid` error class.

# Motivation
Better security updates

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified