### PR TITLE
Move BillingDetails into checkout display data

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -671,6 +671,60 @@ class CheckoutController @Inject internal constructor(
              */
             val mandateText: AnnotatedString?,
         ) {
+            /**
+             * The billing details collected for a payment method.
+             */
+            @Poko
+            @CheckoutSessionPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            class BillingDetails internal constructor(
+                /**
+                 * The customer's billing address.
+                 */
+                val address: Address?,
+                /**
+                 * The customer's email address.
+                 */
+                val email: String?,
+                /**
+                 * The customer's full name.
+                 */
+                val name: String?,
+            ) {
+                /**
+                 * A billing address.
+                 */
+                @Poko
+                @CheckoutSessionPreview
+                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+                class Address internal constructor(
+                    /**
+                     * City, district, suburb, town, or village.
+                     */
+                    val city: String?,
+                    /**
+                     * Two-letter country code (ISO 3166-1 alpha-2).
+                     */
+                    val country: String?,
+                    /**
+                     * Address line 1 (e.g., street, PO Box, or company name).
+                     */
+                    val line1: String?,
+                    /**
+                     * Address line 2 (e.g., apartment, suite, unit, or building).
+                     */
+                    val line2: String?,
+                    /**
+                     * ZIP or postal code.
+                     */
+                    val postalCode: String?,
+                    /**
+                     * State, county, province, or region.
+                     */
+                    val state: String?,
+                )
+            }
+
             private val iconDrawable: Drawable by lazy {
                 DelegateDrawable(imageLoader)
             }
@@ -682,60 +736,6 @@ class CheckoutController @Inject internal constructor(
                 @Composable
                 get() = rememberDrawablePainter(iconDrawable)
         }
-    }
-
-    /**
-     * The billing details collected for a payment method.
-     */
-    @Poko
-    @CheckoutSessionPreview
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    class BillingDetails internal constructor(
-        /**
-         * The customer's billing address.
-         */
-        val address: Address?,
-        /**
-         * The customer's email address.
-         */
-        val email: String?,
-        /**
-         * The customer's full name.
-         */
-        val name: String?,
-    ) {
-        /**
-         * A billing address.
-         */
-        @Poko
-        @CheckoutSessionPreview
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        class Address internal constructor(
-            /**
-             * City, district, suburb, town, or village.
-             */
-            val city: String?,
-            /**
-             * Two-letter country code (ISO 3166-1 alpha-2).
-             */
-            val country: String?,
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
-            val line1: String?,
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            val line2: String?,
-            /**
-             * ZIP or postal code.
-             */
-            val postalCode: String?,
-            /**
-             * State, county, province, or region.
-             */
-            val state: String?,
-        )
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -80,10 +80,10 @@ internal class DefaultCheckoutPaymentOptionDisplayDataFactory @Inject constructo
 }
 
 @OptIn(CheckoutSessionPreview::class)
-private fun PaymentMethod.BillingDetails.toCheckoutBillingDetails(): CheckoutController.BillingDetails {
-    return CheckoutController.BillingDetails(
+private fun PaymentMethod.BillingDetails.toCheckoutBillingDetails(): PaymentOptionDisplayData.BillingDetails {
+    return PaymentOptionDisplayData.BillingDetails(
         address = address?.let { modelAddress ->
-            CheckoutController.BillingDetails.Address(
+            PaymentOptionDisplayData.BillingDetails.Address(
                 city = modelAddress.city,
                 country = modelAddress.country,
                 line1 = modelAddress.line1,


### PR DESCRIPTION
# Summary

Moves the checkout-only `BillingDetails` model under `CheckoutController.Session.PaymentOptionDisplayData`, where it is consumed, and updates the display-data mapper to use the nested type.

# Motivation

Prepare the CheckoutSession API for review by keeping billing-details display data scoped to its sole consumer and making the ownership hierarchy explicit.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
- `./gradlew :paymentsheet:compileDebugKotlin`

# Screenshots

Not applicable — this is an internal model relocation with no UI change.

# Changelog

Not applicable — no user-facing behavior or public API change.
