### PR TITLE
Remove ECE payment result analytics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -24,7 +24,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     private val stateHolder: CheckoutControllerStateHolder,
     private val confirmationHandler: ConfirmationHandler,
     private val operationCoordinator: CheckoutOperationCoordinator,
-    private val eventReporter: ExpressCheckoutElementEventReporter,
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @ViewModelScope private val viewModelScope: CoroutineScope,
@@ -52,12 +51,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             try {
                 confirmationHandler.start(confirmationArgs)
 
-                when (val result = confirmationHandler.awaitResult()) {
-                    is ConfirmationHandler.Result.Succeeded -> eventReporter.onEcePaymentSuccess(expressButton)
-                    is ConfirmationHandler.Result.Failed -> eventReporter.onEcePaymentFailure(expressButton, result)
-                    is ConfirmationHandler.Result.Canceled,
-                    null -> Unit
-                }
+                confirmationHandler.awaitResult()
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -50,8 +50,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         viewModelScope.launch {
             try {
                 confirmationHandler.start(confirmationArgs)
-
-                confirmationHandler.awaitResult()
             } catch (error: CancellationException) {
                 throw error
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementEventReporter.kt
@@ -10,11 +10,8 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.mapOfDurationInSeconds
 import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.analytics.linkContext
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.utils.filterNotNullValues
 import javax.inject.Inject
 
@@ -23,15 +20,6 @@ internal interface ExpressCheckoutElementEventReporter {
 
     fun onEceWalletTapped(
         expressButton: ExpressButton,
-    )
-
-    fun onEcePaymentSuccess(
-        expressButton: ExpressButton,
-    )
-
-    fun onEcePaymentFailure(
-        expressButton: ExpressButton,
-        error: ConfirmationHandler.Result.Failed,
     )
 }
 
@@ -56,32 +44,6 @@ internal class DefaultExpressCheckoutElementEventReporter @Inject constructor(
             eventName = ECE_WALLET_TAPPED_EVENT_NAME,
             additionalParams = durationProvider.elapsed(DurationProvider.Key.ExpressCheckoutElement)
                 .mapOfDurationInSeconds() + paymentMethodParams(expressButton),
-        )
-    }
-
-    override fun onEcePaymentSuccess(expressButton: ExpressButton) {
-        fireEvent(
-            eventName = ECE_PAYMENT_SUCCESS_EVENT_NAME,
-            additionalParams = durationProvider.elapsed(DurationProvider.Key.ExpressCheckoutElement)
-                .mapOfDurationInSeconds() + paymentMethodParams(expressButton),
-        )
-    }
-
-    override fun onEcePaymentFailure(
-        expressButton: ExpressButton,
-        error: ConfirmationHandler.Result.Failed,
-    ) {
-        val confirmationError = error.toConfirmationError()
-            ?: PaymentSheetConfirmationError.Stripe(error.cause)
-        fireEvent(
-            eventName = ECE_PAYMENT_FAILURE_EVENT_NAME,
-            additionalParams = durationProvider.elapsed(DurationProvider.Key.ExpressCheckoutElement)
-                .mapOfDurationInSeconds() +
-                paymentMethodParams(expressButton) +
-                mapOf(
-                    FIELD_ERROR_MESSAGE to confirmationError.analyticsValue,
-                    FIELD_ERROR_CODE to confirmationError.errorCode,
-                ).filterNotNullValues(),
         )
     }
 
@@ -129,13 +91,8 @@ internal class DefaultExpressCheckoutElementEventReporter @Inject constructor(
     private companion object {
         const val ECE_DISPLAYED_EVENT_NAME = "mc_ece_init"
         const val ECE_WALLET_TAPPED_EVENT_NAME = "mc_ece_wallet_tapped"
-        const val ECE_PAYMENT_SUCCESS_EVENT_NAME = "mc_ece_payment_success"
-        const val ECE_PAYMENT_FAILURE_EVENT_NAME = "mc_ece_payment_failure"
-
         const val FIELD_SELECTED_LPM = "selected_lpm"
         const val FIELD_LINK_CONTEXT = "link_context"
-        const val FIELD_ERROR_MESSAGE = "error_message"
-        const val FIELD_ERROR_CODE = "error_code"
         const val FIELD_ORDERED_LPMS = "ordered_lpms"
         const val FIELD_ECE_CONFIG = "ece_config"
         const val FIELD_LINK_VISIBILITY = "link_visibility"

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -9,15 +9,12 @@ import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutOperationCoordinator
 import com.stripe.android.checkout.FakeCheckoutSessionRefresher
 import com.stripe.android.core.Logger
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
@@ -142,45 +139,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         }
     }
 
-    @Test
-    fun `confirm reports ECE payment success when confirmation succeeds`() = runScenario(
-        state = googlePayState(),
-        expressButton = createGooglePayExpressButton(),
-    ) {
-        confirmationHandler.awaitResultTurbine.add(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
-        )
-
-        performer.confirm(expressButton)
-
-        confirmationHandler.startTurbine.awaitItem()
-        assertThat(eventReporter.calls.awaitItem())
-            .isEqualTo(FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentSuccess(expressButton))
-    }
-
-    @Test
-    fun `confirm reports ECE payment failure when confirmation fails`() = runScenario(
-        state = googlePayState(),
-        expressButton = createGooglePayExpressButton(),
-    ) {
-        confirmationHandler.awaitResultTurbine.add(
-            ConfirmationHandler.Result.Failed(
-                cause = IllegalStateException("Payment failed"),
-                message = "Payment failed".resolvableString,
-                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-            )
-        )
-
-        performer.confirm(expressButton)
-
-        confirmationHandler.startTurbine.awaitItem()
-        val call = eventReporter.calls.awaitItem()
-        assertThat(call).isInstanceOf(FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentFailure::class.java)
-        val failureCall = call as FakeExpressCheckoutElementEventReporter.Call.OnEcePaymentFailure
-        assertThat(failureCall.expressButton).isEqualTo(expressButton)
-        assertThat(failureCall.error.cause.message).isEqualTo("Payment failed")
-    }
-
     private fun googlePayState(
         allowedShippingCountries: List<String>? = null,
     ): CheckoutControllerState {
@@ -210,7 +168,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
-        val eventReporter = FakeExpressCheckoutElementEventReporter()
         val errorReporter = FakeErrorReporter()
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
@@ -227,7 +184,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             stateHolder = stateHolder,
             confirmationHandler = confirmationHandler,
             operationCoordinator = operationCoordinator,
-            eventReporter = eventReporter,
             errorReporter = errorReporter,
             statusBarColor = null,
             viewModelScope = backgroundScope,
@@ -236,7 +192,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         Scenario(
             performer = performer,
             confirmationHandler = confirmationHandler,
-            eventReporter = eventReporter,
             errorReporter = errorReporter,
             stateHolder = stateHolder,
             expressButton = expressButton,
@@ -244,14 +199,12 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
 
         confirmationHandler.validate()
         sessionRefresher.ensureAllEventsConsumed()
-        eventReporter.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val performer: DefaultExpressCheckoutElementConfirmationPerformer,
         val confirmationHandler: FakeConfirmationHandler,
-        val eventReporter: FakeExpressCheckoutElementEventReporter,
         val errorReporter: FakeErrorReporter,
         val stateHolder: CheckoutControllerStateHolder,
         val expressButton: ExpressButton,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementEventReporterTest.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.elements.ExpressCheckoutElement.Configuration.GooglePayConfiguration
@@ -16,7 +15,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.utils.FakeDurationProvider
 import org.junit.Test
@@ -91,43 +89,6 @@ internal class DefaultExpressCheckoutElementEventReporterTest {
         assertThat(loggedParams).containsEntry("duration", 1.0f)
         assertThat(loggedParams).containsEntry("selected_lpm", "google_pay")
         assertThat(loggedParams).doesNotContainKey("link_context")
-    }
-
-    @Test
-    fun `onEcePaymentSuccess fires expected event with Link params`() = runScenario {
-        val linkButton = ExpressButton.Link.create(
-            paymentMethodMetadata = paymentMethodMetadata,
-            linkAccountInfo = LinkAccountUpdate.Value(null)
-        )
-
-        reporter.onEcePaymentSuccess(linkButton)
-
-        val loggedParams = executor.getExecutedRequests().single().params
-        assertThat(loggedParams).containsEntry("event", "mc_ece_payment_success")
-        assertThat(loggedParams).containsEntry("example_analytics_metadata", true)
-        assertThat(loggedParams).containsEntry("duration", 1.0f)
-        assertThat(loggedParams).containsEntry("selected_lpm", "link")
-        assertThat(loggedParams).containsKey("link_context")
-    }
-
-    @Test
-    fun `onEcePaymentFailure fires expected event with error params`() = runScenario {
-        reporter.onEcePaymentFailure(
-            expressButton = googlePayButton,
-            error = ConfirmationHandler.Result.Failed(
-                cause = IllegalStateException("Payment failed"),
-                message = "Payment failed".resolvableString,
-                type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(10),
-            ),
-        )
-
-        val loggedParams = executor.getExecutedRequests().single().params
-        assertThat(loggedParams).containsEntry("event", "mc_ece_payment_failure")
-        assertThat(loggedParams).containsEntry("example_analytics_metadata", true)
-        assertThat(loggedParams).containsEntry("duration", 1.0f)
-        assertThat(loggedParams).containsEntry("selected_lpm", "google_pay")
-        assertThat(loggedParams).containsEntry("error_message", "googlePay_10")
-        assertThat(loggedParams).containsEntry("error_code", "10")
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/FakeExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/FakeExpressCheckoutElementEventReporter.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.elements.ece
 
 import app.cash.turbine.Turbine
-import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-
 internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementEventReporter {
     val calls = Turbine<Call>()
 
@@ -14,17 +12,6 @@ internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementE
         calls.add(Call.OnEceWalletTapped(expressButton))
     }
 
-    override fun onEcePaymentSuccess(expressButton: ExpressButton) {
-        calls.add(Call.OnEcePaymentSuccess(expressButton))
-    }
-
-    override fun onEcePaymentFailure(
-        expressButton: ExpressButton,
-        error: ConfirmationHandler.Result.Failed,
-    ) {
-        calls.add(Call.OnEcePaymentFailure(expressButton, error))
-    }
-
     fun ensureAllEventsConsumed() {
         calls.ensureAllEventsConsumed()
     }
@@ -33,12 +20,5 @@ internal class FakeExpressCheckoutElementEventReporter : ExpressCheckoutElementE
         data object OnEceDisplayed : Call
 
         data class OnEceWalletTapped(val expressButton: ExpressButton) : Call
-
-        data class OnEcePaymentSuccess(val expressButton: ExpressButton) : Call
-
-        data class OnEcePaymentFailure(
-            val expressButton: ExpressButton,
-            val error: ConfirmationHandler.Result.Failed,
-        ) : Call
     }
 }


### PR DESCRIPTION
# Summary
Remove ECE payment result analytics


# Motivation
These aren't resilient to process death. On investigation, idk the exact solution yet but I'm pretty confident we won't report ECE specific events via the ECE event reporter. Removing for now to simplify my investigation and future changes

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Authorship

This PR was authored by Codex.