### PR TITLE
Add payment method ordering to Express Checkout Element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -29,12 +29,14 @@ class ExpressCheckoutElement @Inject internal constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     /** Payment methods supported by the Express Checkout Element. */
-    abstract class PaymentMethod private constructor() {
+    abstract class PaymentMethod private constructor() : Parcelable {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
         class GooglePay internal constructor() : PaymentMethod()
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
         class Link internal constructor() : PaymentMethod()
     }
 
@@ -338,6 +340,7 @@ class ExpressCheckoutElement @Inject internal constructor(
         private var shippingAddressRequired: Boolean = false
         private var billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
             BillingDetailsCollectionConfiguration()
+        private var paymentMethodOrder: List<PaymentMethod> = emptyList()
 
         /** Sets the configuration for Link. */
         fun linkConfiguration(
@@ -365,12 +368,26 @@ class ExpressCheckoutElement @Inject internal constructor(
             this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
         }
 
+        /**
+         * Sets the order in which express payment methods are displayed.
+         *
+         * By default, the Express Checkout Element uses dynamic ordering. Payment methods omitted
+         * from [paymentMethodOrder] are displayed after the specified payment methods. Payment
+         * methods that are unavailable are ignored.
+         */
+        fun paymentMethodOrder(
+            paymentMethodOrder: List<PaymentMethod>,
+        ): Configuration = apply {
+            this.paymentMethodOrder = paymentMethodOrder
+        }
+
         @Parcelize
         internal data class State(
             val linkConfiguration: LinkConfiguration.State,
             val googlePayConfiguration: GooglePayConfiguration.State,
             val shippingAddressRequired: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
+            val paymentMethodOrder: List<PaymentMethod>,
         ) : Parcelable
 
         internal fun build(): State = State(
@@ -378,6 +395,7 @@ class ExpressCheckoutElement @Inject internal constructor(
             googlePayConfiguration = googlePayConfiguration.build(),
             shippingAddressRequired = shippingAddressRequired,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
+            paymentMethodOrder = paymentMethodOrder.toList(),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -29,14 +29,12 @@ class ExpressCheckoutElement @Inject internal constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     /** Payment methods supported by the Express Checkout Element. */
-    abstract class PaymentMethod private constructor() : Parcelable {
+    abstract class PaymentMethod private constructor() {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        @Parcelize
         class GooglePay internal constructor() : PaymentMethod()
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        @Parcelize
         class Link internal constructor() : PaymentMethod()
     }
 
@@ -387,15 +385,26 @@ class ExpressCheckoutElement @Inject internal constructor(
             val googlePayConfiguration: GooglePayConfiguration.State,
             val shippingAddressRequired: Boolean,
             val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration.State,
-            val paymentMethodOrder: List<PaymentMethod>,
+            val paymentMethodOrder: List<PaymentMethodType>,
         ) : Parcelable
+
+        internal enum class PaymentMethodType {
+            GooglePay,
+            Link,
+        }
 
         internal fun build(): State = State(
             linkConfiguration = linkConfiguration.build(),
             googlePayConfiguration = googlePayConfiguration.build(),
             shippingAddressRequired = shippingAddressRequired,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.build(),
-            paymentMethodOrder = paymentMethodOrder.toList(),
+            paymentMethodOrder = paymentMethodOrder.map { paymentMethod ->
+                when (paymentMethod) {
+                    is PaymentMethod.GooglePay -> PaymentMethodType.GooglePay
+                    is PaymentMethod.Link -> PaymentMethodType.Link
+                    else -> error("Unsupported payment method: ${paymentMethod::class.java.name}")
+                }
+            },
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
@@ -48,11 +48,13 @@ internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constr
         }
     }
 
-    private fun ExpressCheckoutElement.PaymentMethod.matches(expressButtonType: ExpressButtonType): Boolean {
+    private fun ExpressCheckoutElement.Configuration.PaymentMethodType.matches(
+        expressButtonType: ExpressButtonType,
+    ): Boolean {
         return when (this) {
-            is ExpressCheckoutElement.PaymentMethod.GooglePay -> expressButtonType is ExpressButtonType.GooglePay
-            is ExpressCheckoutElement.PaymentMethod.Link -> expressButtonType is ExpressButtonType.Link
-            else -> false
+            ExpressCheckoutElement.Configuration.PaymentMethodType.GooglePay ->
+                expressButtonType is ExpressButtonType.GooglePay
+            ExpressCheckoutElement.Configuration.PaymentMethodType.Link -> expressButtonType is ExpressButtonType.Link
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
@@ -20,7 +20,7 @@ internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constr
         paymentMethodMetadata: PaymentMethodMetadata,
         expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State,
     ): List<ExpressButtonType> {
-        return paymentMethodMetadata.availableWallets.mapNotNull { walletType ->
+        val availableExpressButtonTypes = paymentMethodMetadata.availableWallets.mapNotNull { walletType ->
             when (walletType) {
                 WalletType.GooglePay -> ExpressButtonType.GooglePay(
                         googlePayConfiguration = expressCheckoutElementConfiguration.googlePayConfiguration,
@@ -34,6 +34,25 @@ internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constr
                         !expressCheckoutElementConfiguration.shippingAddressRequired
                 }
             }
+        }
+
+        val paymentMethodOrder = expressCheckoutElementConfiguration.paymentMethodOrder
+        if (paymentMethodOrder.isEmpty()) {
+            return availableExpressButtonTypes
+        }
+
+        return availableExpressButtonTypes.sortedBy { expressButtonType ->
+            paymentMethodOrder.indexOfFirst { paymentMethod ->
+                paymentMethod.matches(expressButtonType)
+            }.takeIf { it >= 0 } ?: Int.MAX_VALUE
+        }
+    }
+
+    private fun ExpressCheckoutElement.PaymentMethod.matches(expressButtonType: ExpressButtonType): Boolean {
+        return when (this) {
+            is ExpressCheckoutElement.PaymentMethod.GooglePay -> expressButtonType is ExpressButtonType.GooglePay
+            is ExpressCheckoutElement.PaymentMethod.Link -> expressButtonType is ExpressButtonType.Link
+            else -> false
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
@@ -38,6 +38,7 @@ internal class ExpressCheckoutElementTest {
         assertThat(state.billingDetailsCollectionConfiguration.address).isEqualTo(
             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
         )
+        assertThat(state.paymentMethodOrder).isEmpty()
     }
 
     @Test
@@ -81,6 +82,23 @@ internal class ExpressCheckoutElementTest {
             .build()
 
         assertThat(state.shippingAddressRequired).isTrue()
+    }
+
+    @Test
+    fun `configuration builds payment method order`() {
+        val state = ExpressCheckoutElement.Configuration()
+            .paymentMethodOrder(
+                listOf(
+                    ExpressCheckoutElement.PaymentMethod.Link(),
+                    ExpressCheckoutElement.PaymentMethod.GooglePay(),
+                )
+            )
+            .build()
+
+        assertThat(state.paymentMethodOrder[0])
+            .isInstanceOf(ExpressCheckoutElement.PaymentMethod.Link::class.java)
+        assertThat(state.paymentMethodOrder[1])
+            .isInstanceOf(ExpressCheckoutElement.PaymentMethod.GooglePay::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
@@ -95,10 +95,10 @@ internal class ExpressCheckoutElementTest {
             )
             .build()
 
-        assertThat(state.paymentMethodOrder[0])
-            .isInstanceOf(ExpressCheckoutElement.PaymentMethod.Link::class.java)
-        assertThat(state.paymentMethodOrder[1])
-            .isInstanceOf(ExpressCheckoutElement.PaymentMethod.GooglePay::class.java)
+        assertThat(state.paymentMethodOrder).containsExactly(
+            ExpressCheckoutElement.Configuration.PaymentMethodType.Link,
+            ExpressCheckoutElement.Configuration.PaymentMethodType.GooglePay,
+        ).inOrder()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
@@ -73,7 +73,56 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
         assertThat(availableExpressButtonTypes).containsExactly(
             ExpressButtonType.Link,
             ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
+        ).inOrder()
+    }
+
+    @Test
+    fun `create applies configured payment method order`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+            configuration = ExpressCheckoutElement.Configuration()
+                .paymentMethodOrder(
+                    listOf(
+                        ExpressCheckoutElement.PaymentMethod.GooglePay(),
+                        ExpressCheckoutElement.PaymentMethod.Link(),
+                    )
+                ),
         )
+
+        assertThat(availableExpressButtonTypes).containsExactly(
+            ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
+            ExpressButtonType.Link,
+        ).inOrder()
+    }
+
+    @Test
+    fun `create appends payment methods omitted from configured order`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.GooglePay, WalletType.Link),
+            configuration = ExpressCheckoutElement.Configuration()
+                .paymentMethodOrder(listOf(ExpressCheckoutElement.PaymentMethod.Link())),
+        )
+
+        assertThat(availableExpressButtonTypes).containsExactly(
+            ExpressButtonType.Link,
+            ExpressButtonType.GooglePay(TEST_GOOGLE_PAY_CONFIGURATION),
+        ).inOrder()
+    }
+
+    @Test
+    fun `create ignores unavailable payment methods in configured order`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.Link),
+            configuration = ExpressCheckoutElement.Configuration()
+                .paymentMethodOrder(
+                    listOf(
+                        ExpressCheckoutElement.PaymentMethod.GooglePay(),
+                        ExpressCheckoutElement.PaymentMethod.Link(),
+                    )
+                ),
+        )
+
+        assertThat(availableExpressButtonTypes).containsExactly(ExpressButtonType.Link)
     }
 
     @Test


### PR DESCRIPTION
# Summary

Adds paymentMethodOrder to ExpressCheckoutElement.Configuration and applies the configured order to available express buttons. Listed methods appear first, unlisted available methods retain their dynamic order afterward, and unavailable methods are ignored.

# Motivation

Implements the Android API described in the Express Checkout Element mobile API review: https://docs.google.com/document/d/18Mn6y4NG7V-pkiJLRW7wi1w_a0GGAnJWnBkTGYK9Ato/edit?tab=t.0

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Commands:
- ./gradlew :paymentsheet:testDebugUnitTest (6,517 tests)
- ./gradlew :paymentsheet:detekt

# Screenshots

Not applicable; this is a configuration/API behavior change.

# Changelog

Not included because Express Checkout Element is currently a restricted preview API.