### PR TITLE
In sheet update tax region.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -1,23 +1,44 @@
 package com.stripe.android.checkout
 
+import android.app.Application
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutConfirm
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.checkouttesting.createPaymentMethod
+import com.stripe.android.elements.PaymentElement
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
+import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
+import com.stripe.paymentelementtestpages.BillingDetailsPage
+import com.stripe.paymentelementtestpages.VerticalModePage
+import okhttp3.mockwebserver.MockResponse
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutPaymentElementTest {
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
     private val networkRule = NetworkRule()
 
     @get:Rule
@@ -25,6 +46,8 @@ internal class CheckoutPaymentElementTest {
 
     private val contentPage = EmbeddedContentPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
+    private val billingDetailsPage = BillingDetailsPage(testRules.compose)
+    private val verticalModePage = VerticalModePage(testRules.compose)
 
     @After
     fun teardown() {
@@ -85,7 +108,312 @@ internal class CheckoutPaymentElementTest {
         assertThat(checkoutResult).isInstanceOf(CheckoutController.Result.Completed::class.java)
     }
 
+    @Test
+    fun testBillingTaxUpdateRefreshesCheckoutSession() = runAutomaticTaxTest { context, controller ->
+        enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
+
+        contentPage.clickOnLpm("card")
+        fillOutCardAndBillingDetails()
+        formPage.clickPrimaryButton()
+
+        waitForSessionTotal(controller, UPDATED_TOTAL)
+        assertThat(controller.session.value?.tax?.status)
+            .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
+        contentPage.assertHasSelectedLpm("card")
+        context.markTestSucceeded()
+    }
+
+    @Test
+    fun testBillingTaxUpdateFailureCanRetryFromPaymentOptions() = runAutomaticTaxTest { context, controller ->
+        enqueueTaxUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+        }
+
+        context.presentPaymentOptions()
+        verticalModePage.clickNewPaymentMethodButton("card")
+        fillOutCardAndBillingDetails()
+        formPage.clickPrimaryButtonWithoutWaitingForDismissal()
+
+        formPage.assertErrorIsShown(applicationContext.getString(R.string.stripe_something_went_wrong))
+        formPage.waitUntilVisible()
+        formPage.assertPrimaryButtonIsEnabled()
+        assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(INITIAL_TOTAL)
+
+        enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
+        formPage.clickPrimaryButton()
+
+        waitForSessionTotal(controller, UPDATED_TOTAL)
+        assertThat(controller.session.value?.tax?.status)
+            .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
+        contentPage.assertHasSelectedLpm("card")
+        context.markTestSucceeded()
+    }
+
+    @Test
+    fun testBillingTaxUpdateFromVerticalPaymentOptionsRefreshesCheckoutSession() {
+        runPaymentOptionsTaxUpdateTest(PaymentElement.Configuration.PaymentMethodLayout.Vertical)
+    }
+
+    @Test
+    fun testBillingTaxUpdateFromHorizontalPaymentOptionsRefreshesCheckoutSession() {
+        runPaymentOptionsTaxUpdateTest(PaymentElement.Configuration.PaymentMethodLayout.Horizontal)
+    }
+
+    @Test
+    fun testCashAppTaxUpdateFromVerticalPaymentOptionsRefreshesCheckoutSession() {
+        runCashAppPaymentOptionsTaxUpdateTest(PaymentElement.Configuration.PaymentMethodLayout.Vertical)
+    }
+
+    @Test
+    fun testCashAppTaxUpdateFromHorizontalPaymentOptionsRefreshesCheckoutSession() {
+        runCashAppPaymentOptionsTaxUpdateTest(PaymentElement.Configuration.PaymentMethodLayout.Horizontal)
+    }
+
+    private fun runPaymentOptionsTaxUpdateTest(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+    ) {
+        runAutomaticTaxTest(
+            paymentMethodLayout = paymentMethodLayout,
+            checkoutInitResponse = automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_REQUIRES_LOCATION),
+        ) { context, controller ->
+            enqueueTaxUpdate(automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_COMPLETE))
+            contentPage.clickOnLpm("card")
+            fillOutCardAndBillingDetails()
+            formPage.clickPrimaryButton()
+            contentPage.assertHasSelectedLpm("card")
+
+            enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
+
+            context.presentPaymentOptions()
+            preparePaymentOptionsScreen(paymentMethodLayout)
+            clickPaymentOptionsPrimaryButton()
+
+            waitForSessionTotal(controller, UPDATED_TOTAL)
+            assertThat(controller.session.value?.tax?.status)
+                .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
+            contentPage.assertHasSelectedLpm("card")
+            context.markTestSucceeded()
+        }
+    }
+
+    private fun runCashAppPaymentOptionsTaxUpdateTest(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+    ) {
+        enqueueTaxUpdate(automaticTaxResponseWithoutRequiredBilling(INITIAL_TOTAL, TAX_STATUS_COMPLETE))
+        runAutomaticTaxTest(
+            configuration = checkoutConfigurationWithDefaultBillingAddress(paymentMethodLayout),
+            checkoutInitResponse = automaticTaxResponseWithoutRequiredBilling(
+                INITIAL_TOTAL,
+                TAX_STATUS_REQUIRES_LOCATION,
+            ),
+        ) { context, controller ->
+            contentPage.clickOnLpm("cashapp")
+            contentPage.assertHasSelectedLpm("cashapp")
+            assertThat(formPage.isVisible()).isFalse()
+
+            enqueueTaxUpdate(automaticTaxResponseWithoutRequiredBilling(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
+            context.presentPaymentOptions()
+            waitForPaymentOptionsLayout(paymentMethodLayout)
+            clickPaymentOptionsPrimaryButton()
+
+            waitForSessionTotal(controller, UPDATED_TOTAL)
+            assertThat(controller.session.value?.tax?.status)
+                .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
+            contentPage.assertHasSelectedLpm("cashapp")
+            context.markTestSucceeded()
+        }
+    }
+
+    private fun runAutomaticTaxTest(
+        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+    ) = runAutomaticTaxTest(
+        configuration = checkoutConfiguration(PaymentElement.Configuration.PaymentMethodLayout.Vertical),
+        checkoutInitResponse = automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_REQUIRES_LOCATION),
+        block = block,
+    )
+
+    private fun runAutomaticTaxTest(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+        checkoutInitResponse: (MockResponse) -> Unit,
+        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+    ) = runAutomaticTaxTest(
+        configuration = checkoutConfiguration(paymentMethodLayout),
+        checkoutInitResponse = checkoutInitResponse,
+        block = block,
+    )
+
+    private fun runAutomaticTaxTest(
+        configuration: CheckoutController.Configuration,
+        checkoutInitResponse: (MockResponse) -> Unit,
+        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+    ) {
+        lateinit var controller: CheckoutController
+        runCheckoutPaymentElementTest(
+            networkRule = networkRule,
+            checkoutInitResponse = checkoutInitResponse,
+            setup = {
+                controller = it
+                it.configure(
+                    clientSecret = DEFAULT_CLIENT_SECRET,
+                    configuration = configuration,
+                ).getOrThrow()
+            },
+        ) { context ->
+            block(context, controller)
+        }
+    }
+
+    private fun checkoutConfiguration(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+    ): CheckoutController.Configuration {
+        return CheckoutController.Configuration().paymentElement(
+            PaymentElement.Configuration().paymentMethodLayout(paymentMethodLayout)
+        )
+    }
+
+    private fun checkoutConfigurationWithDefaultBillingAddress(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+    ): CheckoutController.Configuration {
+        return checkoutConfiguration(paymentMethodLayout).defaults(
+            CheckoutController.Configuration.Defaults().billingDetails(
+                CheckoutController.Configuration.Defaults.ContactDetails().address(
+                    CheckoutController.Address()
+                        .city(BILLING_ADDRESS_CITY)
+                        .country("US")
+                        .line1(BILLING_ADDRESS_LINE_ONE)
+                        .postalCode(BILLING_ADDRESS_ZIP)
+                        .state(BILLING_ADDRESS_STATE)
+                )
+            )
+        )
+    }
+
+    private fun preparePaymentOptionsScreen(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+    ) {
+        if (paymentMethodLayout == PaymentElement.Configuration.PaymentMethodLayout.Vertical) {
+            formPage.waitUntilVisible()
+            Espresso.pressBack()
+            formPage.waitUntilMissing()
+        }
+        waitForPaymentOptionsLayout(paymentMethodLayout)
+    }
+
+    private fun waitForPaymentOptionsLayout(
+        paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
+    ) {
+        val layoutTag = when (paymentMethodLayout) {
+            PaymentElement.Configuration.PaymentMethodLayout.Vertical -> TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
+            PaymentElement.Configuration.PaymentMethodLayout.Horizontal -> TEST_TAG_LIST
+            PaymentElement.Configuration.PaymentMethodLayout.Automatic -> error("Expected an explicit layout.")
+        }
+        testRules.compose.waitUntil(timeoutMillis = 5_000) {
+            testRules.compose.onAllNodes(hasTestTag(layoutTag))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+    }
+
+    private fun clickPaymentOptionsPrimaryButton() {
+        testRules.compose.waitUntil(timeoutMillis = 5_000) {
+            testRules.compose.onAllNodes(
+                hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON).and(isEnabled())
+            ).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+        }
+        testRules.compose.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+            .performScrollTo()
+            .performClick()
+    }
+
+    private fun enqueueTaxUpdate(responseFactory: (MockResponse) -> Unit) {
+        networkRule.checkoutUpdate(
+            bodyPart("tax_region[country]", "US"),
+            bodyPart("tax_region[line1]", BILLING_ADDRESS_LINE_ONE),
+            bodyPart("tax_region[city]", BILLING_ADDRESS_CITY),
+            bodyPart("tax_region[state]", BILLING_ADDRESS_STATE),
+            bodyPart("tax_region[postal_code]", BILLING_ADDRESS_ZIP),
+            bodyPart("elements_session_client[is_aggregation_expected]", "true"),
+            responseFactory = responseFactory,
+        )
+    }
+
+    private fun fillOutCardAndBillingDetails() {
+        formPage.fillOutCardDetails()
+        billingDetailsPage.line1.performTextReplacement(BILLING_ADDRESS_LINE_ONE)
+        billingDetailsPage.city.performTextReplacement(BILLING_ADDRESS_CITY)
+        billingDetailsPage.state.performScrollTo().performClick()
+        testRules.compose.onNodeWithText("California").performClick()
+        billingDetailsPage.zipCode.performTextReplacement(BILLING_ADDRESS_ZIP)
+    }
+
+    private fun waitForSessionTotal(controller: CheckoutController, total: Long) {
+        testRules.compose.waitUntil(timeoutMillis = 5_000) {
+            controller.session.value?.totalSummary?.totalDueToday == total
+        }
+    }
+
+    private fun automaticTaxResponse(
+        total: Long,
+        taxStatus: String,
+    ): (MockResponse) -> Unit = automaticTaxResponse(
+        total = total,
+        taxStatus = taxStatus,
+        billingAddressCollection = "required",
+    )
+
+    private fun automaticTaxResponseWithoutRequiredBilling(
+        total: Long,
+        taxStatus: String,
+    ): (MockResponse) -> Unit = automaticTaxResponse(
+        total = total,
+        taxStatus = taxStatus,
+        billingAddressCollection = "auto",
+    )
+
+    private fun automaticTaxResponse(
+        total: Long,
+        taxStatus: String,
+        billingAddressCollection: String,
+    ): (MockResponse) -> Unit = { response ->
+        response.testBodyFromFile("checkout-session-init.json") { json ->
+            json.put("customer_email", "checkout@example.com")
+            json.put("billing_address_collection", billingAddressCollection)
+            json.put(
+                "tax_context",
+                JSONObject()
+                    .put("automatic_tax_enabled", true)
+                    .put("automatic_tax_address_source", "session.billing"),
+            )
+            json.put(
+                "tax_meta",
+                JSONObject()
+                    .put("computation_type", "automatic")
+                    .put("status", taxStatus),
+            )
+            json.put(
+                "total_summary",
+                JSONObject()
+                    .put("subtotal", INITIAL_TOTAL)
+                    .put("due", total)
+                    .put("total", total),
+            )
+            json.getJSONObject("elements_session").remove("link_settings")
+            json.getJSONObject("server_built_elements_session_params")
+                .getJSONObject("deferred_intent")
+                .put("amount", total)
+        }
+    }
+
     private companion object {
         const val DEFAULT_CLIENT_SECRET = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example"
+        const val INITIAL_TOTAL = 5_099L
+        const val UPDATED_TOTAL = 5_399L
+        const val BILLING_ADDRESS_LINE_ONE = "510 Townsend St"
+        const val BILLING_ADDRESS_CITY = "San Francisco"
+        const val BILLING_ADDRESS_STATE = "CA"
+        const val BILLING_ADDRESS_ZIP = "94103"
+        const val TAX_STATUS_REQUIRES_LOCATION = "requires_location_inputs"
+        const val TAX_STATUS_COMPLETE = "complete"
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTestRunner.kt
@@ -26,6 +26,10 @@ internal class CheckoutPaymentElementTestRunnerContext(
     private val presenter: CheckoutPresenter,
     private val countDownLatch: CountDownLatch,
 ) {
+    fun presentPaymentOptions() {
+        presenter.paymentElement().present()
+    }
+
     fun confirm() {
         presenter.confirm()
     }
@@ -97,6 +101,8 @@ internal fun runCheckoutPaymentElementTest(
         val didCompleteSuccessfully = countDownLatch.await(successTimeoutSeconds, TimeUnit.SECONDS)
         networkRule.validate()
         assertThat(didCompleteSuccessfully).isTrue()
-        controller.destroy()
+        scenario.onActivity {
+            controller.destroy()
+        }
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentelement
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
@@ -81,17 +83,7 @@ internal class EmbeddedFormPage(
     }
 
     fun clickPrimaryButton() {
-        waitUntilVisible()
-
-        composeTestRule.waitUntil {
-            composeTestRule.onAllNodes(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON).and(isEnabled()))
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-
-        composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
-            .performScrollTo()
-            .performClick()
+        clickPrimaryButtonWithoutWaitingForDismissal()
 
         composeTestRule.waitUntil(5.seconds.inWholeMilliseconds) {
             composeTestRule.onAllNodesWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
@@ -134,6 +126,31 @@ internal class EmbeddedFormPage(
         }
     }
 
+    fun clickPrimaryButtonWithoutWaitingForDismissal() {
+        waitUntilVisible()
+        waitUntilPrimaryButtonIsEnabled()
+
+        primaryButton()
+            .performScrollTo()
+            .performClick()
+    }
+
+    fun assertPrimaryButtonIsEnabled() {
+        waitUntilPrimaryButtonIsEnabled()
+        primaryButton().assertIsEnabled()
+    }
+
+    fun assertErrorIsShown(message: String) {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasText(message))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+        composeTestRule.onNode(hasText(message))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
     fun assertMandateIsShown() {
         waitUntilVisible()
 
@@ -146,5 +163,17 @@ internal class EmbeddedFormPage(
 
         composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
             .assertDoesNotExist()
+    }
+
+    private fun waitUntilPrimaryButtonIsEnabled() {
+        composeTestRule.waitUntil {
+            composeTestRule.onAllNodes(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON).and(isEnabled()))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+    }
+
+    private fun primaryButton(): SemanticsNodeInteraction {
+        return composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/AddressMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/AddressMapper.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.checkout
 
-import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.model.Address
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 
 @OptIn(CheckoutSessionPreview::class)
-internal fun Address.State.asPaymentSheet(): PaymentSheet.Address = PaymentSheet.Address(
+internal fun CheckoutController.Address.State.asPaymentSheet(): PaymentSheet.Address = PaymentSheet.Address(
     city = city,
     country = country,
     line1 = line1,
@@ -13,3 +13,15 @@ internal fun Address.State.asPaymentSheet(): PaymentSheet.Address = PaymentSheet
     postalCode = postalCode,
     state = state,
 )
+
+@OptIn(CheckoutSessionPreview::class)
+internal fun Address.toCheckoutAddress(): CheckoutController.Address.State? {
+    return CheckoutController.Address.State(
+        city = city,
+        country = country ?: return null,
+        line1 = line1,
+        line2 = line2,
+        postalCode = postalCode,
+        state = state,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -4,6 +4,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -22,7 +24,10 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -34,6 +39,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
+    private val sessionRefresher: CheckoutSessionRefresher,
+    private val operationCoordinator: CheckoutOperationCoordinator,
+    private val logger: Logger,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
@@ -70,6 +79,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
                 if (!result.hasBeenConfirmed) {
                     result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
                 }
+                refreshCheckoutSession(result.checkoutSessionResponse)
             }
             is EmbeddedActivityResult.Cancelled -> applyCustomerState(result.customerState)
             is EmbeddedActivityResult.Error -> Unit
@@ -91,7 +101,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handlePaymentOptionsResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
+            is EmbeddedActivityResult.Complete -> {
+                applyCompleteResult(result)
+                refreshCheckoutSession(result.checkoutSessionResponse)
+            }
             is EmbeddedActivityResult.Cancelled -> {
                 applyCustomerState(result.customerState)
                 clearStaleSelection()
@@ -104,6 +117,17 @@ internal class CheckoutSheetLauncher @Inject constructor(
         applyCustomerState(result.customerState)
         selectionHolder.setPreviousNewSelections(result.previousNewSelections)
         selectionHolder.setSelection(result.selection)
+    }
+
+    private fun refreshCheckoutSession(response: CheckoutSessionResponse?) {
+        response ?: return
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                runCatching { sessionRefresher.refresh(response) }
+            }.onFailure {
+                logger.error("Failed to refresh the checkout session after the sheet closed.", it)
+            }
+        }
     }
 
     private fun applyCustomerState(customerState: CustomerState?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -1,15 +1,14 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import android.content.Context
-import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
+import com.stripe.android.checkout.toCheckoutAddress
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
-import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntent
@@ -235,18 +234,6 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             clientAttributionMetadata: ClientAttributionMetadata,
         ): CheckoutSessionConfirmationInterceptor
     }
-}
-
-@OptIn(CheckoutSessionPreview::class)
-private fun Address.toCheckoutAddress(): CheckoutController.Address.State? {
-    return CheckoutController.Address.State(
-        city = city,
-        country = country ?: return null,
-        line1 = line1,
-        line2 = line2,
-        postalCode = postalCode,
-        state = state,
-    )
 }
 
 private fun ShippingInformation?.toCheckoutSessionShipping(): ConfirmCheckoutSessionParams.Shipping? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
 import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
@@ -18,6 +19,7 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -42,6 +44,7 @@ import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmatio
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityContinueCoordinator
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdater
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -183,6 +186,19 @@ internal interface EmbeddedActivityModule {
             @ViewModelScope coroutineScope: CoroutineScope,
         ): ConfirmationHandler {
             return confirmationHandlerFactory.create(coroutineScope)
+        }
+
+        @Provides
+        @Singleton
+        fun provideSheetTaxRegionUpdater(
+            paymentMethodMetadata: PaymentMethodMetadata,
+            taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
+        ): SheetTaxRegionUpdater? {
+            val response = (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
+                ?.checkoutSessionResponse
+                ?.takeIf { it.collectsTaxFromBillingAddress }
+                ?: return null
+            return SheetTaxRegionUpdater(response, taxRegionUpdater)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
-import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
 import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
@@ -19,7 +18,6 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -44,7 +42,6 @@ import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmatio
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityContinueCoordinator
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
-import com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdater
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -186,19 +183,6 @@ internal interface EmbeddedActivityModule {
             @ViewModelScope coroutineScope: CoroutineScope,
         ): ConfirmationHandler {
             return confirmationHandlerFactory.create(coroutineScope)
-        }
-
-        @Provides
-        @Singleton
-        fun provideSheetTaxRegionUpdater(
-            paymentMethodMetadata: PaymentMethodMetadata,
-            taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
-        ): SheetTaxRegionUpdater? {
-            val response = (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
-                ?.checkoutSessionResponse
-                ?.takeIf { it.collectsTaxFromBillingAddress }
-                ?: return null
-            return SheetTaxRegionUpdater(response, taxRegionUpdater)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -19,6 +20,7 @@ internal sealed interface EmbeddedActivityResult : Parcelable {
         val previousNewSelections: Bundle,
         val hasBeenConfirmed: Boolean,
         val customerState: CustomerState?,
+        val checkoutSessionResponse: CheckoutSessionResponse?,
         val shouldInvokeSelectionCallback: Boolean,
         override val launchMode: EmbeddedLaunchMode,
     ) : EmbeddedActivityResult

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -439,6 +439,7 @@ private fun successfulConfirmationResult(
     previousNewSelections = embeddedSelectionHolder.previousNewSelections,
     hasBeenConfirmed = true,
     customerState = customerStateHolder.customer.value,
+    checkoutSessionResponse = null,
     shouldInvokeSelectionCallback = false,
     launchMode = launchMode,
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -241,6 +241,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
                 previousNewSelections = selectionHolder.previousNewSelections,
                 hasBeenConfirmed = false,
                 customerState = customerStateHolder.customer.value,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
                 launchMode = args?.launchMode ?: EmbeddedLaunchMode.Manage,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
@@ -17,7 +17,7 @@ internal interface SheetActivityContinueCoordinator {
 }
 
 internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
-    private val taxRegionUpdater: SheetTaxRegionUpdater?,
+    private val taxRegionUpdater: SheetTaxRegionUpdater,
     private val stateHolder: SheetActivityStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
@@ -27,15 +27,15 @@ internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
 
     override fun onContinue() {
         val selection = selectionHolder.selection.value
-        val updater = taxRegionUpdater
-        if (updater == null) {
+        val taxRegionUpdate = taxRegionUpdater.prepareUpdate(selection)
+        if (taxRegionUpdate == null) {
             stateHolder.setResult(createResult(selection, checkoutSessionResponse = null))
             return
         }
 
         coroutineScope.launch {
             stateHolder.updateProcessing(true)
-            updater.update(selection).fold(
+            taxRegionUpdate().fold(
                 onSuccess = { response ->
                     stateHolder.setResult(createResult(selection, response))
                 },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
@@ -1,9 +1,15 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 internal interface SheetActivityContinueCoordinator {
@@ -11,23 +17,48 @@ internal interface SheetActivityContinueCoordinator {
 }
 
 internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
+    private val taxRegionUpdater: SheetTaxRegionUpdater?,
     private val stateHolder: SheetActivityStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val launchMode: EmbeddedLaunchMode,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
 ) : SheetActivityContinueCoordinator {
 
     override fun onContinue() {
-        stateHolder.setResult(
-            EmbeddedActivityResult.Complete(
-                selection = selectionHolder.selection.value,
-                previousNewSelections = selectionHolder.previousNewSelections,
-                hasBeenConfirmed = false,
-                customerState = customerStateHolder.customer.value,
-                checkoutSessionResponse = null,
-                shouldInvokeSelectionCallback = false,
-                launchMode = launchMode,
+        val selection = selectionHolder.selection.value
+        val updater = taxRegionUpdater
+        if (updater == null) {
+            stateHolder.setResult(createResult(selection, checkoutSessionResponse = null))
+            return
+        }
+
+        coroutineScope.launch {
+            stateHolder.updateProcessing(true)
+            updater.update(selection).fold(
+                onSuccess = { response ->
+                    stateHolder.setResult(createResult(selection, response))
+                },
+                onFailure = { error ->
+                    stateHolder.updateProcessing(false)
+                    stateHolder.updateError(error.stripeErrorMessage())
+                },
             )
+        }
+    }
+
+    private fun createResult(
+        selection: PaymentSelection?,
+        checkoutSessionResponse: CheckoutSessionResponse?,
+    ): EmbeddedActivityResult.Complete {
+        return EmbeddedActivityResult.Complete(
+            selection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
+            hasBeenConfirmed = false,
+            customerState = customerStateHolder.customer.value,
+            checkoutSessionResponse = checkoutSessionResponse,
+            shouldInvokeSelectionCallback = false,
+            launchMode = launchMode,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
@@ -24,6 +24,7 @@ internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
                 previousNewSelections = selectionHolder.previousNewSelections,
                 hasBeenConfirmed = false,
                 customerState = customerStateHolder.customer.value,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = false,
                 launchMode = launchMode,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -111,6 +111,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                         previousNewSelections = selectionHolder.previousNewSelections,
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
+                        checkoutSessionResponse = null,
                         shouldInvokeSelectionCallback = false,
                         launchMode = launchMode,
                     )
@@ -119,6 +120,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                         previousNewSelections = selectionHolder.previousNewSelections,
                         hasBeenConfirmed = true,
                         customerState = customerStateHolder.customer.value,
+                        checkoutSessionResponse = null,
                         shouldInvokeSelectionCallback = false,
                         launchMode = launchMode,
                     )
@@ -129,6 +131,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                             previousNewSelections = selectionHolder.previousNewSelections,
                             hasBeenConfirmed = false,
                             customerState = customerStateHolder.customer.value,
+                            checkoutSessionResponse = null,
                             shouldInvokeSelectionCallback = false,
                             launchMode = launchMode,
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
+import com.stripe.android.checkout.toCheckoutAddress
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.billingDetails
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+
+@OptIn(CheckoutSessionPreview::class)
+internal class SheetTaxRegionUpdater(
+    private val checkoutSessionResponse: CheckoutSessionResponse,
+    private val taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
+) {
+    suspend fun update(selection: PaymentSelection?): Result<CheckoutSessionResponse?> {
+        val address = selection?.billingDetails?.address?.toCheckoutAddress()
+            ?: return Result.success(null)
+
+        return taxRegionUpdater.updateServerStateIfNeeded(
+            checkoutSessionResponse = checkoutSessionResponse,
+            addressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            address = address,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
@@ -2,24 +2,36 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkout.toCheckoutAddress
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import javax.inject.Inject
+
+internal typealias SheetTaxRegionUpdate = suspend () -> Result<CheckoutSessionResponse>
 
 @OptIn(CheckoutSessionPreview::class)
-internal class SheetTaxRegionUpdater(
-    private val checkoutSessionResponse: CheckoutSessionResponse,
+internal class SheetTaxRegionUpdater @Inject constructor(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
     private val taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
 ) {
-    suspend fun update(selection: PaymentSelection?): Result<CheckoutSessionResponse?> {
+    fun prepareUpdate(selection: PaymentSelection?): SheetTaxRegionUpdate? {
+        val checkoutSessionResponse =
+            (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
+                ?.checkoutSessionResponse
+                ?.takeIf { it.collectsTaxFromBillingAddress }
+                ?: return null
         val address = selection?.billingDetails?.address?.toCheckoutAddress()
-            ?: return Result.success(null)
+            ?: return null
 
-        return taxRegionUpdater.updateServerStateIfNeeded(
-            checkoutSessionResponse = checkoutSessionResponse,
-            addressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-            address = address,
-        )
+        return {
+            taxRegionUpdater.updateServerStateIfNeeded(
+                checkoutSessionResponse = checkoutSessionResponse,
+                addressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                address = address,
+            )
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -194,6 +194,7 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = customerState,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
@@ -288,6 +289,7 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
@@ -366,6 +368,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Manage,
         )
@@ -511,6 +514,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = null,
             selection = null,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
@@ -532,6 +536,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -30,9 +31,11 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.asCallbackFor
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -217,6 +220,7 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "cashapp"),
         )
@@ -234,6 +238,7 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "cashapp"),
         )
@@ -241,6 +246,52 @@ internal class CheckoutSheetLauncherTest {
         registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
 
         assertThat(immediateActionWasInvoked()).isFalse()
+    }
+
+    @Test
+    fun `formActivityLauncher refreshes checkout session from complete result`() = testScenario {
+        val response = CheckoutSessionResponseFactory.create()
+        sessionRefresher.enqueueRefreshAction {}
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            hasBeenConfirmed = false,
+            customerState = null,
+            checkoutSessionResponse = response,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.Form(
+                selectedPaymentMethodCode = "card",
+            ),
+        )
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+
+        callback.onActivityResult(result)
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        runCurrent()
+
+        assertThat(awaitRefreshCall()).isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
+    }
+
+    @Test
+    fun `formActivityLauncher does not refresh checkout session when complete result has no response`() = testScenario {
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            hasBeenConfirmed = false,
+            customerState = null,
+            checkoutSessionResponse = null,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.Form(
+                selectedPaymentMethodCode = "card",
+            ),
+        )
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+
+        callback.onActivityResult(result)
+        runCurrent()
+
+        expectNoRefreshCalls()
     }
 
     @Test
@@ -389,6 +440,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = null,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = true,
             launchMode = EmbeddedLaunchMode.Manage,
         )
@@ -550,6 +602,33 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `paymentOptionsResult contains checkout session refresh failure`() = testScenario {
+        val response = CheckoutSessionResponseFactory.create()
+        val expectedError = IllegalStateException("Refresh failed")
+        sessionRefresher.enqueueRefreshAction { throw expectedError }
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            customerState = null,
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            hasBeenConfirmed = false,
+            checkoutSessionResponse = response,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+        val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
+
+        callback.onActivityResult(result)
+        runCurrent()
+
+        assertThat(awaitRefreshCall()).isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        assertThat(logger.errorLogs).containsExactly(
+            "Failed to refresh the checkout session after the sheet closed." to expectedError
+        )
+        assertThat(operationCoordinator.isUpdating.value).isFalse()
+    }
+
+    @Test
     fun `paymentOptionsResult callback updates customer state on cancelled result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
@@ -628,10 +707,12 @@ internal class CheckoutSheetLauncherTest {
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
     }
 
+    @Suppress("LongMethod")
     private fun testScenario(
         block: suspend Scenario.() -> Unit
     ) = runTest {
         var immediateActionInvoked = false
+        val testScope = this
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
@@ -644,6 +725,16 @@ internal class CheckoutSheetLauncherTest {
         )
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
         val errorReporter = FakeErrorReporter()
+        val sessionRefresher = FakeCheckoutSessionRefresher()
+        val logger = FakeLogger()
+        val confirmationHandler = FakeConfirmationHandler()
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            sheetStateHolder = sheetStateHolder,
+            sessionRefresher = sessionRefresher,
+            logger = logger,
+            resultCallback = CheckoutController.ResultCallback {},
+        )
 
         DummyActivityResultCaller.test {
             val sheetLauncher = CheckoutSheetLauncher(
@@ -653,6 +744,10 @@ internal class CheckoutSheetLauncherTest {
                 customerStateHolder = customerStateHolder,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
+                sessionRefresher = sessionRefresher,
+                operationCoordinator = operationCoordinator,
+                logger = logger,
+                coroutineScope = testScope,
                 statusBarColor = null,
                 paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
                 rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
@@ -674,8 +769,15 @@ internal class CheckoutSheetLauncherTest {
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
                 immediateActionWasInvoked = { immediateActionInvoked },
+                sessionRefresher = sessionRefresher,
+                logger = logger,
+                operationCoordinator = operationCoordinator,
+                runCurrent = testScheduler::runCurrent,
             ).block()
         }
+
+        confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -689,7 +791,23 @@ internal class CheckoutSheetLauncherTest {
         val sheetStateHolder: SheetStateHolder,
         val errorReporter: FakeErrorReporter,
         val immediateActionWasInvoked: () -> Boolean,
+        val sessionRefresher: FakeCheckoutSessionRefresher,
+        val logger: FakeLogger,
+        val operationCoordinator: CheckoutOperationCoordinator,
+        private val runCurrent: () -> Unit,
     ) {
+        fun runCurrent() {
+            runCurrent.invoke()
+        }
+
+        suspend fun awaitRefreshCall(): FakeCheckoutSessionRefresher.Call {
+            return sessionRefresher.calls.awaitItem()
+        }
+
+        fun expectNoRefreshCalls() {
+            sessionRefresher.calls.expectNoEvents()
+        }
+
         suspend fun launchForm(code: String) {
             sheetLauncher.launchForm(
                 code = code,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -47,6 +47,7 @@ import org.robolectric.RobolectricTestRunner
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
+@Suppress("LargeClass")
 internal class CheckoutSheetLauncherTest {
 
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -210,6 +210,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = null,
             hasBeenConfirmed = true,
             customerState = null,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
@@ -237,6 +238,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
@@ -266,6 +268,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
                 hasBeenConfirmed = false,
                 customerState = null,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = false,
                 launchMode = EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
@@ -291,6 +294,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
                 hasBeenConfirmed = true,
                 customerState = null,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = false,
                 launchMode = EmbeddedLaunchMode.Form(
                     selectedPaymentMethodCode = "card",
@@ -357,6 +361,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = createCustomerState(),
             selection = null,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
@@ -438,6 +443,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Manage,
         )
@@ -463,6 +469,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 customerState = customerState,
                 selection = selection,
                 hasBeenConfirmed = false,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = true,
                 launchMode = EmbeddedLaunchMode.Manage,
             )
@@ -485,6 +492,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 customerState = customerState,
                 selection = selection,
                 hasBeenConfirmed = false,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = false,
                 launchMode = EmbeddedLaunchMode.Manage,
             )
@@ -529,6 +537,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
@@ -646,6 +655,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = null,
             selection = null,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
@@ -667,6 +677,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
@@ -687,6 +698,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = null,
             selection = null,
             hasBeenConfirmed = true,
+            checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = false,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -94,6 +94,7 @@ internal class EmbeddedSheetActivityTest {
                     selection = null,
                     hasBeenConfirmed = true,
                     customerState = null,
+                    checkoutSessionResponse = null,
                     shouldInvokeSelectionCallback = false,
                     launchMode = EmbeddedLaunchMode.Form(
                         selectedPaymentMethodCode = "card",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -4,19 +4,26 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onIdle
 import androidx.test.espresso.Espresso.pressBack
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
@@ -26,17 +33,22 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.paymentelementtestpages.BillingDetailsPage
 import com.stripe.paymentelementtestpages.FormPage
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import com.stripe.android.paymentsheet.R as PaymentSheetR
 
 @RunWith(RobolectricTestRunner::class)
 internal class EmbeddedSheetActivityTest {
@@ -45,6 +57,7 @@ internal class EmbeddedSheetActivityTest {
     private val networkRule = NetworkRule()
 
     private val formPage = FormPage(composeTestRule)
+    private val billingDetailsPage = BillingDetailsPage(composeTestRule)
     private val primaryButton = composeTestRule.onNode(
         hasTestTag(PRIMARY_BUTTON_TEST_TAG)
             .and(hasParent(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)))
@@ -76,6 +89,68 @@ internal class EmbeddedSheetActivityTest {
     }
 
     @Test
+    fun `processing shows spinner and blocks back on form`() = launch { scenario ->
+        scenario.onActivity { activity ->
+            activity.sheetActivityStateHolder.updateProcessing(true)
+        }
+        composeTestRule.waitForIdle()
+        primaryButton.performScrollTo()
+
+        composeTestRule.onNodeWithText(
+            applicationContext.getString(PaymentSheetR.string.stripe_paymentsheet_primary_button_processing)
+        ).assertIsDisplayed()
+        pressBack()
+        onIdle()
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.screen.value)
+                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+        }
+    }
+
+    @Test
+    fun `checkout Continue displays error and keeps form open`() {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+        }
+
+        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) { scenario ->
+            val expectedError = applicationContext.getString(PaymentSheetR.string.stripe_something_went_wrong)
+            fillOutCheckoutCard()
+            primaryButton.performScrollTo().assertIsEnabled().performClick()
+
+            composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                composeTestRule.onAllNodes(hasText(expectedError))
+                    .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                    .isNotEmpty()
+            }
+            composeTestRule.onNodeWithText(expectedError).performScrollTo().assertIsDisplayed()
+            primaryButton.assertIsEnabled()
+            scenario.onActivity { activity ->
+                assertThat(activity.embeddedNavigator.screen.value)
+                    .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+            }
+        }
+    }
+
+    @Test
+    fun `non-checkout Continue immediately returns without checkout response`() = launch { scenario ->
+        formPage.fillOutCardDetails()
+        primaryButton.performScrollTo().assertIsDisplayed().assertIsEnabled().performClick()
+
+        onIdle()
+        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
+        val parsedResult = EmbeddedSheetContract.parseResult(
+            scenario.result.resultCode,
+            scenario.result.resultData,
+        )
+        assertThat(parsedResult).isInstanceOf<EmbeddedActivityResult.Complete>()
+        val result = parsedResult as EmbeddedActivityResult.Complete
+        assertThat(result.checkoutSessionResponse).isNull()
+        assertThat(result.hasBeenConfirmed).isFalse()
+    }
+
+    @Test
     fun `Primary button label is correctly applied`() = launch(
         configuration = EmbeddedPaymentElement.Configuration
             .Builder("Example, Inc.")
@@ -83,6 +158,30 @@ internal class EmbeddedSheetActivityTest {
             .build()
     ) {
         primaryButton.assert(hasText("Hi mom"))
+    }
+
+    private fun fillOutCheckoutCard() {
+        formPage.waitUntilVisible()
+        formPage.fillOutCardDetails()
+        billingDetailsPage.line1.performTextReplacement("510 Townsend St")
+        billingDetailsPage.city.performTextReplacement("San Francisco")
+        billingDetailsPage.state.performScrollTo().performClick()
+        composeTestRule.onNodeWithText("California").performClick()
+        billingDetailsPage.zipCode.performTextReplacement("94103")
+    }
+
+    private fun checkoutPaymentMethodMetadata(): PaymentMethodMetadata {
+        val response = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+        return PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = response.id,
+                instancesKey = "test_instances_key",
+                checkoutSessionResponse = response,
+            ),
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -2,57 +2,113 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
-import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 internal class DefaultSheetActivityContinueCoordinatorTest {
 
     @Test
-    fun `onContinue returns current sheet state`() = runScenario {
+    fun `without tax region updater returns complete synchronously`() = runScenario(
+        taxRegionResult = null,
+    ) {
         continueCoordinator.onContinue()
 
         assertThat(stateHolder.resultTurbine.awaitItem()).isEqualTo(
-            EmbeddedActivityResult.Complete(
+            completeResult(checkoutSessionResponse = null)
+        )
+        stateHolder.updateProcessingTurbine.expectNoEvents()
+    }
+
+    @Test
+    fun `successful tax region update returns updated response`() = runScenario(
+        taxRegionResult = Result.success(UPDATED_RESPONSE),
+    ) {
+        continueCoordinator.onContinue()
+        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        testScope.runCurrent()
+
+        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
+        assertThat(stateHolder.resultTurbine.awaitItem()).isEqualTo(
+            completeResult(
                 selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
-                previousNewSelections = selectionHolder.previousNewSelections,
-                hasBeenConfirmed = false,
-                customerState = customerStateHolder.customer.value,
-                checkoutSessionResponse = null,
-                shouldInvokeSelectionCallback = false,
-                launchMode = LAUNCH_MODE,
+                checkoutSessionResponse = UPDATED_RESPONSE,
             )
+        )
+        verify(requireNotNull(taxRegionUpdater)).update(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `successful tax region update without response returns complete`() = runScenario(
+        taxRegionResult = Result.success(null),
+    ) {
+        continueCoordinator.onContinue()
+        testScope.runCurrent()
+
+        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
+        assertThat(stateHolder.resultTurbine.awaitItem()).isEqualTo(
+            completeResult(checkoutSessionResponse = null)
         )
     }
 
+    @Test
+    fun `failed tax region update stops processing and shows error`() = runScenario(
+        taxRegionResult = Result.failure(ERROR),
+    ) {
+        continueCoordinator.onContinue()
+        testScope.runCurrent()
+
+        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
+        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isFalse()
+        assertThat(stateHolder.updateErrorTurbine.awaitItem()).isEqualTo(ERROR.stripeErrorMessage())
+        stateHolder.resultTurbine.expectNoEvents()
+    }
+
     private fun runScenario(
+        taxRegionResult: Result<CheckoutSessionResponse?>?,
+        selection: PaymentSelection? = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val stateHolder = FakeSheetActivityStateHolder()
         val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()).apply {
-            setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            setSelection(selection)
         }
-        val customerStateHolder = FakeCustomerStateHolder(
-            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
-        )
+        val customerStateHolder = FakeCustomerStateHolder()
+        val stateHolder = FakeSheetActivityStateHolder()
+        val taxRegionUpdater = taxRegionResult?.let { result ->
+            mock<SheetTaxRegionUpdater>().also { updater ->
+                whenever(updater.update(selection)).thenReturn(result)
+            }
+        }
         val continueCoordinator = DefaultSheetActivityContinueCoordinator(
+            taxRegionUpdater = taxRegionUpdater,
             stateHolder = stateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             launchMode = LAUNCH_MODE,
+            coroutineScope = this,
         )
 
         Scenario(
             continueCoordinator = continueCoordinator,
+            taxRegionUpdater = taxRegionUpdater,
             stateHolder = stateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
+            testScope = this,
         ).block()
 
         stateHolder.validate()
@@ -60,15 +116,32 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
     }
 
     private data class Scenario(
-        val continueCoordinator: SheetActivityContinueCoordinator,
+        val continueCoordinator: DefaultSheetActivityContinueCoordinator,
+        val taxRegionUpdater: SheetTaxRegionUpdater?,
         val stateHolder: FakeSheetActivityStateHolder,
         val selectionHolder: EmbeddedSelectionHolder,
         val customerStateHolder: FakeCustomerStateHolder,
-    )
+        val testScope: TestScope,
+    ) {
+        fun completeResult(
+            selection: PaymentSelection? = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            checkoutSessionResponse: CheckoutSessionResponse?,
+        ): EmbeddedActivityResult.Complete {
+            return EmbeddedActivityResult.Complete(
+                selection = selection,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = false,
+                customerState = customerStateHolder.customer.value,
+                checkoutSessionResponse = checkoutSessionResponse,
+                shouldInvokeSelectionCallback = false,
+                launchMode = LAUNCH_MODE,
+            )
+        }
+    }
 
     private companion object {
-        val LAUNCH_MODE = EmbeddedLaunchMode.Form(
-            selectedPaymentMethodCode = "card",
-        )
+        val UPDATED_RESPONSE = CheckoutSessionResponseFactory.create()
+        val ERROR = IllegalStateException("Tax region update failed")
+        val LAUNCH_MODE = EmbeddedLaunchMode.PaymentOptions
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -1,30 +1,50 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
+import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
 internal class DefaultSheetActivityContinueCoordinatorTest {
 
+    @get:Rule
+    val networkRule = NetworkRule()
+
     @Test
-    fun `without tax region updater returns complete synchronously`() = runScenario(
-        taxRegionResult = null,
+    fun `without tax region update returns complete synchronously`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     ) {
         continueCoordinator.onContinue()
 
@@ -35,51 +55,49 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
     }
 
     @Test
-    fun `successful tax region update returns updated response`() = runScenario(
-        taxRegionResult = Result.success(UPDATED_RESPONSE),
-    ) {
-        continueCoordinator.onContinue()
-        selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        testScope.runCurrent()
+    fun `successful tax region update returns updated response`() {
+        networkRule.checkoutUpdate { response ->
+            response.testBodyFromFile("checkout-session-init.json")
+        }
 
-        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
-        assertThat(stateHolder.resultTurbine.awaitItem()).isEqualTo(
-            completeResult(
-                selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
-                checkoutSessionResponse = UPDATED_RESPONSE,
+        runScenario(paymentMethodMetadata = CHECKOUT_SESSION_METADATA) {
+            continueCoordinator.onContinue()
+            selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            testScope.runCurrent()
+
+            assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
+            val result = stateHolder.resultTurbine.awaitItem() as EmbeddedActivityResult.Complete
+            assertThat(result).isEqualTo(
+                completeResult(
+                    selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+                    checkoutSessionResponse = result.checkoutSessionResponse,
+                )
             )
-        )
-        verify(requireNotNull(taxRegionUpdater)).update(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+            assertThat(result.checkoutSessionResponse?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        }
     }
 
     @Test
-    fun `successful tax region update without response returns complete`() = runScenario(
-        taxRegionResult = Result.success(null),
-    ) {
-        continueCoordinator.onContinue()
-        testScope.runCurrent()
+    fun `failed tax region update stops processing and shows error`() {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"$ERROR_MESSAGE"}}""")
+        }
 
-        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
-        assertThat(stateHolder.resultTurbine.awaitItem()).isEqualTo(
-            completeResult(checkoutSessionResponse = null)
-        )
-    }
+        runScenario(paymentMethodMetadata = CHECKOUT_SESSION_METADATA) {
+            continueCoordinator.onContinue()
+            testScope.runCurrent()
 
-    @Test
-    fun `failed tax region update stops processing and shows error`() = runScenario(
-        taxRegionResult = Result.failure(ERROR),
-    ) {
-        continueCoordinator.onContinue()
-        testScope.runCurrent()
-
-        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
-        assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isFalse()
-        assertThat(stateHolder.updateErrorTurbine.awaitItem()).isEqualTo(ERROR.stripeErrorMessage())
-        stateHolder.resultTurbine.expectNoEvents()
+            assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isTrue()
+            assertThat(stateHolder.updateProcessingTurbine.awaitItem()).isFalse()
+            assertThat(stateHolder.updateErrorTurbine.awaitItem())
+                .isEqualTo(IllegalStateException(ERROR_MESSAGE).stripeErrorMessage())
+            stateHolder.resultTurbine.expectNoEvents()
+        }
     }
 
     private fun runScenario(
-        taxRegionResult: Result<CheckoutSessionResponse?>?,
+        paymentMethodMetadata: PaymentMethodMetadata,
         selection: PaymentSelection? = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
@@ -88,11 +106,10 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
         }
         val customerStateHolder = FakeCustomerStateHolder()
         val stateHolder = FakeSheetActivityStateHolder()
-        val taxRegionUpdater = taxRegionResult?.let { result ->
-            mock<SheetTaxRegionUpdater>().also { updater ->
-                whenever(updater.update(selection)).thenReturn(result)
-            }
-        }
+        val taxRegionUpdater = SheetTaxRegionUpdater(
+            paymentMethodMetadata = paymentMethodMetadata,
+            taxRegionUpdater = checkoutSessionTaxRegionUpdater(),
+        )
         val continueCoordinator = DefaultSheetActivityContinueCoordinator(
             taxRegionUpdater = taxRegionUpdater,
             stateHolder = stateHolder,
@@ -104,7 +121,6 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
 
         Scenario(
             continueCoordinator = continueCoordinator,
-            taxRegionUpdater = taxRegionUpdater,
             stateHolder = stateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
@@ -115,9 +131,27 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
         customerStateHolder.validate()
     }
 
+    private fun checkoutSessionTaxRegionUpdater(): CheckoutSessionTaxRegionUpdater {
+        val checkoutSessionRepository = CheckoutSessionRepository(
+            clientParams = ElementsSessionClientParams(
+                mobileAppId = "com.stripe.android.paymentsheet.test",
+                mobileSessionIdProvider = { "test_session" },
+            ),
+            stripeNetworkClient = DefaultStripeNetworkClient(),
+            analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKey = "pk_test_123",
+            ),
+            publishableKeyProvider = { "pk_test_123" },
+            stripeAccountIdProvider = { null },
+        )
+
+        return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)
+    }
+
     private data class Scenario(
         val continueCoordinator: DefaultSheetActivityContinueCoordinator,
-        val taxRegionUpdater: SheetTaxRegionUpdater?,
         val stateHolder: FakeSheetActivityStateHolder,
         val selectionHolder: EmbeddedSelectionHolder,
         val customerStateHolder: FakeCustomerStateHolder,
@@ -140,8 +174,17 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
     }
 
     private companion object {
-        val UPDATED_RESPONSE = CheckoutSessionResponseFactory.create()
-        val ERROR = IllegalStateException("Tax region update failed")
+        const val ERROR_MESSAGE = "Tax region update failed"
         val LAUNCH_MODE = EmbeddedLaunchMode.PaymentOptions
+        val CHECKOUT_SESSION_METADATA = PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = "cs_test_123",
+                instancesKey = "test_instances_key",
+                checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                    automaticTaxEnabled = true,
+                    taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                ),
+            )
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -24,6 +24,7 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
                 previousNewSelections = selectionHolder.previousNewSelections,
                 hasBeenConfirmed = false,
                 customerState = customerStateHolder.customer.value,
+                checkoutSessionResponse = null,
                 shouldInvokeSelectionCallback = false,
                 launchMode = LAUNCH_MODE,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -447,6 +447,7 @@ internal class DefaultSheetActivityStateHolderTest {
                         selection = expectedSelection,
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
+                        checkoutSessionResponse = null,
                         shouldInvokeSelectionCallback = false,
                         launchMode = EmbeddedLaunchMode.Form(
                             selectedPaymentMethodCode = "card",
@@ -474,6 +475,7 @@ internal class DefaultSheetActivityStateHolderTest {
                         selection = null,
                         hasBeenConfirmed = true,
                         customerState = customerStateHolder.customer.value,
+                        checkoutSessionResponse = null,
                         shouldInvokeSelectionCallback = false,
                         launchMode = EmbeddedLaunchMode.Form(
                             selectedPaymentMethodCode = "card",
@@ -507,6 +509,7 @@ internal class DefaultSheetActivityStateHolderTest {
                         selection = expectedSelection,
                         hasBeenConfirmed = false,
                         customerState = customerStateHolder.customer.value,
+                        checkoutSessionResponse = null,
                         shouldInvokeSelectionCallback = false,
                         launchMode = EmbeddedLaunchMode.Form(
                             selectedPaymentMethodCode = "card",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -75,6 +75,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                     selection = null,
                     hasBeenConfirmed = false,
                     customerState = null,
+                    checkoutSessionResponse = null,
                     shouldInvokeSelectionCallback = false,
                     launchMode = EmbeddedLaunchMode.PaymentOptions,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -36,9 +36,9 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -7,17 +7,26 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onIdle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
@@ -28,6 +37,9 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -45,10 +57,12 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     private val composeTestRule = createAndroidComposeRule<EmbeddedSheetActivity>()
     private val managePage = ManagePage(composeTestRule)
     private val verticalModePage = VerticalModePage(composeTestRule)
+    private val networkRule = NetworkRule()
 
     @get:Rule
     val ruleChain: RuleChain = RuleChain
         .outerRule(composeTestRule)
+        .around(networkRule)
         .around(PaymentConfigurationTestRule(applicationContext))
 
     @Test
@@ -242,14 +256,54 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         composeTestRule.onNodeWithText(errorMessage).assertIsDisplayed()
     }
 
+    @Test
+    fun `saved checkout selection displays update error and re-enables payment options`() {
+        val selection = savedSelectionWithBillingAddress()
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+        }
+
+        launch(
+            selection = selection,
+            paymentMethodMetadata = checkoutPaymentMethodMetadata(),
+        ) { scenario ->
+            val primaryButton = composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
+            val expectedError = applicationContext.getString(R.string.stripe_something_went_wrong)
+            primaryButton.performScrollTo().assertIsDisplayed().assertIsEnabled().performClick()
+
+            composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                composeTestRule.onAllNodesWithText(expectedError)
+                    .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                    .isNotEmpty()
+            }
+            composeTestRule.onNodeWithText(expectedError).performScrollTo().assertIsDisplayed()
+            primaryButton.assertIsEnabled()
+            composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card").assertIsEnabled()
+            scenario.onActivity { activity ->
+                assertThat(activity.embeddedNavigator.screen.value)
+                    .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
+                assertThat(activity.sheetActivityStateHolder.state.value.isProcessing).isFalse()
+            }
+        }
+    }
+
     private fun launch(
         selection: PaymentSelection? = null,
         previousNewSelections: Bundle = Bundle(),
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        ),
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) = launch(
         selection = selection,
         previousNewSelections = previousNewSelections,
-        customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        paymentMethodMetadata = paymentMethodMetadata,
+        customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
+            paymentMethods = (selection as? PaymentSelection.Saved)?.let {
+                listOf(it.paymentMethod)
+            }.orEmpty(),
+        ),
         block = block,
     )
 
@@ -259,6 +313,9 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     ) = launch(
         selection = null,
         previousNewSelections = Bundle(),
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        ),
         customerState = customerState,
         block = block,
     )
@@ -266,6 +323,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     private fun launch(
         selection: PaymentSelection?,
         previousNewSelections: Bundle,
+        paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) {
@@ -273,9 +331,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
                 input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                        paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-                    ),
+                    paymentMethodMetadata = paymentMethodMetadata,
                     configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
@@ -289,5 +345,37 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         ).use { scenario ->
             block(scenario)
         }
+    }
+
+    private fun checkoutPaymentMethodMetadata(): PaymentMethodMetadata {
+        val response = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+        return PaymentMethodMetadataFactory.create(
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = response.id,
+                instancesKey = "test_instances_key",
+                checkoutSessionResponse = response,
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        )
+    }
+
+    private fun savedSelectionWithBillingAddress(): PaymentSelection.Saved {
+        return PaymentSelection.Saved(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                billingDetails = PaymentMethod.BillingDetails(
+                    address = Address(
+                        city = "San Francisco",
+                        country = "US",
+                        line1 = "510 Townsend St",
+                        line2 = "Suite 100",
+                        postalCode = "94103",
+                        state = "CA",
+                    ),
+                ),
+            )
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -6,6 +6,9 @@ import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -34,7 +37,44 @@ internal class SheetTaxRegionUpdaterTest {
     val networkRule = NetworkRule()
 
     @Test
-    fun `update sends the selection billing address and returns the updated response`() = runScenario {
+    fun `prepareUpdate returns null when checkout session does not collect tax from billing address`() = runScenario(
+        paymentMethodMetadata = paymentMethodMetadata(
+            checkoutSessionResponse(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.SHIPPING,
+            )
+        )
+    ) {
+        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+
+        assertThat(update).isNull()
+    }
+
+    @Test
+    fun `prepareUpdate returns null for non-checkout session integration`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+    ) {
+        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+
+        assertThat(update).isNull()
+    }
+
+    @Test
+    fun `prepareUpdate returns null when automatic tax is disabled`() = runScenario(
+        paymentMethodMetadata = paymentMethodMetadata(
+            checkoutSessionResponse(
+                automaticTaxEnabled = false,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            )
+        )
+    ) {
+        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+
+        assertThat(update).isNull()
+    }
+
+    @Test
+    fun `prepared update sends the selection billing address and returns the updated response`() = runScenario {
         networkRule.checkoutUpdate(
             bodyPart("tax_region[country]", "US"),
             bodyPart("tax_region[line1]", "510 Townsend St"),
@@ -46,53 +86,75 @@ internal class SheetTaxRegionUpdaterTest {
             response.testBodyFromFile("checkout-session-init.json")
         }
 
-        val result = updater.update(selectionWithAddress(ADDRESS))
+        val result = requireNotNull(updater.prepareUpdate(selectionWithAddress(ADDRESS))).invoke()
 
-        assertThat(result.getOrThrow()?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        assertThat(result.getOrThrow().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
     }
 
     @Test
-    fun `update returns null when selection is null`() = runScenario {
-        val result = updater.update(selection = null)
+    fun `prepareUpdate returns null when selection is null`() = runScenario {
+        val update = updater.prepareUpdate(selection = null)
 
-        assertThat(result.getOrThrow()).isNull()
+        assertThat(update).isNull()
     }
 
     @Test
-    fun `update returns null when selection has no billing address`() = runScenario {
+    fun `prepareUpdate returns null when selection has no billing address`() = runScenario {
         val selection = PaymentSelection.Saved(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
                 billingDetails = PaymentMethod.BillingDetails(address = null),
             ),
         )
 
-        val result = updater.update(selection)
+        val update = updater.prepareUpdate(selection)
 
-        assertThat(result.getOrThrow()).isNull()
+        assertThat(update).isNull()
     }
 
     @Test
-    fun `update returns null when billing address has no country`() = runScenario {
-        val result = updater.update(selectionWithAddress(ADDRESS.copy(country = null)))
+    fun `prepareUpdate returns null when billing address has no country`() = runScenario {
+        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS.copy(country = null)))
 
-        assertThat(result.getOrThrow()).isNull()
+        assertThat(update).isNull()
     }
 
     @Test
-    fun `update returns failure when the tax region update fails`() = runScenario {
+    fun `prepared update returns failure when the tax region update fails`() = runScenario {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        val result = updater.update(selectionWithAddress(ADDRESS))
+        val result = requireNotNull(updater.prepareUpdate(selectionWithAddress(ADDRESS))).invoke()
 
         assertThat(result.exceptionOrNull()?.message).contains("Invalid tax region")
     }
 
     private fun runScenario(
         block: suspend Scenario.() -> Unit,
+    ) = runScenario(
+        paymentMethodMetadata = paymentMethodMetadata(
+            checkoutSessionResponse(
+                automaticTaxEnabled = true,
+                taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+            )
+        ),
+        block = block,
+    )
+
+    private fun runScenario(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        block: suspend Scenario.() -> Unit,
     ) = runTest {
+        val updater = SheetTaxRegionUpdater(
+            paymentMethodMetadata = paymentMethodMetadata,
+            taxRegionUpdater = checkoutSessionTaxRegionUpdater(),
+        )
+
+        Scenario(updater = updater).block()
+    }
+
+    private fun checkoutSessionTaxRegionUpdater(): CheckoutSessionTaxRegionUpdater {
         val checkoutSessionRepository = CheckoutSessionRepository(
             clientParams = ElementsSessionClientParams(
                 mobileAppId = "com.stripe.android.paymentsheet.test",
@@ -107,17 +169,27 @@ internal class SheetTaxRegionUpdaterTest {
             publishableKeyProvider = { "pk_test_123" },
             stripeAccountIdProvider = { null },
         )
-        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
-            automaticTaxEnabled = true,
-            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-        )
-        val updater = SheetTaxRegionUpdater(
-            checkoutSessionResponse = checkoutSessionResponse,
-            taxRegionUpdater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository),
-        )
 
-        Scenario(updater = updater).block()
+        return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)
     }
+
+    private fun paymentMethodMetadata(
+        checkoutSessionResponse: CheckoutSessionResponse,
+    ) = PaymentMethodMetadataFactory.create(
+        integrationMetadata = IntegrationMetadata.CheckoutSession(
+            id = checkoutSessionResponse.id,
+            instancesKey = "test_instances_key",
+            checkoutSessionResponse = checkoutSessionResponse,
+        )
+    )
+
+    private fun checkoutSessionResponse(
+        automaticTaxEnabled: Boolean,
+        taxAddressSource: CheckoutSessionResponse.TaxAddressSource,
+    ) = CheckoutSessionResponseFactory.create(
+        automaticTaxEnabled = automaticTaxEnabled,
+        taxAddressSource = taxAddressSource,
+    )
 
     private data class Scenario(
         val updater: SheetTaxRegionUpdater,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -1,0 +1,144 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
+import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
+import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.repositories.ElementsSessionClientParams
+import com.stripe.android.testing.FakeAnalyticsRequestExecutor
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class SheetTaxRegionUpdaterTest {
+
+    @get:Rule
+    val networkRule = NetworkRule()
+
+    @Test
+    fun `update sends the selection billing address and returns the updated response`() = runScenario {
+        networkRule.checkoutUpdate(
+            bodyPart("tax_region[country]", "US"),
+            bodyPart("tax_region[line1]", "510 Townsend St"),
+            bodyPart("tax_region[line2]", "Suite 100"),
+            bodyPart("tax_region[city]", "San Francisco"),
+            bodyPart("tax_region[state]", "CA"),
+            bodyPart("tax_region[postal_code]", "94103"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-init.json")
+        }
+
+        val result = updater.update(selectionWithAddress(ADDRESS))
+
+        assertThat(result.getOrThrow()?.id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+    }
+
+    @Test
+    fun `update returns null when selection is null`() = runScenario {
+        val result = updater.update(selection = null)
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `update returns null when selection has no billing address`() = runScenario {
+        val selection = PaymentSelection.Saved(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                billingDetails = PaymentMethod.BillingDetails(address = null),
+            ),
+        )
+
+        val result = updater.update(selection)
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `update returns null when billing address has no country`() = runScenario {
+        val result = updater.update(selectionWithAddress(ADDRESS.copy(country = null)))
+
+        assertThat(result.getOrThrow()).isNull()
+    }
+
+    @Test
+    fun `update returns failure when the tax region update fails`() = runScenario {
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+        }
+
+        val result = updater.update(selectionWithAddress(ADDRESS))
+
+        assertThat(result.exceptionOrNull()?.message).contains("Invalid tax region")
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val checkoutSessionRepository = CheckoutSessionRepository(
+            clientParams = ElementsSessionClientParams(
+                mobileAppId = "com.stripe.android.paymentsheet.test",
+                mobileSessionIdProvider = { "test_session" },
+            ),
+            stripeNetworkClient = DefaultStripeNetworkClient(),
+            analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKey = "pk_test_123",
+            ),
+            publishableKeyProvider = { "pk_test_123" },
+            stripeAccountIdProvider = { null },
+        )
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+        val updater = SheetTaxRegionUpdater(
+            checkoutSessionResponse = checkoutSessionResponse,
+            taxRegionUpdater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository),
+        )
+
+        Scenario(updater = updater).block()
+    }
+
+    private data class Scenario(
+        val updater: SheetTaxRegionUpdater,
+    )
+
+    private companion object {
+        val ADDRESS = Address(
+            city = "San Francisco",
+            country = "US",
+            line1 = "510 Townsend St",
+            line2 = "Suite 100",
+            postalCode = "94103",
+            state = "CA",
+        )
+
+        fun selectionWithAddress(address: Address): PaymentSelection {
+            return PaymentSelection.Saved(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+                    billingDetails = PaymentMethod.BillingDetails(address = address),
+                ),
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Update a Checkout Session's tax region when a customer continues from an embedded form or payment-options sheet with a billing address.

The sheet now:

- sends the collected billing address before dismissal when automatic tax uses the billing address;
- displays processing state and blocks dismissal while the update is running;
- surfaces update failures without closing the sheet; and
- returns the updated Checkout Session so `CheckoutController.session` reflects the recalculated tax and total.

The ordinary `EmbeddedPaymentElement` path remains synchronous and does not perform a tax-region update.

# Motivation

Checkout Sessions using automatic tax with `taxAddressSource == BILLING` collected a full billing address in the embedded sheet but did not send it to the server when Continue was pressed. Merchants therefore continued displaying the pre-tax total until confirmation, and new-card confirmation did not update the tax region at all.

This change updates the session before the sheet closes and refreshes checkout controller state with the returned response, keeping the displayed total consistent with the address the customer entered.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:testDebugUnitTest` — 6,380 tests passed
- `./gradlew detekt`
- `./gradlew :paymentsheet:lintRelease`
- `./gradlew :paymentsheet:apiCheck`

Coverage includes tax-region request mapping, continue-handler success and failure behavior, processing-state transitions, form and payment-options UI behavior, Checkout Session refresh, checkout update failures that keep the sheet open, and the non-checkout regression path.

No tests were ignored.

# Screenshots

Not applicable — this uses existing processing and error UI rather than introducing new visual design.

# Changelog

Not applicable — Checkout Session support is still a preview API, and this change does not alter the public API surface.
