### PR TITLE
Add checkout confirmation analytics metadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler.AnalyticsMetadata.ConfirmationOrigin
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
@@ -48,7 +49,10 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = state.paymentMethodMetadata,
             statusBarColor = statusBarColor,
-            // TODO-codex: set analytics metadata - payment selection, confirm initiated for PE.
+            analyticsMetadata = ConfirmationHandler.AnalyticsMetadata(
+                paymentSelection = state.paymentSelection,
+                confirmationOrigin = ConfirmationOrigin.PaymentElement,
+            ),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -48,6 +48,7 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = state.paymentMethodMetadata,
             statusBarColor = statusBarColor,
+            // TODO-codex: set analytics metadata - payment selection, confirm initiated for PE.
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -6,6 +6,8 @@ import com.stripe.android.core.Logger
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.utils.reportPaymentResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +24,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private val sessionRefresher: CheckoutSessionRefresher,
     private val logger: Logger,
     private val resultCallback: CheckoutController.ResultCallback,
+    private val eventReporter: EventReporter,
 ) {
     private val admissionLock = Any()
     private var pendingMutations = 0
@@ -97,7 +100,6 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    // TODO-codex: report eventReporter reportPaymentResult from somewhere in here or called from here. This is the entrypoint.
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
@@ -106,7 +108,12 @@ internal class CheckoutOperationCoordinator @Inject constructor(
                     // commit, but the session changed server-side, so re-fetch it.
                     val response = (state.result as? ConfirmationHandler.Result.Succeeded)
                         ?.metadata?.get(CheckoutSessionResponseKey)
-                    // TODO-codex: get analytics metadata from result.
+                    state.result.analyticsMetadata?.let { analyticsMetadata ->
+                        eventReporter.reportPaymentResult(
+                            result = state.result,
+                            paymentSelection = analyticsMetadata.paymentSelection,
+                        )
+                    }
                     refreshSession {
                         if (response != null) {
                             sessionRefresher.refresh(response)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -97,6 +97,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
+    // TODO-codex: report eventReporter reportPaymentResult from somewhere in here or called from here. This is the entrypoint.
     suspend fun observeConfirmationResults() {
         confirmationHandler.state.collect { state ->
             if (state is ConfirmationHandler.State.Complete) {
@@ -105,6 +106,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
                     // commit, but the session changed server-side, so re-fetch it.
                     val response = (state.result as? ConfirmationHandler.Result.Succeeded)
                         ?.metadata?.get(CheckoutSessionResponseKey)
+                    // TODO-codex: get analytics metadata from result.
                     refreshSession {
                         if (response != null) {
                             sessionRefresher.refresh(response)

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -179,6 +179,7 @@ internal class DefaultTapToAddConfirmationInteractor(
                     confirmationOption = confirmationOption,
                     paymentMethodMetadata = paymentMethodMetadata,
                     statusBarColor = statusBarColor,
+                    analyticsMetadata = null,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1009,6 +1009,7 @@ internal class CustomerSheetViewModel(
                     ),
                     paymentMethodMetadata = metadata,
                     statusBarColor = statusBarColor,
+                    analyticsMetadata = null,
                 )
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -8,6 +8,7 @@ import com.stripe.android.checkout.asPaymentSheet
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler.AnalyticsMetadata.ConfirmationOrigin
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -105,7 +106,10 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             confirmationOption = confirmationOption,
             paymentMethodMetadata = state.paymentMethodMetadata,
             statusBarColor = statusBarColor,
-            // TODO-codex: set analytics metadata - payment selection, confirm initiated for ECE.
+            analyticsMetadata = ConfirmationHandler.AnalyticsMetadata(
+                paymentSelection = expressButton.toSelection(),
+                confirmationOrigin = ConfirmationOrigin.ExpressCheckoutElement,
+            ),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -105,6 +105,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             confirmationOption = confirmationOption,
             paymentMethodMetadata = state.paymentMethodMetadata,
             statusBarColor = statusBarColor,
+            // TODO-codex: set analytics metadata - payment selection, confirm initiated for ECE.
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -186,6 +186,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = paymentMethodMetadata,
             statusBarColor = statusBarColor,
+            analyticsMetadata = null,
         )
     }
 
@@ -222,6 +223,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             ),
             paymentMethodMetadata = paymentMethodMetadata,
             statusBarColor = statusBarColor,
+            analyticsMetadata = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -80,6 +80,7 @@ internal interface ConfirmationHandler {
          * merchant's chrome. Always `null` on API 35+, where the platform enforces edge-to-edge.
          */
         @ColorInt val statusBarColor: Int?,
+        // TODO-codex: add analytics metadata here.
     ) : Parcelable {
         /**
          * The [StripeIntent] that is being potentially confirmed by the handler
@@ -124,6 +125,7 @@ internal interface ConfirmationHandler {
          */
         data class Canceled(
             val action: Action,
+            // TODO-codex: add analytics metadata here
         ) : Result {
             /**
              * Action to perform if a user cancels a running confirmation process.
@@ -160,6 +162,7 @@ internal interface ConfirmationHandler {
             val intent: StripeIntent,
             val metadata: ConfirmationMetadata = MutableConfirmationMetadata(),
             val completedFullPaymentFlow: Boolean = true,
+            // TODO-codex: add analytics metadata here
         ) : Result {
             override fun log(logger: Logger) {
                 logger.info("ConfirmationHandler.Result.Succeeded")
@@ -174,6 +177,7 @@ internal interface ConfirmationHandler {
             val cause: Throwable,
             val message: ResolvableString,
             val type: ErrorType,
+            // TODO-codex: add analytics metadata here.
         ) : Result {
             override fun log(logger: Logger) {
                 logger.error("ConfirmationHandler.Result.Failed", cause)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.IgnoredOnParcel
@@ -80,7 +81,7 @@ internal interface ConfirmationHandler {
          * merchant's chrome. Always `null` on API 35+, where the platform enforces edge-to-edge.
          */
         @ColorInt val statusBarColor: Int?,
-        // TODO-codex: add analytics metadata here.
+        val analyticsMetadata: AnalyticsMetadata?,
     ) : Parcelable {
         /**
          * The [StripeIntent] that is being potentially confirmed by the handler
@@ -118,6 +119,8 @@ internal interface ConfirmationHandler {
      * Defines the result types that can be returned after completing a confirmation process.
      */
     sealed interface Result {
+        val analyticsMetadata: AnalyticsMetadata?
+
         fun log(logger: Logger)
 
         /**
@@ -125,7 +128,7 @@ internal interface ConfirmationHandler {
          */
         data class Canceled(
             val action: Action,
-            // TODO-codex: add analytics metadata here
+            override val analyticsMetadata: AnalyticsMetadata?,
         ) : Result {
             /**
              * Action to perform if a user cancels a running confirmation process.
@@ -162,7 +165,7 @@ internal interface ConfirmationHandler {
             val intent: StripeIntent,
             val metadata: ConfirmationMetadata = MutableConfirmationMetadata(),
             val completedFullPaymentFlow: Boolean = true,
-            // TODO-codex: add analytics metadata here
+            override val analyticsMetadata: AnalyticsMetadata?,
         ) : Result {
             override fun log(logger: Logger) {
                 logger.info("ConfirmationHandler.Result.Succeeded")
@@ -177,7 +180,7 @@ internal interface ConfirmationHandler {
             val cause: Throwable,
             val message: ResolvableString,
             val type: ErrorType,
-            // TODO-codex: add analytics metadata here.
+            override val analyticsMetadata: AnalyticsMetadata?,
         ) : Result {
             override fun log(logger: Logger) {
                 logger.error("ConfirmationHandler.Result.Failed", cause)
@@ -217,6 +220,17 @@ internal interface ConfirmationHandler {
                  */
                 data class GooglePay(val errorCode: Int) : ErrorType
             }
+        }
+    }
+
+    @Parcelize
+    data class AnalyticsMetadata(
+        val paymentSelection: PaymentSelection,
+        val confirmationOrigin: ConfirmationOrigin,
+    ) : Parcelable {
+        enum class ConfirmationOrigin {
+            ExpressCheckoutElement,
+            PaymentElement,
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -69,6 +69,7 @@ internal class DefaultConfirmationHandler(
                     onHandlerResult(
                         ConfirmationHandler.Result.Canceled(
                             action = ConfirmationHandler.Result.Canceled.Action.None,
+                            analyticsMetadata = initialConfirmationArguments?.analyticsMetadata,
                         )
                     )
                 }
@@ -162,6 +163,7 @@ internal class DefaultConfirmationHandler(
                     ),
                     message = R.string.stripe_something_went_wrong.resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                    analyticsMetadata = arguments.analyticsMetadata,
                 )
             )
 
@@ -195,6 +197,7 @@ internal class DefaultConfirmationHandler(
                         cause = action.cause,
                         message = action.message,
                         type = action.errorType,
+                        analyticsMetadata = arguments.analyticsMetadata,
                     )
                 )
             }
@@ -204,6 +207,7 @@ internal class DefaultConfirmationHandler(
                         intent = action.intent,
                         metadata = action.metadata,
                         completedFullPaymentFlow = action.completedFullPaymentFlow,
+                        analyticsMetadata = arguments.analyticsMetadata,
                     )
                 )
             }
@@ -229,17 +233,17 @@ internal class DefaultConfirmationHandler(
                 intent = result.intent,
                 metadata = result.metadata,
                 completedFullPaymentFlow = result.completedFullPaymentFlow,
-                // TODO-codex: set analytics metadata based on confirmation args
+                analyticsMetadata = initialConfirmationArguments?.analyticsMetadata,
             )
             is ConfirmationDefinition.Result.Failed -> ConfirmationHandler.Result.Failed(
                 cause = result.cause,
                 type = result.type,
                 message = result.message,
-                // TODO-codex: set analytics metadata based on confirmation args
+                analyticsMetadata = initialConfirmationArguments?.analyticsMetadata,
             )
             is ConfirmationDefinition.Result.Canceled -> ConfirmationHandler.Result.Canceled(
                 action = result.action,
-                // TODO-codex: set analytics metadata based on confirmation args
+                analyticsMetadata = initialConfirmationArguments?.analyticsMetadata,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -229,14 +229,17 @@ internal class DefaultConfirmationHandler(
                 intent = result.intent,
                 metadata = result.metadata,
                 completedFullPaymentFlow = result.completedFullPaymentFlow,
+                // TODO-codex: set analytics metadata based on confirmation args
             )
             is ConfirmationDefinition.Result.Failed -> ConfirmationHandler.Result.Failed(
                 cause = result.cause,
                 type = result.type,
                 message = result.message,
+                // TODO-codex: set analytics metadata based on confirmation args
             )
             is ConfirmationDefinition.Result.Canceled -> ConfirmationHandler.Result.Canceled(
                 action = result.action,
+                // TODO-codex: set analytics metadata based on confirmation args
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -67,6 +67,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = confirmationState.paymentMethodMetadata,
             statusBarColor = confirmationState.statusBarColor,
+            analyticsMetadata = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -83,6 +83,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = paymentMethodMetadata,
             statusBarColor = statusBarColor,
+            analyticsMetadata = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -601,6 +601,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                         confirmationOption = option,
                         paymentMethodMetadata = paymentMethodMetadata,
                         statusBarColor = args.statusBarColor,
+                        analyticsMetadata = null,
                     ),
                 )
             } ?: run {
@@ -624,6 +625,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                             cause = exception,
                             message = exception.stripeErrorMessage(),
                             type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                            analyticsMetadata = null,
                         )
                     )
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -584,6 +584,7 @@ internal class DefaultFlowController @Inject internal constructor(
                         confirmationOption = option,
                         paymentMethodMetadata = state.paymentMethodMetadata,
                         statusBarColor = viewModel.statusBarColor,
+                        analyticsMetadata = null,
                     )
                 )
             } ?: run {
@@ -603,6 +604,7 @@ internal class DefaultFlowController @Inject internal constructor(
                         cause = exception,
                         message = exception.stripeErrorMessage(),
                         type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                        analyticsMetadata = null,
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -343,6 +343,7 @@ internal class DefaultWalletButtonsInteractor constructor(
             confirmationOption = confirmationOption,
             paymentMethodMetadata = arguments.paymentMethodMetadata,
             statusBarColor = arguments.statusBarColor,
+            analyticsMetadata = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -7,10 +7,12 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler.AnalyticsMetadata.ConfirmationOrigin
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
@@ -59,6 +61,8 @@ internal class CheckoutConfirmationPerformerTest {
         assertThat(args.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
         assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
         assertThat(args.statusBarColor).isEqualTo(STATUS_BAR_COLOR)
+        assertThat(args.analyticsMetadata?.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(args.analyticsMetadata?.confirmationOrigin).isEqualTo(ConfirmationOrigin.PaymentElement)
     }
 
     @Test
@@ -105,6 +109,7 @@ internal class CheckoutConfirmationPerformerTest {
             sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
             resultCallback = {},
+            eventReporter = FakeEventReporter(),
         )
         val performer = CheckoutConfirmationPerformer(
             confirmationHandler = confirmationHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -12,10 +12,13 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler.AnalyticsMetadata.ConfirmationOrigin
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeLogger
@@ -46,6 +49,28 @@ internal class CheckoutOperationCoordinatorTest {
         }
 
         assertThat(result.getOrThrow()).isEqualTo("result")
+    }
+
+    @Test
+    fun `successful confirmation reports payment result analytics`() = runScenario {
+        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
+        enqueueRefreshAction {}
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = ConfirmationHandler.AnalyticsMetadata(
+                    paymentSelection = PaymentSelection.GooglePay,
+                    confirmationOrigin = ConfirmationOrigin.PaymentElement,
+                ),
+            )
+        )
+        runCurrent()
+
+        val call = eventReporter.paymentSuccessCalls.awaitItem()
+        assertThat(call.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(call.intentId).isEqualTo(PaymentIntentFixtures.PI_SUCCEEDED.id)
+        refreshCalls.awaitItem()
+        resultTurbine.awaitItem()
     }
 
     @Test
@@ -265,7 +290,7 @@ internal class CheckoutOperationCoordinatorTest {
 
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
         )
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
@@ -277,7 +302,8 @@ internal class CheckoutOperationCoordinatorTest {
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
-                ConfirmationHandler.Result.Canceled.Action.InformCancellation
+                ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                analyticsMetadata = null,
             )
         )
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -287,7 +313,7 @@ internal class CheckoutOperationCoordinatorTest {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
         )
 
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -317,7 +343,8 @@ internal class CheckoutOperationCoordinatorTest {
             enqueueRefreshAction {}
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
-                    ConfirmationHandler.Result.Canceled.Action.InformCancellation
+                    ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                    analyticsMetadata = null,
                 )
             )
             refreshCalls.awaitItem()
@@ -335,7 +362,7 @@ internal class CheckoutOperationCoordinatorTest {
 
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
         )
 
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -351,7 +378,8 @@ internal class CheckoutOperationCoordinatorTest {
             enqueueRefreshAction {}
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
-                    ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
+                    ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails,
+                    analyticsMetadata = null,
                 )
             )
             assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -369,7 +397,8 @@ internal class CheckoutOperationCoordinatorTest {
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
-                ConfirmationHandler.Result.Canceled.Action.None
+                ConfirmationHandler.Result.Canceled.Action.None,
+                analyticsMetadata = null,
             )
         )
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -391,6 +420,7 @@ internal class CheckoutOperationCoordinatorTest {
                 cause = expected,
                 message = "Confirmation failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                analyticsMetadata = null,
             )
         )
 
