### PR TITLE
Add CheckoutSession Builder row selection callback

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -23,6 +23,7 @@ import com.stripe.android.elements.ShippingAddressElement
 import com.stripe.android.elements.ece.ExpressButtonType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -756,6 +757,7 @@ class CheckoutController @Inject internal constructor(
     ) {
         private var resultCallback: ResultCallback = ResultCallback {}
         private var integrationName: String = "stripe_checkout"
+        private var rowSelectionImmediateActionCallback: InternalRowSelectionCallback? = null
 
         /**
          * Sets the [ResultCallback] invoked when a payment flow finishes.
@@ -764,6 +766,16 @@ class CheckoutController @Inject internal constructor(
             resultCallback: ResultCallback
         ): Builder = apply {
             this.resultCallback = resultCallback
+        }
+
+        /**
+         * Sets the callback invoked after the customer selects a payment option that requires an
+         * immediate action.
+         */
+        fun rowSelectionImmediateActionCallback(
+            rowSelectionImmediateActionCallback: () -> Unit,
+        ): Builder = apply {
+            this.rowSelectionImmediateActionCallback = rowSelectionImmediateActionCallback
         }
 
         /**
@@ -793,6 +805,7 @@ class CheckoutController @Inject internal constructor(
                 application = application,
                 paymentElementCallbackIdentifier = integrationName,
                 resultCallback = resultCallback,
+                rowSelectionImmediateActionCallback = rowSelectionImmediateActionCallback,
                 checkoutControllerSavedState = checkoutControllerSavedState,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -23,7 +23,6 @@ import com.stripe.android.elements.ShippingAddressElement
 import com.stripe.android.elements.ece.ExpressButtonType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -757,7 +756,8 @@ class CheckoutController @Inject internal constructor(
     ) {
         private var resultCallback: ResultCallback = ResultCallback {}
         private var integrationName: String = "stripe_checkout"
-        private var rowSelectionImmediateActionCallback: InternalRowSelectionCallback? = null
+        private var rowSelectionBehavior: PaymentElement.RowSelectionBehavior =
+            PaymentElement.RowSelectionBehavior.default()
 
         /**
          * Sets the [ResultCallback] invoked when a payment flow finishes.
@@ -769,13 +769,12 @@ class CheckoutController @Inject internal constructor(
         }
 
         /**
-         * Sets the callback invoked after the customer selects a payment option that requires an
-         * immediate action.
+         * Sets how payment-option row selections are handled.
          */
-        fun rowSelectionImmediateActionCallback(
-            rowSelectionImmediateActionCallback: () -> Unit,
+        fun rowSelectionBehavior(
+            rowSelectionBehavior: PaymentElement.RowSelectionBehavior,
         ): Builder = apply {
-            this.rowSelectionImmediateActionCallback = rowSelectionImmediateActionCallback
+            this.rowSelectionBehavior = rowSelectionBehavior
         }
 
         /**
@@ -805,7 +804,7 @@ class CheckoutController @Inject internal constructor(
                 application = application,
                 paymentElementCallbackIdentifier = integrationName,
                 resultCallback = resultCallback,
-                rowSelectionImmediateActionCallback = rowSelectionImmediateActionCallback,
+                rowSelectionBehavior = rowSelectionBehavior,
                 checkoutControllerSavedState = checkoutControllerSavedState,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -67,7 +67,9 @@ internal class CheckoutSheetLauncher @Inject constructor(
         when (result) {
             is EmbeddedActivityResult.Complete -> {
                 applyCompleteResult(result)
-                result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+                if (!result.hasBeenConfirmed) {
+                    result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+                }
             }
             is EmbeddedActivityResult.Cancelled -> applyCustomerState(result.customerState)
             is EmbeddedActivityResult.Error -> Unit

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
@@ -35,6 +36,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+    private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
 ) : EmbeddedSheetLauncher {
 
     init {
@@ -63,7 +65,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
+            is EmbeddedActivityResult.Complete -> {
+                applyCompleteResult(result)
+                result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+            }
             is EmbeddedActivityResult.Cancelled -> applyCustomerState(result.customerState)
             is EmbeddedActivityResult.Error -> Unit
         }
@@ -71,7 +76,12 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private fun handleManageResult(result: EmbeddedActivityResult) {
         when (result) {
-            is EmbeddedActivityResult.Complete -> applyCompleteResult(result)
+            is EmbeddedActivityResult.Complete -> {
+                applyCompleteResult(result)
+                if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
+                    rowSelectionImmediateActionHandler.invoke()
+                }
+            }
             is EmbeddedActivityResult.Cancelled -> Unit
             is EmbeddedActivityResult.Error -> Unit
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Bundle
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -10,6 +11,7 @@ import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
+import javax.inject.Provider
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
@@ -20,6 +22,7 @@ internal class CheckoutStateLoader @Inject constructor(
     private val selectionChooser: EmbeddedSelectionChooser,
     private val stateHolder: CheckoutControllerStateHolder,
     private val customerStateHolder: CustomerStateHolder,
+    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
 ) {
     suspend fun loadInitial(
         configuration: CheckoutController.Configuration.State,
@@ -76,7 +79,7 @@ internal class CheckoutStateLoader @Inject constructor(
                 checkoutSessionResponse = response,
             ),
             integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
-                isRowSelectionImmediateAction = false,
+                isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
                 configuration = embeddedConfig,
                 paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet(),
             ),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -26,6 +26,7 @@ import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.elements.PaymentElement
 import com.stripe.android.elements.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.elements.ece.DefaultAvailableExpressButtonTypesFactory
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
@@ -126,8 +127,7 @@ internal interface CheckoutControllerComponent {
             @BindsInstance application: Application,
             @BindsInstance @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
             @BindsInstance resultCallback: CheckoutController.ResultCallback,
-            @BindsInstance @CheckoutRowSelectionImmediateActionCallback
-            rowSelectionImmediateActionCallback: InternalRowSelectionCallback?,
+            @BindsInstance rowSelectionBehavior: PaymentElement.RowSelectionBehavior,
             @BindsInstance checkoutControllerSavedState: CheckoutControllerSavedState,
         ): CheckoutControllerComponent
     }
@@ -255,9 +255,9 @@ internal interface CheckoutControllerModule {
 
         @Provides
         fun providesInternalRowSelectionCallback(
-            @CheckoutRowSelectionImmediateActionCallback callback: InternalRowSelectionCallback?,
+            rowSelectionBehavior: PaymentElement.RowSelectionBehavior,
         ): InternalRowSelectionCallback? {
-            return callback
+            return PaymentElement.RowSelectionBehavior.getImmediateAction(rowSelectionBehavior)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -126,6 +126,8 @@ internal interface CheckoutControllerComponent {
             @BindsInstance application: Application,
             @BindsInstance @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
             @BindsInstance resultCallback: CheckoutController.ResultCallback,
+            @BindsInstance @CheckoutRowSelectionImmediateActionCallback
+            rowSelectionImmediateActionCallback: InternalRowSelectionCallback?,
             @BindsInstance checkoutControllerSavedState: CheckoutControllerSavedState,
         ): CheckoutControllerComponent
     }
@@ -253,9 +255,9 @@ internal interface CheckoutControllerModule {
 
         @Provides
         fun providesInternalRowSelectionCallback(
-            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
+            @CheckoutRowSelectionImmediateActionCallback callback: InternalRowSelectionCallback?,
         ): InternalRowSelectionCallback? {
-            return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]?.rowSelectionCallback
+            return callback
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutRowSelectionImmediateActionCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutRowSelectionImmediateActionCallback.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.checkout.injection
+
+import javax.inject.Qualifier
+
+@Qualifier
+internal annotation class CheckoutRowSelectionImmediateActionCallback

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutRowSelectionImmediateActionCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutRowSelectionImmediateActionCallback.kt
@@ -1,6 +1,0 @@
-package com.stripe.android.checkout.injection
-
-import javax.inject.Qualifier
-
-@Qualifier
-internal annotation class CheckoutRowSelectionImmediateActionCallback

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -40,7 +40,7 @@ internal interface PaymentElementModule {
 
     @Binds
     fun bindsEmbeddedRowSelectionImmediateActionHandler(
-        handler: DefaultEmbeddedRowSelectionImmediateActionHandler
+        handler: DefaultEmbeddedRowSelectionImmediateActionHandler,
     ): EmbeddedRowSelectionImmediateActionHandler
 
     @Binds

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -46,6 +46,49 @@ class PaymentElement @Inject internal constructor(
         contentHelper.presentPaymentOptions()
     }
 
+    /**
+     * Describes how you handle row selections in [PaymentElement].
+     */
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract class RowSelectionBehavior internal constructor() {
+        private object Default : RowSelectionBehavior()
+
+        private class ImmediateAction(
+            val didSelectPaymentOption: () -> Unit,
+        ) : RowSelectionBehavior()
+
+        @CheckoutSessionPreview
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+            /**
+             * When a payment option is selected, the customer taps a button to continue or confirm payment.
+             * This is the default recommended integration.
+             */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun default(): RowSelectionBehavior {
+                return Default
+            }
+
+            /**
+             * When a payment option is selected, [didSelectPaymentOption] is triggered.
+             * You can implement this method to immediately perform an action, such as calling confirm.
+             */
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun immediateAction(didSelectPaymentOption: () -> Unit): RowSelectionBehavior {
+                return ImmediateAction(didSelectPaymentOption)
+            }
+
+            internal fun getImmediateAction(
+                rowSelectionBehavior: RowSelectionBehavior,
+            ): (() -> Unit)? {
+                return (rowSelectionBehavior as? ImmediateAction)?.didSelectPaymentOption
+            }
+        }
+    }
+
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @OptIn(CardFundingFilteringPrivatePreview::class)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -1225,6 +1225,7 @@ internal class CheckoutControllerTest {
                 application = applicationContext,
                 paymentElementCallbackIdentifier = integrationName,
                 resultCallback = CheckoutController.ResultCallback {},
+                rowSelectionImmediateActionCallback = null,
                 checkoutControllerSavedState = controllerSavedState,
             ).checkoutController
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -1225,7 +1225,7 @@ internal class CheckoutControllerTest {
                 application = applicationContext,
                 paymentElementCallbackIdentifier = integrationName,
                 resultCallback = CheckoutController.ResultCallback {},
-                rowSelectionImmediateActionCallback = null,
+                rowSelectionBehavior = PaymentElement.RowSelectionBehavior.default(),
                 checkoutControllerSavedState = controllerSavedState,
             ).checkoutController
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
@@ -224,6 +223,23 @@ internal class CheckoutSheetLauncherTest {
         registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
 
         assertThat(immediateActionWasInvoked()).isTrue()
+    }
+
+    @Test
+    fun `formActivityLauncher does not invoke immediate action when the result is confirmed`() = testScenario {
+        launchForm("cashapp")
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            hasBeenConfirmed = true,
+            customerState = null,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "cashapp"),
+        )
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+        assertThat(immediateActionWasInvoked()).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
@@ -209,6 +210,23 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `formActivityLauncher invokes immediate action when complete result has selection`() = testScenario {
+        launchForm("cashapp")
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            hasBeenConfirmed = false,
+            customerState = null,
+            shouldInvokeSelectionCallback = false,
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "cashapp"),
+        )
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+        assertThat(immediateActionWasInvoked()).isTrue()
+    }
+
+    @Test
     fun `formActivityLauncher sets customer state but keeps selection on cancelled result`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         launchForm("card")
