### PR TITLE
Fix CVC not cleared when card pill is cleared

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -230,6 +230,7 @@ internal class CardDetailsController(
     private fun dismissCardPill() {
         numberElement.controller.onRawValueChange("")
         expirationDateElement.controller.onRawValueChange("")
+        cvcElement.controller.onRawValueChange("")
         cardPillElement.value = null
     }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardPillElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardPillElement.kt
@@ -204,16 +204,16 @@ private fun DismissButton(
         tint = dismissColor,
         modifier = Modifier
             .size(8.dp)
-            .clearAndSetSemantics {
-                contentDescription = dismissLabel
-                role = Role.Button
-            }
             .clickable(
                 enabled = enabled,
                 interactionSource = dismissInteractionSource,
                 indication = null,
                 onClick = onDismiss,
-            ),
+            )
+            .clearAndSetSemantics {
+                contentDescription = dismissLabel
+                role = Role.Button
+            },
     )
 }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -1,14 +1,18 @@
 package com.stripe.android.ui.core.elements
 
 import android.content.Context
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
@@ -17,7 +21,10 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReporter
+import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.FieldValidationMessageComparator
@@ -344,6 +351,57 @@ class CardDetailsControllerTest {
     }
 
     @Test
+    fun `When card pill is dismissed, pill is hidden and fields are cleared`() = composeTest { controller ->
+        turbineScope {
+            val cardPillTurbine = controller.cardPillElement.testIn(this)
+            val numberControllerValueTurbine =
+                controller.numberElement.controller.rawFieldValue.testIn(this)
+            val expirationControllerValueTurbine =
+                controller.expirationDateElement.controller.rawFieldValue.testIn(this)
+            val cvcControllerValueTurbine = controller.cvcElement.controller.rawFieldValue.testIn(this)
+
+            assertThat(cardPillTurbine.awaitItem()).isNull()
+            assertThat(numberControllerValueTurbine.awaitItem()).isEmpty()
+            assertThat(expirationControllerValueTurbine.awaitItem()).isEmpty()
+            assertThat(cvcControllerValueTurbine.awaitItem()).isEmpty()
+
+            controller.onScannedCard(
+                ScannedCardDetails.Validated(
+                    cardNumber = "4242424242424242",
+                    expirationYear = 2030,
+                    expirationMonth = 6,
+                )
+            )
+
+            controller.cvcElement.controller.onRawValueChange("323")
+
+            idleLooper()
+
+            assertThat(cardPillTurbine.awaitItem()).isNotNull()
+            assertThat(numberControllerValueTurbine.awaitItem()).isEqualTo("4242424242424242")
+            assertThat(expirationControllerValueTurbine.awaitItem()).isEqualTo("0630")
+            assertThat(cvcControllerValueTurbine.awaitItem()).isEqualTo("323")
+
+            composeTestRule.onNodeWithContentDescription(
+                label = context.getString(R.string.stripe_scanned_card_pill_clear_content_description),
+            )
+                .performClick()
+
+            composeTestRule.waitForIdle()
+
+            assertThat(cardPillTurbine.awaitItem()).isNull()
+            assertThat(numberControllerValueTurbine.awaitItem()).isEmpty()
+            assertThat(expirationControllerValueTurbine.awaitItem()).isEmpty()
+            assertThat(cvcControllerValueTurbine.awaitItem()).isEmpty()
+
+            cardPillTurbine.cancelAndIgnoreRemainingEvents()
+            numberControllerValueTurbine.cancelAndIgnoreRemainingEvents()
+            expirationControllerValueTurbine.cancelAndIgnoreRemainingEvents()
+            cvcControllerValueTurbine.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `When new card scanned with no expiry date, should clear date`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
@@ -377,51 +435,65 @@ class CardDetailsControllerTest {
     }
 
     @Test
-    fun `When validated card scanned, CVC field gains focus`() = scannedCardTest(
-        scannedCardDetails = ScannedCardDetails.Validated(
-            cardNumber = "4242424242424242",
-            expirationYear = 2030,
-            expirationMonth = 6,
-        ),
-    ) {
-        composeTestRule.onNodeWithTag(TEST_TAG).assert(isFocused())
+    fun `When validated card scanned, CVC field gains focus`() = composeTest { controller ->
+        composeTestRule.onNodeWithText(CVC_TEXT).assert(!isFocused())
+
+        controller.onScannedCard(
+            ScannedCardDetails.Validated(
+                cardNumber = "4242424242424242",
+                expirationYear = 2030,
+                expirationMonth = 6,
+            )
+        )
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(CVC_TEXT).assert(isFocused())
     }
 
     @Test
-    fun `When card scanned via camera, CVC field does not gain focus`() = scannedCardTest(
-        scannedCardDetails = ScannedCardDetails.Unvalidated(
-            cardNumber = "5555555555554444",
-            expirationYear = 2044,
-            expirationMonth = 4,
+    fun `When card scanned via camera, CVC field does not gain focus`() = composeTest { controller ->
+        composeTestRule.onNodeWithText(CVC_TEXT).assert(!isFocused())
+
+        controller.onScannedCard(
+            ScannedCardDetails.Unvalidated(
+                cardNumber = "5555555555554444",
+                expirationYear = 2044,
+                expirationMonth = 4,
+            )
         )
-    ) {
-        composeTestRule.onNodeWithTag(TEST_TAG).assert(!isFocused())
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(CVC_TEXT).assert(!isFocused())
     }
 
-    private fun scannedCardTest(
-        scannedCardDetails: ScannedCardDetails,
-        block: suspend () -> Unit,
+    private fun composeTest(
+        block: suspend (controller: CardDetailsController) -> Unit,
     ) = runTest {
         val cardController = cardDetailsController()
 
         composeTestRule.setContent {
-            cardController.cvcElement.controller.ComposeUI(
-                enabled = true,
-                field = cardController.cvcElement,
-                modifier = Modifier.testTag(TEST_TAG),
-                hiddenIdentifiers = emptySet(),
-                lastTextFieldIdentifier = null,
-            )
+            CompositionLocalProvider(
+                LocalCardNumberCompletedEventReporter provides FakeCardNumberCompletedEventReporter
+            ) {
+                Column {
+                    cardController.ComposeUI(
+                        enabled = true,
+                        field = CardDetailsElement(
+                            identifier = IdentifierSpec.Generic("card_details"),
+                            cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+                            initialValues = mapOf(),
+                        ),
+                        modifier = Modifier,
+                        hiddenIdentifiers = emptySet(),
+                        lastTextFieldIdentifier = null,
+                    )
+                }
+            }
         }
-        composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithTag(TEST_TAG).assert(!isFocused())
-
-        cardController.onScannedCard(scannedCardDetails)
-
-        composeTestRule.waitForIdle()
-
-        block()
+        block(cardController)
     }
 
     private fun cardDetailsController(
@@ -496,7 +568,13 @@ class CardDetailsControllerTest {
         }
     }
 
+    private object FakeCardNumberCompletedEventReporter : CardNumberCompletedEventReporter {
+        override fun onCardNumberCompleted() {
+            // No-op
+        }
+    }
+
     private companion object {
-        const val TEST_TAG = "CVC_FIELD"
+        const val CVC_TEXT = "CVC"
     }
 }


### PR DESCRIPTION
# Summary
Fix CVC not cleared when card pill is cleared by using `CvcController` in `CardDetailsController` to set the value to empty.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demon -->
Better UX experience for NFC scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/b7514db5-337b-4da5-a878-78258424d28e

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>