@@ -430,6 +460,7 @@ internal class CheckoutOperationCoordinatorTest {
                     cause = expected,
                     message = "Confirmation failed".resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -545,7 +576,7 @@ internal class CheckoutOperationCoordinatorTest {
 
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
         )
 
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -560,7 +591,7 @@ internal class CheckoutOperationCoordinatorTest {
 
             enqueueRefreshAction { releaseRefresh.await() }
             confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
             )
             assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
             resultTurbine.expectNoEvents()
@@ -592,7 +623,7 @@ internal class CheckoutOperationCoordinatorTest {
 
             enqueueRefreshAction { throw expected }
             confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
             )
 
             assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -616,6 +647,7 @@ internal class CheckoutOperationCoordinatorTest {
                 cause = expected,
                 message = "Confirmation failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                analyticsMetadata = null,
             )
         )
 
@@ -662,7 +694,7 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(callbackStarted.await(5, TimeUnit.SECONDS)).isTrue()
 
             confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
             )
             runCurrent()
 
@@ -701,7 +733,8 @@ internal class CheckoutOperationCoordinatorTest {
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
-                ConfirmationHandler.Result.Canceled.Action.None
+                ConfirmationHandler.Result.Canceled.Action.None,
+                analyticsMetadata = null,
             )
         )
         refreshCalls.awaitItem()
