### PR TITLE
Increase NFC scanning timeout to 30 seconds

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningTimeoutManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningTimeoutManager.kt
@@ -51,6 +51,6 @@ internal class DefaultNfcScanningTimeoutManager @Inject constructor(
     }
 
     private companion object {
-        val INACTIVITY_TIMEOUT = 20.seconds
+        val INACTIVITY_TIMEOUT = 30.seconds
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/DefaultNfcScanningTimeoutManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/DefaultNfcScanningTimeoutManagerTest.kt
@@ -42,6 +42,6 @@ internal class DefaultNfcScanningTimeoutManagerTest {
     }
 
     private companion object {
-        val INACTIVITY_TIMEOUT = 20.seconds
+        val INACTIVITY_TIMEOUT = 30.seconds
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -202,7 +202,7 @@ internal class NfcScanningActivityTest {
 
     @Test
     fun `inactivity timeout returns canceled result`() = test {
-        ShadowSystemClock.advanceBy(20.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        ShadowSystemClock.advanceBy(30.seconds.inWholeSeconds, TimeUnit.SECONDS)
         waitForIdle()
 
         assertThat(getResult()).isEqualTo(NfcScanningContract.Result.Canceled)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Increase NFC scanning timeout to 30 seconds 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better UX experience for NFC scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>