### PR TITLE
Deprecate AddressLauncher.Configuration constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
-NEXT_VERSION_BUMP: PATCH
+NEXT_VERSION_BUMP: MINOR
 ## XX.XX.XX - 20XX-XX-XX
+
+### PaymentSheet
+* [DEPRECATED] Deprecated the `AddressLauncher.Configuration` constructors. Use `AddressLauncher.Configuration.Builder` instead.
 
 ## 23.16.0 - 2026-08-18
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 # Migration Guide
 
+## Migrating from versions < 23.17.0
+- Changes to `AddressLauncher.Configuration`:
+  * The constructors have been deprecated and will be removed in a future release. Use `AddressLauncher.Configuration.Builder` instead.
+
 ## Migrating from versions < 23.0.0
 - The SDK now requires Android 6.0+ (API level 23+)
 - The SDK now targets `compileSdkVersion` and `targetSdkVersion` 36

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -83,7 +83,7 @@ class AddressLauncher internal constructor(
     @JvmOverloads
     fun present(
         publishableKey: String,
-        configuration: Configuration = Configuration()
+        configuration: Configuration = Configuration.Builder().build()
     ) {
         val args = AddressElementActivityContract.Args(
             publishableKey = publishableKey,
@@ -115,6 +115,21 @@ class AddressLauncher internal constructor(
         internal val useStripeHostedAutocomplete: Boolean = false,
     ) : Parcelable {
         @JvmOverloads
+        @Deprecated(
+            message = "This will be removed in a future release.",
+            replaceWith = ReplaceWith(
+                "AddressLauncher.Configuration.Builder()" +
+                    ".appearance(appearance)" +
+                    ".address(address)" +
+                    ".allowedCountries(allowedCountries)" +
+                    ".buttonTitle(buttonTitle)" +
+                    ".apply { additionalFields?.let { additionalFields(it) } }" +
+                    ".title(title)" +
+                    ".googlePlacesApiKey(googlePlacesApiKey)" +
+                    ".autocompleteCountries(autocompleteCountries)" +
+                    ".build()",
+            ),
+        )
         constructor(
             /**
              * Configuration for the look and feel of the UI

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
@@ -27,13 +27,15 @@ class AddressFormControllerTest {
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = "123456",
         ),
-        launcherConfig = AddressLauncher.Configuration(
-            address = AddressDetails(
-                address = PaymentSheet.Address(
-                    line1 = "123 Apple Street",
-                )
+        launcherConfig = AddressLauncher.Configuration.Builder()
+            .address(
+                AddressDetails(
+                    address = PaymentSheet.Address(
+                        line1 = "123 Apple Street",
+                    ),
+                ),
             )
-        )
+            .build(),
     ) {
         val fields = awaitItem()
 
@@ -231,11 +233,13 @@ class AddressFormControllerTest {
         phoneNumberConfiguration: AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration,
         phoneNumberElementIsVisible: Boolean,
     ) = fieldsTest(
-        launcherConfig = AddressLauncher.Configuration(
-            additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
-                phone = phoneNumberConfiguration,
-            ),
-        ),
+        launcherConfig = AddressLauncher.Configuration.Builder()
+            .additionalFields(
+                AddressLauncher.AdditionalFieldsConfiguration(
+                    phone = phoneNumberConfiguration,
+                ),
+            )
+            .build(),
     ) {
         val fields = awaitItem()
 
@@ -252,7 +256,8 @@ class AddressFormControllerTest {
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = null,
         ),
-        launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration(),
+        launcherConfig: AddressLauncher.Configuration =
+            AddressLauncher.Configuration.Builder().build(),
         test: suspend TurbineTestContext<List<SectionFieldElement>>.() -> Unit
     ) = addressElementTest(
         initialValues = initialValues,
@@ -272,7 +277,8 @@ class AddressFormControllerTest {
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = null,
         ),
-        launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration(),
+        launcherConfig: AddressLauncher.Configuration =
+            AddressLauncher.Configuration.Builder().build(),
         test: suspend TurbineTestContext<AddressElement>.() -> Unit
     ) = test(autocompleteConfig) {
         val addressFormController = createAddressFormController(
@@ -316,11 +322,13 @@ class AddressFormControllerTest {
 
     private fun TestAutocompleteAddressInteractor.Scenario.createAddressFormController(
         initialValues: Map<IdentifierSpec, String?> = emptyMap(),
-        launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration(
-            additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
-                phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
+        launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration.Builder()
+            .additionalFields(
+                AddressLauncher.AdditionalFieldsConfiguration(
+                    phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
+                ),
             )
-        )
+            .build(),
     ) = AddressFormController(
         interactor = interactor,
         config = launcherConfig,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressLauncherFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressLauncherFixtures.kt
@@ -1,5 +1,5 @@
 package com.stripe.android.paymentsheet.addresselement
 
 internal object AddressLauncherFixtures {
-    internal val BASIC_CONFIG = AddressLauncher.Configuration()
+    internal val BASIC_CONFIG = AddressLauncher.Configuration.Builder().build()
 }


### PR DESCRIPTION
# Summary

This PR adds warning-level compiler guidance to migrate `AddressLauncher.Configuration` constructor calls to the existing builder. Existing configurations continue to have the same runtime behavior.

No constructor signatures, Java overloads, parcel shape, or stored configuration values change. The public API artifact is unchanged.

# What changed

- Deprecated the existing defaulted `AddressLauncher.Configuration` constructor with a builder `ReplaceWith`.
- Migrated internal defaults and test fixtures to `AddressLauncher.Configuration.Builder` so they do not call the deprecated constructor.

# What stays the same

The existing constructor overloads remain available and behaviorally identical. Deprecating the `googlePlacesApiKey` builder methods is deliberately owned by a separate PR.

# Testing

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:compileDebugUnitTestKotlin :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:apiCheck :paymentsheet:detekt --no-daemon`
- `./gradlew :paymentsheet:apiDump --rerun-tasks --no-build-cache --no-daemon`

# Screenshots

Not applicable. This change does not affect UI.

# Changelog

* [DEPRECATED] Deprecated the `AddressLauncher.Configuration` constructors. Use `AddressLauncher.Configuration.Builder` instead.
