### PR TITLE
Add analytics for Checkout Session total changes

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -37,109 +37,104 @@ internal class CheckoutPaymentElementAnalyticsTest {
     private val contentPage = EmbeddedContentPage(testRules.compose)
 
     @Test
-    fun testTotalChangeFailureSendsAnalyticsErrorCode() {
-        val initialTotal = 5099
-        val updatedTotal = 5399
-        // Initial configuration and the post-failure session refresh each report loading.
-        repeat(2) {
+    fun testTotalChangeFailureSendsAnalyticsErrorCode() = runCheckoutPaymentElementTest(
+        networkRule = networkRule,
+        resultCallback = { result ->
+            assertThat(result).isInstanceOf(CheckoutController.Result.Failed::class.java)
+            val failure = result as CheckoutController.Result.Failed
+            assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
+        },
+        checkoutInitResponse = { response ->
+            response.testBodyFromFile("checkout-session-init.json") { json ->
+                json.put("account_settings", JSONObject("""{"country":"US"}"""))
+                json.getJSONObject("total_summary").apply {
+                    put("subtotal", INITIAL_TOTAL)
+                    put("total", INITIAL_TOTAL)
+                }
+                json.put(
+                    "tax_context",
+                    JSONObject(
+                        """
+                        {
+                            "automatic_tax_enabled": true,
+                            "automatic_tax_address_source": "billing"
+                        }
+                        """.trimIndent()
+                    )
+                )
+                json.put(
+                    "customer",
+                    JSONObject(
+                        """
+                        {
+                            "id": "cus_123",
+                            "payment_methods": [{
+                                "id": "pm_12345",
+                                "object": "payment_method",
+                                "type": "card",
+                                "billing_details": {
+                                    "address": {
+                                        "country": "US",
+                                        "postal_code": "12345"
+                                    }
+                                },
+                                "card": {
+                                    "brand": "visa",
+                                    "exp_month": 12,
+                                    "exp_year": 2034,
+                                    "last4": "4242"
+                                }
+                            }],
+                            "can_detach_payment_method": true
+                        }
+                        """.trimIndent()
+                    )
+                )
+            }
+        },
+        setup = { controller ->
+            // Initial configuration and the post-failure session refresh each report loading.
+            repeat(2) {
+                networkRule.validateAnalyticsRequest(
+                    eventName = "mc_load_started",
+                    productUsage = setOf("Checkout"),
+                )
+                networkRule.validateAnalyticsRequest(
+                    eventName = "mc_load_succeeded",
+                    productUsage = setOf("Checkout"),
+                )
+            }
             networkRule.validateAnalyticsRequest(
-                eventName = "mc_load_started",
+                eventName = "mc_initial_displayed_payment_methods",
                 productUsage = setOf("Checkout"),
             )
-            networkRule.validateAnalyticsRequest(
-                eventName = "mc_load_succeeded",
-                productUsage = setOf("Checkout"),
-            )
+            controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+        },
+    ) { context ->
+        contentPage.assertHasSelectedSavedPaymentMethod("pm_12345")
+        networkRule.checkoutUpdate { response ->
+            response.testBodyFromFile("checkout-session-confirm.json") { json ->
+                json.getJSONObject("total_summary").put("total", UPDATED_TOTAL)
+            }
         }
-        networkRule.validateAnalyticsRequest(
-            eventName = "mc_initial_displayed_payment_methods",
-            productUsage = setOf("Checkout"),
-        )
+        networkRule.checkoutInit { response ->
+            response.testBodyFromFile("checkout-session-init.json") { json ->
+                json.put("account_settings", JSONObject("""{"country":"US"}"""))
+            }
+        }
         networkRule.validateAnalyticsRequest(
             eventName = "mc_embedded_payment_failure",
             productUsage = setOf("Checkout"),
             analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
             analyticsPayloadField("error_code", "checkout_session_total_changed"),
         )
-        runCheckoutPaymentElementTest(
-            networkRule = networkRule,
-            resultCallback = { result ->
-                assertThat(result).isInstanceOf(CheckoutController.Result.Failed::class.java)
-                val failure = result as CheckoutController.Result.Failed
-                assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
-            },
-            checkoutInitResponse = { response ->
-                response.testBodyFromFile("checkout-session-init.json") { json ->
-                    json.put("customer_email", "checkout@example.com")
-                    json.getJSONObject("elements_session").remove("link_settings")
-                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
-                    json.getJSONObject("total_summary").apply {
-                        put("subtotal", initialTotal)
-                        put("due", initialTotal)
-                        put("total", initialTotal)
-                    }
-                    json.put(
-                        "tax_context",
-                        JSONObject(
-                            """
-                            {
-                                "automatic_tax_enabled": true,
-                                "automatic_tax_address_source": "billing"
-                            }
-                            """.trimIndent()
-                        )
-                    )
-                    json.put(
-                        "customer",
-                        JSONObject(
-                            """
-                            {
-                                "id": "cus_123",
-                                "payment_methods": [{
-                                    "id": "pm_12345",
-                                    "object": "payment_method",
-                                    "type": "card",
-                                    "billing_details": {
-                                        "address": {
-                                            "country": "US",
-                                            "postal_code": "12345"
-                                        }
-                                    },
-                                    "card": {
-                                        "brand": "visa",
-                                        "exp_month": 12,
-                                        "exp_year": 2034,
-                                        "last4": "4242"
-                                    }
-                                }],
-                                "can_detach_payment_method": true
-                            }
-                            """.trimIndent()
-                        )
-                    )
-                }
-            },
-            setup = { controller ->
-                controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
-            },
-        ) { context ->
-            contentPage.assertHasSelectedSavedPaymentMethod("pm_12345")
-            networkRule.checkoutUpdate { response ->
-                response.testBodyFromFile("checkout-session-confirm.json") { json ->
-                    json.getJSONObject("total_summary").put("total", updatedTotal)
-                }
-            }
-            networkRule.checkoutInit { response ->
-                response.testBodyFromFile("checkout-session-init.json") { json ->
-                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
-                }
-            }
 
-            context.confirm()
-        }
+        context.confirm()
     }
 
     private companion object {
         const val DEFAULT_CLIENT_SECRET = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example"
+        const val INITIAL_TOTAL = 5099
+        const val UPDATED_TOTAL = 5399
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -1,0 +1,145 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
+import com.stripe.android.checkouttesting.checkoutInit
+import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.exception.LocalStripeException
+import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedContentPage
+import com.stripe.android.paymentsheet.validateAnalyticsRequest
+import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
+import com.stripe.android.paymentsheet.utils.TestRules
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(CheckoutSessionPreview::class)
+internal class CheckoutPaymentElementAnalyticsTest {
+    private val networkRule = NetworkRule(
+        hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
+        validationTimeout = 5.seconds,
+    )
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(networkRule = networkRule) {
+        around(AdvancedFraudSignalsTestRule())
+            .around(GooglePayRepositoryTestRule())
+    }
+
+    private val contentPage = EmbeddedContentPage(testRules.compose)
+
+    @Test
+    fun testTotalChangeFailureSendsAnalyticsErrorCode() {
+        val initialTotal = 5099
+        val updatedTotal = 5399
+        // Initial configuration and the post-failure session refresh each report loading.
+        repeat(2) {
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_started",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_succeeded",
+                productUsage = setOf("Checkout"),
+            )
+        }
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_initial_displayed_payment_methods",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_embedded_payment_failure",
+            productUsage = setOf("Checkout"),
+            analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
+            analyticsPayloadField("error_code", "checkout_session_total_changed"),
+        )
+        runCheckoutPaymentElementTest(
+            networkRule = networkRule,
+            resultCallback = { result ->
+                assertThat(result).isInstanceOf(CheckoutController.Result.Failed::class.java)
+                val failure = result as CheckoutController.Result.Failed
+                assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
+            },
+            checkoutInitResponse = { response ->
+                response.testBodyFromFile("checkout-session-init.json") { json ->
+                    json.put("customer_email", "checkout@example.com")
+                    json.getJSONObject("elements_session").remove("link_settings")
+                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
+                    json.getJSONObject("total_summary").apply {
+                        put("subtotal", initialTotal)
+                        put("due", initialTotal)
+                        put("total", initialTotal)
+                    }
+                    json.put(
+                        "tax_context",
+                        JSONObject(
+                            """
+                            {
+                                "automatic_tax_enabled": true,
+                                "automatic_tax_address_source": "billing"
+                            }
+                            """.trimIndent()
+                        )
+                    )
+                    json.put(
+                        "customer",
+                        JSONObject(
+                            """
+                            {
+                                "id": "cus_123",
+                                "payment_methods": [{
+                                    "id": "pm_12345",
+                                    "object": "payment_method",
+                                    "type": "card",
+                                    "billing_details": {
+                                        "address": {
+                                            "country": "US",
+                                            "postal_code": "12345"
+                                        }
+                                    },
+                                    "card": {
+                                        "brand": "visa",
+                                        "exp_month": 12,
+                                        "exp_year": 2034,
+                                        "last4": "4242"
+                                    }
+                                }],
+                                "can_detach_payment_method": true
+                            }
+                            """.trimIndent()
+                        )
+                    )
+                }
+            },
+            setup = { controller ->
+                controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+            },
+        ) { context ->
+            contentPage.assertHasSelectedSavedPaymentMethod("pm_12345")
+            networkRule.checkoutUpdate { response ->
+                response.testBodyFromFile("checkout-session-confirm.json") { json ->
+                    json.getJSONObject("total_summary").put("total", updatedTotal)
+                }
+            }
+            networkRule.checkoutInit { response ->
+                response.testBodyFromFile("checkout-session-init.json") { json ->
+                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
+                }
+            }
+
+            context.confirm()
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_CLIENT_SECRET = "${DEFAULT_CHECKOUT_SESSION_ID}_secret_example"
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -93,17 +93,14 @@ internal class CheckoutPaymentElementAnalyticsTest {
             }
         },
         setup = { controller ->
-            // Initial configuration and the post-failure session refresh each report loading.
-            repeat(2) {
-                networkRule.validateAnalyticsRequest(
-                    eventName = "mc_load_started",
-                    productUsage = setOf("Checkout"),
-                )
-                networkRule.validateAnalyticsRequest(
-                    eventName = "mc_load_succeeded",
-                    productUsage = setOf("Checkout"),
-                )
-            }
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_started",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_succeeded",
+                productUsage = setOf("Checkout"),
+            )
             networkRule.validateAnalyticsRequest(
                 eventName = "mc_initial_displayed_payment_methods",
                 productUsage = setOf("Checkout"),
@@ -127,6 +124,15 @@ internal class CheckoutPaymentElementAnalyticsTest {
             productUsage = setOf("Checkout"),
             analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
             analyticsPayloadField("error_code", "checkout_session_total_changed"),
+        )
+        // The Checkout Session is refreshed after confirmation fails.
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_load_started",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_load_succeeded",
+            productUsage = setOf("Checkout"),
         )
 
         context.confirm()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -106,6 +106,8 @@ internal class CheckoutPaymentElementTest {
 
     @Test
     fun testTotalChangeFailureSendsAnalyticsErrorCode() {
+        val initialTotal = 5099
+        val updatedTotal = 5399
         var checkoutResult: CheckoutController.Result? = null
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
@@ -114,6 +116,11 @@ internal class CheckoutPaymentElementTest {
                 response.testBodyFromFile("checkout-session-init.json") { json ->
                     json.put("customer_email", "checkout@example.com")
                     json.getJSONObject("elements_session").remove("link_settings")
+                    json.getJSONObject("total_summary").apply {
+                        put("subtotal", initialTotal)
+                        put("due", initialTotal)
+                        put("total", initialTotal)
+                    }
                     json.put(
                         "tax_context",
                         JSONObject(
@@ -162,7 +169,7 @@ internal class CheckoutPaymentElementTest {
             contentPage.assertHasSelectedSavedPaymentMethod("pm_12345")
             networkRule.checkoutUpdate { response ->
                 response.testBodyFromFile("checkout-session-confirm.json") { json ->
-                    json.getJSONObject("total_summary").put("total", 5399)
+                    json.getJSONObject("total_summary").put("total", updatedTotal)
                 }
             }
             networkRule.checkoutInit { response ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -108,10 +108,13 @@ internal class CheckoutPaymentElementTest {
     fun testTotalChangeFailureSendsAnalyticsErrorCode() {
         val initialTotal = 5099
         val updatedTotal = 5399
-        var checkoutResult: CheckoutController.Result? = null
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
-            resultCallback = { result -> checkoutResult = result },
+            resultCallback = { result ->
+                assertThat(result).isInstanceOf(CheckoutController.Result.Failed::class.java)
+                val failure = result as CheckoutController.Result.Failed
+                assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
+            },
             checkoutInitResponse = { response ->
                 response.testBodyFromFile("checkout-session-init.json") { json ->
                     json.put("customer_email", "checkout@example.com")
@@ -185,10 +188,6 @@ internal class CheckoutPaymentElementTest {
             AnalyticsRequestExecutor.ENABLED = true
             context.confirm()
         }
-
-        assertThat(checkoutResult).isInstanceOf(CheckoutController.Result.Failed::class.java)
-        val failure = checkoutResult as CheckoutController.Result.Failed
-        assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
     }
 
     private companion object {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.testBodyFromFile
@@ -19,11 +20,13 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
 import com.stripe.android.paymentsheet.validateAnalyticsRequest
+import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestName
 import org.json.JSONObject
 import kotlin.time.Duration.Companion.seconds
 
@@ -35,14 +38,20 @@ internal class CheckoutPaymentElementTest {
     )
 
     @get:Rule
-    val testRules: TestRules = TestRules.create(networkRule = networkRule)
+    val testRules: TestRules = TestRules.create(networkRule = networkRule) {
+        around(AdvancedFraudSignalsTestRule())
+            .around(GooglePayRepositoryTestRule())
+    }
+
+    @get:Rule
+    val testName = TestName()
 
     private val contentPage = EmbeddedContentPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
 
     @Before
     fun setup() {
-        AnalyticsRequestExecutor.ENABLED = false
+        AnalyticsRequestExecutor.ENABLED = testName.methodName == "testTotalChangeFailureSendsAnalyticsErrorCode"
     }
 
     @After
@@ -108,6 +117,27 @@ internal class CheckoutPaymentElementTest {
     fun testTotalChangeFailureSendsAnalyticsErrorCode() {
         val initialTotal = 5099
         val updatedTotal = 5399
+        // Initial configuration and the post-failure session refresh each report loading.
+        repeat(2) {
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_started",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_succeeded",
+                productUsage = setOf("Checkout"),
+            )
+        }
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_initial_displayed_payment_methods",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_embedded_payment_failure",
+            productUsage = setOf("Checkout"),
+            analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
+            analyticsPayloadField("error_code", "checkout_session_total_changed"),
+        )
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
             resultCallback = { result ->
@@ -119,6 +149,7 @@ internal class CheckoutPaymentElementTest {
                 response.testBodyFromFile("checkout-session-init.json") { json ->
                     json.put("customer_email", "checkout@example.com")
                     json.getJSONObject("elements_session").remove("link_settings")
+                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
                     json.getJSONObject("total_summary").apply {
                         put("subtotal", initialTotal)
                         put("due", initialTotal)
@@ -176,16 +207,11 @@ internal class CheckoutPaymentElementTest {
                 }
             }
             networkRule.checkoutInit { response ->
-                response.testBodyFromFile("checkout-session-init.json")
+                response.testBodyFromFile("checkout-session-init.json") { json ->
+                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
+                }
             }
-            networkRule.validateAnalyticsRequest(
-                eventName = "mc_embedded_payment_failure",
-                productUsage = setOf("Checkout"),
-                analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
-                analyticsPayloadField("error_code", "checkout_session_total_changed"),
-            )
 
-            AnalyticsRequestExecutor.ENABLED = true
             context.confirm()
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -4,55 +4,27 @@ import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutConfirm
-import com.stripe.android.checkouttesting.checkoutInit
-import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.checkouttesting.createPaymentMethod
-import com.stripe.android.core.exception.LocalStripeException
-import com.stripe.android.core.networking.AnalyticsRequest
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
-import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.googlepaylauncher.GooglePayRepository
-import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
-import com.stripe.android.paymentsheet.validateAnalyticsRequest
-import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
 import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TestName
-import org.json.JSONObject
-import kotlin.time.Duration.Companion.seconds
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutPaymentElementTest {
-    private val networkRule = NetworkRule(
-        hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
-        validationTimeout = 5.seconds,
-    )
+    private val networkRule = NetworkRule()
 
     @get:Rule
-    val testRules: TestRules = TestRules.create(networkRule = networkRule) {
-        around(AdvancedFraudSignalsTestRule())
-            .around(GooglePayRepositoryTestRule())
-    }
-
-    @get:Rule
-    val testName = TestName()
+    val testRules: TestRules = TestRules.create(networkRule = networkRule)
 
     private val contentPage = EmbeddedContentPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
-
-    @Before
-    fun setup() {
-        AnalyticsRequestExecutor.ENABLED = testName.methodName == "testTotalChangeFailureSendsAnalyticsErrorCode"
-    }
 
     @After
     fun teardown() {
@@ -111,109 +83,6 @@ internal class CheckoutPaymentElementTest {
         }
 
         assertThat(checkoutResult).isInstanceOf(CheckoutController.Result.Completed::class.java)
-    }
-
-    @Test
-    fun testTotalChangeFailureSendsAnalyticsErrorCode() {
-        val initialTotal = 5099
-        val updatedTotal = 5399
-        // Initial configuration and the post-failure session refresh each report loading.
-        repeat(2) {
-            networkRule.validateAnalyticsRequest(
-                eventName = "mc_load_started",
-                productUsage = setOf("Checkout"),
-            )
-            networkRule.validateAnalyticsRequest(
-                eventName = "mc_load_succeeded",
-                productUsage = setOf("Checkout"),
-            )
-        }
-        networkRule.validateAnalyticsRequest(
-            eventName = "mc_initial_displayed_payment_methods",
-            productUsage = setOf("Checkout"),
-        )
-        networkRule.validateAnalyticsRequest(
-            eventName = "mc_embedded_payment_failure",
-            productUsage = setOf("Checkout"),
-            analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
-            analyticsPayloadField("error_code", "checkout_session_total_changed"),
-        )
-        runCheckoutPaymentElementTest(
-            networkRule = networkRule,
-            resultCallback = { result ->
-                assertThat(result).isInstanceOf(CheckoutController.Result.Failed::class.java)
-                val failure = result as CheckoutController.Result.Failed
-                assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
-            },
-            checkoutInitResponse = { response ->
-                response.testBodyFromFile("checkout-session-init.json") { json ->
-                    json.put("customer_email", "checkout@example.com")
-                    json.getJSONObject("elements_session").remove("link_settings")
-                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
-                    json.getJSONObject("total_summary").apply {
-                        put("subtotal", initialTotal)
-                        put("due", initialTotal)
-                        put("total", initialTotal)
-                    }
-                    json.put(
-                        "tax_context",
-                        JSONObject(
-                            """
-                            {
-                                "automatic_tax_enabled": true,
-                                "automatic_tax_address_source": "billing"
-                            }
-                            """.trimIndent()
-                        )
-                    )
-                    json.put(
-                        "customer",
-                        JSONObject(
-                            """
-                            {
-                                "id": "cus_123",
-                                "payment_methods": [{
-                                    "id": "pm_12345",
-                                    "object": "payment_method",
-                                    "type": "card",
-                                    "billing_details": {
-                                        "address": {
-                                            "country": "US",
-                                            "postal_code": "12345"
-                                        }
-                                    },
-                                    "card": {
-                                        "brand": "visa",
-                                        "exp_month": 12,
-                                        "exp_year": 2034,
-                                        "last4": "4242"
-                                    }
-                                }],
-                                "can_detach_payment_method": true
-                            }
-                            """.trimIndent()
-                        )
-                    )
-                }
-            },
-            setup = { controller ->
-                controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
-            },
-        ) { context ->
-            contentPage.assertHasSelectedSavedPaymentMethod("pm_12345")
-            networkRule.checkoutUpdate { response ->
-                response.testBodyFromFile("checkout-session-confirm.json") { json ->
-                    json.getJSONObject("total_summary").put("total", updatedTotal)
-                }
-            }
-            networkRule.checkoutInit { response ->
-                response.testBodyFromFile("checkout-session-init.json") { json ->
-                    json.put("account_settings", JSONObject("""{"country":"US"}"""))
-                }
-            }
-
-            context.confirm()
-        }
     }
 
     private companion object {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -4,27 +4,46 @@ import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutConfirm
+import com.stripe.android.checkouttesting.checkoutInit
+import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.checkouttesting.createPaymentMethod
+import com.stripe.android.core.exception.LocalStripeException
+import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
+import com.stripe.android.paymentsheet.validateAnalyticsRequest
 import com.stripe.android.paymentsheet.utils.TestRules
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.json.JSONObject
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutPaymentElementTest {
-    private val networkRule = NetworkRule()
+    private val networkRule = NetworkRule(
+        hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
+        validationTimeout = 5.seconds,
+    )
 
     @get:Rule
     val testRules: TestRules = TestRules.create(networkRule = networkRule)
 
     private val contentPage = EmbeddedContentPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
+
+    @Before
+    fun setup() {
+        AnalyticsRequestExecutor.ENABLED = false
+    }
 
     @After
     fun teardown() {
@@ -83,6 +102,86 @@ internal class CheckoutPaymentElementTest {
         }
 
         assertThat(checkoutResult).isInstanceOf(CheckoutController.Result.Completed::class.java)
+    }
+
+    @Test
+    fun testTotalChangeFailureSendsAnalyticsErrorCode() {
+        var checkoutResult: CheckoutController.Result? = null
+        runCheckoutPaymentElementTest(
+            networkRule = networkRule,
+            resultCallback = { result -> checkoutResult = result },
+            checkoutInitResponse = { response ->
+                response.testBodyFromFile("checkout-session-init.json") { json ->
+                    json.put("customer_email", "checkout@example.com")
+                    json.getJSONObject("elements_session").remove("link_settings")
+                    json.put(
+                        "tax_context",
+                        JSONObject(
+                            """
+                            {
+                                "automatic_tax_enabled": true,
+                                "automatic_tax_address_source": "billing"
+                            }
+                            """.trimIndent()
+                        )
+                    )
+                    json.put(
+                        "customer",
+                        JSONObject(
+                            """
+                            {
+                                "id": "cus_123",
+                                "payment_methods": [{
+                                    "id": "pm_12345",
+                                    "object": "payment_method",
+                                    "type": "card",
+                                    "billing_details": {
+                                        "address": {
+                                            "country": "US",
+                                            "postal_code": "12345"
+                                        }
+                                    },
+                                    "card": {
+                                        "brand": "visa",
+                                        "exp_month": 12,
+                                        "exp_year": 2034,
+                                        "last4": "4242"
+                                    }
+                                }],
+                                "can_detach_payment_method": true
+                            }
+                            """.trimIndent()
+                        )
+                    )
+                }
+            },
+            setup = { controller ->
+                controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+            },
+        ) { context ->
+            contentPage.assertHasSelectedSavedPaymentMethod("pm_12345")
+            networkRule.checkoutUpdate { response ->
+                response.testBodyFromFile("checkout-session-confirm.json") { json ->
+                    json.getJSONObject("total_summary").put("total", 5399)
+                }
+            }
+            networkRule.checkoutInit { response ->
+                response.testBodyFromFile("checkout-session-init.json")
+            }
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_embedded_payment_failure",
+                productUsage = setOf("Checkout"),
+                analyticsPayloadField("error_message", "checkoutSessionTotalChanged"),
+                analyticsPayloadField("error_code", "checkout_session_total_changed"),
+            )
+
+            AnalyticsRequestExecutor.ENABLED = true
+            context.confirm()
+        }
+
+        assertThat(checkoutResult).isInstanceOf(CheckoutController.Result.Failed::class.java)
+        val failure = checkoutResult as CheckoutController.Result.Failed
+        assertThat(failure.error).isInstanceOf(LocalStripeException::class.java)
     }
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadat
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.ConfirmCheckoutSessionParams
@@ -55,6 +56,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
 ) : IntentConfirmationInterceptor {
 
     private val returnUrl: String = DefaultReturnUrl.create(context).value
+    private val genericErrorMessage: String = context.getString(R.string.stripe_something_went_wrong)
     private val isSaveEnabled: Boolean =
         customerMetadata?.saveConsent is PaymentMethodSaveConsentBehavior.Enabled
 
@@ -130,7 +132,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
         val finalEstimatedTotal = updatedCheckoutSessionResponse?.totalSummary?.totalAmountDue
         if (initialEstimatedTotal != finalEstimatedTotal) {
             val error = LocalStripeException(
-                displayMessage = "The estimated total changed from $initialEstimatedTotal to $finalEstimatedTotal.",
+                displayMessage = genericErrorMessage,
                 analyticsValue = "checkoutSessionTotalChanged",
                 errorCode = "checkout_session_total_changed",
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
@@ -128,8 +129,10 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
         }
         val finalEstimatedTotal = updatedCheckoutSessionResponse?.totalSummary?.totalAmountDue
         if (initialEstimatedTotal != finalEstimatedTotal) {
-            val error = IllegalStateException(
-                "The estimated total changed from $initialEstimatedTotal to $finalEstimatedTotal."
+            val error = LocalStripeException(
+                displayMessage = "The estimated total changed from $initialEstimatedTotal to $finalEstimatedTotal.",
+                analyticsValue = "checkoutSessionTotalChanged",
+                errorCode = "checkout_session_total_changed",
             )
             return Result.failure(error)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf
@@ -169,10 +170,13 @@ class CheckoutSessionConfirmationInterceptorTest {
 
             assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
             val failAction = result as ConfirmationDefinition.Action.Fail
-            assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
+            assertThat(failAction.cause).isInstanceOf<LocalStripeException>()
             assertThat(failAction.cause.message).isEqualTo(
                 "The estimated total changed from 5099 to 5399."
             )
+            val error = failAction.cause as LocalStripeException
+            assertThat(error.analyticsValue()).isEqualTo("checkoutSessionTotalChanged")
+            assertThat(error.stripeError?.code).isEqualTo("checkout_session_total_changed")
             assertThat(failAction.errorType).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Payment)
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -171,9 +172,8 @@ class CheckoutSessionConfirmationInterceptorTest {
             assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
             val failAction = result as ConfirmationDefinition.Action.Fail
             assertThat(failAction.cause).isInstanceOf<LocalStripeException>()
-            assertThat(failAction.cause.message).isEqualTo(
-                "The estimated total changed from 5099 to 5399."
-            )
+            assertThat(failAction.cause.message)
+                .isEqualTo(applicationContext.getString(R.string.stripe_something_went_wrong))
             val error = failAction.cause as LocalStripeException
             assertThat(error.analyticsValue()).isEqualTo("checkoutSessionTotalChanged")
             assertThat(error.stripeError?.code).isEqualTo("checkout_session_total_changed")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.analytics.experiment.LoggableExperiment
+import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -1345,6 +1346,33 @@ class DefaultEventReporterTest {
         assertThat(request.params).containsEntry("selected_lpm", "google_pay")
         assertThat(request.params).containsEntry("has_card_art", false)
         assertThat(request.params).containsEntry("example_from_test", true)
+    }
+
+    @Test
+    fun `onPaymentFailure includes local error analytics values`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        durationProvider.endCalls.push(
+            FakeDurationProvider.EndCall(
+                key = DurationProvider.Key.Checkout,
+                duration = 6.seconds,
+            )
+        )
+        val error = PaymentSheetConfirmationError.Stripe(
+            cause = LocalStripeException(
+                displayMessage = "The estimated total changed.",
+                analyticsValue = "checkoutSessionTotalChanged",
+                errorCode = "checkout_session_total_changed",
+            )
+        )
+
+        eventReporter.onPaymentFailure(
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            error = error,
+        )
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("error_message", "checkoutSessionTotalChanged")
+        assertThat(request.params).containsEntry("error_code", "checkout_session_total_changed")
     }
 
     @Test


### PR DESCRIPTION
# Summary

Add analytics for Checkout Session total changes

# Motivation

Make it possible to identify in analytics that CS confirmation failed because of a tax update https://jira.corp.stripe.com/browse/MOBILESDK-4723

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified