### PR TITLE
Add saved payment method confirmation screen to Embedded

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -13,14 +13,11 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.DismissKeyboardOnProcessing
 import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
-import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
-import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmUI
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
 import com.stripe.android.ui.core.elements.Mandate
@@ -36,27 +33,13 @@ internal fun FormScreenContent(
     onClick: () -> Unit,
     onProcessingCompleted: () -> Unit,
     state: SheetActivityStateHolder.State,
-    updateSelection: (PaymentSelection.Saved) -> Unit,
-    savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
 ) {
     val interactorState by interactor.state.collectAsState()
 
     DismissKeyboardOnProcessing(interactorState.isProcessing)
 
     EventReporterProvider(eventReporter) {
-        if (state.savedPaymentSelectionToConfirm == null) {
-            VerticalModeFormUI(
-                interactor = interactor,
-                showsWalletHeader = false
-            )
-        } else {
-            SavedPaymentMethodConfirmUI(
-                savedPaymentMethodConfirmInteractor = savedPaymentMethodConfirmInteractorFactory.create(
-                    initialSelection = state.savedPaymentSelectionToConfirm,
-                    updateSelection = updateSelection,
-                ),
-            )
-        }
+        VerticalModeFormUI(interactor = interactor, showsWalletHeader = false)
         USBankAccountMandate(state)
         FormActivityError(state)
         Spacer(Modifier.height(40.dp))

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -28,6 +29,7 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
+import com.stripe.android.paymentsheet.utils.DismissKeyboardOnProcessing
 import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.utils.addPaymentMethodTitle
@@ -37,6 +39,7 @@ import com.stripe.android.paymentsheet.verticalmode.ManageScreenUI
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutUI
 import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmUI
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.stripeFormInsets
@@ -124,6 +127,7 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageAll -> eventReporter.onShowManageSavedPaymentMethods()
             is Screen.ManageUpdate -> eventReporter.onShowEditablePaymentOption()
             is Screen.Form -> Unit
+            is Screen.SavedPaymentMethodConfirm -> Unit
             is Screen.VerticalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
             is Screen.HorizontalPaymentOptions -> eventReporter.onShowNewPaymentOptions()
         }
@@ -134,6 +138,7 @@ internal class EmbeddedNavigator private constructor(
             is Screen.ManageAll -> Unit
             is Screen.ManageUpdate -> eventReporter.onHideEditablePaymentOption()
             is Screen.Form -> Unit
+            is Screen.SavedPaymentMethodConfirm -> Unit
             is Screen.VerticalPaymentOptions -> Unit
             is Screen.HorizontalPaymentOptions -> Unit
         }
@@ -209,7 +214,6 @@ internal class EmbeddedNavigator private constructor(
             private val sheetActivityStateHolder: SheetActivityStateHolder,
             private val confirmationHelper: SheetActivityConfirmationHelper,
             private val embeddedSelectionHolder: EmbeddedSelectionHolder,
-            private val savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
             private val customerStateHolder: CustomerStateHolder,
             private val launchMode: EmbeddedLaunchMode.Form,
         ) : Screen(), Closeable {
@@ -237,19 +241,14 @@ internal class EmbeddedNavigator private constructor(
                     },
                     onProcessingCompleted = {
                         sheetActivityStateHolder.setResult(
-                            EmbeddedActivityResult.Complete(
-                                selection = null,
-                                previousNewSelections = embeddedSelectionHolder.previousNewSelections,
-                                hasBeenConfirmed = true,
-                                customerState = customerStateHolder.customer.value,
-                                shouldInvokeSelectionCallback = false,
+                            successfulConfirmationResult(
+                                embeddedSelectionHolder = embeddedSelectionHolder,
+                                customerStateHolder = customerStateHolder,
                                 launchMode = launchMode,
                             )
                         )
                     },
                     state = state,
-                    updateSelection = embeddedSelectionHolder::setSelection,
-                    savedPaymentMethodConfirmInteractorFactory = savedPaymentMethodConfirmInteractorFactory,
                 )
             }
 
@@ -263,7 +262,6 @@ internal class EmbeddedNavigator private constructor(
                 private val sheetActivityStateHolder: SheetActivityStateHolder,
                 private val confirmationHelper: SheetActivityConfirmationHelper,
                 private val embeddedSelectionHolder: EmbeddedSelectionHolder,
-                private val savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory,
                 private val customerStateHolder: CustomerStateHolder,
             ) {
                 fun create(launchMode: EmbeddedLaunchMode.Form): Form {
@@ -279,12 +277,62 @@ internal class EmbeddedNavigator private constructor(
                         sheetActivityStateHolder = sheetActivityStateHolder,
                         confirmationHelper = confirmationHelper,
                         embeddedSelectionHolder = embeddedSelectionHolder,
-                        savedPaymentMethodConfirmInteractorFactory = savedPaymentMethodConfirmInteractorFactory,
                         customerStateHolder = customerStateHolder,
                         launchMode = launchMode,
                     )
                 }
             }
+        }
+
+        class SavedPaymentMethodConfirm(
+            private val interactor: SavedPaymentMethodConfirmInteractor,
+            private val isLiveMode: Boolean,
+            private val eventReporter: EventReporter,
+            private val sheetActivityStateHolder: SheetActivityStateHolder,
+            private val confirmationHelper: SheetActivityConfirmationHelper,
+            private val embeddedSelectionHolder: EmbeddedSelectionHolder,
+            private val customerStateHolder: CustomerStateHolder,
+            private val launchMode: EmbeddedLaunchMode,
+        ) : Screen(), Closeable {
+            override fun topBarState() = stateFlowOf(
+                PaymentSheetTopBarStateFactory.create(isLiveMode, PaymentSheetTopBarState.Editable.Never)
+            )
+
+            override fun title() = stateFlowOf<ResolvableString?>(null)
+            override fun isPerformingNetworkOperation() = sheetActivityStateHolder.state.mapAsStateFlow {
+                it.isProcessing
+            }
+
+            @Composable
+            override fun Content() {
+                val state by sheetActivityStateHolder.state.collectAsState()
+                DismissKeyboardOnProcessing(state.isProcessing)
+
+                EventReporterProvider(eventReporter) {
+                    Column {
+                        SavedPaymentMethodConfirmUI(interactor)
+                        USBankAccountMandate(state)
+                        FormActivityError(state)
+                        Spacer(Modifier.height(40.dp))
+                        FormActivityPrimaryButton(
+                            state = state,
+                            onProcessingCompleted = {
+                                sheetActivityStateHolder.setResult(
+                                    successfulConfirmationResult(
+                                        embeddedSelectionHolder = embeddedSelectionHolder,
+                                        customerStateHolder = customerStateHolder,
+                                        launchMode = launchMode,
+                                    )
+                                )
+                            },
+                            onClick = confirmationHelper::confirm,
+                        )
+                        PaymentSheetContentPadding()
+                    }
+                }
+            }
+
+            override fun close() = interactor.close()
         }
 
         class VerticalPaymentOptions(
@@ -386,3 +434,16 @@ internal class EmbeddedNavigator private constructor(
         data class ReplaceCurrentScreen(val screen: Screen) : Action()
     }
 }
