### PR TITLE
Increase NFC scanning fade out time from 200 to 270ms

### DIFF
--- a/paymentsheet/res/anim/stripe_nfc_screen_fade_out.xml
+++ b/paymentsheet/res/anim/stripe_nfc_screen_fade_out.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="270"
+    android:fromAlpha="1"
+    android:toAlpha="0" />

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.nfcscan.ui.NfcScanningScreen
 import com.stripe.android.common.nfcscan.ui.NfcScanningTheme
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
 import kotlinx.coroutines.flow.collectLatest
@@ -92,6 +93,6 @@ internal class NfcScanningActivity : AppCompatActivity() {
 
     override fun finish() {
         super.finish()
-        fadeOut()
+        fadeOut(fadeOut = R.anim.stripe_nfc_screen_fade_out)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/nfcscan/NfcScanningActivityTest.kt
@@ -16,6 +16,7 @@ import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.utils.AnimationConstants
@@ -228,7 +229,7 @@ internal class NfcScanningActivityTest {
         assertThat(shadowActivity.pendingTransitionEnterAnimationResourceId)
             .isEqualTo(AnimationConstants.FADE_IN)
         assertThat(shadowActivity.pendingTransitionExitAnimationResourceId)
-            .isEqualTo(AnimationConstants.FADE_OUT)
+            .isEqualTo(R.anim.stripe_nfc_screen_fade_out)
     }
 
     private fun test(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/AnimationConstants.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/AnimationConstants.kt
@@ -18,11 +18,14 @@ object AnimationConstants {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun Activity.fadeOut() {
+fun Activity.fadeOut(
+    fadeIn: Int = FADE_IN,
+    fadeOut: Int = FADE_OUT
+) {
     if (Build.VERSION.SDK_INT >= 34) {
-        overrideActivityTransition(Activity.OVERRIDE_TRANSITION_CLOSE, FADE_IN, FADE_OUT)
+        overrideActivityTransition(Activity.OVERRIDE_TRANSITION_CLOSE, fadeIn, fadeOut)
     } else {
         @Suppress("DEPRECATION")
-        overridePendingTransition(FADE_IN, FADE_OUT)
+        overridePendingTransition(fadeIn, fadeOut)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Increase NFC scanning fade out time from 200 to 270ms

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better UX experience for NFC scanning

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/ef85d5f4-f5e4-4748-9589-e31c91d87373

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>