@@ -342,6 +360,23 @@ internal class CheckoutSheetLauncherTest {
         assertThat(customerStateHolder.customer.value).isEqualTo(customerState)
         assertThat(selectionHolder.selection.value).isEqualTo(selection)
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(immediateActionWasInvoked()).isFalse()
+    }
+
+    @Test
+    fun `manageSheetLauncher invokes immediate action for saved selection when flagged`() = testScenario {
+        val result = EmbeddedActivityResult.Complete(
+            previousNewSelections = Bundle(),
+            customerState = null,
+            selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            hasBeenConfirmed = false,
+            shouldInvokeSelectionCallback = true,
+            launchMode = EmbeddedLaunchMode.Manage,
+        )
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(result)
+
+        assertThat(immediateActionWasInvoked()).isTrue()
     }
 
     @Test
@@ -575,6 +610,7 @@ internal class CheckoutSheetLauncherTest {
     private fun testScenario(
         block: suspend Scenario.() -> Unit
     ) = runTest {
+        var immediateActionInvoked = false
         val lifecycleOwner = TestLifecycleOwner()
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
@@ -598,6 +634,7 @@ internal class CheckoutSheetLauncherTest {
                 errorReporter = errorReporter,
                 statusBarColor = null,
                 paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+                rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
             )
             val registerCall = awaitRegisterCall()
             val launcher = awaitNextRegisteredLauncher()
@@ -615,6 +652,7 @@ internal class CheckoutSheetLauncherTest {
                 sheetLauncher = sheetLauncher,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
+                immediateActionWasInvoked = { immediateActionInvoked },
             ).block()
         }
     }