@@ -724,7 +757,7 @@ internal class CheckoutOperationCoordinatorTest {
 
             enqueueRefreshAction {}
             confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
             )
 
             assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
@@ -806,12 +839,14 @@ internal class CheckoutOperationCoordinatorTest {
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
         val sessionRefresher = FakeCheckoutSessionRefresher()
+        val eventReporter = FakeEventReporter()
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
             logger = logger,
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+            eventReporter = eventReporter,
         )
         val observerJob = backgroundScope.launch {
             coordinator.observeConfirmationResults()
@@ -826,11 +861,13 @@ internal class CheckoutOperationCoordinatorTest {
             sessionRefresher = sessionRefresher,
             observerJob = observerJob,
             testScope = this,
+            eventReporter = eventReporter,
         ).block()
 
         confirmationHandler.validate()
         resultTurbine.ensureAllEventsConsumed()
         sessionRefresher.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     private class Scenario(
@@ -841,6 +878,7 @@ internal class CheckoutOperationCoordinatorTest {
         private val sessionRefresher: FakeCheckoutSessionRefresher,
         val observerJob: Job,
         private val testScope: TestScope,
+        val eventReporter: FakeEventReporter,
     ) : CoroutineScope by testScope {
         val response = CheckoutSessionResponseFactory.create(id = "cs_confirmed")
         val backgroundScope = testScope.backgroundScope
@@ -862,5 +900,6 @@ internal class CheckoutOperationCoordinatorTest {
         metadata = MutableConfirmationMetadata().apply {
             set(CheckoutSessionResponseKey, response)
         },
+        analyticsMetadata = null,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -247,7 +247,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             val intent = PaymentIntentFixtures.PI_SUCCEEDED
 
             confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(intent),
+                ConfirmationHandler.Result.Succeeded(intent, analyticsMetadata = null),
             )
 
             assertThat(awaitItem().primaryButton.state)
@@ -277,7 +277,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             val intent = PaymentIntentFixtures.PI_SUCCEEDED
 
             confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(intent),
+                ConfirmationHandler.Result.Succeeded(intent, analyticsMetadata = null),
             )
 
             assertThat(awaitItem().primaryButton.state)
@@ -312,6 +312,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                     cause = exception,
                     message = errorMessage,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 ),
             )
 
