### PR TITLE
Add appearance support to Checkout Payment Element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -39,6 +39,6 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         walletButtons = null,
         opensCardScannerAutomatically = ConfigurationDefaults.opensCardScannerAutomatically,
         userOverrideCountry = ConfigurationDefaults.userOverrideCountry,
-        appearance = ConfigurationDefaults.appearance,
+        appearance = configuration.paymentElementConfiguration.appearance,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -26,6 +26,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .googlePay(configuration.toGooglePayConfiguration(checkoutSessionResponse))
             .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
             .shippingDetails(collectedDetails.toShippingDetails())
+            .appearance(configuration.paymentElementConfiguration.appearance)
             .build()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -5,8 +5,10 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -38,10 +40,20 @@ class PaymentElement @Inject internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Configuration {
+        private var appearance: PaymentSheet.Appearance = ConfigurationDefaults.appearance
         private var embeddedViewDisplaysMandateText: Boolean = true
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
         private var paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
+
+        /**
+         * Sets the visual appearance of the payment element and any sheets it presents.
+         */
+        fun appearance(
+            appearance: PaymentSheet.Appearance
+        ): Configuration = apply {
+            this.appearance = appearance
+        }
 
         /**
          * Controls whether [Content] displays mandate text below the payment methods.
@@ -81,12 +93,14 @@ class PaymentElement @Inject internal constructor(
 
         @Parcelize
         internal data class State(
+            val appearance: PaymentSheet.Appearance,
             val embeddedViewDisplaysMandateText: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
             val paymentMethodLayout: PaymentMethodLayout,
         ) : Parcelable
 
         internal fun build(): State = State(
+            appearance = appearance,
             embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
             paymentMethodLayout = paymentMethodLayout,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.checkout
 
+import androidx.compose.ui.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Address
 import com.stripe.android.common.configuration.ConfigurationDefaults
@@ -17,6 +18,24 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutCommonConfigurationFactoryTest {
+
+    @Test
+    fun `propagates payment element appearance`() {
+        val appearance = PaymentSheet.Appearance(
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = Color.Red),
+        )
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(PaymentElement.Configuration().appearance(appearance))
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.appearance).isEqualTo(appearance)
+    }
 
     @Test
     fun `matches the common configuration derived from the embedded configuration`() {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerConfigurationTest.kt
@@ -1,12 +1,36 @@
 package com.stripe.android.checkout
 
+import androidx.compose.ui.graphics.Color
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.elements.PaymentElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Test
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutControllerConfigurationTest {
+    @Test
+    fun `payment element appearance uses the default appearance`() {
+        val state = CheckoutController.Configuration().build()
+
+        assertThat(state.paymentElementConfiguration.appearance)
+            .isEqualTo(ConfigurationDefaults.appearance)
+    }
+
+    @Test
+    fun `payment element appearance uses the configured appearance`() {
+        val appearance = PaymentSheet.Appearance(
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = Color.Red),
+        )
+        val state = CheckoutController.Configuration()
+            .paymentElement(PaymentElement.Configuration().appearance(appearance))
+            .build()
+
+        assertThat(state.paymentElementConfiguration.appearance).isEqualTo(appearance)
+    }
+
     @Test
     fun `api configuration is null by default`() {
         val state = CheckoutController.Configuration().build()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.checkout
 
+import androidx.compose.ui.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Address
 import com.stripe.android.elements.PaymentElement
@@ -15,6 +16,24 @@ import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConf
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutEmbeddedConfigurationFactoryTest {
+
+    @Test
+    fun `propagates payment element appearance`() {
+        val appearance = PaymentSheet.Appearance(
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = Color.Red),
+        )
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(PaymentElement.Configuration().appearance(appearance))
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.appearance).isEqualTo(appearance)
+    }
 
     @Test
     fun `uses the provided merchant display name`() {


### PR DESCRIPTION
# Summary

- Add `PaymentElement.Configuration.appearance(...)` for Checkout integrations.
- Pass the configured appearance to Checkout's embedded and common Payment Element configurations.
- Keep Checkout's Payment Element theme scoped to its configuration instead of mutable global theme state.

Stacked on parent PR #14049.

# Motivation

Checkout currently hardcodes the default PaymentSheet appearance, so callers cannot theme its Payment Element. Passing the configured appearance through both configuration paths lets the scoped Embedded theme added earlier apply consistently to inline content and presented sheets.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Commands:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutControllerConfigurationTest' --tests 'com.stripe.android.checkout.CheckoutCommonConfigurationFactoryTest' --tests 'com.stripe.android.checkout.CheckoutEmbeddedConfigurationFactoryTest'`
- `./gradlew :paymentsheet:compileDebugKotlin`
- `./gradlew :paymentsheet:apiCheck`
- `./gradlew :paymentsheet:detekt`

# Screenshots

Not applicable; this PR only wires appearance configuration into the already-tested Embedded theme.

# Changelog

No changelog entry. Checkout is a restricted preview API.
