### PR TITLE
Use Embedded appearance for payment option icons

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactory.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.darkThemeIconUrl
@@ -16,6 +17,7 @@ import com.stripe.android.paymentsheet.model.lightThemeIconUrl
 import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.model.shippingDetails
+import com.stripe.android.paymentsheet.model.shouldUseDarkThemeIcon
 import com.stripe.android.paymentsheet.model.toPaymentSheetBillingDetails
 import javax.inject.Inject
 
@@ -28,6 +30,7 @@ internal class PaymentOptionDisplayDataFactory @Inject constructor(
     fun create(
         selection: PaymentSelection?,
         paymentMethodMetadata: PaymentMethodMetadata,
+        appearance: PaymentSheet.Appearance,
     ): EmbeddedPaymentElement.PaymentOptionDisplayData? {
         if (selection == null) {
             return null
@@ -59,7 +62,7 @@ internal class PaymentOptionDisplayDataFactory @Inject constructor(
                     drawableResourceIdNight = selection.drawableResourceIdNight,
                     lightThemeIconUrl = selection.lightThemeIconUrl,
                     darkThemeIconUrl = selection.darkThemeIconUrl,
-                    useDarkThemeIcon = null,
+                    useDarkThemeIcon = appearance.shouldUseDarkThemeIcon(context),
                 )
             },
             billingDetails = selection.billingDetails?.toPaymentSheetBillingDetails(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataHolder.kt
@@ -35,6 +35,7 @@ internal class DefaultPaymentOptionDisplayDataHolder @Inject constructor(
                     _paymentOption.value = paymentOptionDisplayDataFactory.create(
                         selection = selection,
                         paymentMethodMetadata = state.paymentMethodMetadata,
+                        appearance = state.configuration.appearance,
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -39,21 +39,17 @@ internal class PaymentOptionFactory @Inject constructor(
                     drawableResourceIdNight = drawableResourceId,
                     lightThemeIconUrl = lightThemeIconUrl,
                     darkThemeIconUrl = darkThemeIconUrl,
-                    useDarkThemeIcon = useDarkThemeIcon(appearance),
+                    useDarkThemeIcon = appearance?.shouldUseDarkThemeIcon(context),
                 )
             },
         )
     }
+}
 
-    private fun useDarkThemeIcon(appearance: PaymentSheet.Appearance?): Boolean? {
-        if (appearance == null) {
-            return null
-        }
-
-        val isDark = appearance.themeMode.isDarkTheme(context.isSystemDarkTheme())
-        val componentColor = Color(appearance.getColors(isDark).component)
-        return componentColor.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
-    }
+internal fun PaymentSheet.Appearance.shouldUseDarkThemeIcon(context: Context): Boolean {
+    val isDark = themeMode.isDarkTheme(context.isSystemDarkTheme())
+    val componentColor = Color(getColors(isDark).component)
+    return componentColor.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
 }
 
 internal val PaymentSelection.shippingDetails: AddressDetails?

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactoryTest.kt
@@ -1,9 +1,12 @@
 package com.stripe.android.paymentelement.embedded.content
 
+import android.content.Context
+import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
@@ -18,21 +21,27 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentelement.ShippingDetailsInPaymentOptionPreview
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@OptIn(AppearanceAPIAdditionsPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentOptionDisplayDataFactoryTest {
 
     private val displayDataFactory = createFactory()
+    private val appearance = PaymentSheet.Appearance()
 
     @Test
     fun `create uses link account brand for saved Link passthrough card label`() {
@@ -47,6 +56,7 @@ internal class PaymentOptionDisplayDataFactoryTest {
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 linkBrand = LinkBrand.Link,
             ),
+            appearance = appearance,
         )
 
         assertThat(option?.label).isEqualTo("Onelink")
@@ -63,6 +73,7 @@ internal class PaymentOptionDisplayDataFactoryTest {
                 )
             ),
             paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.billingDetails).isEqualTo(paymentSheetBillingDetails)
@@ -72,7 +83,8 @@ internal class PaymentOptionDisplayDataFactoryTest {
     fun `create does not attach BillingDetails for Google Pay`() {
         val option = displayDataFactory.create(
             selection = PaymentSelection.GooglePay,
-            paymentMethodMetadata = paymentMethodMetadata
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.billingDetails).isNull()
@@ -82,7 +94,8 @@ internal class PaymentOptionDisplayDataFactoryTest {
     fun `selecting saved card does not attach mandate to paymentMethodMetadata`() {
         val option = displayDataFactory.create(
             selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            paymentMethodMetadata = paymentMethodMetadata
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.mandateText).isNull()
@@ -92,7 +105,8 @@ internal class PaymentOptionDisplayDataFactoryTest {
     fun `selecting new card does attach mandate to paymentMethodMetadata`() {
         val option = displayDataFactory.create(
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
-            paymentMethodMetadata = paymentMethodMetadata
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.mandateText).isNotNull()
@@ -102,7 +116,8 @@ internal class PaymentOptionDisplayDataFactoryTest {
     fun `selecting google pay does not attach mandate to paymentMethodMetadata`() {
         val option = displayDataFactory.create(
             selection = PaymentSelection.GooglePay,
-            paymentMethodMetadata = paymentMethodMetadata
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.mandateText).isNull()
@@ -134,7 +149,8 @@ internal class PaymentOptionDisplayDataFactoryTest {
                     unredactedPhoneNumber = "+15555555555",
                 ),
             ),
-            paymentMethodMetadata = paymentMethodMetadata
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.shippingDetails).isEqualTo(
@@ -163,18 +179,99 @@ internal class PaymentOptionDisplayDataFactoryTest {
                 selectedPayment = null,
                 shippingAddress = null,
             ),
-            paymentMethodMetadata = paymentMethodMetadata
+            paymentMethodMetadata = paymentMethodMetadata,
+            appearance = appearance,
         )
 
         assertThat(option?.shippingDetails).isNull()
     }
 
+    @Test
+    @Config(qualifiers = "notnight")
+    fun `always dark with dark component uses dark icon on light system`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysDark,
+        lightComponent = Color.White,
+        darkComponent = Color.Black,
+    ) {
+        assertThat(loadedUrl).isEqualTo(DARK_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `always light with light component uses light icon on dark system`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysLight,
+        lightComponent = Color.White,
+        darkComponent = Color.Black,
+    ) {
+        assertThat(loadedUrl).isEqualTo(LIGHT_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "notnight")
+    fun `automatic with light component uses light icon on light system`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.Automatic,
+        lightComponent = Color.White,
+        darkComponent = Color.Black,
+    ) {
+        assertThat(loadedUrl).isEqualTo(LIGHT_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `automatic with dark component uses dark icon on dark system`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.Automatic,
+        lightComponent = Color.White,
+        darkComponent = Color.Black,
+    ) {
+        assertThat(loadedUrl).isEqualTo(DARK_ICON_URL)
+    }
+
+    private fun runIconScenario(
+        themeMode: PaymentSheet.ThemeMode,
+        lightComponent: Color,
+        darkComponent: Color,
+        block: IconScenario.() -> Unit,
+    ) = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val imageLoader = FakeStripeImageLoader()
+        val factory = createFactory(
+            iconLoader = PaymentSelection.IconLoader(
+                resources = context.resources,
+                imageLoader = imageLoader,
+            ),
+        )
+        val appearance = PaymentSheet.Appearance.Builder()
+            .colorsLight(PaymentSheet.Colors.Builder.light().component(lightComponent).build())
+            .colorsDark(PaymentSheet.Colors.Builder.dark().component(darkComponent).build())
+            .themeMode(themeMode)
+            .build()
+        val selection = PaymentSelection.CustomPaymentMethod(
+            id = "cpm_123",
+            billingDetails = null,
+            label = "CPM".resolvableString,
+            lightThemeIconUrl = LIGHT_ICON_URL,
+            darkThemeIconUrl = DARK_ICON_URL,
+        )
+
+        requireNotNull(
+            factory.create(
+                selection = selection,
+                paymentMethodMetadata = paymentMethodMetadata,
+                appearance = appearance,
+            )
+        ).imageLoader()
+
+        IconScenario(loadedUrl = imageLoader.awaitLoadCall().url).apply(block)
+        imageLoader.ensureAllEventsConsumed()
+    }
+
     companion object {
         private fun createFactory(
+            iconLoader: PaymentSelection.IconLoader = mock(),
             cardArtDrawableLoader: PaymentOptionCardArtDrawableLoader = PaymentOptionCardArtDrawableLoader { null },
             linkAccountHolder: LinkAccountHolder = LinkAccountHolder(SavedStateHandle()),
         ) = PaymentOptionDisplayDataFactory(
-            iconLoader = mock(),
+            iconLoader = iconLoader,
             cardArtDrawableLoader = cardArtDrawableLoader,
             context = ApplicationProvider.getApplicationContext(),
             linkAccountHolder = linkAccountHolder,
@@ -215,5 +312,12 @@ internal class PaymentOptionDisplayDataFactoryTest {
             isGooglePayReady = true,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         )
+
+        private const val LIGHT_ICON_URL = "light_icon_url"
+        private const val DARK_ICON_URL = "dark_icon_url"
     }
+
+    private data class IconScenario(
+        val loadedUrl: String,
+    )
 }


### PR DESCRIPTION
# Summary

- Use `EmbeddedPaymentElement.Configuration.appearance` when choosing light or dark payment-option icons.
- Remove Embedded's final dependency on the mutable global appearance parsed into `StripeTheme`.
- Preserve the existing component-luminance behavior while changing only the source of the theme.

Stacked on parent PR #14047.

# Motivation

Embedded payment-option icons should use the appearance belonging to the current Embedded configuration. Reading mutable global theme state can use values written by another PaymentSheet-owned surface.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

Not applicable; this changes icon-theme selection logic without changing layout.

# Changelog

No changelog entry. This is an internal migration with no API changes.