@@ -350,6 +351,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                     cause = exception,
                     message = errorMessage,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 ),
             )
 
@@ -474,7 +476,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             assertThat(awaitItem().form.enabled).isTrue()
 
             confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Complete(
-                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED),
+                ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null),
             )
 
             assertThat(awaitItem().form.enabled).isFalse()
@@ -494,6 +496,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                     cause = Exception("Payment failed"),
                     message = "Payment failed".resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 ),
             )
 
@@ -519,6 +522,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                 intent = PaymentIntentFactory.create(
                     status = StripeIntent.Status.Succeeded,
                 ),
+                analyticsMetadata = null,
             ),
         )
     ) {
@@ -541,6 +545,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                     cause = Exception("Payment failed"),
                     message = "Payment failed".resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 ),
             )
             cvcFormHelper.updateState(CvcFormHelper.State.Complete(cvc = "123"))

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -819,6 +819,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD
                     ),
+                    analyticsMetadata = null,
                 )
             )
             assertThat(awaitItem()).isInstanceOf<SelectPaymentMethod>()
@@ -847,6 +848,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = SetupIntentFactory.create(CARD_PAYMENT_METHOD),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -885,6 +887,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD,
                     ),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -926,6 +929,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     cause = IllegalStateException(message),
                     message = message.resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1035,6 +1039,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = SetupIntentFactory.create(CARD_PAYMENT_METHOD),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1581,6 +1586,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 intent = SetupIntentFactory.create(
                     paymentMethod = PaymentMethodFactory.card(),
                 ),
