### PR TITLE
Add direct API support for Alipay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ NEXT_VERSION_BUMP: MINOR
 ### PaymentSheet
 * [DEPRECATED] Deprecated the `googlePlacesApiKey` builder methods and the `AddressLauncher.Configuration` constructor overloads that accept a Google Places API key. Address autocomplete is now available to all merchants without providing a Google Places API key. Existing integrations can remove the key without losing autocomplete, and integrations that did not provide one receive autocomplete automatically.
 
+### Payments
+* [ADDED][14089](https://github.com/stripe/stripe-android/pull/14089) Support for Alipay when using `SetupIntent` through the direct APIs.
+
 ### Identity
 * [ADDED][13176](https://github.com/stripe/stripe-android/pull/13176) Added guided 3D selfie capture for supported verification sessions, including left and right pose collection.
 

--- a/example/src/main/java/com/stripe/example/activity/AlipayPaymentNativeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/AlipayPaymentNativeActivity.kt
@@ -2,6 +2,9 @@ package com.stripe.example.activity
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import com.alipay.sdk.app.PayTask
 import com.stripe.android.ApiResultCallback
@@ -36,6 +39,12 @@ class AlipayPaymentNativeActivity : StripeIntentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(viewBinding.root) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updatePadding(top = insets.top, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         viewBinding.confirmWithPaymentButton.text =
             resources.getString(R.string.confirm_alipay_button)

--- a/example/src/main/java/com/stripe/example/activity/AlipayPaymentWebActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/AlipayPaymentWebActivity.kt
@@ -3,6 +3,9 @@ package com.stripe.example.activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentConfiguration
@@ -36,6 +39,12 @@ class AlipayPaymentWebActivity : StripeIntentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(viewBinding.root) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updatePadding(top = insets.top, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         viewBinding.confirmWithPaymentButton.text =
             resources.getString(R.string.confirm_alipay_button)

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -273,7 +273,7 @@ constructor(
             "alipay",
             isReusable = false,
             isVoucher = false,
-            requiresMandate = false,
+            requiresMandate = true,
             requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -26,6 +26,8 @@ class PaymentMethodCreateParams
 constructor(
     internal val code: PaymentMethodCode,
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val requiresMandate: Boolean,
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val requiresMandateForPaymentIntent: Boolean =
+        requiresMandate,
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val card: Card? = null,
     private val ideal: Ideal? = null,
     private val fpx: Fpx? = null,
@@ -60,6 +62,7 @@ constructor(
     fun copy(
         code: PaymentMethodCode = this.code,
         requiresMandate: Boolean = this.requiresMandate,
+        requiresMandateForPaymentIntent: Boolean = this.requiresMandateForPaymentIntent,
         card: Card? = this.card,
         ideal: Ideal? = this.ideal,
         fpx: Fpx? = this.fpx,
@@ -82,6 +85,7 @@ constructor(
         return PaymentMethodCreateParams(
             code = code,
             requiresMandate = requiresMandate,
+            requiresMandateForPaymentIntent = requiresMandateForPaymentIntent,
             card = card,
             ideal = ideal,
             fpx = fpx,
@@ -126,6 +130,7 @@ constructor(
     ) : this(
         type.code,
         type.requiresMandate,
+        type.requiresMandateForPaymentIntent,
         card,
         ideal,
         fpx,

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -264,13 +264,13 @@ sealed interface StripeIntent : StripeModel {
 
         @Parcelize
         internal data class AlipayRedirect constructor(
-            val data: String,
+            val data: String?,
             val authCompleteUrl: String?,
             val webViewUrl: Uri,
             val returnUrl: String? = null
         ) : NextActionData() {
 
-            internal constructor(data: String, webViewUrl: String, returnUrl: String? = null) :
+            internal constructor(data: String?, webViewUrl: String, returnUrl: String? = null) :
                 this(data, extractReturnUrl(data), Uri.parse(webViewUrl), returnUrl)
 
             private companion object {
@@ -280,8 +280,8 @@ sealed interface StripeIntent : StripeModel {
                  * return_url param, as a hint to the backend to ping Alipay for
                  * the updated state
                  */
-                private fun extractReturnUrl(data: String): String? = runCatching {
-                    Uri.parse("alipay://url?$data")
+                private fun extractReturnUrl(data: String?): String? = runCatching {
+                    Uri.parse("alipay://url?$${requireNotNull(data)}")
                         .getQueryParameter("return_url")?.takeIf {
                             StripeUrlUtils.isStripeUrl(it)
                         }

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -4,9 +4,11 @@ import android.net.Uri
 import android.os.Parcelable
 import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
+import androidx.core.net.toUri
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.utils.StripeUrlUtils
 import dev.drewhamilton.poko.Poko
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -263,28 +265,55 @@ sealed interface StripeIntent : StripeModel {
         ) : NextActionData()
 
         @Parcelize
-        internal data class AlipayRedirect constructor(
-            val data: String?,
-            val authCompleteUrl: String?,
+        internal data class AlipayRedirect(
+            val type: Type,
             val webViewUrl: Uri,
-            val returnUrl: String? = null
+            val returnUrl: String?
         ) : NextActionData() {
+            sealed interface Type : Parcelable {
+                @Parcelize
+                data object Default : Type
 
-            internal constructor(data: String?, webViewUrl: String, returnUrl: String? = null) :
-                this(data, extractReturnUrl(data), Uri.parse(webViewUrl), returnUrl)
+                @Parcelize
+                data class WithNativeData(val data: String) : Type {
+                    @IgnoredOnParcel
+                    val authCompleteUrl: String? by lazy {
+                        extractReturnUrl(data)
+                    }
+                }
+            }
 
-            private companion object {
+            internal companion object {
+                fun create(
+                    data: String?,
+                    webViewUrl: String,
+                    returnUrl: String? = null
+                ): AlipayRedirect {
+                    val webViewUri = webViewUrl.toUri()
+
+                    val type = if (data != null) {
+                        Type.WithNativeData(data = data)
+                    } else {
+                        Type.Default
+                    }
+
+                    return AlipayRedirect(
+                        type = type,
+                        webViewUrl = webViewUri,
+                        returnUrl = returnUrl,
+                    )
+                }
+
                 /**
                  * The alipay data string is formatted as query parameters.
                  * When authenticate is complete, we make a request to the
                  * return_url param, as a hint to the backend to ping Alipay for
                  * the updated state
                  */
-                private fun extractReturnUrl(data: String?): String? = runCatching {
-                    Uri.parse("alipay://url?$${requireNotNull(data)}")
-                        .getQueryParameter("return_url")?.takeIf {
-                            StripeUrlUtils.isStripeUrl(it)
-                        }
+                private fun extractReturnUrl(data: String): String? = runCatching {
+                    "alipay://url?$$data".toUri().getQueryParameter("return_url")?.takeIf {
+                        StripeUrlUtils.isStripeUrl(it)
+                    }
                 }.getOrNull()
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -157,9 +157,9 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             json: JSONObject
         ): StripeIntent.NextActionData.AlipayRedirect {
             return StripeIntent.NextActionData.AlipayRedirect(
-                json.getString(FIELD_NATIVE_DATA),
-                json.getString(FIELD_URL),
-                optString(json, FIELD_RETURN_URL)
+                data = optString(json, FIELD_NATIVE_DATA),
+                webViewUrl = json.getString(FIELD_URL),
+                returnUrl = optString(json, FIELD_RETURN_URL),
             )
         }
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -156,7 +156,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
         override fun parse(
             json: JSONObject
         ): StripeIntent.NextActionData.AlipayRedirect {
-            return StripeIntent.NextActionData.AlipayRedirect(
+            return StripeIntent.NextActionData.AlipayRedirect.create(
                 data = optString(json, FIELD_NATIVE_DATA),
                 webViewUrl = json.getString(FIELD_URL),
                 returnUrl = optString(json, FIELD_RETURN_URL),

--- a/payments-core/src/main/java/com/stripe/android/networking/DefaultAlipayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/DefaultAlipayRepository.kt
@@ -26,7 +26,7 @@ internal class DefaultAlipayRepository(
 
         val nextActionData = paymentIntent.nextActionData
 
-        if (nextActionData is StripeIntent.NextActionData.AlipayRedirect) {
+        if (nextActionData is StripeIntent.NextActionData.AlipayRedirect && nextActionData.data != null) {
             val output = authenticator.onAuthenticationRequest(nextActionData.data)
             val result = output[ALIPAY_RESULT_FIELD]
 

--- a/payments-core/src/main/java/com/stripe/android/networking/DefaultAlipayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/DefaultAlipayRepository.kt
@@ -26,12 +26,15 @@ internal class DefaultAlipayRepository(
 
         val nextActionData = paymentIntent.nextActionData
 
-        if (nextActionData is StripeIntent.NextActionData.AlipayRedirect && nextActionData.data != null) {
-            val output = authenticator.onAuthenticationRequest(nextActionData.data)
+        if (
+            nextActionData is StripeIntent.NextActionData.AlipayRedirect &&
+            nextActionData.type is StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData
+        ) {
+            val output = authenticator.onAuthenticationRequest(nextActionData.type.data)
             val result = output[ALIPAY_RESULT_FIELD]
 
             if (result == AlipayAuthResult.RESULT_CODE_SUCCESS) {
-                pingAlipayEndpointBeforeRetrievingPaymentIntentStatus(nextActionData, requestOptions)
+                pingAlipayEndpointBeforeRetrievingPaymentIntentStatus(nextActionData.type, requestOptions)
             }
 
             val outcome = when (output[ALIPAY_RESULT_FIELD]) {
@@ -48,13 +51,15 @@ internal class DefaultAlipayRepository(
     }
 
     private suspend fun pingAlipayEndpointBeforeRetrievingPaymentIntentStatus(
-        redirect: StripeIntent.NextActionData.AlipayRedirect,
+        withNativeData: StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData,
         requestOptions: ApiRequest.Options,
     ) {
+        val authCompleteUrl = withNativeData.authCompleteUrl
+
         // Alipay requires us to hit an endpoint before retrieving the PaymentIntent to ensure the
         // status is up-to-date.
-        if (redirect.authCompleteUrl != null) {
-            stripeRepository.retrieveObject(redirect.authCompleteUrl, requestOptions)
+        if (authCompleteUrl != null) {
+            stripeRepository.retrieveObject(authCompleteUrl, requestOptions)
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/AlipayRedirectTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/AlipayRedirectTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -9,7 +10,7 @@ import kotlin.test.Test
 class AlipayRedirectTest {
     @Test
     fun `Alipay data should parse return_url correctly`() {
-        val data = StripeIntent.NextActionData.AlipayRedirect(
+        val data = StripeIntent.NextActionData.AlipayRedirect.create(
             "_input_charset=utf-8&app_pay=Y" +
                 "&currency=USD&forex_biz=FP" +
                 "&notify_url=https%3A%2F%2Fhooks.stripe.com%2Falipay%2Falipay%2Fhook%2F6255d30b067c8f7a162c79c654483646%2Fsrc_1Gt188KlwPmebFhp4SWhZwn1" +
@@ -30,21 +31,27 @@ class AlipayRedirectTest {
                 "&total_fee=1.00",
             WEB_URL
         )
-        assertThat(data.authCompleteUrl).isEqualTo(
+        assertThat(data.withNativeDataType().authCompleteUrl).isEqualTo(
             "https://hooks.stripe.com/adapter/alipay/redirect/complete/src_1Gt188KlwPmebFhp4SWhZwn1/src_client_secret_RMaQKPfAmHOdUwcNhXEjolR4"
         )
     }
 
     @Test
     fun `Alipay data should handle missing data`() {
-        val data = StripeIntent.NextActionData.AlipayRedirect("", WEB_URL)
-        assertThat(data.authCompleteUrl).isNull()
+        val data = StripeIntent.NextActionData.AlipayRedirect.create("", WEB_URL)
+        assertThat(data.withNativeDataType().authCompleteUrl).isNull()
     }
 
     @Test
     fun `Alipay data should ignore non-stripe urls`() {
-        val data = StripeIntent.NextActionData.AlipayRedirect("return_url=https://google.com", WEB_URL)
-        assertThat(data.authCompleteUrl).isNull()
+        val data = StripeIntent.NextActionData.AlipayRedirect.create("return_url=https://google.com", WEB_URL)
+        assertThat(data.withNativeDataType().authCompleteUrl).isNull()
+    }
+
+    private fun StripeIntent.NextActionData.AlipayRedirect.withNativeDataType():
+        StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData {
+        assertThat(type).isInstanceOf<StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData>()
+        return type as StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -511,6 +511,14 @@ class ConfirmPaymentIntentParamsTest {
                     "return_url" to "stripe://return_url",
                     "payment_method_data" to mapOf(
                         "type" to "alipay"
+                    ),
+                    "mandate_data" to mapOf(
+                        "customer_acceptance" to mapOf(
+                            "type" to "online",
+                            "online" to mapOf(
+                                "infer_from_client" to true
+                            )
+                        )
                     )
                 )
             )

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -1602,6 +1602,71 @@ internal object PaymentIntentFixtures {
         PARSER.parse(ALIPAY_REQUIRES_ACTION_JSON)!!
     }
 
+    val ALIPAY_REQUIRES_ACTION_NO_NATIVE_DATA_JSON by lazy {
+        JSONObject(
+            """
+        {
+          "id": "pi_1HDEFVKlwPmebFhpCobFP55H",
+          "object": "payment_intent",
+          "amount": 100,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_1HDEFVKlwPmebFhpCobFP55H_secret_XW8sADccCxtusewAwn5z9kAiw",
+          "confirmation_method": "automatic",
+          "created": 1596740133,
+          "currency": "usd",
+          "description": "Example PaymentIntent",
+          "last_payment_error": null,
+          "livemode": true,
+          "next_action": {
+            "alipay_handle_redirect": {
+              "native_data": null,
+              "native_url": null,
+              "return_url": "example://return_url",
+              "url": "https://hooks.stripe.com/redirect/authenticate/src_1HDEFWKlwPmebFhp6tcpln8T?client_secret=src_client_secret_S6H9mVMKK6qxk9YxsUvbH55K"
+            },
+            "type": "alipay_handle_redirect"
+          },
+          "payment_method": {
+            "id": "pm_1HDEFVKlwPmebFhpKYYkSm8H",
+            "object": "payment_method",
+            "alipay": {},
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
+            },
+            "created": 1596740133,
+            "customer": null,
+            "livemode": true,
+            "type": "alipay"
+          },
+          "payment_method_types": [
+            "alipay"
+          ],
+          "receipt_email": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "status": "requires_action"
+        }
+            """.trimIndent()
+        )
+    }
+
+    val ALIPAY_REQUIRES_ACTION_NO_NATIVE_DATA by lazy {
+        PARSER.parse(ALIPAY_REQUIRES_ACTION_NO_NATIVE_DATA_JSON)!!
+    }
+
     val ALIPAY_TEST_MODE_JSON by lazy {
         JSONObject(
             """

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/NextActionDataParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/NextActionDataParserTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
 import com.stripe.android.model.StripeIntent
 import org.json.JSONObject
 import org.junit.runner.RunWith
@@ -110,5 +111,44 @@ internal class NextActionDataParserTest {
         val nextActionData = NextActionDataParser().parse(nextActionJson)
 
         assertThat(nextActionData).isNull()
+    }
+
+    @Test
+    fun `parse with alipay_handle_redirect and native_data present should create AlipayRedirect with data`() {
+        val nextActionJson = JSONObject(
+            """
+            {
+                "type": "alipay_handle_redirect",
+                "alipay_handle_redirect": {
+                    "native_data": "native_data_value",
+                    "url": "https://example.com/alipay"
+                }
+            }
+            """.trimIndent()
+        )
+
+        val nextActionData = NextActionDataParser().parse(nextActionJson)
+        assertThat(nextActionData).isInstanceOf<StripeIntent.NextActionData.AlipayRedirect>()
+        val alipayRedirect = nextActionData as StripeIntent.NextActionData.AlipayRedirect
+        assertThat(alipayRedirect.data).isEqualTo("native_data_value")
+    }
+
+    @Test
+    fun `parse with alipay_handle_redirect and native_data missing should create AlipayRedirect with null data`() {
+        val nextActionJson = JSONObject(
+            """
+            {
+                "type": "alipay_handle_redirect",
+                "alipay_handle_redirect": {
+                    "url": "https://example.com/alipay"
+                }
+            }
+            """.trimIndent()
+        )
+
+        val nextActionData = NextActionDataParser().parse(nextActionJson)
+        assertThat(nextActionData).isInstanceOf<StripeIntent.NextActionData.AlipayRedirect>()
+        val alipayRedirect = nextActionData as StripeIntent.NextActionData.AlipayRedirect
+        assertThat(alipayRedirect.data).isNull()
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/NextActionDataParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/NextActionDataParserTest.kt
@@ -130,11 +130,13 @@ internal class NextActionDataParserTest {
         val nextActionData = NextActionDataParser().parse(nextActionJson)
         assertThat(nextActionData).isInstanceOf<StripeIntent.NextActionData.AlipayRedirect>()
         val alipayRedirect = nextActionData as StripeIntent.NextActionData.AlipayRedirect
-        assertThat(alipayRedirect.data).isEqualTo("native_data_value")
+        assertThat(alipayRedirect.type).isInstanceOf<StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData>()
+        val type = alipayRedirect.type as StripeIntent.NextActionData.AlipayRedirect.Type.WithNativeData
+        assertThat(type.data).isEqualTo("native_data_value")
     }
 
     @Test
-    fun `parse with alipay_handle_redirect and native_data missing should create AlipayRedirect with null data`() {
+    fun `parse with alipay_handle_redirect and native_data missing should create default AlipayRedirect`() {
         val nextActionJson = JSONObject(
             """
             {
@@ -149,6 +151,6 @@ internal class NextActionDataParserTest {
         val nextActionData = NextActionDataParser().parse(nextActionJson)
         assertThat(nextActionData).isInstanceOf<StripeIntent.NextActionData.AlipayRedirect>()
         val alipayRedirect = nextActionData as StripeIntent.NextActionData.AlipayRedirect
-        assertThat(alipayRedirect.data).isNull()
+        assertThat(alipayRedirect.type).isEqualTo(StripeIntent.NextActionData.AlipayRedirect.Type.Default)
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
@@ -130,7 +130,7 @@ class PaymentIntentJsonParserTest {
         )
         assertThat(paymentIntent?.nextActionData)
             .isEqualTo(
-                StripeIntent.NextActionData.AlipayRedirect(
+                StripeIntent.NextActionData.AlipayRedirect.create(
                     "_input_charset=utf-8&app_pay=Y&currency=USD&forex_biz=FP&notify_url=https%3A%2F%2Fhooks.stripe.com%2Falipay%2Falipay%2Fhook%2F6255d30b067c8f7a162c79c654483646%2Fsrc_1HDEFWKlwPmebFhp6tcpln8T&out_trade_no=src_1HDEFWKlwPmebFhp6tcpln8T&partner=2088621828244481&payment_type=1&product_code=NEW_WAP_OVERSEAS_SELLER&return_url=https%3A%2F%2Fhooks.stripe.com%2Fadapter%2Falipay%2Fredirect%2Fcomplete%2Fsrc_1HDEFWKlwPmebFhp6tcpln8T%2Fsrc_client_secret_S6H9mVMKK6qxk9YxsUvbH55K&secondary_merchant_id=acct_1EqOyCKlwPmebFhp&secondary_merchant_industry=5734&secondary_merchant_name=Yuki-Test&sendFormat=normal&service=create_forex_trade_wap&sign=b691876a7f0bd889530f54a271d314d5&sign_type=MD5&subject=Yuki-Test&supplier=Yuki-Test&timeout_rule=20m&total_fee=1.00",
                     "https://hooks.stripe.com/redirect/authenticate/src_1HDEFWKlwPmebFhp6tcpln8T?client_secret=src_client_secret_S6H9mVMKK6qxk9YxsUvbH55K",
                     "example://return_url"

--- a/payments-core/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/DefaultAlipayRepositoryTest.kt
@@ -89,6 +89,21 @@ internal class DefaultAlipayRepositoryTest {
                 REQUEST_OPTIONS
             )
         }
+
+        assertThat(exception.message)
+            .isEqualTo("Unable to authenticate Payment Intent with Alipay SDK")
+    }
+
+    @Test
+    fun `authenticate() should throw exception when alipay redirect data is null`() = runTest {
+        val exception = assertFailsWith<RuntimeException> {
+            repository.authenticate(
+                PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION_NO_NATIVE_DATA,
+                createAuthenticator(AlipayAuthResult.RESULT_CODE_SUCCESS),
+                REQUEST_OPTIONS
+            )
+        }
+
         assertThat(exception.message)
             .isEqualTo("Unable to authenticate Payment Intent with Alipay SDK")
     }


### PR DESCRIPTION
# Summary
Add direct API support for Alipay by:
- Updating `PaymentMethod` to set `requiresMandate` to `true` for `Alipay`
- Updating `NextActionDataParser` to make `data` field nullable.

# Motivation
Merchant request to support direct API usage of Alipay

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified