### PR TITLE
Fix saved payment method E2E flake

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -183,7 +183,7 @@ internal class TestCard : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText(secondCardNumber.takeLast(4), substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )


### PR DESCRIPTION
# Summary

Use the standard PaymentSheet UI timeout while waiting for the most recently saved card to become the selected default payment method in the Chrome managed-device E2E test.

This is a single-layer draft PR against `master`.

Committed and created by Codex.

# Motivation

`testDefaultSavedPaymentMethodUsedAfterMultipleSaves` intermittently exhausted its hardcoded 5-second wait while returning-customer PaymentSheet state was still loading. The test already checks the exact saved-payment-method tag, selected state, and card last four digits, so this keeps that contract intact while using the suite's established 15-second UI budget.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
- Focused Pixel 2/API 33 Chrome Shampoo smoke: 2/2 executions passed.
- Focused Pixel 2/API 33 Chrome Shampoo soak: 50/50 executions passed (iterations 0–49, no failed-iteration markers).
- Focused Pixel 2/API 33 Chrome normal RetryRule run: passed without retry.
- `git diff --check`

ShampooRule was used only as local diagnostic instrumentation and is absent from this PR.

# Screenshots

Not applicable; this is a test synchronization change with no UI changes.

# Changelog

Not applicable; this changes test synchronization only and does not affect the SDK's public behavior or API.
