### PR TITLE
Refresh Checkout Session after confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -101,14 +101,16 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
                 completeConfirmation { wasRestored ->
-                    when (val result = state.result) {
-                        is ConfirmationHandler.Result.Succeeded -> {
-                            result.metadata[CheckoutSessionResponseKey]?.let { response ->
-                                refreshSession { sessionRefresher.refresh(response) }
-                            }
+                    // A confirmation returning through an activity result has no fresh response to
+                    // commit, but the session changed server-side, so re-fetch it.
+                    val response = (state.result as? ConfirmationHandler.Result.Succeeded)
+                        ?.metadata?.get(CheckoutSessionResponseKey)
+                    refreshSession {
+                        if (response != null) {
+                            sessionRefresher.refresh(response)
+                        } else {
+                            sessionRefresher.refresh()
                         }
-
-                        else -> refreshSession { sessionRefresher.refresh() }
                     }
                     state.result.asCheckoutResult(wasRestored)
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -825,6 +825,19 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `refresh commits a complete session status to the state holder`() = runMutationScenario {
+        networkRule.checkoutInit(
+            responseFactory = successResponseFactory { json -> json.put("status", "complete") },
+        )
+
+        val result = controller.runServerUpdate { Result.success(Unit) }
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(controller.session.value?.status)
+            .isInstanceOf(CheckoutController.Session.Status.Complete::class.java)
+    }
+
+    @Test
     fun `runServerUpdate returns failure when serverUpdate throws`() = runMutationScenario {
         val before = controller.session.value
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -263,9 +263,11 @@ internal class CheckoutOperationCoordinatorTest {
         assertThat(arguments).isNull()
         resultTurbine.expectNoEvents()
 
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
         )
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
     }
 
@@ -283,10 +285,12 @@ internal class CheckoutOperationCoordinatorTest {
         assertThat(coordinator.isUpdating.value).isFalse()
 
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
         )
 
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
@@ -329,10 +333,12 @@ internal class CheckoutOperationCoordinatorTest {
     fun `successful confirmation is delivered as completed`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
         )
 
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
         assertThat(coordinator.isUpdating.value).isFalse()
     }
@@ -534,15 +540,69 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `successful confirmation without response does not refresh the checkout session`() = runScenario {
+    fun `successful confirmation without response refreshes the checkout session`() = runScenario {
         coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
+        enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
         )
 
+        assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
-        refreshCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `refreshed session is committed under operation gate before delivering result without response`() {
+        val releaseRefresh = CompletableDeferred<Unit>()
+        runScenario {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+            enqueueRefreshAction { releaseRefresh.await() }
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+            assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
+            resultTurbine.expectNoEvents()
+
+            val mutationStarted = CompletableDeferred<Unit>()
+            val mutation = backgroundScope.async {
+                coordinator.runMutation {
+                    mutationStarted.complete(Unit)
+                    Result.success(Unit)
+                }
+            }
+            runCurrent()
+
+            assertThat(mutationStarted.isCompleted).isFalse()
+            assertThat(coordinator.isUpdating.value).isTrue()
+
+            releaseRefresh.complete(Unit)
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+            assertThat(mutation.await().isSuccess).isTrue()
+        }
+    }
+
+    @Test
+    fun `refresh failure after successful confirmation is logged and still delivers completed`() {
+        val expected = IllegalStateException("Refresh failed")
+        val logger = FakeLogger()
+        runScenario(logger = logger) {
+            coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+
+            enqueueRefreshAction { throw expected }
+            confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            )
+
+            assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
+            assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+            assertThat(logger.errorLogs).containsExactly(
+                "Failed to refresh the checkout session after confirmation." to expected
+            )
+            assertThat(coordinator.isUpdating.value).isFalse()
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
+        }
     }
 
     @Test
@@ -662,10 +722,12 @@ internal class CheckoutOperationCoordinatorTest {
         coordinator.isUpdating.test {
             assertThat(awaitItem()).isTrue()
 
+            enqueueRefreshAction {}
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
             )
 
+            assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
             assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
             assertThat(awaitItem()).isFalse()
         }


### PR DESCRIPTION
# Summary

Refresh Checkout Session state after every terminal confirmation result. Immediate confirmations commit the response already returned by the server; confirmations returning from a next action re-fetch the session before the merchant receives `Result.Completed`.

# Motivation

After a 3DS or redirect flow, the controller retained the pre-confirmation Checkout Session response, leaving `session.value.status` open and its totals stale despite a successful payment. The activity-result path has no fresh session response to commit, so it must reload the session server-side.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
- `./gradlew :paymentsheet:testDebugUnitTest --tests '*CheckoutOperationCoordinatorTest*' --tests '*CheckoutControllerTest*' --tests '*DefaultCheckoutSessionRefresherTest*'`
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable: this changes Checkout Session state refresh behavior without a visual UI change.

# Changelog

Not applicable: this is an internal correctness fix and does not require a changelog entry.
