### PR TITLE
Close saved payment method confirmation interactors

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -477,7 +477,7 @@ internal sealed interface PaymentSheetScreen {
     class SavedPaymentMethodConfirm(
         private val interactor: SavedPaymentMethodConfirmInteractor,
         private val isLiveMode: Boolean,
-    ) : PaymentSheetScreen {
+    ) : PaymentSheetScreen, Closeable {
         override val buyButtonState = stateFlowOf(
             BuyButtonState(visible = true)
         )
@@ -510,6 +510,10 @@ internal sealed interface PaymentSheetScreen {
         @Composable
         override fun Content(modifier: Modifier) {
             SavedPaymentMethodConfirmUI(interactor)
+        }
+
+        override fun close() {
+            interactor.close()
         }
 
         companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
@@ -20,6 +20,7 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -27,6 +28,8 @@ import javax.inject.Inject
 
 internal interface SavedPaymentMethodConfirmInteractor {
     val state: StateFlow<State>
+
+    fun close()
 
     data class State(
         val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
@@ -55,7 +58,7 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
     val processing: StateFlow<Boolean>,
     val updateSelection: (PaymentSelection.Saved) -> Unit,
     val paymentMethodMetadata: PaymentMethodMetadata,
-    val coroutineScope: CoroutineScope,
+    coroutineScope: CoroutineScope,
 ) : SavedPaymentMethodConfirmInteractor {
     private val displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
         displayName = displayName,
@@ -80,12 +83,14 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
         initialSelection.withLinkState(it)
     }
 
-    init {
-        coroutineScope.launch {
-            selection.collectLatest {
-                updateSelection(it)
-            }
+    private val updateSelectionJob: Job = coroutineScope.launch {
+        selection.collectLatest {
+            updateSelection(it)
         }
+    }
+
+    override fun close() {
+        updateSelectionJob.cancel()
     }
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
@@ -21,9 +22,17 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.rules.RuleChain
 import kotlin.test.Test
 
-class DefaultSavedPaymentMethodConfirmInteractorTest {
+internal class DefaultSavedPaymentMethodConfirmInteractorTest {
+    private val closeInteractorRule = CleanupTestRule(DefaultSavedPaymentMethodConfirmInteractor::close)
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(closeInteractorRule)
+
     @Test
     fun `form updates enabled state based on processing state`() = runTest {
         val processing = MutableStateFlow(false)
@@ -95,6 +104,39 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
         updateSelectionCalls.ensureAllEventsConsumed()
     }
 
+    @Test
+    fun `when closed, selection is no longer updated`() = runTest {
+        val linkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
+            initialState = SavedPaymentMethodLinkFormHelper.State.Unused
+        )
+        val updateSelectionCalls = Turbine<PaymentSelection.Saved>()
+        val interactor = getDefaultSavedPaymentMethodConfirmInteractor(
+            linkFormHelper = linkFormHelper,
+            processing = MutableStateFlow(false),
+            updateSelection = { updateSelectionCalls.add(it) },
+            coroutineScope = backgroundScope,
+        )
+
+        val userInput = UserInput.SignIn(email = "test@example.com")
+        linkFormHelper.updateState(
+            SavedPaymentMethodLinkFormHelper.State.Complete(
+                userInput = userInput
+            )
+        )
+
+        advanceUntilIdle()
+
+        assertThat(updateSelectionCalls.awaitItem().linkInput).isEqualTo(userInput)
+
+        interactor.close()
+        linkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Unused)
+
+        advanceUntilIdle()
+
+        updateSelectionCalls.expectNoEvents()
+        updateSelectionCalls.ensureAllEventsConsumed()
+    }
+
     private fun getDefaultSavedPaymentMethodConfirmInteractor(
         linkFormHelper: SavedPaymentMethodLinkFormHelper = FakeSavedPaymentMethodLinkFormHelper(),
         processing: StateFlow<Boolean> = MutableStateFlow(false),
@@ -104,15 +146,17 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
         coroutineScope: CoroutineScope,
     ): DefaultSavedPaymentMethodConfirmInteractor {
         val paymentMethod = PaymentMethodFactory.card()
-        return DefaultSavedPaymentMethodConfirmInteractor(
-            initialSelection = PaymentSelection.Saved(paymentMethod),
-            displayName = "Card".resolvableString,
-            linkAccount = linkAccount,
-            savedPaymentMethodLinkFormHelper = linkFormHelper,
-            processing = processing,
-            updateSelection = updateSelection,
-            paymentMethodMetadata = paymentMethodMetadata,
-            coroutineScope = coroutineScope,
+        return closeInteractorRule.track(
+            DefaultSavedPaymentMethodConfirmInteractor(
+                initialSelection = PaymentSelection.Saved(paymentMethod),
+                displayName = "Card".resolvableString,
+                linkAccount = linkAccount,
+                savedPaymentMethodLinkFormHelper = linkFormHelper,
+                processing = processing,
+                updateSelection = updateSelection,
+                paymentMethodMetadata = paymentMethodMetadata,
+                coroutineScope = coroutineScope,
+            )
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
@@ -57,6 +57,10 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
     )
     override val state: StateFlow<SavedPaymentMethodConfirmInteractor.State> = _state.asStateFlow()
 
+    override fun close() {
+        // No-op.
+    }
+
     class Factory : SavedPaymentMethodConfirmInteractor.Factory {
         override fun create(
             initialSelection: PaymentSelection.Saved,


### PR DESCRIPTION
# Summary

Close saved-payment-method confirmation interactors when their PaymentSheet screen is removed.

# Motivation

The interactor keeps a selection collector in a shared scope. Closing its owned job prevents it from continuing to update selection after the confirmation screen has been dismissed.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

No tests were newly ignored.

# Screenshots

Not applicable: lifecycle-only internal change with no visual UI change.

# Changelog

Not applicable: internal lifecycle cleanup with no user-visible API or behavior change.
