### PR TITLE
Seed LPM billing tests through production form definitions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -32,7 +32,7 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 
 internal sealed interface UiDefinitionFactory {
-    class Arguments(
+    data class Arguments(
         val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
         val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
         val initialValues: Map<IdentifierSpec, String?>,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -8,8 +8,11 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.BlikConfig
 import com.stripe.android.ui.core.elements.BlikElement
+import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.SimpleTextFieldController
 
 internal object BlikDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Blik
@@ -42,6 +45,12 @@ private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple() {
         arguments: UiDefinitionFactory.Arguments,
         builder: FormElementsBuilder,
     ) {
-        builder.element(SectionElement.wrap(BlikElement()))
+        val blikElement = BlikElement(
+            controller = SimpleTextFieldController(
+                textFieldConfig = BlikConfig(),
+                initialValue = arguments.initialValues[IdentifierSpec.BlikCode],
+            ),
+        )
+        builder.element(SectionElement.wrap(blikElement))
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 
 internal object TestUiDefinitionFactoryArgumentsFactory {
@@ -23,6 +24,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+        initialValues: Map<IdentifierSpec, String?>? = null,
         linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
         linkInlineHandler: LinkInlineHandler? = null,
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
@@ -38,7 +40,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         } catch (_: Throwable) {
             null
         }
-        return UiDefinitionFactory.Arguments.Factory.Default(
+        val delegate = UiDefinitionFactory.Arguments.Factory.Default(
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory(context),
             paymentMethodCreateParams = paymentMethodCreateParams,
             paymentMethodOptionsParams = paymentMethodOptionsParams,
@@ -54,6 +56,29 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = isNfcScanningAvailable,
         )
+        return if (initialValues == null) {
+            delegate
+        } else {
+            InitialValuesOverridingFactory(delegate = delegate, initialValues = initialValues)
+        }
+    }
+
+    /**
+     * Seeds a form the way production does: at element construction, through
+     * [UiDefinitionFactory.Arguments.initialValues], rather than by pushing values into elements
+     * that have already been built.
+     */
+    private class InitialValuesOverridingFactory(
+        private val delegate: UiDefinitionFactory.Arguments.Factory,
+        private val initialValues: Map<IdentifierSpec, String?>,
+    ) : UiDefinitionFactory.Arguments.Factory {
+        override fun create(
+            metadata: PaymentMethodMetadata,
+            requiresMandate: Boolean,
+        ): UiDefinitionFactory.Arguments {
+            val arguments = delegate.create(metadata, requiresMandate)
+            return arguments.copy(initialValues = arguments.initialValues + initialValues)
+        }
     }
 
     private fun cardAccountRangeRepositoryFactory(context: Context?): CardAccountRangeRepository.Factory {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -11,12 +11,14 @@ import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotio
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
 
 internal fun PaymentMethodDefinition.formElements(
     metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+    initialValues: Map<IdentifierSpec, String?>? = null,
     initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
     setAsDefaultMatchesSaveForFutureUse: Boolean = false,
@@ -33,6 +35,7 @@ internal fun PaymentMethodDefinition.formElements(
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 paymentMethodOptionsParams = paymentMethodOptionsParams,
                 paymentMethodExtraParams = paymentMethodExtraParams,
+                initialValues = initialValues,
                 linkConfigurationCoordinator = linkConfigurationCoordinator,
                 autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
                 initialLinkUserInput = initialLinkUserInput,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinitionTest.kt
@@ -5,6 +5,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.elements.BlikElement
+import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import org.junit.Test
 
@@ -22,6 +24,17 @@ class BlikDefinitionTest {
         val sectionElement = formElements[0] as SectionElement
         assertThat(sectionElement.fields).hasSize(1)
         assertThat(sectionElement.fields[0].identifier.v1).isEqualTo("blik[code]")
+    }
+
+    @Test
+    fun `createFormElements seeds the blik code from initialValues`() {
+        val formElements = BlikDefinition.formElements(
+            metadata = blikMetadata,
+            initialValues = mapOf(IdentifierSpec.BlikCode to "123456"),
+        )
+
+        val blikElement = (formElements[0] as SectionElement).fields[0] as BlikElement
+        assertThat(blikElement.controller.rawFieldValue.value).isEqualTo("123456")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -5,7 +5,6 @@ import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.TestUiDefinitionFactoryArgumentsFactory
-import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -15,11 +14,7 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
-import com.stripe.android.ui.core.elements.BsbElement
-import com.stripe.android.uicore.elements.AddressFieldsElement
-import com.stripe.android.uicore.elements.CheckboxFieldElement
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -69,40 +64,27 @@ internal class LpmBillingAddressFormValuesToParamsTest {
         val formViewModel = createFormViewModel(
             paymentMethodType = config.paymentMethodType,
             metadata = metadata,
-            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
+            initialValues = rawValues,
         )
 
-        val sectionFields = formViewModel.elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-
-        sectionFields.forEach { it.setRawValue(rawValues) }
-        formViewModel.elements
-            .filterIsInstance<BsbElement>()
-            .forEach { element ->
-                rawValues[element.identifier]?.let { element.controller.onValueChange(it) }
-            }
-        sectionFields
-            .filterIsInstance<AddressFieldsElement>()
-            .forEach { it.countryElement.setRawValue(rawValues) }
-        formViewModel.elements
-            .filterIsInstance<CheckboxFieldElement>()
-            .forEach { element ->
-                rawValues[element.identifier]?.let { element.controller.onValueChange(it.toBoolean()) }
-            }
-
-        return formViewModel.createFormParams(config.paymentMethodType, metadata)
+        return formViewModel.createFormParams(
+            paymentMethodType = config.paymentMethodType,
+            metadata = metadata,
+            rawValues = rawValues,
+        )
     }
 
     private fun createFormViewModel(
         paymentMethodType: PaymentMethod.Type,
         metadata: PaymentMethodMetadata,
-        uiDefinitionFactoryArgumentsFactory: UiDefinitionFactory.Arguments.Factory,
+        initialValues: Map<IdentifierSpec, String?>,
     ): FormViewModel {
         val formElements = requireNotNull(
             metadata.formElementsForCode(
                 code = paymentMethodType.code,
-                uiDefinitionFactoryArgumentsFactory = uiDefinitionFactoryArgumentsFactory,
+                uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(
+                    initialValues = initialValues,
+                ),
             ),
         )
 
@@ -120,12 +102,23 @@ internal class LpmBillingAddressFormValuesToParamsTest {
     private suspend fun FormViewModel.createFormParams(
         paymentMethodType: PaymentMethod.Type,
         metadata: PaymentMethodMetadata,
+        rawValues: Map<IdentifierSpec, String?>,
     ): LpmBillingAddressFormParams {
         val supportedPaymentMethod = requireNotNull(
             metadata.supportedPaymentMethodForCode(paymentMethodType.code),
         )
-        val paymentSelection = requireNotNull(completeFormValues.first())
-            .transformToPaymentSelection(supportedPaymentMethod, metadata)
+        val formFieldValues = requireNotNull(completeFormValues.first()) {
+            "The ${paymentMethodType.code} form never completed. A required field was not seeded, " +
+                "which means its definition ignores UiDefinitionFactory.Arguments.initialValues."
+        }
+
+        // A form with elements must report at least one seeded value, otherwise its definition
+        // ignored initialValues and the assertion in the test body would be vacuous.
+        if (elements.isNotEmpty()) {
+            assertThat(formFieldValues.fieldValuePairs.keys).containsAnyIn(rawValues.keys)
+        }
+
+        val paymentSelection = formFieldValues.transformToPaymentSelection(supportedPaymentMethod, metadata)
 
         require(paymentSelection is PaymentSelection.New)
 


### PR DESCRIPTION
# Summary

Seed LPM billing-address form values through `UiDefinitionFactory.Arguments.initialValues`, matching the production form-construction path. Make `UiDefinitionFactory.Arguments` copyable for delegating factories, teach Blik's definition to consume its initial code, and remove the test-only post-construction element mutation.

# Motivation

`LpmBillingAddressFormValuesToParamsTest` previously encoded a snapshot of the element tree and pushed values through four bespoke branches after elements were constructed. Production seeds values while definitions build their elements. Sharing that path reduces test-only machinery and makes the test fail when a payment-method definition ignores initial values.

Blik was the only covered bespoke input definition that did not read `arguments.initialValues`; this change makes it consistent with sibling definitions. This is a consistency and regression-coverage improvement, not a user-visible Blik restoration fix, because production's `InitialValuesFactory` still does not receive payment-method options parameters.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- Focused billing-address, Blik, and Konbini tests: 47 tests passed
- LPM foundations and paymentsheet forms consumer sweep: 567 tests passed
- Full `:paymentsheet:testDebugUnitTest`: 6,357 tests passed
- `:paymentsheet:verifyPaparazziDebug`
- `detekt`
- `:paymentsheet:apiCheck :payments-ui-core:apiCheck :stripe-ui-core:apiCheck`

No tests were newly ignored.

# Screenshots

| Before | After |
| --- | --- |
| Not applicable — behavior-preserving form seeding refactor | Not applicable — Paparazzi verification passed with no golden changes |

# Changelog

Not applicable — this is an internal/test consistency refactor with no user-visible behavior change.
