### PR TITLE
Extract embedded sheet continue coordination

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -32,12 +32,14 @@ import com.stripe.android.paymentelement.embedded.manage.InitialManageScreenFact
 import com.stripe.android.paymentelement.embedded.manage.ManageSavedPaymentMethodMutatorFactory
 import com.stripe.android.paymentelement.embedded.sheet.DefaultEmbeddedFormScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityConfirmationHelper
+import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityContinueCoordinator
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityRegistrar
 import com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedFormScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.InitialPaymentOptionsScreenFactory
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityConfirmationHelper
+import com.stripe.android.paymentelement.embedded.sheet.SheetActivityContinueCoordinator
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityRegistrar
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
@@ -118,6 +120,11 @@ internal interface EmbeddedActivityModule {
     fun bindsConfirmationHelper(
         confirmationHelper: DefaultSheetActivityConfirmationHelper
     ): SheetActivityConfirmationHelper
+
+    @Binds
+    fun bindsContinueCoordinator(
+        continueCoordinator: DefaultSheetActivityContinueCoordinator
+    ): SheetActivityContinueCoordinator
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -1,14 +1,13 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedManageScreenInteractorFactory
 import com.stripe.android.paymentelement.embedded.manage.EmbeddedUpdateScreenInteractorFactory
@@ -53,6 +52,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private val formScreenFactory: EmbeddedFormScreenFactory,
     private val linkAccountHolder: LinkAccountHolder,
     private val addPaymentMethodInteractorFactory: EmbeddedAddPaymentMethodInteractorFactory,
+    private val continueCoordinator: SheetActivityContinueCoordinator,
 ) {
     fun createInitialScreen(): List<EmbeddedNavigator.Screen> {
         return when (paymentMethodMetadata.paymentMethodOrientation()) {
@@ -93,17 +93,9 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
         )
     }
 
-    private fun onContinueClick() {
-        sheetActivityStateHolder.setResult(
-            EmbeddedActivityResult.Complete(
-                selection = selectionHolder.selection.value,
-                previousNewSelections = selectionHolder.previousNewSelections,
-                hasBeenConfirmed = false,
-                customerState = customerStateHolder.customer.value,
-                shouldInvokeSelectionCallback = false,
-                launchMode = EmbeddedLaunchMode.PaymentOptions,
-            )
-        )
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun onContinueClick() {
+        continueCoordinator.onContinue()
     }
 
     private fun createFormHelper(coroutineScope: CoroutineScope): FormHelper {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityConfirmationHelper.kt
@@ -7,12 +7,9 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayBillingEmailOverrideProvider
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.OnClickOverrideDelegate
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
-import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -28,12 +25,10 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val configuration: EmbeddedPaymentElement.Configuration,
     private val selectionHolder: EmbeddedSelectionHolder,
-    private val stateHelper: SheetActivityStateHolder,
+    private val continueCoordinator: SheetActivityContinueCoordinator,
     private val onClickDelegate: OnClickOverrideDelegate,
     private val eventReporter: EventReporter,
-    private val customerStateHolder: CustomerStateHolder,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val launchMode: EmbeddedLaunchMode,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
 ) : SheetActivityConfirmationHelper {
 
@@ -47,16 +42,7 @@ internal class DefaultSheetActivityConfirmationHelper @Inject constructor(
 
             when (configuration.formSheetAction) {
                 EmbeddedPaymentElement.FormSheetAction.Continue -> {
-                    stateHelper.setResult(
-                        EmbeddedActivityResult.Complete(
-                            selection = selectionHolder.selection.value,
-                            previousNewSelections = selectionHolder.previousNewSelections,
-                            hasBeenConfirmed = false,
-                            customerState = customerStateHolder.customer.value,
-                            shouldInvokeSelectionCallback = false,
-                            launchMode = launchMode,
-                        )
-                    )
+                    continueCoordinator.onContinue()
                 }
                 EmbeddedPaymentElement.FormSheetAction.Confirm -> {
                     confirmationArgs()?.let { args ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import javax.inject.Inject
+
+internal interface SheetActivityContinueCoordinator {
+    fun onContinue()
+}
+
+internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
+    private val stateHolder: SheetActivityStateHolder,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val launchMode: EmbeddedLaunchMode,
+) : SheetActivityContinueCoordinator {
+
+    override fun onContinue() {
+        stateHolder.setResult(
+            EmbeddedActivityResult.Complete(
+                selection = selectionHolder.selection.value,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = false,
+                customerState = customerStateHolder.customer.value,
+                shouldInvokeSelectionCallback = false,
+                launchMode = launchMode,
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityConfirmationHelperTest.kt
@@ -10,11 +10,8 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.OnClickDelegateOverrideImpl
-import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
@@ -27,7 +24,9 @@ internal class DefaultSheetActivityConfirmationHelperTest {
     val coroutineTestRule = CoroutineTestRule()
 
     @Test
-    fun `confirm invokes onClickOverride when set`() = testScenario {
+    fun `confirm invokes onClickOverride instead of continue coordinator when set`() = testScenario(
+        configurationModifier = { formSheetAction(EmbeddedPaymentElement.FormSheetAction.Continue) },
+    ) {
         val onClickTurbine = Turbine<Unit>()
         onClickDelegate.set {
             onClickTurbine.add(Unit)
@@ -38,6 +37,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
         assertThat(onClickTurbine.awaitItem()).isNotNull()
         onClickTurbine.ensureAllEventsConsumed()
         confirmationHandler.startTurbine.expectNoEvents()
+        continueCoordinator.onContinueCalls.expectNoEvents()
     }
 
     @Test
@@ -74,25 +74,14 @@ internal class DefaultSheetActivityConfirmationHelperTest {
     }
 
     @Test
-    fun `when formSheetAction=continue confirm returns result`() = testScenario(
+    fun `when formSheetAction=continue confirm delegates to continue coordinator`() = testScenario(
         configurationModifier = { formSheetAction(EmbeddedPaymentElement.FormSheetAction.Continue) }
     ) {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
         confirmationHelper.confirm()
 
-        assertThat(stateHelper.resultTurbine.awaitItem()).isEqualTo(
-            EmbeddedActivityResult.Complete(
-                previousNewSelections = selectionHolder.previousNewSelections,
-                selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
-                hasBeenConfirmed = false,
-                customerState = null,
-                shouldInvokeSelectionCallback = false,
-                launchMode = EmbeddedLaunchMode.Form(
-                    selectedPaymentMethodCode = "card",
-                ),
-            )
-        )
+        assertThat(continueCoordinator.onContinueCalls.awaitItem()).isEqualTo(Unit)
 
         assertThat(eventReporter.pressConfirmButtonCalls.awaitItem())
             .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
@@ -103,7 +92,6 @@ internal class DefaultSheetActivityConfirmationHelperTest {
         EmbeddedPaymentElement.Configuration.Builder.() -> EmbeddedPaymentElement.Configuration.Builder = {
             this
         },
-        customerStateHolder: FakeCustomerStateHolder = FakeCustomerStateHolder(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val confirmationHandler = FakeConfirmationHandler()
@@ -114,7 +102,7 @@ internal class DefaultSheetActivityConfirmationHelperTest {
             .configurationModifier()
             .build()
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val stateHelper = FakeSheetActivityStateHolder()
+        val continueCoordinator = FakeSheetActivityContinueCoordinator()
         val onClickDelegate = OnClickDelegateOverrideImpl()
         val eventReporter = FakeEventReporter()
         val confirmationHelper = DefaultSheetActivityConfirmationHelper(
@@ -122,35 +110,30 @@ internal class DefaultSheetActivityConfirmationHelperTest {
             confirmationHandler = confirmationHandler,
             configuration = configuration,
             selectionHolder = selectionHolder,
-            stateHelper = stateHelper,
+            continueCoordinator = continueCoordinator,
             onClickDelegate = onClickDelegate,
             eventReporter = eventReporter,
-            customerStateHolder = customerStateHolder,
             coroutineScope = backgroundScope,
-            launchMode = EmbeddedLaunchMode.Form(
-                selectedPaymentMethodCode = "card",
-            ),
             statusBarColor = null,
         )
 
         Scenario(
             confirmationHelper = confirmationHelper,
             confirmationHandler = confirmationHandler,
-            stateHelper = stateHelper,
+            continueCoordinator = continueCoordinator,
             onClickDelegate = onClickDelegate,
             eventReporter = eventReporter,
             selectionHolder = selectionHolder,
         ).block()
         eventReporter.validate()
         confirmationHandler.validate()
-        stateHelper.validate()
-        customerStateHolder.validate()
+        continueCoordinator.validate()
     }
 
     private class Scenario(
         val confirmationHelper: DefaultSheetActivityConfirmationHelper,
         val confirmationHandler: FakeConfirmationHandler,
-        val stateHelper: FakeSheetActivityStateHolder,
+        val continueCoordinator: FakeSheetActivityContinueCoordinator,
         val onClickDelegate: OnClickDelegateOverrideImpl,
         val eventReporter: FakeEventReporter,
         val selectionHolder: EmbeddedSelectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.FakeCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class DefaultSheetActivityContinueCoordinatorTest {
+
+    @Test
+    fun `onContinue returns current sheet state`() = runScenario {
+        continueCoordinator.onContinue()
+
+        assertThat(stateHolder.resultTurbine.awaitItem()).isEqualTo(
+            EmbeddedActivityResult.Complete(
+                selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                hasBeenConfirmed = false,
+                customerState = customerStateHolder.customer.value,
+                shouldInvokeSelectionCallback = false,
+                launchMode = LAUNCH_MODE,
+            )
+        )
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val stateHolder = FakeSheetActivityStateHolder()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()).apply {
+            setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        }
+        val customerStateHolder = FakeCustomerStateHolder(
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        )
+        val continueCoordinator = DefaultSheetActivityContinueCoordinator(
+            stateHolder = stateHolder,
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            launchMode = LAUNCH_MODE,
+        )
+
+        Scenario(
+            continueCoordinator = continueCoordinator,
+            stateHolder = stateHolder,
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+        ).block()
+
+        stateHolder.validate()
+        customerStateHolder.validate()
+    }
+
+    private data class Scenario(
+        val continueCoordinator: SheetActivityContinueCoordinator,
+        val stateHolder: FakeSheetActivityStateHolder,
+        val selectionHolder: EmbeddedSelectionHolder,
+        val customerStateHolder: FakeCustomerStateHolder,
+    )
+
+    private companion object {
+        val LAUNCH_MODE = EmbeddedLaunchMode.Form(
+            selectedPaymentMethodCode = "card",
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityContinueCoordinator.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import app.cash.turbine.Turbine
+
+internal class FakeSheetActivityContinueCoordinator : SheetActivityContinueCoordinator {
+    val onContinueCalls = Turbine<Unit>()
+
+    override fun onContinue() {
+        onContinueCalls.add(Unit)
+    }
+
+    fun validate() {
+        onContinueCalls.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -160,6 +160,13 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         assertThat(screens.first()).isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
     }
 
+    @Test
+    fun `continue click delegates to continue coordinator`() = testScenario {
+        factory.onContinueClick()
+
+        assertThat(continueCoordinator.onContinueCalls.awaitItem()).isEqualTo(Unit)
+    }
+
     @Suppress("LongMethod")
     private fun testScenario(
         isGooglePayReady: Boolean = true,
@@ -180,6 +187,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         val eventReporter = FakeEventReporter()
         val testScope = TestScope(UnconfinedTestDispatcher())
         val sheetActivityStateHolder = FakeSheetActivityStateHolder()
+        val continueCoordinator = FakeSheetActivityContinueCoordinator()
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
@@ -254,6 +262,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             formScreenFactory = formScreenFactory,
             linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
             addPaymentMethodInteractorFactory = addPaymentMethodInteractorFactory,
+            continueCoordinator = continueCoordinator,
         )
 
         Scenario(
@@ -262,8 +271,10 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             customerStateHolder = customerStateHolder,
             navigator = navigator,
             sheetActivityStateHolder = sheetActivityStateHolder,
+            continueCoordinator = continueCoordinator,
         ).block()
         eventReporter.validate()
+        continueCoordinator.validate()
     }
 
     private class Scenario(
@@ -272,6 +283,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
         val customerStateHolder: CustomerStateHolder,
         val navigator: EmbeddedNavigator,
         val sheetActivityStateHolder: FakeSheetActivityStateHolder,
+        val continueCoordinator: FakeSheetActivityContinueCoordinator,
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeCustomerStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakeCustomerStateHolder.kt
@@ -9,9 +9,10 @@ import kotlinx.coroutines.flow.StateFlow
 
 internal class FakeCustomerStateHolder(
     paymentMethods: List<PaymentMethod> = emptyList(),
+    private val customerState: CustomerState? = null,
 ) : CustomerStateHolder {
     override val customer: StateFlow<CustomerState?>
-        get() = stateFlowOf<CustomerState?>(null)
+        get() = stateFlowOf(customerState)
 
     override val paymentMethods: StateFlow<List<PaymentMethod>> = stateFlowOf(paymentMethods)
 


### PR DESCRIPTION
# Summary

Centralize embedded-sheet Continue completion in a dedicated coordinator shared by form and payment-options flows.

# Motivation

Both embedded-sheet entry points independently assembled the same activity result. Consolidating that behavior creates a single, behavior-preserving completion seam for future orchestration while removing result construction from UI factories and confirmation routing.

Committed and created by Codex.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityContinueCoordinatorTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityConfirmationHelperTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.InitialPaymentOptionsScreenFactoryTest'`
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable; this is an internal behavior-preserving refactor with no UI changes.

# Changelog

Not applicable; this does not change public or user-visible behavior.
