### PR TITLE
Fix saved card readiness test flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -134,7 +134,7 @@ internal class TestCard : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText(cardNumber.takeLast(4), substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )


### PR DESCRIPTION
# Summary

Wait for the expected selected saved-card semantics state using the shared UI timeout.

# Motivation

The saved-card E2E test could time out after five seconds while PaymentSheet was still loading the selected saved payment method.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Focused Chrome managed-device test passed; an earlier 50-iteration Shampoo soak passed for this test. Shampoo instrumentation is not included in this PR.

# Screenshots

Not applicable: test-only synchronization change.

# Changelog

Not applicable: no customer-facing SDK behavior change.