+
+private fun successfulConfirmationResult(
+    embeddedSelectionHolder: EmbeddedSelectionHolder,
+    customerStateHolder: CustomerStateHolder,
+    launchMode: EmbeddedLaunchMode,
+) = EmbeddedActivityResult.Complete(
+    selection = null,
+    previousNewSelections = embeddedSelectionHolder.previousNewSelections,
+    hasBeenConfirmed = true,
+    customerState = customerStateHolder.customer.value,
+    shouldInvokeSelectionCallback = false,
+    launchMode = launchMode,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactory.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import javax.inject.Inject
+
+internal class SavedPaymentMethodConfirmScreenFactory @Inject constructor(
+    private val interactorFactory: SavedPaymentMethodConfirmInteractor.Factory,
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val eventReporter: EventReporter,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+    private val confirmationHelper: SheetActivityConfirmationHelper,
+    private val embeddedSelectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val launchMode: EmbeddedLaunchMode,
+) {
+    fun create(selection: PaymentSelection.Saved) = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
+        interactor = interactorFactory.create(selection, embeddedSelectionHolder::setSelection),
+        isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+        eventReporter = eventReporter,
+        sheetActivityStateHolder = sheetActivityStateHolder,
+        confirmationHelper = confirmationHelper,
+        embeddedSelectionHolder = embeddedSelectionHolder,
+        customerStateHolder = customerStateHolder,
+        launchMode = launchMode,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.amount
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -33,6 +32,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 internal interface SheetActivityStateHolder {
@@ -45,8 +45,6 @@ internal interface SheetActivityStateHolder {
 
     fun setResult(result: EmbeddedActivityResult)
 
-    fun updateSavedPaymentSelectionToConfirm(selection: PaymentSelection.Saved?)
-
     data class State(
         val primaryButtonLabel: ResolvableString,
         val isEnabled: Boolean,
@@ -55,7 +53,6 @@ internal interface SheetActivityStateHolder {
         val shouldDisplayLockIcon: Boolean,
         val error: ResolvableString? = null,
         val mandateText: ResolvableString? = null,
-        val savedPaymentSelectionToConfirm: PaymentSelection.Saved? = null,
     )
 }
 
@@ -71,6 +68,8 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
     private val tapToAddHelper: TapToAddHelper,
     private val customerStateHolder: CustomerStateHolder,
     private val launchMode: EmbeddedLaunchMode,
+    private val embeddedNavigatorProvider: Provider<EmbeddedNavigator>,
+    private val savedPaymentMethodConfirmScreenFactoryProvider: Provider<SavedPaymentMethodConfirmScreenFactory>,
 ) : SheetActivityStateHolder {
     private val _state = MutableStateFlow(
         SheetActivityStateHolder.State(
@@ -80,7 +79,6 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
             isProcessing = false,
             shouldDisplayLockIcon = launchMode !is EmbeddedLaunchMode.PaymentOptions &&
                 configuration.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm,
-            savedPaymentSelectionToConfirm = null,
         )
     )
     override val state: StateFlow<SheetActivityStateHolder.State> = _state
@@ -93,33 +91,32 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
     init {
         coroutineScope.launch {
             tapToAddHelper.nextStep.collect { result ->
-                val formResult = when (result) {
+                val activityResult = when (result) {
                     is TapToAddNextStep.ConfirmSavedPaymentMethod -> {
-                        updateSavedPaymentSelectionToConfirm(
-                            result.paymentSelection,
+                        val screen = savedPaymentMethodConfirmScreenFactoryProvider.get().create(
+                            selection = result.paymentSelection,
+                        )
+                        embeddedNavigatorProvider.get().performAction(
+                            EmbeddedNavigator.Action.ReplaceCurrentScreen(screen)
                         )
                         null
                     }
-                    is TapToAddNextStep.ShowSavedPaymentMethods -> {
-                        EmbeddedActivityResult.Complete(
-                            selection = result.paymentSelection,
-                            previousNewSelections = selectionHolder.previousNewSelections,
-                            hasBeenConfirmed = false,
-                            customerState = customerStateHolder.customer.value,
-                            shouldInvokeSelectionCallback = false,
-                            launchMode = launchMode,
-                        )
-                    }
-                    TapToAddNextStep.Complete -> {
-                        EmbeddedActivityResult.Complete(
-                            selection = null,
-                            previousNewSelections = selectionHolder.previousNewSelections,
-                            hasBeenConfirmed = true,
-                            customerState = customerStateHolder.customer.value,
-                            shouldInvokeSelectionCallback = false,
-                            launchMode = launchMode,
-                        )
-                    }
+                    is TapToAddNextStep.ShowSavedPaymentMethods -> EmbeddedActivityResult.Complete(
+                        selection = result.paymentSelection,
+                        previousNewSelections = selectionHolder.previousNewSelections,
+                        hasBeenConfirmed = false,
+                        customerState = customerStateHolder.customer.value,
+                        shouldInvokeSelectionCallback = false,
+                        launchMode = launchMode,
+                    )
+                    TapToAddNextStep.Complete -> EmbeddedActivityResult.Complete(
+                        selection = null,
+                        previousNewSelections = selectionHolder.previousNewSelections,
+                        hasBeenConfirmed = true,
+                        customerState = customerStateHolder.customer.value,
+                        shouldInvokeSelectionCallback = false,
+                        launchMode = launchMode,
+                    )
                     is TapToAddNextStep.Continue -> {
                         customerStateHolder.addPaymentMethod(result.paymentSelection.paymentMethod)
                         EmbeddedActivityResult.Complete(
@@ -132,9 +129,7 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                         )
                     }
                 }
-                formResult?.let {
-                    setResult(it)
-                }
+                activityResult?.let(::setResult)
             }
         }
 
@@ -196,12 +191,6 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                     isEnabled = selectionHolder.selection.value != null,
                 )
             }
-        }
-    }
-
-    override fun updateSavedPaymentSelectionToConfirm(selection: PaymentSelection.Saved?) {
-        _state.update {
-            it.copy(savedPaymentSelectionToConfirm = selection)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -23,10 +23,11 @@ import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
+import com.stripe.android.paymentelement.embedded.sheet.FakeSheetActivityConfirmationHelper
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
@@ -44,6 +45,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import java.util.Locale
+import javax.inject.Provider
 
 @OptIn(AppearanceAPIAdditionsPreview::class)
 internal class FormActivityScreenShotTest {
@@ -125,13 +127,42 @@ internal class FormActivityScreenShotTest {
 
     @Test
     fun testFormActivity_confirmSavedPaymentMethod() {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
+        val confirmationHandler = FakeConfirmationHandler()
+        val customerStateHolder = FakeCustomerStateHolder()
+        val launchMode = EmbeddedLaunchMode.Form(
+            selectedPaymentMethodCode = "card",
+        )
+        val stateHolder = DefaultSheetActivityStateHolder(
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectionHolder = selectionHolder,
+            configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
+            coroutineScope = TestScope(UnconfinedTestDispatcher()),
+            onClickDelegate = OnClickDelegateOverrideImpl(),
+            eventReporter = FakeEventReporter(),
+            confirmationHandler = confirmationHandler,
+            tapToAddHelper = FakeTapToAddHelper.noOp(),
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+            embeddedNavigatorProvider = Provider { error("Not expected") },
+            savedPaymentMethodConfirmScreenFactoryProvider = Provider { error("Not expected") },
+        )
+        val screen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
+            interactor = FakeSavedPaymentMethodConfirmInteractor(formEnabled = false),
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+            eventReporter = FakeEventReporter(),
+            sheetActivityStateHolder = stateHolder,
+            confirmationHelper = FakeSheetActivityConfirmationHelper(),
+            embeddedSelectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+        )
+
         paparazziRule.snapshot {
-            TestFormActivityUi(
-                ConfirmationHandler.State.Idle,
-                savedPaymentMethodSelectionToConfirm = PaymentSelection.Saved(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                ),
-            )
+            ViewModelStoreOwnerContext {
+                screen.Content()
+            }
         }
     }
 
@@ -177,7 +208,6 @@ internal class FormActivityScreenShotTest {
         confirmationState: ConfirmationHandler.State,
         enabled: Boolean = false,
         usBankMandate: ResolvableString? = null,
-        savedPaymentMethodSelectionToConfirm: PaymentSelection.Saved? = null,
     ) {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
@@ -196,6 +226,8 @@ internal class FormActivityScreenShotTest {
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
             ),
+            embeddedNavigatorProvider = Provider { error("Not expected") },
+            savedPaymentMethodConfirmScreenFactoryProvider = Provider { error("Not expected") },
         )
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
@@ -220,7 +252,6 @@ internal class FormActivityScreenShotTest {
         )
 
         stateHolder.updateMandate(usBankMandate)
-        stateHolder.updateSavedPaymentSelectionToConfirm(savedPaymentMethodSelectionToConfirm)
         val state by stateHolder.state.collectAsState()
 
         ViewModelStoreOwnerContext {
@@ -231,8 +262,6 @@ internal class FormActivityScreenShotTest {
                     onClick = {},
                     onProcessingCompleted = {},
                     state = state.copy(isEnabled = enabled),
-                    updateSelection = {},
-                    savedPaymentMethodConfirmInteractorFactory = FakeSavedPaymentMethodConfirmInteractor.Factory(),
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -492,7 +492,6 @@ internal class EmbeddedNavigatorTest {
                     processingState = PrimaryButtonProcessingState.Idle(null),
                     isProcessing = false,
                     shouldDisplayLockIcon = true,
-                    savedPaymentSelectionToConfirm = null,
                 )
             ),
             onContinueClick = {},
@@ -619,6 +618,67 @@ internal class EmbeddedNavigatorTest {
         formScreen.close()
         assertThat(formInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
         formInteractor.validate()
+    }
+
+    @Test
+    fun `SavedPaymentMethodConfirm close calls interactor close`() = runTest {
+        val (screen, interactor) = createSavedPaymentMethodConfirmScreen()
+
+        screen.close()
+
+        assertThat(interactor.closeCalls.awaitItem()).isEqualTo(Unit)
+        interactor.validate()
+    }
+
+    @Test
+    fun `SavedPaymentMethodConfirm topBarState hides test mode label in live mode`() {
+        val (screen, interactor) = createSavedPaymentMethodConfirmScreen(isLiveMode = true)
+
+        val topBarState = screen.topBarState().value!!
+
+        assertThat(topBarState.showTestModeLabel).isFalse()
+        assertThat(topBarState.showEditMenu).isFalse()
+        assertThat(topBarState.isEditing).isFalse()
+        interactor.validate()
+    }
+
+    @Test
+    fun `SavedPaymentMethodConfirm topBarState shows test mode label in test mode`() {
+        val (screen, interactor) = createSavedPaymentMethodConfirmScreen(isLiveMode = false)
+
+        val topBarState = screen.topBarState().value!!
+
+        assertThat(topBarState.showTestModeLabel).isTrue()
+        assertThat(topBarState.showEditMenu).isFalse()
+        assertThat(topBarState.isEditing).isFalse()
+        interactor.validate()
+    }
+
+    @Test
+    fun `SavedPaymentMethodConfirm title returns null`() {
+        val (screen, interactor) = createSavedPaymentMethodConfirmScreen()
+
+        assertThat(screen.title().value).isNull()
+        interactor.validate()
+    }
+
+    @Test
+    fun `SavedPaymentMethodConfirm maps processing state from state holder`() {
+        val stateHolder = FakeSheetActivityStateHolder(
+            initialState = SheetActivityStateHolder.State(
+                primaryButtonLabel = "Confirm".resolvableString,
+                isEnabled = false,
+                processingState = PrimaryButtonProcessingState.Processing,
+                isProcessing = true,
+                shouldDisplayLockIcon = true,
+            )
+        )
+        val (screen, interactor) = createSavedPaymentMethodConfirmScreen(
+            stateHolder = stateHolder,
+        )
+
+        assertThat(screen.isPerformingNetworkOperation().value).isTrue()
+        interactor.validate()
     }
 
     @Test
@@ -757,7 +817,6 @@ internal class EmbeddedNavigatorTest {
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = selectionHolder,
-            savedPaymentMethodConfirmInteractorFactory = FakeSavedPaymentMethodConfirmInteractor.Factory(),
             customerStateHolder = FakeCustomerStateHolder(paymentMethods = savedPaymentMethods),
         )
     }
@@ -778,7 +837,6 @@ internal class EmbeddedNavigatorTest {
                     processingState = PrimaryButtonProcessingState.Idle(null),
                     isProcessing = isProcessing,
                     shouldDisplayLockIcon = true,
-                    savedPaymentSelectionToConfirm = null,
                 )
             ),
             onContinueClick = {},
@@ -800,7 +858,6 @@ internal class EmbeddedNavigatorTest {
                     processingState = PrimaryButtonProcessingState.Idle(null),
                     isProcessing = isProcessing,
                     shouldDisplayLockIcon = true,
-                    savedPaymentSelectionToConfirm = null,
                 )
             ),
             onContinueClick = {},
@@ -817,13 +874,39 @@ internal class EmbeddedNavigatorTest {
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
-            savedPaymentMethodConfirmInteractorFactory = FakeSavedPaymentMethodConfirmInteractor.Factory(),
             customerStateHolder = FakeCustomerStateHolder(),
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = "card",
             ),
         )
         return screen to formInteractor
+    }
+
+    private fun createSavedPaymentMethodConfirmScreen(
+        isLiveMode: Boolean = true,
+        stateHolder: FakeSheetActivityStateHolder = FakeSheetActivityStateHolder(),
+        confirmationHelper: FakeSheetActivityConfirmationHelper = FakeSheetActivityConfirmationHelper(),
+        selectionHolder: DefaultEmbeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
+        customerStateHolder: FakeCustomerStateHolder = FakeCustomerStateHolder(),
+        launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.Form(
+            selectedPaymentMethodCode = "card",
+        ),
+    ): Pair<
+        EmbeddedNavigator.Screen.SavedPaymentMethodConfirm,
+        FakeSavedPaymentMethodConfirmInteractor
+    > {
+        val interactor = FakeSavedPaymentMethodConfirmInteractor()
+        val screen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
+            interactor = interactor,
+            isLiveMode = isLiveMode,
+            eventReporter = FakeEventReporter(),
+            sheetActivityStateHolder = stateHolder,
+            confirmationHelper = confirmationHelper,
+            embeddedSelectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+        )
+        return screen to interactor
     }
 
     private class TestFormInteractor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -28,15 +29,34 @@ import com.stripe.android.paymentelement.embedded.form.confirmationStateConfirmi
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
+import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
+import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
+import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
+import com.stripe.android.testing.CleanupTestRule
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
+import javax.inject.Provider
 
-class DefaultSheetActivityStateHolderTest {
+@Suppress("LargeClass")
+internal class DefaultSheetActivityStateHolderTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val closeFormInteractorRule = CleanupTestRule(VerticalModeFormInteractor::close)
+
     @Test
     fun `state initializes correctly`() = testScenario {
         stateHolder.state.test {
@@ -473,27 +493,89 @@ class DefaultSheetActivityStateHolderTest {
     }
 
     @Test
-    fun `TapToAddResult confirm saved payment method sets saved payment method confirm selection`() {
+    fun `TapToAddResult confirm saved payment method replaces current screen`() {
         val tapToAddHelper = FakeTapToAddHelper()
-        val customerStateHolder = FakeCustomerStateHolder()
+        val interactorFactory = RecordingSavedPaymentMethodConfirmInteractorFactory()
         val expectedSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
         testScenario(
             tapToAddHelper = tapToAddHelper,
-            customerStateHolder = customerStateHolder,
+            initialScreen = createHorizontalPaymentOptionsScreen(),
+            savedPaymentMethodConfirmInteractorFactory = interactorFactory,
         ) {
-            stateHolder.state.test {
-                awaitAndVerifyInitialState()
-
-                tapToAddHelper.emitNextStep(
-                    TapToAddNextStep.ConfirmSavedPaymentMethod(
-                        paymentSelection = expectedSelection,
+            stateHolder.result.test {
+                navigator.screen.test {
+                    assertThat(awaitItem()).isInstanceOf(
+                        EmbeddedNavigator.Screen.HorizontalPaymentOptions::class.java
                     )
-                )
 
-                assertThat(awaitItem().savedPaymentSelectionToConfirm).isEqualTo(
-                    expectedSelection,
-                )
+                    tapToAddHelper.emitNextStep(
+                        TapToAddNextStep.ConfirmSavedPaymentMethod(
+                            paymentSelection = expectedSelection,
+                        )
+                    )
+
+                    assertThat(awaitItem()).isInstanceOf(
+                        EmbeddedNavigator.Screen.SavedPaymentMethodConfirm::class.java
+                    )
+                    assertThat(navigator.canGoBack).isFalse()
+                }
+
+                expectNoEvents()
             }
+
+            assertThat(interactorFactory.createCalls.awaitItem()).isEqualTo(expectedSelection)
+            interactorFactory.createCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `TapToAddResult confirm saved payment method preserves previous screen and closes replaced form`() {
+        val tapToAddHelper = FakeTapToAddHelper()
+        val confirmInteractor = FakeSavedPaymentMethodConfirmInteractor()
+        val interactorFactory = RecordingSavedPaymentMethodConfirmInteractorFactory(confirmInteractor)
+        val expectedSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
+        val paymentOptionsInteractor = FakePaymentMethodVerticalLayoutInteractor.create()
+        val paymentOptionsScreen = createVerticalPaymentOptionsScreen(paymentOptionsInteractor)
+        val formInteractor = RecordingVerticalModeFormInteractor()
+        closeFormInteractorRule.track(formInteractor)
+        val formScreen = createFormScreen(formInteractor)
+        testScenario(
+            tapToAddHelper = tapToAddHelper,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+            initialBackStack = listOf(paymentOptionsScreen, formScreen),
+            savedPaymentMethodConfirmInteractorFactory = interactorFactory,
+        ) {
+            stateHolder.result.test {
+                navigator.screen.test {
+                    assertThat(awaitItem()).isSameInstanceAs(formScreen)
+
+                    tapToAddHelper.emitNextStep(
+                        TapToAddNextStep.ConfirmSavedPaymentMethod(
+                            paymentSelection = expectedSelection,
+                        )
+                    )
+
+                    assertThat(awaitItem()).isInstanceOf(
+                        EmbeddedNavigator.Screen.SavedPaymentMethodConfirm::class.java
+                    )
+                    assertThat(navigator.canGoBack).isTrue()
+                    assertThat(formInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+
+                    navigator.performAction(EmbeddedNavigator.Action.Back)
+
+                    assertThat(awaitItem()).isSameInstanceAs(paymentOptionsScreen)
+                    assertThat(navigator.canGoBack).isFalse()
+                    assertThat(confirmInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+                }
+
+                expectNoEvents()
+            }
+
+            assertThat(interactorFactory.createCalls.awaitItem()).isEqualTo(expectedSelection)
+            interactorFactory.validate()
+            formInteractor.validate()
+            confirmInteractor.validate()
+            paymentOptionsInteractor.validate()
         }
     }
 
@@ -502,6 +584,7 @@ class DefaultSheetActivityStateHolderTest {
         val stateHolder: DefaultSheetActivityStateHolder,
         val confirmationHandler: FakeConfirmationHandler,
         val onClickOverrideDelegate: OnClickOverrideDelegate,
+        val navigator: EmbeddedNavigator,
     )
 
     private fun testScenario(
@@ -512,21 +595,46 @@ class DefaultSheetActivityStateHolderTest {
         launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.Form(
             selectedPaymentMethodCode = "card",
         ),
+        initialScreen: EmbeddedNavigator.Screen = EmbeddedNavigator.Screen.ManageAll(
+            FakeManageScreenInteractor()
+        ),
+        initialBackStack: List<EmbeddedNavigator.Screen> = listOf(initialScreen),
+        savedPaymentMethodConfirmInteractorFactory: SavedPaymentMethodConfirmInteractor.Factory =
+            FakeSavedPaymentMethodConfirmInteractor.Factory(),
         block: suspend Scenario.() -> Unit
     ) = runTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent)
         val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
         val onClickOverrideDelegate = OnClickDelegateOverrideImpl()
         val confirmationHandler = FakeConfirmationHandler()
+        val viewModelScope = TestScope(UnconfinedTestDispatcher())
+        val navigator = EmbeddedNavigator(
+            coroutineScope = viewModelScope,
+            initialBackStack = initialBackStack,
+            eventReporter = FakeEventReporter(),
+        )
+        lateinit var screenFactory: SavedPaymentMethodConfirmScreenFactory
         val stateHolder = DefaultSheetActivityStateHolder(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
             configuration = config,
-            coroutineScope = TestScope(UnconfinedTestDispatcher()),
+            coroutineScope = viewModelScope,
             onClickDelegate = onClickOverrideDelegate,
             eventReporter = FakeEventReporter(),
             confirmationHandler = confirmationHandler,
             tapToAddHelper = tapToAddHelper,
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+            embeddedNavigatorProvider = Provider { navigator },
+            savedPaymentMethodConfirmScreenFactoryProvider = Provider { screenFactory },
+        )
+        screenFactory = SavedPaymentMethodConfirmScreenFactory(
+            interactorFactory = savedPaymentMethodConfirmInteractorFactory,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = FakeEventReporter(),
+            sheetActivityStateHolder = stateHolder,
+            confirmationHelper = FakeSheetActivityConfirmationHelper(),
+            embeddedSelectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             launchMode = launchMode,
         )
@@ -536,7 +644,98 @@ class DefaultSheetActivityStateHolderTest {
             stateHolder = stateHolder,
             confirmationHandler = confirmationHandler,
             onClickOverrideDelegate = onClickOverrideDelegate,
+            navigator = navigator,
         ).block()
+    }
+
+    private class RecordingSavedPaymentMethodConfirmInteractorFactory(
+        private val interactor: SavedPaymentMethodConfirmInteractor = FakeSavedPaymentMethodConfirmInteractor(),
+    ) : SavedPaymentMethodConfirmInteractor.Factory {
+        val createCalls = Turbine<PaymentSelection.Saved>()
+
+        override fun create(
+            initialSelection: PaymentSelection.Saved,
+            updateSelection: (PaymentSelection.Saved) -> Unit,
+        ): SavedPaymentMethodConfirmInteractor {
+            createCalls.add(initialSelection)
+            return interactor
+        }
+
+        fun validate() {
+            createCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private class RecordingVerticalModeFormInteractor : VerticalModeFormInteractor {
+        override val isLiveMode: Boolean = true
+        override val state: StateFlow<VerticalModeFormInteractor.State>
+            get() = error("Not expected")
+
+        val handleViewActionCalls = Turbine<VerticalModeFormInteractor.ViewAction>()
+        val closeCalls = Turbine<Unit>()
+
+        override fun handleViewAction(viewAction: VerticalModeFormInteractor.ViewAction) {
+            handleViewActionCalls.add(viewAction)
+        }
+
+        override fun close() {
+            closeCalls.add(Unit)
+        }
+
+        fun validate() {
+            handleViewActionCalls.ensureAllEventsConsumed()
+            closeCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private fun createFormScreen(
+        interactor: VerticalModeFormInteractor,
+    ): EmbeddedNavigator.Screen.Form {
+        return EmbeddedNavigator.Screen.Form(
+            formInteractor = interactor,
+            eventReporter = FakeEventReporter(),
+            sheetActivityStateHolder = FakeSheetActivityStateHolder(),
+            confirmationHelper = FakeSheetActivityConfirmationHelper(),
+            embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
+            customerStateHolder = FakeCustomerStateHolder(),
+            launchMode = EmbeddedLaunchMode.Form(selectedPaymentMethodCode = "card"),
+        )
+    }
+
+    private fun createVerticalPaymentOptionsScreen(
+        interactor: FakePaymentMethodVerticalLayoutInteractor,
+    ): EmbeddedNavigator.Screen.VerticalPaymentOptions {
+        return EmbeddedNavigator.Screen.VerticalPaymentOptions(
+            interactor = interactor,
+            isLiveMode = true,
+            sheetActivityState = stateFlowOf(
+                SheetActivityStateHolder.State(
+                    primaryButtonLabel = "Continue".resolvableString,
+                    isEnabled = true,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    isProcessing = false,
+                    shouldDisplayLockIcon = false,
+                )
+            ),
+            onContinueClick = {},
+        )
+    }
+
+    private fun createHorizontalPaymentOptionsScreen(): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
+        return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
+            interactor = FakeAddPaymentMethodInteractor(FakeAddPaymentMethodInteractor.createState()),
+            eventReporter = FakeEventReporter(),
+            sheetActivityState = stateFlowOf(
+                SheetActivityStateHolder.State(
+                    primaryButtonLabel = "Continue".resolvableString,
+                    isEnabled = true,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    isProcessing = false,
+                    shouldDisplayLockIcon = false,
+                )
+            ),
+            onContinueClick = {},
+        )
     }
 
     private suspend fun TurbineTestContext<SheetActivityStateHolder.State>.awaitAndVerifyInitialState() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
@@ -4,26 +4,30 @@ import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
-internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
-    val selectionTurbine = Turbine<PaymentSelection.Saved?>()
+internal class FakeSheetActivityStateHolder(
+    initialState: SheetActivityStateHolder.State = SheetActivityStateHolder.State(
+        primaryButtonLabel = "".resolvableString,
+        isEnabled = false,
+        processingState = PrimaryButtonProcessingState.Idle(null),
+        isProcessing = false,
+        shouldDisplayLockIcon = true,
+    ),
+) : SheetActivityStateHolder {
+    private val _state = MutableStateFlow(initialState)
+    override val state: StateFlow<SheetActivityStateHolder.State> = _state.asStateFlow()
 
-    override val state = MutableStateFlow(
-        SheetActivityStateHolder.State(
-            primaryButtonLabel = "".resolvableString,
-            isEnabled = false,
-            processingState = PrimaryButtonProcessingState.Idle(null),
-            isProcessing = false,
-            shouldDisplayLockIcon = true,
-            savedPaymentSelectionToConfirm = null,
-        )
-    )
+    fun updateState(transform: (SheetActivityStateHolder.State) -> SheetActivityStateHolder.State) {
+        _state.update(transform)
+    }
 
     val resultTurbine = Turbine<EmbeddedActivityResult>()
     val updateErrorTurbine = Turbine<ResolvableString?>()
@@ -49,10 +53,6 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
 
     override fun setResult(result: EmbeddedActivityResult) {
         resultTurbine.add(result)
-    }
-
-    override fun updateSavedPaymentSelectionToConfirm(selection: PaymentSelection.Saved?) {
-        selectionTurbine.add(selection)
     }
 
     fun validate() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -20,7 +20,6 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.verticalmode.FakeManageScreenInteractor
-import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
@@ -215,7 +214,6 @@ internal class InitialPaymentOptionsScreenFactoryTest {
                 sheetActivityStateHolder = sheetActivityStateHolder,
                 confirmationHelper = FakeSheetActivityConfirmationHelper(),
                 embeddedSelectionHolder = selectionHolder,
-                savedPaymentMethodConfirmInteractorFactory = FakeSavedPaymentMethodConfirmInteractor.Factory(),
                 customerStateHolder = customerStateHolder,
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import org.junit.Rule
@@ -134,6 +135,36 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             assertThat(activity.embeddedNavigator.screen.value)
                 .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
         }
+    }
+
+    @Test
+    fun `configuration change keeps saved payment method confirmation screen`() = launch { scenario ->
+        val interactor = FakeSavedPaymentMethodConfirmInteractor()
+        lateinit var originalScreen: EmbeddedNavigator.Screen.SavedPaymentMethodConfirm
+        scenario.onActivity { activity ->
+            originalScreen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
+                interactor = interactor,
+                isLiveMode = true,
+                eventReporter = activity.eventReporter,
+                sheetActivityStateHolder = activity.sheetActivityStateHolder,
+                confirmationHelper = FakeSheetActivityConfirmationHelper(),
+                embeddedSelectionHolder = activity.selectionHolder,
+                customerStateHolder = activity.customerStateHolder,
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
+            )
+            activity.embeddedNavigator.performAction(
+                EmbeddedNavigator.Action.ReplaceCurrentScreen(originalScreen)
+            )
+        }
+        onIdle()
+
+        scenario.recreate()
+        onIdle()
+
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.screen.value).isSameInstanceAs(originalScreen)
+        }
+        interactor.validate()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactoryTest.kt
@@ -1,0 +1,115 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentsheet.FakeCustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
+import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class SavedPaymentMethodConfirmScreenFactoryTest {
+    @Test
+    fun `create passes initial selection to interactor factory`() = runTest {
+        val interactorFactory = FakeInteractorFactory()
+        val initialSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        val factory = createFactory(interactorFactory)
+
+        factory.create(initialSelection)
+
+        assertThat(interactorFactory.createCalls.awaitItem().initialSelection).isEqualTo(initialSelection)
+        interactorFactory.validate()
+    }
+
+    @Test
+    fun `create wires interactor selection updates to selection holder`() = runTest {
+        val interactorFactory = FakeInteractorFactory()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
+        val factory = createFactory(
+            interactorFactory = interactorFactory,
+            selectionHolder = selectionHolder,
+        )
+        val updatedSelection = PaymentSelection.Saved(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_updated")
+        )
+
+        factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+        interactorFactory.createCalls.awaitItem().updateSelection(updatedSelection)
+
+        assertThat(selectionHolder.selection.value).isEqualTo(updatedSelection)
+        interactorFactory.validate()
+    }
+
+    @Test
+    fun `create derives live mode from payment method metadata`() = runTest {
+        val interactorFactory = FakeInteractorFactory()
+        val factory = createFactory(
+            interactorFactory = interactorFactory,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    isLiveMode = true,
+                )
+            ),
+        )
+
+        val screen = factory.create(PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+
+        assertThat(screen.topBarState().value!!.showTestModeLabel).isFalse()
+        interactorFactory.createCalls.awaitItem()
+        interactorFactory.validate()
+    }
+
+    private fun createFactory(
+        interactorFactory: SavedPaymentMethodConfirmInteractor.Factory,
+        selectionHolder: DefaultEmbeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+    ): SavedPaymentMethodConfirmScreenFactory {
+        return SavedPaymentMethodConfirmScreenFactory(
+            interactorFactory = interactorFactory,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = FakeEventReporter(),
+            sheetActivityStateHolder = FakeSheetActivityStateHolder(),
+            confirmationHelper = FakeSheetActivityConfirmationHelper(),
+            embeddedSelectionHolder = selectionHolder,
+            customerStateHolder = FakeCustomerStateHolder(),
+            launchMode = EmbeddedLaunchMode.Form(
+                selectedPaymentMethodCode = "card",
+            ),
+        )
+    }
+
+    private class FakeInteractorFactory : SavedPaymentMethodConfirmInteractor.Factory {
+        val createCalls = Turbine<CreateCall>()
+
+        override fun create(
+            initialSelection: PaymentSelection.Saved,
+            updateSelection: (PaymentSelection.Saved) -> Unit,
+        ): SavedPaymentMethodConfirmInteractor {
+            createCalls.add(
+                CreateCall(
+                    initialSelection = initialSelection,
+                    updateSelection = updateSelection,
+                )
+            )
+            return FakeSavedPaymentMethodConfirmInteractor()
+        }
+
+        fun validate() {
+            createCalls.ensureAllEventsConsumed()
+        }
+
+        data class CreateCall(
+            val initialSelection: PaymentSelection.Saved,
+            val updateSelection: (PaymentSelection.Saved) -> Unit,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenTest.kt
@@ -1,0 +1,206 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.os.Build
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentsheet.FakeCustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
+import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.uicore.StripeTheme
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalComposeUiApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+internal class SavedPaymentMethodConfirmScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @Test
+    fun `primary button click confirms payment`() = runTest {
+        runScenario {
+            composeRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG).performClick()
+
+            assertThat(confirmationHelper.confirmCalls.awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `confirmation error is displayed`() = runTest {
+        runScenario(
+            initialState = defaultState().copy(
+                error = "Something went wrong".resolvableString,
+            ),
+        ) {
+            composeRule.onNodeWithText("Something went wrong").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `processing dismisses keyboard`() = runTest {
+        val keyboardController = FakeSoftwareKeyboardController()
+        runScenario(
+            initialState = defaultState().copy(
+                isEnabled = false,
+                processingState = PrimaryButtonProcessingState.Processing,
+                isProcessing = true,
+            ),
+            keyboardController = keyboardController,
+        ) {
+            composeRule.waitForIdle()
+
+            assertThat(keyboardController.hideCalls.awaitItem()).isEqualTo(Unit)
+            keyboardController.validate()
+        }
+    }
+
+    @Test
+    fun `completed processing emits successful activity result`() = runTest {
+        runScenario(
+            initialState = defaultState().copy(
+                isEnabled = false,
+                processingState = PrimaryButtonProcessingState.Completed,
+                isProcessing = true,
+            ),
+        ) {
+            composeRule.mainClock.advanceTimeBy(5_000)
+            composeRule.waitForIdle()
+
+            val result = stateHolder.resultTurbine.awaitItem() as EmbeddedActivityResult.Complete
+            assertThat(result.selection).isNull()
+            assertThat(result.previousNewSelections).isEqualTo(selectionHolder.previousNewSelections)
+            assertThat(result.hasBeenConfirmed).isTrue()
+            assertThat(result.customerState).isEqualTo(customerStateHolder.customer.value)
+            assertThat(result.shouldInvokeSelectionCallback).isFalse()
+            assertThat(result.launchMode).isEqualTo(launchMode)
+        }
+    }
+
+    @Test
+    fun `completed processing preserves PaymentOptions launch mode`() = runTest {
+        val launchMode = EmbeddedLaunchMode.PaymentOptions
+        runScenario(
+            initialState = defaultState().copy(
+                isEnabled = false,
+                processingState = PrimaryButtonProcessingState.Completed,
+                isProcessing = true,
+            ),
+            launchMode = launchMode,
+        ) {
+            composeRule.mainClock.advanceTimeBy(5_000)
+            composeRule.waitForIdle()
+
+            val result = stateHolder.resultTurbine.awaitItem() as EmbeddedActivityResult.Complete
+            assertThat(result.launchMode).isEqualTo(launchMode)
+        }
+    }
+
+    private suspend fun runScenario(
+        initialState: SheetActivityStateHolder.State = defaultState(),
+        keyboardController: SoftwareKeyboardController? = null,
+        launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.Form(
+            selectedPaymentMethodCode = "card",
+        ),
+        block: suspend Scenario.() -> Unit,
+    ) {
+        val interactor = FakeSavedPaymentMethodConfirmInteractor(formEnabled = true)
+        val stateHolder = FakeSheetActivityStateHolder(initialState)
+        val confirmationHelper = FakeSheetActivityConfirmationHelper()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle())
+        val customerStateHolder = FakeCustomerStateHolder()
+        val eventReporter = FakeEventReporter()
+        val screen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
+            interactor = interactor,
+            isLiveMode = true,
+            eventReporter = eventReporter,
+            sheetActivityStateHolder = stateHolder,
+            confirmationHelper = confirmationHelper,
+            embeddedSelectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+        )
+
+        composeRule.setContent {
+            CompositionLocalProvider(
+                LocalSoftwareKeyboardController provides keyboardController,
+            ) {
+                StripeTheme {
+                    screen.Content()
+                }
+            }
+        }
+
+        Scenario(
+            stateHolder = stateHolder,
+            confirmationHelper = confirmationHelper,
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            launchMode = launchMode,
+        ).block()
+
+        stateHolder.validate()
+        confirmationHelper.validate()
+        interactor.validate()
+        eventReporter.validate()
+    }
+
+    private fun defaultState() = SheetActivityStateHolder.State(
+        primaryButtonLabel = "Pay".resolvableString,
+        isEnabled = true,
+        processingState = PrimaryButtonProcessingState.Idle(null),
+        isProcessing = false,
+        shouldDisplayLockIcon = true,
+    )
+
+    private class FakeSoftwareKeyboardController : SoftwareKeyboardController {
+        val hideCalls = Turbine<Unit>()
+
+        override fun show() = Unit
+
+        override fun hide() {
+            hideCalls.add(Unit)
+        }
+
+        fun validate() {
+            hideCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private class Scenario(
+        val stateHolder: FakeSheetActivityStateHolder,
+        val confirmationHelper: FakeSheetActivityConfirmationHelper,
+        val selectionHolder: DefaultEmbeddedSelectionHolder,
+        val customerStateHolder: FakeCustomerStateHolder,
+        val launchMode: EmbeddedLaunchMode,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSavedPaymentMethodConfirmTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSavedPaymentMethodConfirmTest.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.paymentsheet.navigation
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class PaymentSheetScreenSavedPaymentMethodConfirmTest {
+    @Test
+    fun `close closes interactor`() = runTest {
+        val interactor = FakeSavedPaymentMethodConfirmInteractor()
+        val screen = PaymentSheetScreen.SavedPaymentMethodConfirm(
+            interactor = interactor,
+            isLiveMode = true,
+        )
+
+        screen.close()
+
+        assertThat(interactor.closeCalls.awaitItem()).isEqualTo(Unit)
+        interactor.validate()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -61,6 +61,7 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verifyNoMoreInteractions
+import javax.inject.Provider
 import com.stripe.android.uicore.R as UiCoreR
 
 internal class DefaultVerticalModeFormInteractorTest {
@@ -326,6 +327,8 @@ internal class DefaultVerticalModeFormInteractorTest {
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = paymentMethodCode,
             ),
+            embeddedNavigatorProvider = Provider { error("Not expected") },
+            savedPaymentMethodConfirmScreenFactoryProvider = Provider { error("Not expected") },
         )
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import app.cash.turbine.Turbine
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
@@ -18,6 +19,8 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class FakeSavedPaymentMethodConfirmInteractor(
     formEnabled: Boolean = false,
 ) : SavedPaymentMethodConfirmInteractor {
+    val closeCalls = Turbine<Unit>()
+
     private val _state = MutableStateFlow(
         SavedPaymentMethodConfirmInteractor.State(
             displayableSavedPaymentMethod = DisplayableSavedPaymentMethod.create(
@@ -58,7 +61,11 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
     override val state: StateFlow<SavedPaymentMethodConfirmInteractor.State> = _state.asStateFlow()
 
     override fun close() {
-        // No-op.
+        closeCalls.add(Unit)
+    }
+
+    fun validate() {
+        closeCalls.ensureAllEventsConsumed()
     }
 
     class Factory : SavedPaymentMethodConfirmInteractor.Factory {


### PR DESCRIPTION
# Summary

This single-layer PR targets `master` and moves Embedded Payment Element's saved payment method confirmation UI into a dedicated `EmbeddedNavigator` screen. It adds replace-current-screen navigation, wires screen creation through a factory, and centralizes the successful confirmation result.

It also adds and updates coverage for screen lifecycle, back-stack behavior, configuration changes, confirmation results, and the existing confirmation screenshot.

# Motivation

Saved payment method confirmation was conditionally rendered inside the form screen, so it was not represented in the navigation back stack and did not own its interactor lifecycle. Representing confirmation as a screen lets Embedded replace and close the form screen, preserve the correct previous screen, retain confirmation across activity recreation, and close the confirmation interactor when the screen leaves the stack.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest` — passed.

Ignored tests: None.

# Screenshots

Not applicable: this changes navigation and lifecycle ownership with no intended visual change; the existing saved payment method confirmation screenshot test was updated and passes.

# Changelog

Not applicable: this is an internal Embedded Payment Element navigation refactor with no public API or intended user-visible behavior change.
