### PR TITLE
Probe WebView test IDs without failing the interaction

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/WebviewInteraction.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/WebviewInteraction.kt
@@ -2,6 +2,7 @@ package com.stripe.android.test.core
 
 import android.os.SystemClock.elapsedRealtime
 import android.os.SystemClock.sleep
+import androidx.test.espresso.web.model.Atoms.script
 import androidx.test.espresso.web.sugar.Web.WebInteraction
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.Locator
@@ -9,6 +10,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 internal val WEBVIEW_ELEMENT_TIMEOUT: Duration = 30.seconds
+
+private const val RENDERED_TEST_ID_PREFIX = "testId="
 
 internal class WebElementMatch(
     val testId: String,
@@ -41,26 +44,59 @@ internal fun WebInteraction<Void>.withElementByAnyTestId(
 ): WebElementMatch {
     require(testIds.isNotEmpty()) { "testIds must not be empty" }
 
+    var lastProbe: String? = null
     var lastFailure: Throwable? = null
     return retryUntil(
         timeout = timeout,
         pollInterval = 1.seconds,
-        failureMessage = "No WebView element found with data-testid in " +
-            testIds.joinToString(prefix = "[", postfix = "]") { "'$it'" },
+        failureMessage = {
+            "No WebView element found with data-testid in " +
+                testIds.joinToString(prefix = "[", postfix = "]") { "'$it'" } +
+                " within $timeout; last probe: ${lastProbe ?: "none"}"
+        },
         failureCause = { lastFailure },
     ) {
-        testIds.firstNotNullOfOrNull { testId ->
-            runCatching {
-                WebElementMatch(
-                    testId = testId,
-                    interaction = withElement(findElement(Locator.CSS_SELECTOR, "[data-testid='$testId']")),
-                )
-            }.onFailure {
-                lastFailure = it
-            }.getOrNull()
-        }
+        runCatching {
+            val probe = probePage(testIds).also { lastProbe = it }
+            probe.takeIf { it.startsWith(RENDERED_TEST_ID_PREFIX) }
+                ?.removePrefix(RENDERED_TEST_ID_PREFIX)
+                ?.let { testId ->
+                    WebElementMatch(
+                        testId = testId,
+                        interaction = withElement(findElement(Locator.CSS_SELECTOR, cssSelector(testId))),
+                    )
+                }
+        }.onFailure { lastFailure = it }.getOrNull()
     }
 }
+
+/**
+ * Reports the first of [testIds] the page currently renders, or, while none of them is present, what the
+ * page is showing instead. Answering both in one script evaluation keeps a poll that finds nothing off the
+ * exception path: probing with [findElement] signals absence by throwing, which routes every poll taken
+ * before the pane renders through Espresso's failure handler, and that handler captures a screenshot per
+ * failure, costing seconds of the timeout budget per selector per poll on a loaded device. The reported
+ * page also lets a lookup failure distinguish a page that never loaded from a loaded page that renders
+ * none of the expected controls, without a second interaction once the test is already failing.
+ *
+ * The script has to be a function definition rather than a bare statement body. Espresso inlines a
+ * function definition into the page, but hands a statement body to `eval`, which the hosted auth page's
+ * Content-Security-Policy rejects for lacking `unsafe-eval`.
+ */
+private fun WebInteraction<Void>.probePage(testIds: List<String>): String {
+    val probeScript = testIds.joinToString(
+        separator = "\n",
+        prefix = "function() {\n",
+        postfix = "\nreturn 'url=' + document.location.href + ' readyState=' + document.readyState;\n}",
+    ) { testId ->
+        """if (document.querySelector("${cssSelector(testId)}") !== null) { """ +
+            """return "$RENDERED_TEST_ID_PREFIX$testId"; }"""
+    }
+
+    return perform(script(probeScript)).get().value?.toString() ?: "no probe result"
+}
+
+private fun cssSelector(testId: String): String = "[data-testid='$testId']"
 
 /**
  * Retry until the given block returns a non-null value or the timeout is reached. Polls frequently so
@@ -69,7 +105,7 @@ internal fun WebInteraction<Void>.withElementByAnyTestId(
 private fun <T> retryUntil(
     timeout: Duration,
     pollInterval: Duration,
-    failureMessage: String,
+    failureMessage: () -> String,
     failureCause: () -> Throwable?,
     block: () -> T?,
 ): T {
@@ -79,7 +115,7 @@ private fun <T> retryUntil(
         sleep(pollInterval.inWholeMilliseconds)
     }
 
-    val error = AssertionError("$failureMessage within $timeout")
+    val error = AssertionError(failureMessage())
     failureCause()?.let(error::initCause)
     throw error
 }


### PR DESCRIPTION
# Summary

Poll for Financial Connections Lite WebView controls with a single script evaluation that reports absence as a return value, instead of probing each candidate `data-testid` with `findElement` and catching the resulting exception.

# Motivation

`testUSBankAccountLiteSuccess` fails intermittently with either `No WebView element found with data-testid in ['institution-default', 'agree-button'] within 30s` or a 90 second per-test timeout.

Espresso's `DriverAtoms.findElement` signals an absent element by throwing, and every throw runs `DefaultFailureHandler`, which captures a screenshot. On the Chrome managed device that capture **always** timed out after 5 seconds (`Failed to take screenshot / Timed out waiting for 5000 ms`). Because the helper probed each candidate selector separately, one poll taken before the pane rendered cost roughly 10-13 seconds instead of the intended 1.

Measured from a 50-iteration soak on `master`:

- 134 polls found no element; 133 of them paid a 5 second screenshot stall.
- The first-pane lookup in the failing iteration got **3 polls in 32 seconds**, not 30. A lookup nominally bounded at 30 seconds therefore overran its own budget.
- Iterations that took 5 absent-element polls ran 40-62s; iterations that took 1-2 ran 24-26s. The screenshot path was the dominant source of runtime variance, and its forced redraw of every window degraded the device it was measuring.
- The failing iteration additionally hit an unrelated device slowdown (playground activity display went 604ms to 4451ms, Choreographer skipping 127-178 frames), so setup consumed 40s rather than the usual 3s. That left 50s for a WebView flow that routinely needed 21-58s only because of the polling overhead.

Absence is now a return value rather than an exception, so no poll reaches the failure handler, and one interaction covers every candidate selector instead of one interaction each.

Two details are load-bearing:

- The probe script must be a **function definition**. Espresso inlines a function definition into the page but hands a bare statement body to `eval`, and the hosted auth page's Content-Security-Policy has no `unsafe-eval`, so a statement body fails with status 13.
- The page URL and `readyState` travel back in the same probe result. A lookup failure can then distinguish a page that never loaded from a loaded page missing the expected controls, without adding a second interaction on the already-failing path.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Command:

```
CI=true ./gradlew \
  -Pandroid.experimental.androidTest.numManagedDeviceShards=1 \
  -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 \
  '-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.lpm.TestUSBankAccount#testUSBankAccountLiteSuccess' \
  :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest \
  --init-script build-configuration/instrumentation-test-init.gradle
```

- 2 Shampoo iterations of `testUSBankAccountLiteSuccess`: pass.
- 50 Shampoo iterations of the final candidate: 50/50 pass, 0 failed iterations, 250/250 pane clicks, 0 screenshot stalls, 0 `Atom evaluation returned null` events.
- `testUSBankAccountLiteSuccess` and `testUSBankAccountLiteCancelAllowsUserToContinue` each pass once in the normal rule configuration.
- `:paymentsheet-example:detekt` passes; no detekt findings in the changed file.

Iteration duration against the 90s per-test deadline:

| | before | after |
| --- | --- | --- |
| median | ~40s | 21.9s |
| max | 90.5s (failed) | 37.4s |
| screenshot stalls | 133 | 0 |

Shampoo instrumentation was diagnostic-only and is not part of this diff.

# Screenshots

Not applicable: test-only synchronization change.

# Changelog

Not applicable: no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)