### PR TITLE
Add card brand acceptance to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CardBrandAcceptanceMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CardBrandAcceptanceMapper.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.checkout
+
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun PaymentElement.Configuration.CardBrandAcceptance.asPaymentSheet(): PaymentSheet.CardBrandAcceptance =
+    when (this) {
+        is PaymentElement.Configuration.CardBrandAcceptance.All -> PaymentSheet.CardBrandAcceptance.All
+        is PaymentElement.Configuration.CardBrandAcceptance.Allowed -> {
+            PaymentSheet.CardBrandAcceptance.Allowed(brands.map { it.asPaymentSheet() })
+        }
+        is PaymentElement.Configuration.CardBrandAcceptance.Disallowed -> {
+            PaymentSheet.CardBrandAcceptance.Disallowed(brands.map { it.asPaymentSheet() })
+        }
+    }
+
+@OptIn(CheckoutSessionPreview::class)
+private fun PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.asPaymentSheet():
+    PaymentSheet.CardBrandAcceptance.BrandCategory =
+    when (this) {
+        PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Visa ->
+            PaymentSheet.CardBrandAcceptance.BrandCategory.Visa
+        PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Mastercard ->
+            PaymentSheet.CardBrandAcceptance.BrandCategory.Mastercard
+        PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Amex ->
+            PaymentSheet.CardBrandAcceptance.BrandCategory.Amex
+        PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Discover ->
+            PaymentSheet.CardBrandAcceptance.BrandCategory.Discover
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -32,7 +32,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
         paymentMethodOrder = configuration.paymentElementConfiguration.paymentMethodOrder,
         externalPaymentMethods = ConfigurationDefaults.externalPaymentMethods,
-        cardBrandAcceptance = ConfigurationDefaults.cardBrandAcceptance,
+        cardBrandAcceptance = configuration.paymentElementConfiguration.cardBrandAcceptance.asPaymentSheet(),
         allowedCardFundingTypes = configuration.paymentElementConfiguration.allowedCardFundingTypes.asPaymentSheet(),
         customPaymentMethods = ConfigurationDefaults.customPaymentMethods,
         googlePlacesApiKey = null,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -31,6 +31,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             )
             .preferredNetworks(configuration.paymentElementConfiguration.preferredNetworks)
             .paymentMethodOrder(configuration.paymentElementConfiguration.paymentMethodOrder)