+                analyticsMetadata = null,
             )
         )
 
@@ -1617,6 +1623,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 cause = IllegalStateException("Failed!"),
                 message = "Failed!".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                analyticsMetadata = null,
             )
         )
 
@@ -1653,6 +1660,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 intent = SetupIntentFactory.create(
                     paymentMethod = PaymentMethodFactory.card(),
                 ),
+                analyticsMetadata = null,
             )
         )
 
@@ -1687,6 +1695,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 cause = IllegalStateException("Failed!"),
                 message = "Failed!".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                analyticsMetadata = null,
             )
         )
 
@@ -2014,6 +2023,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     intent = SetupIntentFactory.create(
                         paymentMethod = US_BANK_ACCOUNT_VERIFIED,
                     ),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2465,6 +2475,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD,
                     ),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2506,6 +2517,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     intent = SetupIntentFactory.create(
                         paymentMethod = US_BANK_ACCOUNT,
                     ),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2683,6 +2695,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                         intent = SetupIntentFactory.create(
                             paymentMethod = CARD_WITH_NETWORKS_PAYMENT_METHOD,
                         ),
+                        analyticsMetadata = null,
                     )
                 )
 
@@ -2998,6 +3011,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = SetupIntentFactory.create(acceptedCardPaymentMethod),
+                    analyticsMetadata = null,
                 )
             )
 
@@ -3196,6 +3210,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                         intent = SetupIntentFactory.create(
                             paymentMethod = attachedPaymentMethod,
                         ),
+                        analyticsMetadata = null,
                     )
                 )
 
@@ -3236,6 +3251,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                         intent = SetupIntentFactory.create(
                             paymentMethod = attachedPaymentMethod,
                         ),
+                        analyticsMetadata = null,
                     )
                 )
 
@@ -3470,6 +3486,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD,
                     ),
+                    analyticsMetadata = null,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -19,12 +19,14 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler.AnalyticsMetadata.ConfirmationOrigin
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
@@ -88,6 +90,9 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             val option = args.confirmationOption as GooglePayConfirmationOption
             assertThat(option.config.shippingAddressParameters).isNull()
             assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
+            assertThat(args.analyticsMetadata?.paymentSelection).isEqualTo(expressButton.toSelection())
+            assertThat(args.analyticsMetadata?.confirmationOrigin)
+                .isEqualTo(ConfirmationOrigin.ExpressCheckoutElement)
         }
     }
 
@@ -214,7 +219,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         expressButton = createGooglePayExpressButton(),
     ) {
         confirmationHandler.awaitResultTurbine.add(
-            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED)
+            ConfirmationHandler.Result.Succeeded(PaymentIntentFixtures.PI_SUCCEEDED, analyticsMetadata = null)
         )
 
         performer.confirm(expressButton)
@@ -234,6 +239,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
                 cause = IllegalStateException("Payment failed"),
                 message = "Payment failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                analyticsMetadata = null,
             )
         )
 
@@ -300,6 +306,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
             resultCallback = {},
