### PR TITLE
Keep the Lite web view on its page across recreation

### DIFF
--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsLiteViewModel.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsLiteViewModel.kt
@@ -18,7 +18,6 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetFlowType
 import com.stripe.android.financialconnections.launcher.flowType
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.FinishWithResult
-import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenAuthFlowWithUrl
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenCustomTab
 import com.stripe.android.financialconnections.lite.di.Di
 import com.stripe.android.financialconnections.lite.repository.FinancialConnectionsLiteRepository
@@ -65,7 +64,6 @@ internal class FinancialConnectionsLiteViewModel(
                     hostedAuthUrl = requireNotNull(hostedAuthUrl)
                 )
                 _state.update { state }
-                _viewEffects.emit(OpenAuthFlowWithUrl(state.hostedAuthUrl))
             }.onFailure {
                 handleError(it, "Failed to synchronize session")
             }
@@ -180,7 +178,6 @@ internal class FinancialConnectionsLiteViewModel(
     )
 
     internal sealed class ViewEffect {
-        data class OpenAuthFlowWithUrl(val url: String) : ViewEffect()
         data class OpenCustomTab(val url: String) : ViewEffect()
         data class FinishWithResult(val result: FinancialConnectionsSheetActivityResult) : ViewEffect()
     }

--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
@@ -35,8 +35,9 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetFlowType
 import com.stripe.android.financialconnections.launcher.flowType
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.FinishWithResult
-import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenAuthFlowWithUrl
 import com.stripe.android.financialconnections.lite.FinancialConnectionsLiteViewModel.ViewEffect.OpenCustomTab
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layout.stripe_activity_lite) {
@@ -68,14 +69,44 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
         setupWebView()
         setupBackButtonHandling()
 
+        if (!restoreWebViewState(savedInstanceState)) {
+            openAuthFlow()
+        }
+
         lifecycleScope.launch {
             viewModel.viewEffects.collect { viewEffect ->
                 when (viewEffect) {
-                    is OpenAuthFlowWithUrl -> webView.loadUrl(viewEffect.url)
                     is FinishWithResult -> finishWithResult(viewEffect.result)
                     is OpenCustomTab -> openCustomTab(viewEffect.url)
                 }
             }
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        if (::webView.isInitialized) {
+            webView.saveState(outState)
+        }
+    }
+
+    /**
+     * Puts the recreated web view back on the page the flow had reached, and reports whether it did.
+     *
+     * Without this the recreated web view starts blank, and the retained view model has already produced
+     * the hosted auth URL, so nothing would put a page back on screen.
+     */
+    private fun restoreWebViewState(savedInstanceState: Bundle?): Boolean {
+        return savedInstanceState != null && webView.restoreState(savedInstanceState) != null
+    }
+
+    /**
+     * Loads the hosted auth URL once it is known. Read from view model state rather than from an event so
+     * that an activity recreated before the flow had a page to restore still receives it.
+     */
+    private fun openAuthFlow() {
+        lifecycleScope.launch {
+            webView.loadUrl(viewModel.state.filterNotNull().first().hostedAuthUrl)
         }
     }
 


### PR DESCRIPTION
# Summary

Save and restore `FinancialConnectionsSheetLiteActivity`'s web view, and read the hosted auth URL from view model state instead of from a one-shot event.

# Motivation

`FinancialConnectionsSheetLiteActivity` declares no `android:configChanges` and never saved its web view, so any configuration change gave it a fresh blank one. The hosted auth URL only ever arrived as an `OpenAuthFlowWithUrl` event on a `MutableSharedFlow` with no replay, and the view model that emits it is retained across recreation. The recreated activity therefore had nothing to load, and the sheet stayed blank until the user backed out of the flow.

Loading only when nothing was restored is what keeps this from being a different regression: reloading the initial URL unconditionally would throw a user who rotates mid-flow back to the first pane.

This is a distinct bug from #14071. It was found while investigating that flake and is **not** the cause of it — see below.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

`FinancialConnectionsLiteViewModel.Factory` builds its dependencies from the `Di` object, so the activity cannot be given a fake repository and there is no seam for a Robolectric test of this path. Rather than add mutable test-only global state to production code, this was verified against a real web view on a device. The view model's side of the contract — `state.hostedAuthUrl` being populated after synchronization — is already covered by `FinancialConnectionsLiteViewModelTest`.

Verified on the Pixel 2 API 33 Chrome managed device by temporarily rotating the device twice (`setOrientationLeft` / `setOrientationNatural`) partway through `TestUSBankAccount#testUSBankAccountLiteSuccess`, immediately after the first Lite pane is clicked. That instrumentation is diagnostic only and is not part of this diff.

**Without this change**, logcat shows `FinancialConnectionsSheetLiteActivity` destroyed and recreated, after which the web view has no document at all — JavaScript evaluation times out and the next pane lookup fails:

```
AssertionError: No WebView element found with data-testid in ['agree-button'] within 30s; last probe: none
Caused by: java.util.concurrent.TimeoutException: Waited 10000000000 nanoseconds ...
```

**With this change**, the activity is recreated twice (`@fea158e` to `@89fc1d2` to `@1062399`), the page returns both times, and the flow runs through all five panes to `stripe_android.bankaccountcollector.finished`. `synchronize` is still called once per launch rather than once per activity instance, confirming the view model is retained and that a replayless event could not have been redelivered.

Also run: `:financial-connections-lite:testDebugUnitTest`, `:financial-connections-lite:detekt`, `:financial-connections-lite:apiCheck`.

# Screenshots

Not applicable: the change is visible only as the flow no longer going blank after a configuration change.

# Changelog

Not applicable: `financial-connections-lite` internals, no public API change.

## Note on the flake this came from

`#14063` proposed moving this URL to persistent state on the theory that the event could be dropped before the activity's collector started, and that this was blanking the web view in `testUSBankAccountLiteSuccess`. That theory does not hold:

- `lifecycleScope.launch` runs on `Dispatchers.Main.immediate`, so called from `onCreate` on the main thread the block executes inline and `viewEffects.collect` registers its subscriber before `onCreate` returns. The emitter runs on `Dispatchers.IO` and must finish an HTTPS `synchronize` round trip first.
- Across 134 Lite launches in soak runs, the URL was delivered every time.
- In the failing iteration the web view had rendered and been clicked twice before the deadline expired.

The flake had a different cause, fixed in #14071. This PR keeps the persistent-state part of #14063 because it is needed for recreation, and pairs it with web view state restoration so recreation resumes instead of restarting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)