### PR TITLE
Preserve Financial Connections Lite initial auth URL

### DIFF
--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsLiteViewModel.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsLiteViewModel.kt
@@ -18,7 +18,6 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetFlowType
 import com.stripe.android.financialconnections.launcher.flowType
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.FinishWithResult
-import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenAuthFlowWithUrl
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenCustomTab
 import com.stripe.android.financialconnections.lite.di.Di
 import com.stripe.android.financialconnections.lite.repository.FinancialConnectionsLiteRepository
@@ -65,7 +64,6 @@ internal class FinancialConnectionsLiteViewModel(
                     hostedAuthUrl = requireNotNull(hostedAuthUrl)
                 )
                 _state.update { state }
-                _viewEffects.emit(OpenAuthFlowWithUrl(state.hostedAuthUrl))
             }.onFailure {
                 handleError(it, "Failed to synchronize session")
             }
@@ -180,7 +178,6 @@ internal class FinancialConnectionsLiteViewModel(
     )
 
     internal sealed class ViewEffect {
-        data class OpenAuthFlowWithUrl(val url: String) : ViewEffect()
         data class OpenCustomTab(val url: String) : ViewEffect()
         data class FinishWithResult(val result: FinancialConnectionsSheetActivityResult) : ViewEffect()
     }

--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
@@ -35,7 +35,6 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetFlowType
 import com.stripe.android.financialconnections.launcher.flowType
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.FinishWithResult
-import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenAuthFlowWithUrl
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenCustomTab
 import kotlinx.coroutines.launch
 
@@ -69,9 +68,14 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
         setupBackButtonHandling()
 
         lifecycleScope.launch {
+            viewModel.state.collect { state ->
+                state?.hostedAuthUrl?.let(webView::loadUrl)
+            }
+        }
+
+        lifecycleScope.launch {
             viewModel.viewEffects.collect { viewEffect ->
                 when (viewEffect) {
-                    is OpenAuthFlowWithUrl -> webView.loadUrl(viewEffect.url)
                     is FinishWithResult -> finishWithResult(viewEffect.result)
                     is OpenCustomTab -> openCustomTab(viewEffect.url)
                 }


### PR DESCRIPTION
# Summary

Load Financial Connections Lite's initial hosted-auth URL from persistent view-model state.

# Motivation

The initial URL was emitted through a non-replaying event flow. If synchronization completed before the activity collector started, the event was lost and the WebView remained blank.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Focused Chrome managed-device Lite US-bank test passed two Shampoo iterations. A subsequent 50-iteration soak reached iteration 33 before timing out in a later server-rendered pane; Shampoo instrumentation is not included in this PR.

# Screenshots

Not applicable: lifecycle/state-delivery change.

# Changelog

Not applicable: no API change.
