### PR TITLE
Move Link configuration to payment element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -20,7 +20,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         merchantDisplayName = configuration.resolveMerchantDisplayName(checkoutSessionResponse, appName),
         customer = ConfigurationDefaults.customer,
         googlePay = configuration.toGooglePayConfiguration(checkoutSessionResponse),
-        link = configuration.linkConfiguration.asPaymentSheet(),
+        link = configuration.paymentElementConfiguration.linkConfiguration.asPaymentSheet(),
         defaultBillingDetails = collectedDetails.toBillingDetails(checkoutSessionResponse),
         shippingDetails = collectedDetails.toShippingDetails(),
         allowsDelayedPaymentMethods = ConfigurationDefaults.allowsDelayedPaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -9,8 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.CollectMissingLinkBillingDetailsPreview
-import com.stripe.android.LinkDisallowFundingSourceCreationPreview
 import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.common.ui.DelegateDrawable
@@ -813,7 +811,6 @@ class CheckoutController @Inject internal constructor(
         private var apiConfiguration: ApiConfiguration? = null
         private var merchantDisplayName: String? = null
         private var googlePayConfiguration: GooglePayConfiguration? = null
-        private var linkConfiguration: LinkConfiguration = LinkConfiguration()
         private var defaults: Defaults = Defaults()
         private var paymentElementConfiguration: PaymentElement.Configuration = PaymentElement.Configuration()
         private var currencySelectorElementConfiguration: CurrencySelectorElement.Configuration =
@@ -899,15 +896,6 @@ class CheckoutController @Inject internal constructor(
         }
 
         /**
-         * Sets the Link configuration for this checkout session.
-         */
-        fun linkConfiguration(
-            configuration: LinkConfiguration,
-        ): Configuration = apply {
-            this.linkConfiguration = configuration
-        }
-
-        /**
          * Prefill values for the customer's details. If known up front, these prepopulate the
          * elements (and the Checkout Session) so the customer doesn't re-enter them.
          */
@@ -923,7 +911,6 @@ class CheckoutController @Inject internal constructor(
             val apiConfiguration: ApiConfiguration.State?,
             val merchantDisplayName: String?,
             val googlePayConfiguration: GooglePayConfiguration.State?,
-            val linkConfiguration: LinkConfiguration.State,
             val defaults: Defaults.State,
             val paymentElementConfiguration: PaymentElement.Configuration.State,
             val currencySelectorElementConfiguration: CurrencySelectorElement.Configuration.State,
@@ -942,84 +929,8 @@ class CheckoutController @Inject internal constructor(
                 shippingAddressElementConfiguration = shippingAddressElementConfiguration.build(),
                 expressCheckoutElementConfiguration = expressCheckoutElementConfiguration.build(),
                 googlePayConfiguration = googlePayConfiguration?.build(),
-                linkConfiguration = linkConfiguration.build(),
                 defaults = defaultsState,
             )
-        }
-
-        /**
-         * Builder for Link configuration used by checkout.
-         */
-        @CheckoutSessionPreview
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        class LinkConfiguration {
-            private var display: Display = Display.Automatic
-            private var collectMissingBillingDetailsForExistingPaymentMethods: Boolean = true
-            private var disallowFundingSourceCreation: Set<String> = emptySet()
-
-            /**
-             * Sets when Link is displayed in the payment element.
-             */
-            fun display(display: Display): LinkConfiguration = apply {
-                this.display = display
-            }
-
-            /**
-             * Sets whether Link collects missing billing details for existing payment methods.
-             */
-            @CollectMissingLinkBillingDetailsPreview
-            fun collectMissingBillingDetailsForExistingPaymentMethods(
-                collectMissingBillingDetailsForExistingPaymentMethods: Boolean,
-            ): LinkConfiguration = apply {
-                this.collectMissingBillingDetailsForExistingPaymentMethods =
-                    collectMissingBillingDetailsForExistingPaymentMethods
-            }
-
-            /**
-             * Sets Link funding sources that cannot be created.
-             */
-            @LinkDisallowFundingSourceCreationPreview
-            fun disallowFundingSourceCreation(
-                disallowFundingSourceCreation: Set<String>,
-            ): LinkConfiguration = apply {
-                this.disallowFundingSourceCreation = disallowFundingSourceCreation
-            }
-
-            @Parcelize
-            internal data class State(
-                val display: Display,
-                val collectMissingBillingDetailsForExistingPaymentMethods: Boolean,
-                val disallowFundingSourceCreation: Set<String>,
-            ) : Parcelable
-
-            internal fun build(): State = State(
-                display = display,
-                collectMissingBillingDetailsForExistingPaymentMethods =
-                    collectMissingBillingDetailsForExistingPaymentMethods,
-                disallowFundingSourceCreation = disallowFundingSourceCreation.toSet(),
-            )
-
-            /**
-             * Display configuration for Link.
-             */
-            @CheckoutSessionPreview
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            enum class Display {
-                /**
-                 * Link is displayed when available.
-                 */
-                Automatic,
-
-                /**
-                 * Link is never displayed.
-                 */
-                Never,
-
-                /**
-                 * Link remains enabled but its button or row is hidden from the payment element UI.
-                 */
-                WalletButtonHidden,
-            }
         }
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/LinkConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/LinkConfigurationMapper.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.checkout
 
+import com.stripe.android.elements.PaymentElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 
 @OptIn(CheckoutSessionPreview::class)
-internal fun CheckoutController.Configuration.LinkConfiguration.State.asPaymentSheet():
+internal fun PaymentElement.Configuration.LinkConfiguration.State.asPaymentSheet():
     PaymentSheet.LinkConfiguration =
     PaymentSheet.LinkConfiguration(
         display = display.asPaymentSheet(),
@@ -16,12 +17,12 @@ internal fun CheckoutController.Configuration.LinkConfiguration.State.asPaymentS
     )
 
 @OptIn(CheckoutSessionPreview::class)
-private fun CheckoutController.Configuration.LinkConfiguration.Display.asPaymentSheet():
+private fun PaymentElement.Configuration.LinkConfiguration.Display.asPaymentSheet():
     PaymentSheet.LinkConfiguration.Display = when (this) {
-    CheckoutController.Configuration.LinkConfiguration.Display.Automatic ->
+    PaymentElement.Configuration.LinkConfiguration.Display.Automatic ->
         PaymentSheet.LinkConfiguration.Display.Automatic
-    CheckoutController.Configuration.LinkConfiguration.Display.Never ->
+    PaymentElement.Configuration.LinkConfiguration.Display.Never ->
         PaymentSheet.LinkConfiguration.Display.Never
-    CheckoutController.Configuration.LinkConfiguration.Display.WalletButtonHidden ->
+    PaymentElement.Configuration.LinkConfiguration.Display.WalletButtonHidden ->
         PaymentSheet.LinkConfiguration.Display.WalletButtonHidden
 }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import com.stripe.android.CollectMissingLinkBillingDetailsPreview
+import com.stripe.android.LinkDisallowFundingSourceCreationPreview
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -47,6 +49,7 @@ class PaymentElement @Inject internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @OptIn(CardFundingFilteringPrivatePreview::class)
+    @Suppress("TooManyFunctions")
     class Configuration {
         private var embeddedViewDisplaysMandateText: Boolean = true
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
@@ -59,6 +62,7 @@ class PaymentElement @Inject internal constructor(
         private var allowedCardFundingTypes: List<CardFundingType> = CardFundingType.entries
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
         private var appearance: Appearance = Appearance()
+        private var linkConfiguration: LinkConfiguration = LinkConfiguration()
 
         /**
          * Controls whether [Content] displays mandate text below the payment methods.
@@ -161,6 +165,88 @@ class PaymentElement @Inject internal constructor(
             this.appearance = appearance
         }
 
+        /**
+         * Sets the Link configuration for the payment element.
+         */
+        fun linkConfiguration(configuration: LinkConfiguration): Configuration = apply {
+            this.linkConfiguration = configuration
+        }
+
+        /**
+         * Builder for Link configuration used by the payment element.
+         */
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class LinkConfiguration {
+            private var display: Display = Display.Automatic
+            private var collectMissingBillingDetailsForExistingPaymentMethods: Boolean = true
+            private var disallowFundingSourceCreation: Set<String> = emptySet()
+
+            /**
+             * Sets when Link is displayed in the payment element.
+             */
+            fun display(display: Display): LinkConfiguration = apply {
+                this.display = display
+            }
+
+            /**
+             * Sets whether Link collects missing billing details for existing payment methods.
+             */
+            @CollectMissingLinkBillingDetailsPreview
+            fun collectMissingBillingDetailsForExistingPaymentMethods(
+                collectMissingBillingDetailsForExistingPaymentMethods: Boolean,
+            ): LinkConfiguration = apply {
+                this.collectMissingBillingDetailsForExistingPaymentMethods =
+                    collectMissingBillingDetailsForExistingPaymentMethods
+            }
+
+            /**
+             * Sets Link funding sources that cannot be created.
+             */
+            @LinkDisallowFundingSourceCreationPreview
+            fun disallowFundingSourceCreation(
+                disallowFundingSourceCreation: Set<String>,
+            ): LinkConfiguration = apply {
+                this.disallowFundingSourceCreation = disallowFundingSourceCreation
+            }
+
+            @Parcelize
+            internal data class State(
+                val display: Display,
+                val collectMissingBillingDetailsForExistingPaymentMethods: Boolean,
+                val disallowFundingSourceCreation: Set<String>,
+            ) : Parcelable
+
+            internal fun build(): State = State(
+                display = display,
+                collectMissingBillingDetailsForExistingPaymentMethods =
+                    collectMissingBillingDetailsForExistingPaymentMethods,
+                disallowFundingSourceCreation = disallowFundingSourceCreation.toSet(),
+            )
+
+            /**
+             * Display configuration for Link.
+             */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class Display {
+                /**
+                 * Link is displayed when available.
+                 */
+                Automatic,
+
+                /**
+                 * Link is never displayed.
+                 */
+                Never,
+
+                /**
+                 * Link remains enabled but its button or row is hidden from the payment element UI.
+                 */
+                WalletButtonHidden,
+            }
+        }
+
         @Parcelize
         @OptIn(CardFundingFilteringPrivatePreview::class)
         internal data class State(
@@ -174,6 +260,7 @@ class PaymentElement @Inject internal constructor(
             val allowedCardFundingTypes: List<CardFundingType>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
             val appearance: Appearance.State,
+            val linkConfiguration: LinkConfiguration.State,
         ) : Parcelable
 
         @OptIn(CardFundingFilteringPrivatePreview::class)
@@ -188,6 +275,7 @@ class PaymentElement @Inject internal constructor(
             allowedCardFundingTypes = allowedCardFundingTypes,
             termsDisplay = termsDisplay,
             appearance = appearance.build(),
+            linkConfiguration = linkConfiguration.build(),
         )
 
         /** Options to allow or disallow card brands. */

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -130,14 +130,15 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
-    fun `maps Link configuration`() {
+    fun `maps Link configuration from payment element configuration`() {
         val result = factory().create(
-            configuration = CheckoutController.Configuration()
-                .linkConfiguration(
-                    CheckoutController.Configuration.LinkConfiguration()
-                        .display(CheckoutController.Configuration.LinkConfiguration.Display.Never)
+            configuration = CheckoutController.Configuration().paymentElement(
+                PaymentElement.Configuration().linkConfiguration(
+                    PaymentElement.Configuration.LinkConfiguration().display(
+                        PaymentElement.Configuration.LinkConfiguration.Display.Never
+                    )
                 )
-                .build(),
+            ).build(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
             collectedDetails = collectedDetails(),
         )


### PR DESCRIPTION
# Summary

Move Checkout Session Link configuration into `PaymentElement.Configuration`, including its builder setter and state.

# Motivation

Fixes https://github.com/stripe/stripe-android/pull/14039#issuecomment-5335003541 by making Link configuration part of the payment element configuration it controls.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutCommonConfigurationFactoryTest`.

# Screenshots

Not applicable — this changes configuration ownership only; there is no UI change.

# Changelog

Not applicable — this is a library-group preview API ownership correction with no behavior change.