+            eventReporter = FakeEventReporter(),
         )
         val performer = DefaultExpressCheckoutElementConfirmationPerformer(
             stateHolder = stateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementEventReporterTest.kt
@@ -138,6 +138,7 @@ internal class DefaultExpressCheckoutElementEventReporterTest {
                 cause = IllegalStateException("Payment failed"),
                 message = "Payment failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(10),
+                analyticsMetadata = null,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -61,6 +61,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -100,6 +101,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -127,6 +129,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -169,7 +172,8 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Failed(
                 cause = error,
                 message = errorMessage,
-                type = ConfirmationHandler.Result.Failed.ErrorType.Payment
+                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                analyticsMetadata = null,
             )
         )
 
@@ -193,7 +197,10 @@ internal class DefaultLinkConfirmationHandlerTest {
         )
 
         confirmationHandler.awaitResultTurbine.add(
-            item = ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.None)
+            item = ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.None,
+                analyticsMetadata = null,
+            )
         )
 
         val result = handler.confirm(
@@ -241,6 +248,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -279,6 +287,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -310,6 +319,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -341,6 +351,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -372,6 +383,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -405,6 +417,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -440,6 +453,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 
@@ -481,6 +495,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -516,6 +531,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -551,6 +567,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -611,6 +628,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -652,6 +670,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -693,6 +712,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
+                analyticsMetadata = null,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -641,6 +641,7 @@ class ConfirmationMediatorTest {
             confirmationOption = FakeConfirmationOption(),
             statusBarColor = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            analyticsMetadata = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -208,4 +208,5 @@ internal val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
         passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
     ),
     statusBarColor = null,
+    analyticsMetadata = null,
 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
@@ -301,6 +302,7 @@ class DefaultConfirmationHandlerTest {
 
         assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
         assertThat(successResult.completedFullPaymentFlow).isTrue()
+        assertThat(successResult.analyticsMetadata).isEqualTo(ANALYTICS_METADATA)
 
         assertThat(confirmationSaverTurbine.awaitItem()).isNotNull()
     }
@@ -343,6 +345,7 @@ class DefaultConfirmationHandlerTest {
         assertThat(failedResult.cause.message).isEqualTo("Failed!")
         assertThat(failedResult.message).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
         assertThat(failedResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
+        assertThat(failedResult.analyticsMetadata).isEqualTo(ANALYTICS_METADATA)
     }
 
     @Test
@@ -354,6 +357,7 @@ class DefaultConfirmationHandlerTest {
         val canceledResult = completeState.result.assertCanceled()
 
         assertThat(canceledResult.action).isEqualTo(ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails)
+        assertThat(canceledResult.analyticsMetadata).isEqualTo(ANALYTICS_METADATA)
     }
 
     @Test
@@ -1132,11 +1136,16 @@ class DefaultConfirmationHandlerTest {
     private data object SomeStringMetadataKey : ConfirmationMetadata.Key<String>
 
     private companion object {
+        val ANALYTICS_METADATA = ConfirmationHandler.AnalyticsMetadata(
+            paymentSelection = PaymentSelection.GooglePay,
+            confirmationOrigin = ConfirmationHandler.AnalyticsMetadata.ConfirmationOrigin.PaymentElement,
+        )
         const val SOME_DEFINITION_PERSISTED_KEY = "SomeParameters"
         const val AWAITING_CONFIRMATION_RESULT_KEY = "AwaitingConfirmationResult"
 
         val CONFIRMATION_PARAMETERS = com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS.copy(
-            confirmationOption = SomeConfirmationDefinition.Option
+            confirmationOption = SomeConfirmationDefinition.Option,
+            analyticsMetadata = ANALYTICS_METADATA,
         )
 
         val UPDATED_PAYMENT_INTENT = PAYMENT_INTENT.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -310,6 +310,7 @@ internal class IntentConfirmationFlowTest {
                 ),
             ),
             statusBarColor = null,
+            analyticsMetadata = null,
         )
     }
 
@@ -354,6 +355,7 @@ internal class IntentConfirmationFlowTest {
                     phoneNumber = "1234567890"
                 ),
             ),
+            analyticsMetadata = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
@@ -180,6 +180,7 @@ internal class AttestationConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 attestOnIntentConfirmation = true,
             ),
+            analyticsMetadata = null,
         )
 
         const val ATTESTATION_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -201,6 +201,7 @@ internal class BacsConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
+            analyticsMetadata = null,
         )
 
         const val BACS_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinitionTest.kt
@@ -111,6 +111,7 @@ internal class PaymentOptionCardArtPrefetchConfirmationDefinitionTest {
                 confirmationOption = FakeConfirmationOption(),
                 statusBarColor = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                analyticsMetadata = null,
             ),
         ).apply { block() }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -189,6 +189,7 @@ internal class PassiveChallengeConfirmationActivityTest {
                 shippingDetails = AddressDetails(),
                 passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
             ),
+            analyticsMetadata = null,
         )
 
         const val PASSIVE_CHALLENGE_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -171,6 +171,7 @@ internal class CustomPaymentMethodConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
+            analyticsMetadata = null,
         )
 
         const val CPM_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -246,6 +246,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFactory.create(),
             ),
+            analyticsMetadata = null,
         )
 
         private val CUSTOM_PAYMENT_METHOD_TYPE = PaymentSheet.CustomPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -187,6 +187,7 @@ internal class CvcRecollectionConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
+            analyticsMetadata = null,
         )
 
         const val CVC_RECOLLECTION_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -197,6 +197,7 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
+            analyticsMetadata = null,
         )
 
         const val EPM_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -291,6 +291,7 @@ internal class GooglePayConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
+            analyticsMetadata = null,
         )
 
         const val GOOGLE_PAY_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -105,6 +105,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                     confirmationOption = LINK_CONFIRMATION_OPTION,
                     statusBarColor = null,
                     paymentMethodMetadata = paymentMethodMetadata,
+                    analyticsMetadata = null,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -50,6 +50,7 @@ internal suspend fun assertIntentConfirmed(
                     shippingDetails = params.shippingDetails,
                     integrationMetadata = params.integrationMetadata,
                 ),
+                analyticsMetadata = null,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -39,6 +39,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
                 cause = exception,
                 message = "Error".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+                analyticsMetadata = null,
             )
         )
         assertThat(callbackHelper.callbackTurbine.awaitItem()).isEqualTo(
@@ -54,6 +55,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = null,
             )
         )
         assertThat(callbackHelper.stateHelper.stateTurbine.awaitItem()).isNull()
@@ -65,7 +67,10 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         assertThat(confirmationStateHolder.state).isNotNull()
         assertThat(callbackHelper.stateHelper.stateTurbine.expectMostRecentItem()).isNotNull()
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.InformCancellation)
+            ConfirmationHandler.Result.Canceled(
+                action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                analyticsMetadata = null,
+            )
         )
         assertThat(callbackHelper.callbackTurbine.awaitItem()).isInstanceOf<EmbeddedPaymentElement.Result.Canceled>()
         assertThat(confirmationStateHolder.state).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -47,6 +47,7 @@ class EmbeddedConfirmationStarterTest {
                     paymentMethod = PaymentMethodFactory.card(random = true),
                 )
             ),