@@ -629,6 +667,7 @@ internal class CheckoutSheetLauncherTest {
         val sheetLauncher: EmbeddedSheetLauncher,
         val sheetStateHolder: SheetStateHolder,
         val errorReporter: FakeErrorReporter,
+        val immediateActionWasInvoked: () -> Boolean,
     ) {
         suspend fun launchForm(code: String) {
             sheetLauncher.launchForm(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
@@ -71,6 +72,17 @@ internal class CheckoutStateLoaderTest {
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
 
         assertThat(stateHolder.state?.paymentMethodMetadata).isNotNull()
+    }
+
+    @Test
+    fun `loadInitial reports immediate row selection action to payment element loader`() = runScenario(
+        internalRowSelectionCallback = {},
+    ) {
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        val integrationConfiguration = paymentElementLoader.lastIntegrationConfiguration
+            as PaymentElementLoader.Configuration.Embedded
+        assertThat(integrationConfiguration.isRowSelectionImmediateAction).isTrue()
     }
 
     @Test
@@ -452,6 +464,7 @@ internal class CheckoutStateLoaderTest {
         shouldFail: Boolean = false,
         isGooglePayAvailable: Boolean = false,
         customer: CustomerState? = null,
+        internalRowSelectionCallback: (() -> Unit)? = null,
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
@@ -493,6 +506,7 @@ internal class CheckoutStateLoaderTest {
             selectionChooser = chooser,
             stateHolder = stateHolder,
             customerStateHolder = customerStateHolder,
+            internalRowSelectionCallback = { internalRowSelectionCallback },
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
@@ -101,4 +101,27 @@ internal class PaymentElementTest {
 
         composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertIsDisplayed()
     }
+
+    @Test
+    fun `default row selection behavior has no immediate action`() {
+        val immediateAction = PaymentElement.RowSelectionBehavior.getImmediateAction(
+            rowSelectionBehavior = PaymentElement.RowSelectionBehavior.default(),
+        )
+
+        assertThat(immediateAction).isNull()
+    }
+
+    @Test
+    fun `immediate row selection behavior invokes its callback`() {
+        var callbackInvoked = false
+        val immediateAction = PaymentElement.RowSelectionBehavior.getImmediateAction(
+            rowSelectionBehavior = PaymentElement.RowSelectionBehavior.immediateAction {
+                callbackInvoked = true
+            },
+        )
+
+        requireNotNull(immediateAction).invoke()
+
+        assertThat(callbackInvoked).isTrue()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -39,6 +39,9 @@ internal class FakePaymentElementLoader(
     private val integrationMetadata: IntegrationMetadata? = null,
 ) : PaymentElementLoader {
 
+    var lastIntegrationConfiguration: PaymentElementLoader.Configuration? = null
+        private set
+
     fun updateStripeIntent(intent: StripeIntent) {
         this.stripeIntent = intent
     }
@@ -90,6 +93,7 @@ internal class FakePaymentElementLoader(
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
     ): Result<PaymentElementLoader.State> {
+        lastIntegrationConfiguration = integrationConfiguration
         delay(delay)
         return if (shouldFail) {
             Result.failure(IllegalStateException("oh no"))


### PR DESCRIPTION
# Summary

Adds `CheckoutController.Builder.rowSelectionImmediateActionCallback` for Checkout Session integrations. The callback is supplied when building the controller, rather than when retrieving the payment element.

# Motivation

Row-selection behavior belongs to the controller integration configuration and must be available while the Checkout Session state is initialized. This keeps `CheckoutPresenter.paymentElement()` parameterless and aligns callback lifetime with the controller.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
`./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutStateLoaderTest' --tests 'com.stripe.android.checkout.CheckoutSheetLauncherTest' --tests 'com.stripe.android.checkout.CheckoutControllerTest'`

# Screenshots

Not applicable — this is a non-visual API and callback-wiring change.

# Changelog

Not applicable — this is an internal, restricted Checkout Session preview API change.
