### PR TITLE
Remove common configuration from checkout state

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Parcelable
 import com.stripe.android.checkout.CheckoutController.Session
-import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.elements.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -22,7 +21,6 @@ internal data class CheckoutControllerState(
     val collectedDetails: CheckoutCollectedDetails,
     val paymentMethodMetadata: PaymentMethodMetadata,
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
-    val commonConfiguration: CommonConfiguration,
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,
     val previousNewSelections: Bundle,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -108,7 +108,6 @@ internal class CheckoutStateLoader @Inject constructor(
             collectedDetails = collectedDetails,
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
-            commonConfiguration = commonConfiguration,
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,
             previousNewSelections = carryForward.previousNewSelections,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -3,7 +3,6 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.elements.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.elements.ece.FakeAvailableExpressButtonTypesFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -26,11 +25,6 @@ internal object CheckoutControllerStateFactory {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration: CommonConfiguration = CheckoutCommonConfigurationFactory(appName = "Example, Inc.").create(
-            configuration = configuration,
-            checkoutSessionResponse = checkoutSessionResponse,
-            collectedDetails = collectedDetails,
-        ),
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
@@ -42,7 +36,6 @@ internal object CheckoutControllerStateFactory {
             collectedDetails = collectedDetails,
             paymentMethodMetadata = paymentMethodMetadata,
             embeddedConfiguration = embeddedConfiguration,
-            commonConfiguration = commonConfiguration,
             paymentSelection = paymentSelection,
             temporarySelection = temporarySelection,
             previousNewSelections = previousNewSelections,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -201,11 +201,6 @@ internal class CheckoutControllerStateHolderTest {
         collectedDetails = CheckoutCollectedDetails(email = null),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration = CheckoutCommonConfigurationFactory(appName = "Example, Inc.").create(
-            configuration = CheckoutController.Configuration().build(),
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
-            collectedDetails = CheckoutCollectedDetails(email = null),
-        ),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.elements.PaymentElement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -85,16 +84,6 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
-    fun `loadInitial commits common configuration derived from the controller configuration`() = runScenario {
-        loader.loadInitial(
-            configuration = CheckoutController.Configuration().build(),
-            checkoutSessionResponse = response(merchantCountry = "US"),
-        )
-
-        assertThat(stateHolder.state?.commonConfiguration?.googlePay?.countryCode).isEqualTo("US")
-    }
-
-    @Test
     fun `loadInitial applies payment element appearance to the global theme`() = runScenario {
         val previousTheme = StripeThemeSnapshot()
         try {
@@ -132,35 +121,6 @@ internal class CheckoutStateLoaderTest {
 
         assertThat(stateHolder.state?.paymentMethodMetadata?.paymentMethodOrder)
             .isEqualTo(listOf("klarna", "card"))
-    }
-
-    @Test
-    fun `loadInitial passes preferred networks to common configuration`() = runScenario {
-        loader.loadInitial(
-            configuration = CheckoutController.Configuration()
-                .paymentElement(
-                    PaymentElement.Configuration().preferredNetworks(
-                        listOf(CardBrand.CartesBancaires, CardBrand.Visa)
-                    )
-                )
-                .build(),
-            checkoutSessionResponse = response(),
-        )
-
-        assertThat(stateHolder.state?.commonConfiguration?.preferredNetworks)
-            .isEqualTo(listOf(CardBrand.CartesBancaires, CardBrand.Visa))
-    }
-
-    @Test
-    fun `loadInitial passes opens card scanner automatically to common configuration`() = runScenario {
-        loader.loadInitial(
-            configuration = CheckoutController.Configuration()
-                .paymentElement(PaymentElement.Configuration().opensCardScannerAutomatically(true))
-                .build(),
-            checkoutSessionResponse = response(),
-        )
-
-        assertThat(stateHolder.state?.commonConfiguration?.opensCardScannerAutomatically).isTrue()
     }
 
     @Test
@@ -415,11 +375,6 @@ internal class CheckoutStateLoaderTest {
         collectedDetails = CheckoutCollectedDetails(email = null),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        commonConfiguration = CheckoutCommonConfigurationFactory(appName = "Example, Inc.").create(
-            configuration = CheckoutController.Configuration().build(),
-            checkoutSessionResponse = checkoutSessionResponse,
-            collectedDetails = CheckoutCollectedDetails(email = null),
-        ),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove common configuration from checkout state

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
CommonConfiguration has several fields which are not actually "common" in checkout, e.g. billingDetailsCollectionConfiguration, googlePayConfiguration, and linkConfiguration. These are different between PE and ECE. Storing this commonConfiguration makes it really easy to use the wrong value, so I'm just removing this footgun

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
