### PR TITLE
Use checkout merchant country for Google Pay updates

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallback.kt
@@ -8,7 +8,6 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
@@ -29,16 +28,12 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
             return notConfiguredResponse()
         }
 
-        val googlePayConfiguration = currentState.commonConfiguration.googlePay ?: run {
-            reportUnexpectedCallbackTrigger(VALUE_WITHOUT_CONFIG)
-
-            return notConfiguredResponse()
-        }
+        val countryCode = currentState.checkoutSessionResponse.merchantCountry
 
         return when (val trigger = paymentDataUpdate.callbackTrigger) {
             GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
             GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress -> {
-                updateShippingAddress(googlePayConfiguration, currentState, paymentDataUpdate)
+                updateShippingAddress(countryCode, currentState, paymentDataUpdate)
             }
             GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption,
             GooglePayPaymentDataUpdate.CallbackTrigger.Offer -> {
@@ -51,7 +46,7 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
                 )
 
                 mapToResponse(
-                    configuration = googlePayConfiguration,
+                    countryCode = countryCode,
                     response = currentState.checkoutSessionResponse,
                     paymentDataUpdate = paymentDataUpdate,
                 )
@@ -60,14 +55,14 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
     }
 
     private suspend fun updateShippingAddress(
-        googlePayConfiguration: PaymentSheet.GooglePayConfiguration,
+        countryCode: String?,
         currentState: CheckoutControllerState,
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse {
         val address = when (val result = addressBuilder.build(paymentDataUpdate)) {
             is CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Unavailable -> {
                 return mapToResponse(
-                    configuration = googlePayConfiguration,
+                    countryCode = countryCode,
                     response = currentState.checkoutSessionResponse,
                     paymentDataUpdate = paymentDataUpdate,
                 )
@@ -83,7 +78,7 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
             address = address,
         ).fold(
             onSuccess = { response ->
-                mapToResponse(googlePayConfiguration, response, paymentDataUpdate)
+                mapToResponse(countryCode, response, paymentDataUpdate)
             },
             onFailure = { error ->
                 GooglePayPaymentDataUpdateResponse(
@@ -99,11 +94,11 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
     }
 
     private fun mapToResponse(
-        configuration: PaymentSheet.GooglePayConfiguration,
+        countryCode: String?,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate
     ): GooglePayPaymentDataUpdateResponse {
-        return mapper.toResponse(configuration, response, paymentDataUpdate)
+        return mapper.toResponse(countryCode, response, paymentDataUpdate)
     }
 
     private fun reportUnexpectedCallbackTrigger(trigger: String) {
@@ -130,6 +125,5 @@ internal class CheckoutGooglePayPaymentDataUpdateCallback @Inject constructor(
         const val FIELD_UNEXPECTED_TRIGGER_TYPE = "unexpected_trigger_type"
         const val VALUE_SHIPPING_OPTION_TRIGGER = "shipping_option"
         const val VALUE_OFFER_TRIGGER = "offer"
-        const val VALUE_WITHOUT_CONFIG = "without_config"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateMapper.kt
@@ -8,14 +8,13 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
 internal interface CheckoutGooglePayPaymentDataUpdateMapper {
     fun toResponse(
-        configuration: PaymentSheet.GooglePayConfiguration,
+        countryCode: String?,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse
@@ -26,7 +25,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapper @Inject construct
     private val context: Context,
 ) : CheckoutGooglePayPaymentDataUpdateMapper {
     override fun toResponse(
-        configuration: PaymentSheet.GooglePayConfiguration,
+        countryCode: String?,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate
     ): GooglePayPaymentDataUpdateResponse {
@@ -36,7 +35,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapper @Inject construct
             newTransactionInfo = GooglePayJsonFactory.TransactionInfo(
                 currencyCode = response.currency.uppercase(),
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
-                countryCode = configuration.countryCode.takeIf { it.isNotEmpty() },
+                countryCode = countryCode?.takeIf { it.isNotEmpty() },
                 transactionId = response.stripeIntent()?.id,
                 totalPrice = response.totalSummary?.totalAmountDue ?: response.amount,
                 totalPriceLabel = context.getString(R.string.stripe_google_pay_total),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallbackTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutGooglePayPaymentDataUpdateCallbackTest.kt
@@ -6,7 +6,6 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
@@ -49,34 +48,27 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
     }
 
     @Test
-    fun `onPaymentDataChanged returns error and reports when google pay is not configured`() = runScenario(
+    fun `onPaymentDataChanged maps state when merchant country is unavailable`() = runScenario(
         state = CheckoutControllerStateFactory.create(
-            commonConfiguration = CommonConfigurationFactory.create(
-                googlePay = null,
-            ),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = null),
         ),
+        addressBuilderResult = CheckoutGooglePayPaymentDataUpdateAddressBuilder.Result.Unavailable,
+        mapperResponse = GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null),
     ) {
-        val response = callback.onPaymentDataChanged(
-            GooglePayPaymentDataUpdate(
-                callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
-                shippingAddress = null,
-            )
+        val paymentDataUpdate = GooglePayPaymentDataUpdate(
+            callbackTrigger = GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+            shippingAddress = null,
         )
 
-        assertThat(response.newTransactionInfo).isNull()
+        val response = callback.onPaymentDataChanged(paymentDataUpdate)
 
-        val error = response.error
-        assertThat(error).isNotNull()
-        assertThat(error?.reason).isEqualTo(GooglePayPaymentDataError.Reason.OtherError)
-        assertThat(error?.message).isEqualTo("Something went wrong")
-        assertThat(error?.intent).isEqualTo(GooglePayPaymentDataError.Intent.ShippingAddress)
+        assertThat(response).isEqualTo(providedMapperResponse)
+        assertThat(addressBuilder.buildCalls.awaitItem()).isEqualTo(paymentDataUpdate)
 
-        val call = errorReporter.awaitCall()
-        assertThat(call.errorEvent).isEqualTo(
-            ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER
-        )
-        assertThat(call.additionalNonPiiParams)
-            .isEqualTo(mapOf("unexpected_trigger_type" to "without_config"))
+        val toResponseCall = mapper.toResponseCalls.awaitItem()
+        assertThat(toResponseCall.countryCode).isNull()
+        assertThat(toResponseCall.response).isEqualTo(providedState?.checkoutSessionResponse)
+        assertThat(toResponseCall.paymentDataUpdate).isEqualTo(paymentDataUpdate)
     }
 
     @Test
@@ -154,7 +146,7 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
 
         val toResponseCall = mapper.toResponseCalls.awaitItem()
 
-        assertThat(toResponseCall.configuration).isEqualTo(providedState?.commonConfiguration?.googlePay)
+        assertThat(toResponseCall.countryCode).isEqualTo(providedState?.checkoutSessionResponse?.merchantCountry)
         assertThat(toResponseCall.response).isEqualTo(providedState?.checkoutSessionResponse)
         assertThat(toResponseCall.paymentDataUpdate).isEqualTo(paymentDataUpdate)
 
@@ -188,7 +180,7 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
             assertThat(response).isEqualTo(providedMapperResponse)
 
             val toResponseCall = mapper.toResponseCalls.awaitItem()
-            assertThat(toResponseCall.configuration).isEqualTo(providedState?.commonConfiguration?.googlePay)
+            assertThat(toResponseCall.countryCode).isEqualTo(providedState?.checkoutSessionResponse?.merchantCountry)
             assertThat(toResponseCall.response).isEqualTo(providedState?.checkoutSessionResponse)
             assertThat(toResponseCall.paymentDataUpdate).isEqualTo(paymentDataUpdate)
         }
@@ -228,7 +220,7 @@ internal class CheckoutGooglePayPaymentDataUpdateCallbackTest {
             assertThat(updateCall.checkoutSessionResponse).isEqualTo(providedState?.checkoutSessionResponse)
 
             val toResponseCall = mapper.toResponseCalls.awaitItem()
-            assertThat(toResponseCall.configuration).isEqualTo(providedState?.commonConfiguration?.googlePay)
+            assertThat(toResponseCall.countryCode).isEqualTo(providedState?.checkoutSessionResponse?.merchantCountry)
             assertThat(toResponseCall.response).isEqualTo(providedUpdateResult.getOrNull())
             assertThat(toResponseCall.paymentDataUpdate.callbackTrigger).isEqualTo(callbackTrigger)
             assertThat(toResponseCall.paymentDataUpdate.shippingAddress).isEqualTo(SHIPPING_ADDRESS)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutGooglePayPaymentDataUpdateMapperTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayDisplayItemsFactory
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import org.junit.Test
@@ -33,7 +32,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
         )
 
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(countryCode = "US"),
+            countryCode = "US",
             response = response,
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
@@ -54,9 +53,9 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
     }
 
     @Test
-    fun `toResponse uses country code from configuration`() {
+    fun `toResponse uses provided country code`() {
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(countryCode = "CA"),
+            countryCode = "CA",
             response = CheckoutSessionResponseFactory.create(),
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
@@ -65,9 +64,21 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
     }
 
     @Test
-    fun `toResponse returns null country code when configuration country code is blank`() {
+    fun `toResponse returns null country code when provided country code is blank`() {
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(countryCode = ""),
+            countryCode = "",
+            response = CheckoutSessionResponseFactory.create(),
+            paymentDataUpdate = PAYMENT_DATA_UPDATE,
+        )
+
+        assertThat(result.newTransactionInfo).isNotNull()
+        assertThat(result.newTransactionInfo?.countryCode).isNull()
+    }
+
+    @Test
+    fun `toResponse returns null country code when country code is unavailable`() {
+        val result = mapper.toResponse(
+            countryCode = null,
             response = CheckoutSessionResponseFactory.create(),
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
@@ -84,7 +95,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
         )
 
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(),
+            countryCode = "US",
             response = response,
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
@@ -95,7 +106,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
     @Test
     fun `toResponse uses checkout session amount when total summary is absent`() {
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(),
+            countryCode = "US",
             response = CheckoutSessionResponseFactory.create(
                 amount = 1000L,
                 totalSummary = null,
@@ -109,7 +120,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
     @Test
     fun `toResponse uses payment intent id as transaction id`() {
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(),
+            countryCode = "US",
             response = CheckoutSessionResponseFactory.create(
                 paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 setupIntent = null,
@@ -124,7 +135,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
     @Test
     fun `toResponse uses setup intent id as transaction id when no payment intent`() {
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(),
+            countryCode = "US",
             response = CheckoutSessionResponseFactory.create(
                 paymentIntent = null,
                 setupIntent = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT,
@@ -143,7 +154,7 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
         )
 
         val result = mapper.toResponse(
-            configuration = googlePayConfiguration(),
+            countryCode = "US",
             response = response,
             paymentDataUpdate = PAYMENT_DATA_UPDATE,
         )
@@ -151,13 +162,6 @@ internal class DefaultCheckoutGooglePayPaymentDataUpdateMapperTest {
         assertThat(result.newTransactionInfo?.displayItems)
             .isEqualTo(GooglePayDisplayItemsFactory.create(response, context))
     }
-
-    private fun googlePayConfiguration(
-        countryCode: String = "US",
-    ) = PaymentSheet.GooglePayConfiguration(
-        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-        countryCode = countryCode,
-    )
 
     private fun totalSummary(
         totalAmountDue: Long,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateMapper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutGooglePayPaymentDataUpdateMapper.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.Turbine
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
 @OptIn(CheckoutSessionPreview::class)
@@ -14,13 +13,13 @@ internal class FakeCheckoutGooglePayPaymentDataUpdateMapper(
     val toResponseCalls = Turbine<ToResponseCall>()
 
     override fun toResponse(
-        configuration: PaymentSheet.GooglePayConfiguration,
+        countryCode: String?,
         response: CheckoutSessionResponse,
         paymentDataUpdate: GooglePayPaymentDataUpdate,
     ): GooglePayPaymentDataUpdateResponse {
         toResponseCalls.add(
             ToResponseCall(
-                configuration = configuration,
+                countryCode = countryCode,
                 response = response,
                 paymentDataUpdate = paymentDataUpdate,
             )
@@ -33,7 +32,7 @@ internal class FakeCheckoutGooglePayPaymentDataUpdateMapper(
     }
 
     data class ToResponseCall(
-        val configuration: PaymentSheet.GooglePayConfiguration,
+        val countryCode: String?,
         val response: CheckoutSessionResponse,
         val paymentDataUpdate: GooglePayPaymentDataUpdate,
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use checkout merchant country for Google Pay updates

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Using commonConfiguration.googlePay is a little fraught bc PE and ECE have different google pay configurations. We can just use the merchant country from the checkout session response which is what checkout elements sdk does internally anyways

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