+            analyticsMetadata = null,
         )
 
         confirmationStarter.start(arguments)
@@ -89,6 +90,7 @@ class EmbeddedConfirmationStarterTest {
             confirmationState = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = intent,
+                    analyticsMetadata = null,
                 ),
             ),
         ) {
@@ -113,7 +115,8 @@ class EmbeddedConfirmationStarterTest {
         test(
             confirmationState = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Canceled(
-                    action = ConfirmationHandler.Result.Canceled.Action.InformCancellation
+                    action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                    analyticsMetadata = null,
                 ),
             ),
         ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
@@ -22,12 +22,14 @@ internal fun confirmationStateComplete(succeeded: Boolean): ConfirmationHandler.
     val result = if (succeeded) {
         ConfirmationHandler.Result.Succeeded(
             PaymentIntentFixtures.PI_SUCCEEDED,
+            analyticsMetadata = null,
         )
     } else {
         ConfirmationHandler.Result.Failed(
             cause = Throwable(),
             message = "Something went wrong".resolvableString,
-            type = ConfirmationHandler.Result.Failed.ErrorType.Internal
+            type = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+            analyticsMetadata = null,
         )
     }
     return ConfirmationHandler.State.Complete(result)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -213,7 +213,8 @@ class DefaultSheetActivityStateHolderTest {
 
             confirmationHandler.state.value = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Canceled(
-                    action = ConfirmationHandler.Result.Canceled.Action.None
+                    action = ConfirmationHandler.Result.Canceled.Action.None,
+                    analyticsMetadata = null,
                 )
             )
             val canceledState = awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -805,6 +805,7 @@ internal class PaymentSheetActivityTest {
             confirmationHandler.state.value = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
+                    analyticsMetadata = null,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -705,6 +705,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
                     action = ConfirmationHandler.Result.Canceled.Action.None,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -776,6 +777,7 @@ internal class PaymentSheetViewModelTest {
                     cause = Exception("Test exception"),
                     message = PaymentsCoreR.string.stripe_internal_error.resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -858,6 +860,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -968,6 +971,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1003,6 +1007,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1055,6 +1060,7 @@ internal class PaymentSheetViewModelTest {
                     cause = error,
                     message = error.errorMessage,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
             verify(eventReporter)
@@ -1086,6 +1092,7 @@ internal class PaymentSheetViewModelTest {
                     cause = InvalidDeferredIntentUsageException(),
                     message = "An error occurred!".resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1107,6 +1114,7 @@ internal class PaymentSheetViewModelTest {
                     cause = error,
                     message = R.string.stripe_something_went_wrong.resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1136,6 +1144,7 @@ internal class PaymentSheetViewModelTest {
                     cause = error,
                     message = errorMessage.resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1356,6 +1365,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
                     action = ConfirmationHandler.Result.Canceled.Action.None,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -1458,6 +1468,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Canceled(
                     action = ConfirmationHandler.Result.Canceled.Action.None,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2004,6 +2015,7 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2048,6 +2060,7 @@ internal class PaymentSheetViewModelTest {
                     cause = Exception(error),
                     message = error.resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2123,6 +2136,7 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             result = ConfirmationHandler.Result.Succeeded(
                 intent = PAYMENT_INTENT,
+                analyticsMetadata = null,
             )
         )
 
@@ -2161,6 +2175,7 @@ internal class PaymentSheetViewModelTest {
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
                     },
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2198,7 +2213,8 @@ internal class PaymentSheetViewModelTest {
                     intent = PAYMENT_INTENT,
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
-                    }
+                    },
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2237,6 +2253,7 @@ internal class PaymentSheetViewModelTest {
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
                     },
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2561,6 +2578,7 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = null,
             )
         )
 
@@ -2606,6 +2624,7 @@ internal class PaymentSheetViewModelTest {
                 cause = IllegalStateException("This failed!"),
                 message = "This failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(errorCode = 10),
+                analyticsMetadata = null,
             )
         )
 
@@ -2641,6 +2660,7 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = null,
             )
         )
 
@@ -2679,6 +2699,7 @@ internal class PaymentSheetViewModelTest {
                 cause = IllegalStateException("This failed!"),
                 message = "This failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(errorCode = 10),
+                analyticsMetadata = null,
             )
         )
 
@@ -2716,6 +2737,7 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = null,
             )
         )
 
@@ -2760,6 +2782,7 @@ internal class PaymentSheetViewModelTest {
                 cause = IllegalStateException("This failed!"),
                 message = "This failed".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(errorCode = 10),
+                analyticsMetadata = null,
             )
         )
 
@@ -3339,7 +3362,7 @@ internal class PaymentSheetViewModelTest {
         assertThat(startTurbine.awaitItem()).isNotNull()
 
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT, analyticsMetadata = null)
         )
 
         val call = eventReporter.billingAddressCompletedCalls.awaitItem()
@@ -3359,7 +3382,7 @@ internal class PaymentSheetViewModelTest {
         assertThat(startTurbine.awaitItem()).isNotNull()
 
         confirmationState.value = ConfirmationHandler.State.Complete(
-            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT)
+            ConfirmationHandler.Result.Succeeded(intent = PAYMENT_INTENT, analyticsMetadata = null)
         )
 
         eventReporter.billingAddressCompletedCalls.ensureAllEventsConsumed()
