### PR TITLE
Stabilize authorization readiness checks

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1259,8 +1259,7 @@ internal class PlaygroundTestDriver(
         )
         selectors.complete.click()
 
-        // PaymentSheetActivity is now on screen
-        waitForNotPlaygroundActivity()
+        waitForPaymentSheetActivity()
     }
 
     private fun launchCustom(clickMultiStep: Boolean = true) {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -84,7 +84,7 @@ internal class Selectors(
         } else if (testParameters.paymentMethodCode == Blik.code) {
             30.seconds
         } else {
-            5.seconds
+            DEFAULT_UI_TIMEOUT
         }
     )
 


### PR DESCRIPTION
# Summary

Wait for PaymentSheetActivity after launch and give generic payment processing the shared UI readiness bound.

# Motivation

The launch helper treated a null activity as ready, and browser-return authorization could exceed the generic five-second processing wait.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Focused Chrome managed-device `TestAuthorization#testAuthorizeFailure` passed two Shampoo iterations after the processing-timeout change. Shampoo instrumentation is not included in this PR.

# Screenshots

Not applicable: E2E synchronization-only change.

# Changelog

Not applicable: no customer-facing SDK behavior change.
