### PR TITLE
Standardize network-backed saved method timeouts

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -219,7 +219,7 @@ internal class TestCard : BasePlaygroundTest() {
                 selectors.composeTestRule.waitUntilExactlyOneExists(
                     matcher = hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
                         .and(hasText(cardNumber.takeLast(4), substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )
@@ -269,7 +269,7 @@ internal class TestCard : BasePlaygroundTest() {
                 selectors.composeTestRule.waitUntilExactlyOneExists(
                     matcher = hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)
                         .and(hasText(secondCardNumber.takeLast(4), substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Initializatio
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
+import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
@@ -91,7 +92,7 @@ internal class TestConfirmationToken : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText(cardNumber.takeLast(4), substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -104,7 +104,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText(IBAN.takeLast(4), substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -108,7 +108,7 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText("6789", substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )
@@ -139,7 +139,7 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
                     matcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
                         .and(isSelected())
                         .and(hasText("6789", substring = true)),
-                    timeoutMillis = 5000L
+                    timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds
                 )
             },
         )


### PR DESCRIPTION
# Summary

Replace the remaining hardcoded 5-second saved-payment-method waits with the standard 15-second `DEFAULT_UI_TIMEOUT`.

This is a single-layer draft PR against `master`.

Committed and created by Codex.

# Motivation

These tests save a payment method on the server, then create a new PaymentSheet or FlowController instance and wait for that network-backed saved-method state to appear. Matching the default UI timeout for these network-backed waits avoids a series of one-off flakes while preserving each test's exact payment-method assertion.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
- Grouped Pixel 2/API 33 Chrome Shampoo smoke: all 6 filtered methods passed iterations 0–1, for 12/12 actual method executions.
- Grouped 50-iteration Shampoo soak: in progress across the same 6 filtered methods.
- `git diff --check`

ShampooRule is diagnostic-only and is absent from this PR.

# Screenshots

Not applicable; this is a test synchronization change with no UI changes.

# Changelog

Not applicable; this changes test synchronization only and does not affect the SDK's public behavior or API.
