### PR TITLE
Add Google Pay configuration to PaymentElement

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -62,6 +62,7 @@ class PaymentElement @Inject internal constructor(
         private var allowedCardFundingTypes: List<CardFundingType> = CardFundingType.entries
         private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
         private var appearance: Appearance = Appearance()
+        private var googlePayConfiguration: GooglePayConfiguration = GooglePayConfiguration()
         private var linkConfiguration: LinkConfiguration = LinkConfiguration()
 
         /**
@@ -166,10 +167,157 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
+         * Sets the Google Pay configuration for the payment element.
+         */
+        fun googlePayConfiguration(
+            googlePayConfiguration: GooglePayConfiguration
+        ): Configuration = apply {
+            this.googlePayConfiguration = googlePayConfiguration
+        }
+
+        /**
          * Sets the Link configuration for the payment element.
          */
         fun linkConfiguration(configuration: LinkConfiguration): Configuration = apply {
             this.linkConfiguration = configuration
+        }
+
+        /**
+         * Configuration related to Google Pay.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @CheckoutSessionPreview
+        class GooglePayConfiguration {
+
+            /**
+             * Display configuration for Google Pay.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class Display {
+                /**
+                 * Google Pay will be displayed when available.
+                 */
+                Automatic,
+
+                /**
+                 * Google Pay will never be displayed.
+                 */
+                Never,
+            }
+
+            private var display: Display = Display.Automatic
+            private var label: String? = null
+            private var buttonType: ButtonType = ButtonType.Pay
+            private var additionalEnabledNetworks: List<String> = emptyList()
+
+            /**
+             * Sets the display configuration for Google Pay.
+             *
+             * @param display The display configuration for Google Pay.
+             */
+            fun display(display: Display): GooglePayConfiguration = apply {
+                this.display = display
+            }
+
+            /**
+             * Sets the label displayed with the amount.
+             *
+             * @param label An optional label to display with the amount. Google Pay may or may not display
+             * this label depending on its own internal logic. Defaults to a generic label if none is
+             * provided.
+             */
+            fun label(label: String): GooglePayConfiguration = apply {
+                this.label = label
+            }
+
+            /**
+             * Sets the Google Pay button type.
+             *
+             * @param buttonType The Google Pay button type to use. Set to "Pay" by default. See
+             * [Google's documentation](https://developers.google.com/pay/api/android/reference/request-objects#ButtonOptions)
+             * for more information on button types.
+             */
+            fun buttonType(buttonType: ButtonType): GooglePayConfiguration = apply {
+                this.buttonType = buttonType
+            }
+
+            /**
+             * Sets additional card networks that Google Pay can display.
+             *
+             * @param additionalEnabledNetworks An optional List<String> to signal GooglePay to
+             * display additional enabled networks (e.g. 'INTERAC')
+             */
+            fun additionalEnabledNetworks(
+                additionalEnabledNetworks: List<String>
+            ): GooglePayConfiguration = apply {
+                this.additionalEnabledNetworks = additionalEnabledNetworks
+            }
+
+            @CheckoutSessionPreview
+            /**
+             * Google Pay button type options
+             *
+             * See
+             * [Google's documentation](https://developers.google.com/pay/api/android/reference/request-objects#ButtonOptions)
+             * for more information on button types.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class ButtonType {
+                /**
+                 * Displays "Buy with" alongside the Google Pay logo.
+                 */
+                Buy,
+
+                /**
+                 * Displays "Book with" alongside the Google Pay logo.
+                 */
+                Book,
+
+                /**
+                 * Displays "Checkout with" alongside the Google Pay logo.
+                 */
+                Checkout,
+
+                /**
+                 * Displays "Donate with" alongside the Google Pay logo.
+                 */
+                Donate,
+
+                /**
+                 * Displays "Order with" alongside the Google Pay logo.
+                 */
+                Order,
+
+                /**
+                 * Displays "Pay with" alongside the Google Pay logo.
+                 */
+                Pay,
+
+                /**
+                 * Displays "Subscribe with" alongside the Google Pay logo.
+                 */
+                Subscribe,
+
+                /**
+                 * Displays only the Google Pay logo.
+                 */
+                Plain
+            }
+
+            @Parcelize
+            internal data class State(
+                val display: Display,
+                val label: String?,
+                val buttonType: ButtonType,
+                val additionalEnabledNetworks: List<String>,
+            ) : Parcelable
+
+            internal fun build(): State = State(
+                display = display,
+                label = label,
+                buttonType = buttonType,
+                additionalEnabledNetworks = additionalEnabledNetworks,
+            )
         }
 
         /**
@@ -260,6 +408,7 @@ class PaymentElement @Inject internal constructor(
             val allowedCardFundingTypes: List<CardFundingType>,
             val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
             val appearance: Appearance.State,
+            val googlePayConfiguration: GooglePayConfiguration.State,
             val linkConfiguration: LinkConfiguration.State,
         ) : Parcelable
 
@@ -275,6 +424,7 @@ class PaymentElement @Inject internal constructor(
             allowedCardFundingTypes = allowedCardFundingTypes,
             termsDisplay = termsDisplay,
             appearance = appearance.build(),
+            googlePayConfiguration = googlePayConfiguration.build(),
             linkConfiguration = linkConfiguration.build(),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.elements
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.elements.PaymentElement.Configuration.GooglePayConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContent
@@ -27,6 +29,35 @@ internal class PaymentElementTest {
 
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
+
+    @Test
+    fun `configuration builds default Google Pay values`() {
+        val googlePayConfiguration = PaymentElement.Configuration().build().googlePayConfiguration
+
+        assertThat(googlePayConfiguration.display).isEqualTo(GooglePayConfiguration.Display.Automatic)
+        assertThat(googlePayConfiguration.label).isNull()
+        assertThat(googlePayConfiguration.buttonType).isEqualTo(GooglePayConfiguration.ButtonType.Pay)
+        assertThat(googlePayConfiguration.additionalEnabledNetworks).isEmpty()
+    }
+
+    @Test
+    fun `configuration builds requested Google Pay values`() {
+        val googlePayConfiguration = PaymentElement.Configuration()
+            .googlePayConfiguration(
+                GooglePayConfiguration()
+                    .display(GooglePayConfiguration.Display.Never)
+                    .label("Complete your purchase")
+                    .buttonType(GooglePayConfiguration.ButtonType.Checkout)
+                    .additionalEnabledNetworks(listOf("INTERAC"))
+            )
+            .build()
+            .googlePayConfiguration
+
+        assertThat(googlePayConfiguration.display).isEqualTo(GooglePayConfiguration.Display.Never)
+        assertThat(googlePayConfiguration.label).isEqualTo("Complete your purchase")
+        assertThat(googlePayConfiguration.buttonType).isEqualTo(GooglePayConfiguration.ButtonType.Checkout)
+        assertThat(googlePayConfiguration.additionalEnabledNetworks).containsExactly("INTERAC")
+    }
 
     @Test
     fun `present delegates to the content helper`() = runTest {


### PR DESCRIPTION
# Summary

Add GooglePayConfiguration to PaymentElement.Configuration using the same API shape as ExpressCheckoutElement.Configuration.GooglePayConfiguration, including its builder setter and internal state.

This PR intentionally does not change any existing ECE Google Pay configuration mappings or call sites. Those will be merged where needed in a follow-up.

# Authorship

This change was authored by Codex.

# Testing

- [x] ./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.elements.PaymentElementTest
- [x] ./gradlew :paymentsheet:detekt
- [ ] Manually verified

# Screenshots

Not applicable — configuration API change only.