@@ -3395,7 +3418,7 @@ internal class PaymentSheetViewModelTest {
                 paymentSheetLoader.enqueueSuccess(stripeIntent = stripeIntent)
 
                 awaitResultTurbine.add(
-                    ConfirmationHandler.Result.Succeeded(intent = stripeIntent)
+                    ConfirmationHandler.Result.Succeeded(intent = stripeIntent, analyticsMetadata = null)
                 )
 
                 assertThat(awaitItem()).isEqualTo(PaymentSheetResult.Completed())
@@ -3434,6 +3457,7 @@ internal class PaymentSheetViewModelTest {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = stripeIntent,
+                    analyticsMetadata = null,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -256,6 +256,7 @@ internal class DefaultFlowControllerTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 completedFullPaymentFlow = false,
+                analyticsMetadata = null,
             )
         )
 
@@ -333,6 +334,7 @@ internal class DefaultFlowControllerTest {
                     cause = InvalidDeferredIntentUsageException(),
                     message = "An error occurred!".resolvableString,
                     type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    analyticsMetadata = null,
                 )
             )
 
@@ -383,6 +385,7 @@ internal class DefaultFlowControllerTest {
                 cause = InvalidDeferredIntentUsageException(),
                 message = "An error occurred!".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(errorCode),
+                analyticsMetadata = null,
             )
         )
 
@@ -1439,6 +1442,7 @@ internal class DefaultFlowControllerTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(
                 action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                analyticsMetadata = null,
             )
         )
 
@@ -1479,6 +1483,7 @@ internal class DefaultFlowControllerTest {
                 cause = IllegalStateException("Failed!"),
                 message = "Failed!".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                analyticsMetadata = null,
             )
         )
 
@@ -1750,6 +1755,7 @@ internal class DefaultFlowControllerTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = null,
             )
         )
 
@@ -1780,6 +1786,7 @@ internal class DefaultFlowControllerTest {
                 cause = Exception("something went wrong"),
                 message = "something went wrong".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                analyticsMetadata = null,
             )
         )
 
@@ -1953,6 +1960,7 @@ internal class DefaultFlowControllerTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                analyticsMetadata = null,
             )
         )
 
@@ -1986,6 +1994,7 @@ internal class DefaultFlowControllerTest {
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
                     },
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2019,6 +2028,7 @@ internal class DefaultFlowControllerTest {
                     metadata = MutableConfirmationMetadata().apply {
                         set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
                     },
+                    analyticsMetadata = null,
                 )
             )
 
@@ -2237,6 +2247,7 @@ internal class DefaultFlowControllerTest {
                 cause = Exception("An error!"),
                 message = "An error!".resolvableString,
                 type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
+                analyticsMetadata = null,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
@@ -22,7 +22,8 @@ class ConfirmationReportingUtilsTest {
         val epmError = ConfirmationHandler.Result.Failed(
             cause = Exception(),
             message = "Something went wrong".resolvableString,
-            type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod
+            type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod,
+            analyticsMetadata = null,
         )
 
         val confirmationError = epmError.toConfirmationError()
@@ -39,7 +40,8 @@ class ConfirmationReportingUtilsTest {
                 )
             ),
             message = "Something went wrong".resolvableString,
-            type = ConfirmationHandler.Result.Failed.ErrorType.Payment
+            type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+            analyticsMetadata = null,
         )
 
         val confirmationError = stripeError.toConfirmationError()
@@ -53,7 +55,8 @@ class ConfirmationReportingUtilsTest {
         val googlePayError = ConfirmationHandler.Result.Failed(
             cause = Exception(),
             message = "Something went wrong".resolvableString,
-            type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(12)
+            type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(12),
+            analyticsMetadata = null,
         )
 
         val confirmationError = googlePayError.toConfirmationError()
@@ -67,7 +70,8 @@ class ConfirmationReportingUtilsTest {
         val merchantError = ConfirmationHandler.Result.Failed(
             cause = Exception(),
             message = "Something went wrong".resolvableString,
-            type = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration
+            type = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
+            analyticsMetadata = null,
         )
 
         val confirmationError = merchantError.toConfirmationError()
@@ -82,6 +86,7 @@ class ConfirmationReportingUtilsTest {
             metadata = MutableConfirmationMetadata().apply {
                 set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
             },
+            analyticsMetadata = null,
         )
 
         eventReporter.reportPaymentResult(result, PaymentSelection.GooglePay)
@@ -98,7 +103,8 @@ class ConfirmationReportingUtilsTest {
         val result = ConfirmationHandler.Result.Failed(
             cause = Exception(),
             message = "Something went wrong".resolvableString,
-            type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(12)
+            type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(12),
+            analyticsMetadata = null,
         )
 
         eventReporter.reportPaymentResult(result, PaymentSelection.GooglePay)


### PR DESCRIPTION
## Summary
- carry payment selection and confirmation origin through confirmation arguments and terminal results
- report CheckoutController payment results from the operation coordinator, including restored confirmations
- preserve dedicated ECE success and failure reporting while adding generic payment result analytics

## Testing
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:detekt`