### PR TITLE
Make PaymentSheet test retries opt-in

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.utils.ProductIntegrationType
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+import com.stripe.android.testing.RetryRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -24,7 +25,10 @@ internal class HCaptchaTokenTest {
     // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
     // but it's okay if it takes a bit to happen.
     private val networkRule = NetworkRule(validationTimeout = 5.seconds)
-    private val testRules: TestRules = TestRules.create(networkRule = networkRule)
+    private val testRules: TestRules = TestRules.create(
+        networkRule = networkRule,
+        retryRule = RetryRule(5),
+    )
 
     @get:Rule
     val rules: RuleChain = RuleChain.emptyRuleChain()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.utils
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.testing.RetryRule
 import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
@@ -29,13 +28,16 @@ class TestRules private constructor(
             composeTestRule: ComposeTestRule = createEmptyComposeRule(),
             networkRule: NetworkRule = NetworkRule(),
             terminalTestRule: TerminalWrapperTestRule = TerminalWrapperTestRule(enabled = false),
+            retryRule: TestRule? = null,
             block: RuleChain.() -> RuleChain = { this }
         ): TestRules {
             val chain = RuleChain.emptyRuleChain()
                 .around(DetectLeaksAfterTestSuccess())
                 .around(FakeGooglePayRepositoryRule())
                 .around(composeTestRule)
-                .around(RetryRule(5))
+                .let { chain ->
+                    retryRule?.let(chain::around) ?: chain
+                }
                 .around(networkRule)
                 .around(terminalTestRule)
                 .block()


### PR DESCRIPTION
# Summary
Make `paymentsheet` instrumentation-test retries opt-in instead of applying `RetryRule` to every consumer of `TestRules`.

`HCaptchaTokenTest` continues to use five attempts because its passive hCaptcha flow reaches a real external service. The retry remains between `ComposeTestRule` and `NetworkRule`, allowing Compose to own one coroutine-test lifecycle while recreating network fixtures for each attempt.

Committed and created by Codex.

# Motivation
The shared rule previously retried 34 otherwise-hermetic test classes containing 244 declared `@Test` methods. Their Stripe API traffic is redirected to local `MockWebServer`, and their external-looking dependencies are controlled locally:

- Google Pay uses fake repositories/clients and intercepted activities.
- Places autocomplete uses a fake Places client.
- Attestation, NFC scanning, and browser redirects use intercepted activity results or intents.
- Tap to Add uses a fake Terminal delegate.

These tests do not depend on real network availability, so retrying them can conceal deterministic synchronization, state-leak, or device-test failures. Passive hCaptcha is the sole audited exception and opts into retry explicitly.

The retry position is intentional. A managed-device experiment that wrapped the entire rule chain retried Compose's `runTest` lifecycle and failed with `Only a single call to runTest can be performed during one test`. Keeping Compose outside retry and NetworkRule inside retry avoids that failure and resets mock-network state between attempts.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin`
- `CI=true ./gradlew --no-configuration-cache :paymentsheet:pixel2api33imeDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.paymentsheet.HCaptchaTokenTest#newPaymentMethod_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest`
- Temporarily forced the focused hCaptcha test's first attempt to fail. Device logs showed `Failed attempt 1 out of 5`; the retry completed the full test successfully. The temporary failure was then removed and the clean focused test passed again.
- No tests were ignored.

# Screenshots
Not applicable: test-infrastructure-only change with no visual output.

# Changelog
Not applicable: this does not change the public SDK or user-visible behavior.
