### PR TITLE
Fix 3DS2 not cancelling properly on user navigation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -76,7 +76,11 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
                         )
                     )
                 }
-                shouldRefreshOrPollIntent(stripeIntent, result.flowOutcome) -> {
+                shouldRefreshOrPollIntent(
+                    stripeIntent = stripeIntent,
+                    flowOutcome = result.flowOutcome,
+                    canCancelSource = result.canCancelSource
+                ) -> {
                     val intent = if (shouldCallRefreshIntent(stripeIntent)) {
                         refreshStripeIntent(
                             clientSecret = result.clientSecret,
@@ -167,8 +171,15 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
 
     private fun shouldRefreshOrPollIntent(
         stripeIntent: StripeIntent,
-        @StripeIntentResult.Outcome flowOutcome: Int
+        @StripeIntentResult.Outcome flowOutcome: Int,
+        canCancelSource: Boolean
     ): Boolean {
+        // An explicit WebView dismissal must cancel the source instead of polling. Unlike Custom
+        // Tabs, the in-app WebView can distinguish user cancellation from an ambiguous return.
+        if (flowOutcome == CANCELED && shouldCancelIntentSource(stripeIntent, canCancelSource)) {
+            return false
+        }
+
         // For some payment methods, after user confirmation(resulting in flowOutCome == SUCCEEDED),
         // there is a delay when Stripe backend transfers its state out of "requires_action".
         // For a PaymentIntent with such payment method, we will need to poll the refresh endpoint

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -146,6 +146,59 @@ internal class PaymentIntentFlowResultProcessorTest {
         }
 
     @Test
+    fun `3ds2 web view cancellation cancels source instead of polling`() =
+        runTest(testDispatcher) {
+            val intent = PaymentIntentFixtures.PI_VISA_3DS2.copy(
+                status = StripeIntent.Status.RequiresAction
+            )
+            whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
+                Result.success(intent)
+            )
+            whenever(mockStripeRepository.cancelPaymentIntentSource(any(), any(), any())).thenReturn(
+                Result.success(PaymentIntentFixtures.PAYMENT_INTENT_WITH_CANCELED_3DS2_SOURCE)
+            )
+
+            createProcessor().processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = requireNotNull(intent.clientSecret),
+                    sourceId = "source_id",
+                    flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                    canCancelSource = true
+                )
+            ).getOrThrow()
+
+            verify(mockStripeRepository).cancelPaymentIntentSource(any(), eq("source_id"), any())
+            verify(mockStripeRepository).retrievePaymentIntent(any(), any(), any())
+        }
+
+    @Test
+    fun `ambiguous redirect return polls instead of canceling source`() =
+        runTest(testDispatcher) {
+            val intent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                status = StripeIntent.Status.RequiresAction,
+                paymentMethod = PaymentMethodFactory.revolutPay(),
+                paymentMethodTypes = listOf("card", "revolut_pay")
+            )
+            val succeededIntent = intent.copy(status = StripeIntent.Status.Succeeded)
+            whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
+                Result.success(intent),
+                Result.success(succeededIntent)
+            )
+
+            val result = createProcessor().processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = requireNotNull(intent.clientSecret),
+                    sourceId = "source_id",
+                    flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
+                    canCancelSource = true
+                )
+            ).getOrThrow()
+
+            assertThat(result.intent.status).isEqualTo(StripeIntent.Status.Succeeded)
+            verify(mockStripeRepository, never()).cancelPaymentIntentSource(any(), any(), any())
+        }
+
+    @Test
     fun `no refresh when user cancels the payment`() = runTest(testDispatcher) {
         whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
             Result.success(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -74,6 +74,32 @@ internal class SetupIntentFlowResultProcessorTest {
         }
 
     @Test
+    fun `3ds2 web view cancellation cancels source instead of polling`() =
+        runTest(testDispatcher) {
+            val intent = SetupIntentFixtures.SI_3DS2_PROCESSING.copy(
+                status = StripeIntent.Status.RequiresAction
+            )
+            whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
+                Result.success(intent)
+            )
+            whenever(mockStripeRepository.cancelSetupIntentSource(any(), any(), any())).thenReturn(
+                Result.success(SetupIntentFixtures.CANCELLED)
+            )
+
+            processor.processResult(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = requireNotNull(intent.clientSecret),
+                    sourceId = "source_id",
+                    flowOutcome = StripeIntentResult.Outcome.CANCELED,
+                    canCancelSource = true
+                )
+            ).getOrThrow()
+
+            verify(mockStripeRepository).cancelSetupIntentSource(any(), eq("source_id"), any())
+            verify(mockStripeRepository).retrieveSetupIntent(any(), any(), any())
+        }
+
+    @Test
     fun `3ds2 canceled with processing intent should succeed`() =
         runTest(testDispatcher) {
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(


### PR DESCRIPTION
# Summary
Fix 3DS2 not cancelling properly on user navigation by checking if the source should cancel in `shouldRefreshOrPollIntent`. If the flow outcome is cancelled and the `shouldCancelSource` flag is `true`, refresh & polling will be skipped and go to cancelling the source instead.

All LPMs using web auth have `shouldCancelSource` as `false` when launching `PaymentAuthWebViewActivity` with the [exception of 3DS2](https://github.com/stripe/stripe-android/blob/393f743ec811efa78849a0c08c95ee34b6827e9b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt#L229-L230) which has it set to `true` but is not respected in `PaymentFlowResultProcessor`.

Intent before: [pi_3U6bBrLu5o3P18Zp0TYkMZx6](https://go/o/pi_3U6bBrLu5o3P18Zp0TYkMZx6) (stays on `requires_action`)
Intent after: [pi_3U6bEvLu5o3P18Zp15S7FqTI](https://go/o/pi_3U6bEvLu5o3P18Zp15S7FqTI) (moves to `requires_payment_method`)

# Motivation
[RUN_MOBILESDK-5527](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5527)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified