### PR TITLE
Move Klarna billing elements into form builder

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -3,7 +3,12 @@ package com.stripe.android.lpmfoundations.luxe
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.CountryElement
+import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 
 internal class FormElementsBuilder(
     private val arguments: UiDefinitionFactory.Arguments,
@@ -19,6 +24,7 @@ internal class FormElementsBuilder(
     private var requireBillingAddressCollection: Boolean = false
     private var availableCountries: Set<String> =
         arguments.billingDetailsCollectionConfiguration.allowedBillingCountries
+    private var countryRequirement: CountryRequirement? = null
 
     init {
         // Setup the required contact information fields based on the merchant billingDetailsCollectionConfiguration.
@@ -78,6 +84,16 @@ internal class FormElementsBuilder(
         }
     }
 
+    fun requireCountry(
+        allowedCountryCodes: Set<String>,
+        initialValue: String?,
+    ): FormElementsBuilder = apply {
+        countryRequirement = CountryRequirement(
+            allowedCountryCodes = allowedCountryCodes,
+            initialValue = initialValue,
+        )
+    }
+
     fun footer(formElement: FormElement): FormElementsBuilder = apply {
         footerFormElements += formElement
     }
@@ -94,17 +110,41 @@ internal class FormElementsBuilder(
 
             addAll(uiFormElements)
 
-            if (requireBillingAddressCollection) {
-                val elements = AddressSpec(allowedCountryCodes = availableCountries).transform(
-                    initialValues = arguments.initialValues,
-                    shippingValues = arguments.shippingValues,
-                    autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+            countryRequirement?.let { requirement ->
+                add(
+                    SectionElement.wrap(
+                        CountryElement(
+                            identifier = IdentifierSpec.Country,
+                            controller = DropdownFieldController(
+                                config = CountryConfig(requirement.allowedCountryCodes),
+                                initialValue = requirement.initialValue,
+                            )
+                        )
+                    )
                 )
+            }
 
-                addAll(elements)
+            if (requireBillingAddressCollection) {
+                addAll(createAddressElements(hideCountry = countryRequirement != null))
             }
 
             addAll(footerFormElements) // Order footers last.
         }
     }
+
+    private fun createAddressElements(hideCountry: Boolean): List<FormElement> {
+        return AddressSpec(
+            allowedCountryCodes = availableCountries,
+            hideCountry = hideCountry,
+        ).transform(
+            initialValues = arguments.initialValues,
+            shippingValues = arguments.shippingValues,
+            autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+        )
+    }
+
+    private data class CountryRequirement(
+        val allowedCountryCodes: Set<String>,
+        val initialValue: String?,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -13,16 +13,11 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
 import com.stripe.android.ui.core.elements.StaticTextElement
-import com.stripe.android.uicore.elements.CountryConfig
-import com.stripe.android.uicore.elements.CountryElement
-import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.SectionElement
 
 internal object KlarnaDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Klarna
@@ -66,38 +61,11 @@ private object KlarnaUiDefinitionFactory : UiDefinitionFactory.Simple() {
             .requireContactInformationIfAllowed(ContactInformationCollectionMode.Email)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Email)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Phone)
-            .ignoreBillingAddressRequirements()
-            .element(
-                formElement = SectionElement.wrap(
-                    sectionFieldElement = CountryElement(
-                        identifier = IdentifierSpec.Country,
-                        controller = DropdownFieldController(
-                            config = CountryConfig(
-                                onlyShowCountryCodes =
-                                metadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                            ),
-                            initialValue = arguments.initialValues[IdentifierSpec.Country],
-                        )
-                    )
-                )
+            .requireCountry(
+                allowedCountryCodes = metadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
+                initialValue = arguments.initialValues[IdentifierSpec.Country],
             )
             .apply {
-                if (
-                    metadata.billingDetailsCollectionConfiguration.address ==
-                    PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
-                ) {
-                    AddressSpec(
-                        allowedCountryCodes = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                        hideCountry = true,
-                    ).transform(
-                        initialValues = arguments.initialValues,
-                        shippingValues = arguments.shippingValues,
-                        autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
-                    ).forEach {
-                        element(it)
-                    }
-                }
-
                 if (KlarnaDefinition.requiresMandate(metadata)) {
                     builder.footer(
                         formElement = MandateTextElement(
@@ -156,11 +124,9 @@ private object KlarnaRemovedFormUiDefinitionFactory : UiDefinitionFactory.Simple
                         stringResId = R.string.stripe_klarna_buy_now_pay_later
                     )
                 )
-                .element(
-                    getKlarnaCountryElement(
-                        allowedCountryCodes = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                        initialValue = metadata.stripeIntent.countryCode
-                    )
+                .requireCountry(
+                    allowedCountryCodes = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
+                    initialValue = metadata.stripeIntent.countryCode,
                 )
         }
 
@@ -172,22 +138,5 @@ private object KlarnaRemovedFormUiDefinitionFactory : UiDefinitionFactory.Simple
                 )
             )
         }
-    }
-
-    private fun getKlarnaCountryElement(
-        allowedCountryCodes: Set<String>,
-        initialValue: String?
-    ): FormElement {
-        val identifier = IdentifierSpec.Generic("billing_details[address][country]")
-
-        return SectionElement.wrap(
-            CountryElement(
-                identifier = identifier,
-                controller = DropdownFieldController(
-                    CountryConfig(allowedCountryCodes),
-                    initialValue = initialValue
-                )
-            )
-        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.ui.core.elements.EmptyFormElement
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -68,6 +69,108 @@ class FormElementsBuilderTest {
         assertThat(formElements[2].identifier.v1).isEqualTo("element")
         assertThat(formElements[3].identifier.v1).isEqualTo("billing_details[address]_section")
         assertThat(formElements[4].identifier.v1).isEqualTo("footer")
+    }
+
+    @Test
+    fun `build orders country requirement after ordinary elements and before footers`() {
+        val formElements = FormElementsBuilder(arguments())
+            .element(EmptyFormElement(identifier = IdentifierSpec(v1 = "element")))
+            .footer(EmptyFormElement(identifier = IdentifierSpec(v1 = "footer")))
+            .requireCountry(
+                allowedCountryCodes = setOf("US", "CA"),
+                initialValue = "US",
+            )
+            .build()
+
+        assertThat(formElements).hasSize(3)
+        assertThat(formElements[0].identifier.v1).isEqualTo("element")
+        assertThat(formElements[1].identifier.v1).isEqualTo("billing_details[address][country]_section")
+        assertThat(formElements[2].identifier.v1).isEqualTo("footer")
+    }
+
+    @Test
+    fun `country requirement contains only allowed countries`() {
+        val countryElement = FormElementsBuilder(arguments())
+            .requireCountry(
+                allowedCountryCodes = setOf("US", "CA"),
+                initialValue = null,
+            )
+            .build()
+            .countryElement()
+
+        assertThat(countryElement.controller.displayItems).containsExactly(
+            "\uD83C\uDDFA\uD83C\uDDF8 United States",
+            "\uD83C\uDDE8\uD83C\uDDE6 Canada",
+        )
+    }
+
+    @Test
+    fun `country requirement uses declared initial value`() {
+        val countryElement = FormElementsBuilder(arguments())
+            .requireCountry(
+                allowedCountryCodes = setOf("US", "CA"),
+                initialValue = "CA",
+            )
+            .build()
+            .countryElement()
+
+        assertThat(countryElement.controller.rawFieldValue.value).isEqualTo("CA")
+    }
+
+    @Test
+    fun `country requirement returns country-only output without full address collection`() {
+        val formElements = FormElementsBuilder(
+            arguments(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                )
+            )
+        )
+            .requireCountry(
+                allowedCountryCodes = setOf("US", "CA"),
+                initialValue = "US",
+            )
+            .build()
+
+        assertThat(formElements).hasSize(1)
+        formElements.countryElement()
+    }
+
+    @Test
+    fun `full address collection adds country requirement and address fields with country hidden`() {
+        val formElements = FormElementsBuilder(
+            arguments(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                    allowedCountries = setOf("US", "CA"),
+                )
+            )
+        )
+            .requireCountry(
+                allowedCountryCodes = setOf("US", "CA"),
+                initialValue = "US",
+            )
+            .build()
+
+        assertThat(formElements).hasSize(2)
+        formElements.countryElement()
+        val addressElement = (formElements[1] as SectionElement).fields.single() as AddressElement
+        assertThat(addressElement.fields.value).doesNotContain(addressElement.countryElement)
+    }
+
+    @Test
+    fun `full address collection without country requirement keeps country in address fields`() {
+        val formElements = FormElementsBuilder(
+            arguments(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                )
+            )
+        ).build()
+
+        assertThat(formElements).hasSize(1)
+        val addressElement = (formElements.single() as SectionElement).fields.single() as AddressElement
+        assertThat(addressElement.fields.value).contains(addressElement.countryElement)
     }
 
     @Test
@@ -280,6 +383,11 @@ class FormElementsBuilderTest {
     private inline fun <reified T : SectionFieldElement> SectionElement.assertSingleElementInSection() {
         assertThat(fields).hasSize(1)
         assertThat(fields[0]).isInstanceOf<T>()
+    }
+
+    private fun List<FormElement>.countryElement(): CountryElement {
+        val section = single { it.identifier.v1 == "billing_details[address][country]_section" } as SectionElement
+        return section.fields.single() as CountryElement
     }
 
     private fun getSection(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionNoFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionNoFormTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionElement
 import org.junit.Rule
@@ -89,6 +90,26 @@ class KlarnaDefinitionNoFormTest {
         assertThat(formElements[1].identifier.v1)
             .isEqualTo("billing_details[address][country]_section")
         assertThat(formElements[2].identifier.v1).isEqualTo("mandate")
+    }
+
+    @Test
+    fun `createFormElements uses setup intent country before default billing country`() {
+        val formElements = KlarnaDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFactory.create(
+                    paymentMethodTypes = listOf("card", "klarna"),
+                    countryCode = "US",
+                ),
+                defaultBillingDetails = PaymentSheet.BillingDetails(
+                    address = PaymentSheet.Address(country = "CA"),
+                ),
+            )
+        )
+
+        assertThat(formElements).hasSize(3)
+        assertThat(formElements[1].identifier.v1).isEqualTo("billing_details[address][country]_section")
+        val countryElement = (formElements[1] as SectionElement).fields.single() as CountryElement
+        assertThat(countryElement.controller.rawFieldValue.value).isEqualTo("US")
     }
 
     @Test


### PR DESCRIPTION
# Summary

Klarna retains the same country, address, header, contact, and mandate fields, including their ordering and initial values.

This PR adds an internal `FormElementsBuilder.requireCountry(...)` requirement. Country collection is modeled as a minimum requirement independent of merchant Full-address collection. The builder places the separate country section after ordinary form elements and before billing-address fields and footers.

For regular Klarna, Never and Automatic remain country-only. Full retains the separate country section followed by the merchant-requested address fields with their embedded country field hidden. The removed-form SetupIntent non-Full path continues to initialize country from `stripeIntent.countryCode`.

# Motivation

Both Klarna factories previously constructed country elements directly, and the regular factory also constructed its Full-address fields directly. Moving these declarations into `FormElementsBuilder` gives billing elements one fixed ordering boundary while preserving each Klarna path's allowed countries and initial country value.

The feature-flag selection and production entry path remain unchanged. This is the production child of test-only #14091, which is now merged.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.lpmfoundations.luxe.FormElementsBuilderTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinitionTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinitionNoFormTest' --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.LpmBillingAddressFormValuesToParamsTest'`
- `./gradlew :paymentsheet:verifyPaparazziDebug --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.LpmBillingAddressScreenshotTest'`
- `./gradlew :paymentsheet:detekt`
- `./gradlew :paymentsheet:apiCheck`
- `git diff --check`

All listed commands passed. Paparazzi verified all 76 current cases with zero failures or errors. All 11 inherited Klarna PNGs remain byte-identical to `master`. The #14091 fixture, snapshots, feature-flag selection, public API, API artifacts, and changelog are unchanged.

# Screenshots

No visual change. This PR verifies the 11 inherited Klarna screenshots without recording new baselines.

# Changelog

Not applicable. This is an internal, behavior-preserving refactor with no public API change.