+            .cardBrandAcceptance(configuration.paymentElementConfiguration.cardBrandAcceptance.asPaymentSheet())
             .allowedCardFundingTypes(configuration.paymentElementConfiguration.allowedCardFundingTypes.asPaymentSheet())
             .opensCardScannerAutomatically(
                 configuration.paymentElementConfiguration.opensCardScannerAutomatically

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -55,6 +55,7 @@ class PaymentElement @Inject internal constructor(
         private var opensCardScannerAutomatically: Boolean = false
         private var preferredNetworks: List<CardBrand> = emptyList()
         private var paymentMethodOrder: List<String> = emptyList()
+        private var cardBrandAcceptance: CardBrandAcceptance = CardBrandAcceptance.All
         private var allowedCardFundingTypes: List<CardFundingType> = CardFundingType.entries
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
         private var appearance: Appearance = Appearance()
@@ -125,6 +126,16 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
+         * Specifies the card brands accepted by the payment element.
+         *
+         * By default, all card brands are accepted. This is a client-side setting and is not
+         * currently supported in Link.
+         */
+        fun cardBrandAcceptance(cardBrandAcceptance: CardBrandAcceptance): Configuration = apply {
+            this.cardBrandAcceptance = cardBrandAcceptance
+        }
+
+        /**
          * Specifies the card funding types accepted by the payment element.
          *
          * By default, all card funding types are accepted. This is a client-side setting and is
@@ -159,6 +170,7 @@ class PaymentElement @Inject internal constructor(
             val opensCardScannerAutomatically: Boolean,
             val preferredNetworks: List<CardBrand>,
             val paymentMethodOrder: List<String>,
+            val cardBrandAcceptance: CardBrandAcceptance,
             val allowedCardFundingTypes: List<CardFundingType>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
             val appearance: Appearance.State,
@@ -172,10 +184,64 @@ class PaymentElement @Inject internal constructor(
             opensCardScannerAutomatically = opensCardScannerAutomatically,
             preferredNetworks = preferredNetworks,
             paymentMethodOrder = paymentMethodOrder,
+            cardBrandAcceptance = cardBrandAcceptance,
             allowedCardFundingTypes = allowedCardFundingTypes,
             termsDisplay = termsDisplay,
             appearance = appearance.build(),
         )
+
+        /** Options to allow or disallow card brands. */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        sealed class CardBrandAcceptance : Parcelable {
+            /** Card brand categories that can be allowed or disallowed. */
+            @Parcelize
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class BrandCategory : Parcelable {
+                /** Visa branded cards. */
+                Visa,
+
+                /** Mastercard branded cards. */
+                Mastercard,
+
+                /** Amex branded cards. */
+                Amex,
+
+                /** Discover Global Network branded cards. */
+                Discover,
+            }
+
+            @Parcelize
+            internal data object All : CardBrandAcceptance()
+
+            @Parcelize
+            internal data class Allowed(
+                val brands: List<BrandCategory>
+            ) : CardBrandAcceptance()
+
+            @Parcelize
+            internal data class Disallowed(
+                val brands: List<BrandCategory>
+            ) : CardBrandAcceptance()
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            companion object {
+                /** Accepts all card brands supported by Stripe. */
+                @JvmStatic
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                fun all(): CardBrandAcceptance = All
+
+                /** Accepts only the specified card brands. */
+                @JvmStatic
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                fun allowed(brands: List<BrandCategory>): CardBrandAcceptance = Allowed(brands)
+
+                /** Accepts all card brands except the specified ones. */
+                @JvmStatic
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                fun disallowed(brands: List<BrandCategory>): CardBrandAcceptance = Disallowed(brands)
+            }
+        }
 
         /**
          * Card funding categories that can be filtered.

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -216,6 +216,31 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps card brand acceptance to common configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().cardBrandAcceptance(
+                    PaymentElement.Configuration.CardBrandAcceptance.disallowed(
+                        listOf(PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Amex)
+                    )
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.cardBrandAcceptance).isEqualTo(
+            PaymentSheet.CardBrandAcceptance.disallowed(
+                listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Amex)
+            )
+        )
+    }
+
+    @Test
     fun `maps allowed card funding types to common configuration`() {
         val configuration = CheckoutController.Configuration()
             .paymentElement(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -208,6 +208,31 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps card brand acceptance to embedded configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().cardBrandAcceptance(
+                    PaymentElement.Configuration.CardBrandAcceptance.disallowed(
+                        listOf(PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Amex)
+                    )
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.cardBrandAcceptance).isEqualTo(
+            PaymentSheet.CardBrandAcceptance.disallowed(
+                listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Amex)
+            )
+        )
+    }
+
+    @Test
     fun `maps allowed card funding types to embedded configuration`() {
         val configuration = CheckoutController.Configuration()
             .paymentElement(


### PR DESCRIPTION
# Summary
Adds card-brand acceptance configuration to the checkout `PaymentElement` preview API and maps it into both common and embedded PaymentSheet configurations.

# Motivation
Checkout integrations need to control which card brands the Payment Element accepts. This propagates the configured allowlist or blocklist to the underlying PaymentSheet configuration for both checkout presentation modes.

# Testing
Tests were updated to cover card-brand-acceptance mapping in the common and embedded configuration factories. They have not been run in this session.

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

No tests were ignored.

# Screenshots
Not applicable — this is configuration API and mapping logic with no direct UI change.

# Changelog
Not applicable — this is a library-group, checkout-session-preview configuration API.
