### PR TITLE
Remove synchronization map & ensure register & deregister happen on the main thread.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
@@ -1,16 +1,18 @@
 package com.stripe.android.googlepaylauncher
 
+import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
-import java.util.Collections.synchronizedMap
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object GooglePayPaymentDataUpdateCallbackRegistry {
-    private val registeredCallbacks = synchronizedMap(mutableMapOf<String, GooglePayPaymentDataUpdateCallback>())
+    private val registeredCallbacks = mutableMapOf<String, GooglePayPaymentDataUpdateCallback>()
 
+    @MainThread
     fun register(key: String, callback: GooglePayPaymentDataUpdateCallback) {
         registeredCallbacks[key] = callback
     }
 
+    @MainThread
     fun deregister(key: String) {
         registeredCallbacks.remove(key)
     }


### PR DESCRIPTION
# Summary
Remove synchronization map & ensure register & deregister happen on the main thread.

# Motivation
Unnecessary synchronization for GPay callback handling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified