### PR TITLE
Enable Checkout Session payment methods

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -23,9 +23,8 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         link = configuration.linkConfiguration.asPaymentSheet(),
         defaultBillingDetails = collectedDetails.toBillingDetails(checkoutSessionResponse),
         shippingDetails = collectedDetails.toShippingDetails(),
-        allowsDelayedPaymentMethods = ConfigurationDefaults.allowsDelayedPaymentMethods,
-        allowsPaymentMethodsRequiringShippingAddress =
-            ConfigurationDefaults.allowsPaymentMethodsRequiringShippingAddress,
+        allowsDelayedPaymentMethods = true,
+        allowsPaymentMethodsRequiringShippingAddress = true,
         billingDetailsCollectionConfiguration =
             configuration.toBillingDetailsCollectionConfiguration(checkoutSessionResponse),
         preferredNetworks = configuration.paymentElementConfiguration.preferredNetworks,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -41,6 +41,8 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))
             .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
             .shippingDetails(collectedDetails.toShippingDetails())
+            .allowsDelayedPaymentMethods(true)
+            .allowsPaymentMethodsRequiringShippingAddress(true)
             .build()
     }
 }


### PR DESCRIPTION
# Summary

Enable delayed payment methods and payment methods that require shipping addresses for Checkout Session in both common and embedded configurations.

# Motivation

Keep Checkout Session configuration behavior consistent between the common and embedded Checkout flows so both can surface the same supported payment methods.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutCommonConfigurationFactoryTest`

# Screenshots

Not applicable — this change does not alter UI layout or visuals.

# Changelog

Not applicable — this is an internal Checkout Session configuration alignment.
