### PR TITLE
Remove RetryRule from test classes in paymentsheet module.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentsheet.state.LinkSignupModeResult
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
-import com.stripe.android.testing.RetryRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.tta.testing.TapToAddCardAddedPage
 import com.stripe.android.tta.testing.TapToAddCardCollectionTestHelper
@@ -77,7 +76,6 @@ class TapToAddActivityTest {
         .around(imageLoaderTestRule)
         .around(FeatureFlagTestRule(FeatureFlags.forceTapToAddWithTerminal, isEnabled = true))
         .around(PaymentConfigurationTestRule(applicationContext))
-        .around(RetryRule(3))
         .around(intentsRule)
 
     private val linkHelper = TapToAddLinkTestHelper(composeTestRule, networkRule)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
-import com.stripe.android.testing.RetryRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.setupPaymentMethodDetachResponse
@@ -68,7 +67,6 @@ internal class EmbeddedSheetActivityTest {
         .outerRule(composeTestRule)
         .around(networkRule)
         .around(PaymentConfigurationTestRule(applicationContext))
-        .around(RetryRule(3))
 
     @Test
     fun `when launched without args should finish with error result`() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -52,7 +52,6 @@ import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeErrorReporter
-import com.stripe.android.testing.RetryRule
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -93,7 +92,6 @@ internal class PaymentOptionsActivityTest {
         .around(coroutineScopeCleanupRule)
         .around(composeTestRule)
         .around(networkRule)
-        .around(RetryRule(3))
 
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -124,7 +124,6 @@ import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.ResetMockRule
-import com.stripe.android.testing.RetryRule
 import com.stripe.android.testing.SessionTestRule
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -191,7 +190,6 @@ internal class PaymentSheetViewModelTest {
         .around(SessionTestRule())
         .around(PaymentElementCallbackTestRule())
         .around(ResetMockRule(eventReporter))
-        .around(RetryRule(3))
 
     @BeforeTest
     fun setup() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentConfigurationTestRule
-import com.stripe.android.testing.RetryRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.UsBankPaymentMethodDetails
@@ -61,7 +60,6 @@ internal class VerticalModePaymentSheetActivityTest {
         .around(composeTestRule)
         .around(networkRule)
         .around(PaymentConfigurationTestRule(applicationContext))
-        .around(RetryRule(3))
 
     @Test
     fun `Allows paying with card`() = runTest(


### PR DESCRIPTION
# Summary
Removed the use of RetryRule from various test classes in the paymentsheet module.

These don't have any reason to be flakey (they're not invoking a real network, or anything like that).

# Motivation
RetryRule is no longer needed and was removed to clean up test setup and reduce complexity.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog