### PR TITLE
Pass CustomerSheet appearance to payment option factory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -40,7 +40,7 @@ class CustomerSheet internal constructor(
     activityResultRegistryOwner: ActivityResultRegistryOwner,
     viewModelStoreOwner: ViewModelStoreOwner,
     private val integrationType: CustomerSheetIntegration.Type,
-    private val paymentOptionFactory: PaymentOptionFactory,
+    private val paymentOptionFactory: CustomerSheetPaymentOptionFactory,
     private val callback: CustomerSheetResultCallback,
     private val statusBarColor: () -> Int?,
 ) {
@@ -153,7 +153,11 @@ class CustomerSheet internal constructor(
                     paymentMethods.getOrNull()?.find {
                         it.id == paymentOption.id
                     }
-                }?.toPaymentOptionSelection(paymentOptionFactory, request.configuration.googlePayEnabled)
+                }?.toPaymentOptionSelection(
+                    paymentOptionFactory = paymentOptionFactory,
+                    appearance = request.configuration.appearance,
+                    canUseGooglePay = request.configuration.googlePayEnabled,
+                )
             }
 
             selection.fold(
@@ -171,8 +175,13 @@ class CustomerSheet internal constructor(
         // A null result means the sheet was torn down by the OS without returning a result (e.g.
         // when a `singleTask` host is relaunched). Leave the caller's state untouched in that case.
         result?.let {
+            val appearance = viewModel.configureRequest?.configuration?.appearance
+                ?: ConfigurationDefaults.appearance
             callback.onCustomerSheetResult(
-                it.toPublicResult(paymentOptionFactory)
+                it.toPublicResult(
+                    paymentOptionFactory = paymentOptionFactory,
+                    appearance = appearance,
+                )
             )
         }
     }
@@ -586,43 +595,52 @@ class CustomerSheet internal constructor(
                 integration = integration,
             )
 
+            val paymentOptionFactoryDelegate = PaymentOptionFactory(
+                iconLoader = PaymentSelection.IconLoader(
+                    resources = application.resources,
+                    imageLoader = DefaultStripeImageLoader(application),
+                ),
+                cardArtDrawableLoader = DefaultPaymentOptionCardArtDrawableLoader(
+                    paymentOptionCardArtProvider = DefaultPaymentOptionCardArtProvider(
+                        imageOptimizer = StripeCdnImageOptimizer,
+                    ),
+                    imageLoader = DefaultStripeImageLoader(application),
+                    errorReporter = ErrorReporter.createFallbackInstance(
+                        context = application,
+                        productUsage = setOf("CustomerSheet"),
+                    ),
+                    context = application,
+                ),
+                context = application,
+            )
+
             return CustomerSheet(
                 application = application,
                 viewModelStoreOwner = viewModelStoreOwner,
                 lifecycleOwner = lifecycleOwner,
                 activityResultRegistryOwner = activityResultRegistryOwner,
                 integrationType = integration.type,
-                paymentOptionFactory = PaymentOptionFactory(
-                    iconLoader = PaymentSelection.IconLoader(
-                        resources = application.resources,
-                        imageLoader = DefaultStripeImageLoader(application),
-                    ),
-                    cardArtDrawableLoader = DefaultPaymentOptionCardArtDrawableLoader(
-                        paymentOptionCardArtProvider = DefaultPaymentOptionCardArtProvider(
-                            imageOptimizer = StripeCdnImageOptimizer,
-                        ),
-                        imageLoader = DefaultStripeImageLoader(application),
-                        errorReporter = ErrorReporter.createFallbackInstance(
-                            context = application,
-                            productUsage = setOf("CustomerSheet"),
-                        ),
-                        context = application,
-                    ),
-                    context = application,
-                ),
+                paymentOptionFactory = CustomerSheetPaymentOptionFactory { selection, appearance ->
+                    paymentOptionFactoryDelegate.create(
+                        selection = selection,
+                        linkBrand = null,
+                        appearance = appearance,
+                    )
+                },
                 callback = callback,
                 statusBarColor = statusBarColor,
             )
         }
 
         internal fun PaymentSelection?.toPaymentOptionSelection(
-            paymentOptionFactory: PaymentOptionFactory,
+            paymentOptionFactory: CustomerSheetPaymentOptionFactory,
+            appearance: PaymentSheet.Appearance,
             canUseGooglePay: Boolean,
         ): PaymentOptionSelection? {
             return when (this) {
                 is PaymentSelection.GooglePay -> {
                     PaymentOptionSelection.GooglePay(
-                        paymentOption = paymentOptionFactory.create(this, null, appearance = null),
+                        paymentOption = paymentOptionFactory.create(this, appearance),
                     ).takeIf {
                         canUseGooglePay
                     }
@@ -630,7 +648,7 @@ class CustomerSheet internal constructor(
                 is PaymentSelection.Saved -> {
                     PaymentOptionSelection.PaymentMethod(
                         paymentMethod = this.paymentMethod,
-                        paymentOption = paymentOptionFactory.create(this, null, appearance = null)
+                        paymentOption = paymentOptionFactory.create(this, appearance)
                     )
                 }
                 else -> null

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetPaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetPaymentOptionFactory.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.customersheet
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentOption
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal fun interface CustomerSheetPaymentOptionFactory {
+    fun create(
+        selection: PaymentSelection,
+        appearance: PaymentSheet.Appearance,
+    ): PaymentOption
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/InternalCustomerSheetResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/InternalCustomerSheetResult.kt
@@ -5,14 +5,15 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.bundleOf
 import com.stripe.android.customersheet.CustomerSheet.Companion.toPaymentOptionSelection
-import com.stripe.android.paymentsheet.model.PaymentOptionFactory
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
 internal sealed class InternalCustomerSheetResult : Parcelable {
     abstract fun toPublicResult(
-        paymentOptionFactory: PaymentOptionFactory,
+        paymentOptionFactory: CustomerSheetPaymentOptionFactory,
+        appearance: PaymentSheet.Appearance,
     ): CustomerSheetResult
 
     /**
@@ -23,10 +24,15 @@ internal sealed class InternalCustomerSheetResult : Parcelable {
         val paymentSelection: PaymentSelection?
     ) : InternalCustomerSheetResult() {
         override fun toPublicResult(
-            paymentOptionFactory: PaymentOptionFactory,
+            paymentOptionFactory: CustomerSheetPaymentOptionFactory,
+            appearance: PaymentSheet.Appearance,
         ): CustomerSheetResult {
             return CustomerSheetResult.Selected(
-                selection = paymentSelection?.toPaymentOptionSelection(paymentOptionFactory, canUseGooglePay = true)
+                selection = paymentSelection?.toPaymentOptionSelection(
+                    paymentOptionFactory = paymentOptionFactory,
+                    appearance = appearance,
+                    canUseGooglePay = true,
+                )
             )
         }
     }
@@ -39,10 +45,15 @@ internal sealed class InternalCustomerSheetResult : Parcelable {
         val paymentSelection: PaymentSelection?
     ) : InternalCustomerSheetResult() {
         override fun toPublicResult(
-            paymentOptionFactory: PaymentOptionFactory,
+            paymentOptionFactory: CustomerSheetPaymentOptionFactory,
+            appearance: PaymentSheet.Appearance,
         ): CustomerSheetResult {
             return CustomerSheetResult.Canceled(
-                selection = paymentSelection?.toPaymentOptionSelection(paymentOptionFactory, canUseGooglePay = true)
+                selection = paymentSelection?.toPaymentOptionSelection(
+                    paymentOptionFactory = paymentOptionFactory,
+                    appearance = appearance,
+                    canUseGooglePay = true,
+                )
             )
         }
     }
@@ -55,7 +66,8 @@ internal sealed class InternalCustomerSheetResult : Parcelable {
         val exception: Throwable
     ) : InternalCustomerSheetResult() {
         override fun toPublicResult(
-            paymentOptionFactory: PaymentOptionFactory,
+            paymentOptionFactory: CustomerSheetPaymentOptionFactory,
+            appearance: PaymentSheet.Appearance,
         ): CustomerSheetResult {
             return CustomerSheetResult.Failed(exception)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetPaymentOptionSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetPaymentOptionSelectionTest.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.customersheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.customersheet.CustomerSheet.Companion.toPaymentOptionSelection
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlin.test.Test
+
+@OptIn(AppearanceAPIAdditionsPreview::class)
+internal class CustomerSheetPaymentOptionSelectionTest {
+
+    @Test
+    fun `saved selection forwards appearance to payment option factory`() = runScenario(
+        selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+    ) {
+        assertThat(result).isInstanceOf(PaymentOptionSelection.PaymentMethod::class.java)
+        assertThat(result?.paymentOption).isSameInstanceAs(paymentOptionFactory.paymentOption)
+        assertCreateCall()
+    }
+
+    @Test
+    fun `Google Pay selection forwards appearance to payment option factory`() = runScenario(
+        selection = PaymentSelection.GooglePay,
+    ) {
+        assertThat(result).isInstanceOf(PaymentOptionSelection.GooglePay::class.java)
+        assertThat(result?.paymentOption).isSameInstanceAs(paymentOptionFactory.paymentOption)
+        assertCreateCall()
+    }
+
+    private fun runScenario(
+        selection: PaymentSelection,
+        test: Scenario.() -> Unit,
+    ) {
+        val appearance = PaymentSheet.Appearance(
+            themeMode = PaymentSheet.ThemeMode.AlwaysDark,
+        )
+        val paymentOptionFactory = FakeCustomerSheetPaymentOptionFactory()
+        val result = selection.toPaymentOptionSelection(
+            paymentOptionFactory = paymentOptionFactory,
+            appearance = appearance,
+            canUseGooglePay = true,
+        )
+
+        Scenario(
+            selection = selection,
+            appearance = appearance,
+            paymentOptionFactory = paymentOptionFactory,
+            result = result,
+        ).test()
+    }
+
+    private data class Scenario(
+        val selection: PaymentSelection,
+        val appearance: PaymentSheet.Appearance,
+        val paymentOptionFactory: FakeCustomerSheetPaymentOptionFactory,
+        val result: PaymentOptionSelection?,
+    ) {
+        fun assertCreateCall() {
+            assertThat(paymentOptionFactory.createCalls).hasSize(1)
+            assertThat(paymentOptionFactory.createCalls.single().selection).isSameInstanceAs(selection)
+            assertThat(paymentOptionFactory.createCalls.single().appearance).isSameInstanceAs(appearance)
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerSheetPaymentOptionFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerSheetPaymentOptionFactory.kt
@@ -1,0 +1,32 @@
+@file:Suppress("DEPRECATION")
+
+package com.stripe.android.customersheet
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentOption
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal class FakeCustomerSheetPaymentOptionFactory(
+    val paymentOption: PaymentOption = PaymentOption(
+        drawableResourceId = 0,
+        label = "Test payment option",
+    ),
+) : CustomerSheetPaymentOptionFactory {
+    val createCalls = mutableListOf<CreateCall>()
+
+    override fun create(
+        selection: PaymentSelection,
+        appearance: PaymentSheet.Appearance,
+    ): PaymentOption {
+        createCalls += CreateCall(
+            selection = selection,
+            appearance = appearance,
+        )
+        return paymentOption
+    }
+
+    data class CreateCall(
+        val selection: PaymentSelection,
+        val appearance: PaymentSheet.Appearance,
+    )
+}


### PR DESCRIPTION
# Summary

- Pass `CustomerSheet.Configuration.appearance` to `PaymentOptionFactory` when converting retrieved selections and activity results.
- Use a narrow CustomerSheet factory contract that requires the appearance source to be explicit.
- Add focused tests for Saved and Google Pay selection conversion.

Follow-up to merged PR #14049.

# Motivation

CustomerSheet already owns an appearance, but its returned payment options currently drop that value and pass `null` to `PaymentOptionFactory`. Current Saved and Google Pay icons do not have theme-specific URLs, so this does not change their rendering today; it ensures future themed icons use the CustomerSheet configuration without another plumbing change.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Commands:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.customersheet.CustomerSheetPaymentOptionSelectionTest'`
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.customersheet.CustomerSheetTest' --tests 'com.stripe.android.paymentsheet.model.PaymentOptionFactoryTest'`
- `./gradlew :paymentsheet:compileDebugKotlin`
- `./gradlew :paymentsheet:apiCheck`
- `./gradlew :paymentsheet:detekt`

# Screenshots

Not applicable; current CustomerSheet selection icons are unchanged.

# Changelog

No changelog entry. This is internal appearance plumbing for future themed icons.
